### PR TITLE
fix: bug where a variable is used before it's declared.

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -269,8 +269,8 @@ class UserProfile extends Component {
 
 		console.log('phoneNumberPubliclyAccessible', phoneNumberPubliclyAccessible)
 		let isUserSelf = targetUserId === requestorId
-		let canEditFields = isUserAdmin || isUserSelf
 		const isUserAdmin = requestorRole === 'Administrator'
+		let canEditFields = isUserAdmin || isUserSelf
 
 		if (isLoading === true) {
 			return <Loading />


### PR DESCRIPTION
This fixes a bug in the user profile page where a variable is used before it's declared which is causing an error.