### PR TITLE
Low priority 5a: timer stops counting after clicking stop

### DIFF
--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Badge, Button } from 'reactstrap'
-import {startTimer, pauseTimer, updateTimer, getTimerData} from '../../actions/timer'
+import { startTimer, pauseTimer, updateTimer, getTimerData } from '../../actions/timer'
 import TimeEntryForm from '../Timelog/TimeEntryForm'
 import './Timer.css'
 import axios from "axios";
-import {ENDPOINTS} from "../../utils/URL";
+import { ENDPOINTS } from "../../utils/URL";
 
 const Timer = () => {
   const data = {
@@ -26,7 +26,7 @@ const Timer = () => {
   let intervalSec = null;
   let intervalMin = null;
   let intervalThreeMin = null;
-  
+
   const toggle = () => setModal(modal => !modal)
 
   const reset = async () => {
@@ -72,7 +72,7 @@ const Timer = () => {
   }
 
   const handleStop = () => {
-    if (handlePause()){ toggle() }
+    toggle();
   }
 
   useEffect(() => {
@@ -91,11 +91,11 @@ const Timer = () => {
   }, [pausedAt])
 
   useEffect(() => {
-      try {
-        setIsActive(isWorking);
-      } catch {
+    try {
+      setIsActive(isWorking);
+    } catch {
 
-       }
+    }
 
   }, [isWorking]);
 
@@ -172,7 +172,7 @@ const Timer = () => {
         isOpen={modal}
         timer={{ hours, minutes }}
         data={data}
-        userProfile = {userProfile}
+        userProfile={userProfile}
         resetTimer={reset}
       />
     </div>


### PR DESCRIPTION
Fixes low priority bug 5a.

> The time log should keep running until "submit" is hit. This way people get credit for the time it takes them to write their entry and/or they can use that open window to keep a record of what they are doing, while the timer keeps running 

Summary: 

- The timer will now continue to count up until the entry has been submitted, not after the stop button has been pressed. This makes time log entries take into account how long it takes to fill out the form as intended.