### PR TITLE
High priority 3A and 3B: Fixed issues resulting from differences in local time versus PST

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.21",
     "moment": "^2.25.3",
-    "moment-timezone": "^0.5.31",
+    "moment-timezone": "^0.5.33",
     "pdfmake": "^0.1.65",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/src/__tests__/Timelog/TimeEntry.test.js
+++ b/src/__tests__/Timelog/TimeEntry.test.js
@@ -5,7 +5,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import {

--- a/src/__tests__/Timelog/TimeEntryForm.test.js
+++ b/src/__tests__/Timelog/TimeEntryForm.test.js
@@ -5,7 +5,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import {
   authMock, userProfileMock, timeEntryMock, userProjectMock,
 } from '../mockStates';
@@ -39,12 +39,12 @@ describe('<TimeEntryForm />', () => {
         userId={data.personId}
         edit={false}
         data={data}
-          isOpen
+        isOpen
         toggle={toggle}
         timer
         userProfile={userProfile}
         resetTimer
-        
+
       />,
       {
         store,
@@ -89,8 +89,8 @@ describe('<TimeEntryForm />', () => {
   });
   it('should render the tangible tip info and the content', () => {
     const tips = screen.getByTitle('tangibleTip');
-    userEvent.click(tips,1);
-    expect(screen.getByText(/Intangible time is time logged*/i)).toBeInTheDocument();  
+    userEvent.click(tips, 1);
+    expect(screen.getByText(/Intangible time is time logged*/i)).toBeInTheDocument();
   });
   it('should render the correct tangible checkbox', () => {
     const checkbox = screen.getByRole('checkbox');
@@ -115,7 +115,7 @@ describe('<TimeEntryForm />', () => {
     expect(minutes).toHaveValue(0);
     userEvent.click(screen.getByRole('button', { name: /submit/i }));
     expect(screen.getByText('Time should be greater than 0')).toBeInTheDocument();
-    
+
   });
   it('should populate errors if project field is empty or invalid', async () => {
     const projectField = screen.getByDisplayValue(/select project/i);
@@ -149,7 +149,7 @@ describe('<TimeEntryFormEdit />', () => {
         timer
         userProfile={userProfile}
         resetTimer
-        
+
       />,
       {
         store,
@@ -177,10 +177,10 @@ describe('<TimeEntryFormEdit />', () => {
     expect(minutes).toBeInTheDocument();
     expect(projectField).toBeInTheDocument();
     expect(noteField).toBeInTheDocument();
-    fireEvent.change(hours,{ target : { value: '6' }});
+    fireEvent.change(hours, { target: { value: '6' } });
     await sleep(10);
     //userEvent.selectOptions(projectField,userProjectMock.projects[1].projectId)
-    fireEvent.change(noteField,{ target : { value: 'Edit Note. This should work normally. Does this thing work? \n https://www.google.com/' }});
+    fireEvent.change(noteField, { target: { value: 'Edit Note. This should work normally. Does this thing work? \n https://www.google.com/' } });
     expect(hours).toHaveValue(6);
     //expect(projectField).toHaveValue(userProjectMock.projects[1].projectId);
     fireEvent.click(screen.getByRole('button', { name: /save/i }));

--- a/src/__tests__/Timelog/TimeEntryForm.test.js
+++ b/src/__tests__/Timelog/TimeEntryForm.test.js
@@ -54,7 +54,7 @@ describe('<TimeEntryForm />', () => {
   it('should dispatch the right action with the right payload after add new time entry', async () => {
     const expectedPayload = {
       personId: data.personId,
-      dateOfWork: moment().format('YYYY-MM-DD'),
+      dateOfWork: moment().tz('America/Los_Angeles').format('YYYY-MM-DD'),
       notes: '',
       isTangible: 'true',
       projectId: userProjectMock.projects[0].projectId,

--- a/src/__tests__/Timelog/TimeEntryForm_edit.test.js
+++ b/src/__tests__/Timelog/TimeEntryForm_edit.test.js
@@ -5,7 +5,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import {
   authMock, userProfileMock, timeEntryMock, userProjectMock,
 } from '../mockStates';

--- a/src/__tests__/Timelog/TimeEntryForm_edit.test.js
+++ b/src/__tests__/Timelog/TimeEntryForm_edit.test.js
@@ -72,7 +72,7 @@ describe('<TimeEntryForm edit/>', () => {
     userEvent.click(screen.getByRole('button', { name: /clear form/i }));
     expect(screen.getAllByRole('spinbutton')[0]).toHaveValue(0);
     expect(screen.getAllByRole('spinbutton')[1]).toHaveValue(0);
-    expect(screen.getByLabelText('Date')).toHaveValue(moment().format('YYYY-MM-DD'));
+    expect(screen.getByLabelText('Date')).toHaveValue(moment().tz('America/Los_Angeles').format('YYYY-MM-DD'));
     expect(screen.getByRole('combobox')).toHaveValue('');
   });
 

--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -12,20 +12,30 @@ import { ENDPOINTS } from '../utils/URL';
  * number === 2 week before last
 */
 export const getTimeEntriesForWeek = (userId, offset) => {
+
+    //TODO: Environment variable for server timezone
+
     const fromDate = moment()
+        .tz('America/Los_Angeles')
         .startOf('week')
-        .subtract(offset, 'weeks');
-        const toDate = moment()
+        .subtract(offset, 'weeks')
+        .format('YYYY-MM-DD')
+
+    const toDate = moment()
+        .tz('America/Los_Angeles')
         .endOf('week')
-        .subtract(offset, 'weeks');
+        .subtract(offset, 'weeks')
+        .format('YYYY-MM-DD')
+
+
     const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate, toDate);
     return async (dispatch) => {
         let loggedOut = false;
-        const res = await axios.get(url).catch((error)=>{
-			if (error.status===401) {
-				//logout error
-				loggedOut = true;
-			}
+        const res = await axios.get(url).catch((error) => {
+            if (error.status === 401) {
+                //logout error
+                loggedOut = true;
+            }
         });
         if (!loggedOut || !res || !res.data) {
             await dispatch(setTimeEntriesForWeek(res.data, offset));
@@ -37,11 +47,11 @@ export const getTimeEntriesForPeriod = (userId, fromDate, toDate) => {
     const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate, toDate);
     return async (dispatch) => {
         let loggedOut = false;
-        const res = await axios.get(url).catch((error)=>{
-			if (error.status === 401) {
-				//logout error
-				loggedOut = true;
-			}
+        const res = await axios.get(url).catch((error) => {
+            if (error.status === 401) {
+                //logout error
+                loggedOut = true;
+            }
         });
         if (!loggedOut || !res || !res.data) {
             await dispatch(setTimeEntriesForPeriod(res.data));

--- a/src/components/Timelog/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm.jsx
@@ -392,7 +392,7 @@ const TimeEntryForm = ({
     if (closed) {
       //make sure form clears before close
       inputs = { ...initialState };
-      setClose(true);
+      act(setClose(true));
     }
     setInputs({ ...initialState });
     setReminder({ ...initialReminder });

--- a/src/components/Timelog/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm.jsx
@@ -31,7 +31,7 @@ const TimeEntryForm = ({
   const fromTimer = !_.isEmpty(timer);
   const [submitDisabled, setSubmitDisabled] = useState(false);
   const initialState = {
-    dateOfWork: moment().format('YYYY-MM-DD'),
+    dateOfWork: moment().tz('America/Los_Angeles').format('YYYY-MM-DD'),
     hours: 0,
     minutes: 0,
     projectId: '',
@@ -41,7 +41,7 @@ const TimeEntryForm = ({
   };
   const initialReminder = {
     notification: false,
-    has_link: data && data.notes && data.notes.includes('http') ?  true : false,
+    has_link: data && data.notes && data.notes.includes('http') ? true : false,
     remind: '',
     num_words: data && data.notes && data.notes.split(' ').length > 10 ? 10 : 0,
     edit_count: data ? data.editCount : 0,
@@ -70,7 +70,7 @@ const TimeEntryForm = ({
     if (close && inputs.projectId == '') {
       //double make sure close is set to false to stop form from reclosing on open
       close = false;
-      setClose((close)=>{
+      setClose((close) => {
         setTimeout(function myfunc() {
           toggle();
         }, 100);
@@ -80,7 +80,7 @@ const TimeEntryForm = ({
   }, [close, inputs])
 
   useEffect(() => {
-    
+
   }, [inputs])
 
   const openModal = () => setReminder(reminder => ({
@@ -154,7 +154,7 @@ const TimeEntryForm = ({
     if (inputs.dateOfWork === '') {
       result.dateOfWork = 'Date is required';
     } else {
-      const date = moment(inputs.dateOfWork);
+      const date = moment(inputs.dateOfWork).tz('America/Los_Angeles');
       if (!date.isValid()) {
         result.dateOfWork = 'Invalid date';
       }
@@ -312,7 +312,7 @@ const TimeEntryForm = ({
     //   totalComittedHours: totalTime,
     // };
     //await dispatch(updateUserProfile(userProfile._id, updatedUserprofile));
-    
+
     if (fromTimer) {
       if (status === 200) {
         const timerStatus = await dispatch(stopTimer(userId));
@@ -391,11 +391,11 @@ const TimeEntryForm = ({
   const clearForm = (closed) => {
     if (closed) {
       //make sure form clears before close
-      inputs = {...initialState};
+      inputs = { ...initialState };
       setClose(true);
     }
-    setInputs({...initialState});
-    setReminder({...initialReminder});
+    setInputs({ ...initialState });
+    setReminder({ ...initialReminder });
     setErrors({});
   };
 
@@ -434,14 +434,14 @@ const TimeEntryForm = ({
                 onChange={handleInputChange}
               />
             ) : (
-                <Input
-                  type="date"
-                  name="dateOfWork"
-                  id="dateOfWork"
-                  value={inputs.dateOfWork}
-                  disabled
-                />
-              )}
+              <Input
+                type="date"
+                name="dateOfWork"
+                id="dateOfWork"
+                value={inputs.dateOfWork}
+                disabled
+              />
+            )}
             {'dateOfWork' in errors && (
               <div className="text-danger">
                 <small>{errors.dateOfWork}</small>
@@ -542,8 +542,8 @@ const TimeEntryForm = ({
                   onChange={handleCheckboxChange}
                 />
               ) : (
-                  <Input type="checkbox" name="isTangible" checked={inputs.isTangible} disabled />
-                )}{' '}
+                <Input type="checkbox" name="isTangible" checked={inputs.isTangible} disabled />
+              )}{' '}
               Tangible&nbsp;<i
                 className="fa fa-info-circle"
                 data-tip

--- a/src/components/Timelog/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm.jsx
@@ -392,7 +392,7 @@ const TimeEntryForm = ({
     if (closed) {
       //make sure form clears before close
       inputs = { ...initialState };
-      act(setClose(true));
+      setClose(true);
     }
     setInputs({ ...initialState });
     setReminder({ ...initialReminder });

--- a/src/components/Timelog/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm.jsx
@@ -15,7 +15,7 @@ import {
   ModalBody,
   ModalFooter,
 } from 'reactstrap';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import _ from 'lodash';
 import { Editor } from '@tinymce/tinymce-react';
 // import ReactHtmlParser from 'react-html-parser'

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -1,33 +1,19 @@
-import React, { Component } from 'react'
+import React, { Component } from 'react';
+
 import {
-  Container,
-  Row,
-  Col,
-  Card,
-  CardTitle,
-  CardSubtitle,
-  CardHeader,
-  CardBody,
-  Nav,
-  NavItem,
-  NavLink,
-  TabContent,
-  TabPane,
-  Form,
-  FormGroup,
-  Label,
-  Input,
-  Button,
-  Modal,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
+  Container, Row, Col,
+  Card, CardTitle, CardSubtitle, CardHeader,
+  CardBody, Nav, NavItem, NavLink, TabContent,
+  TabPane, Form, FormGroup, Label, Input, Button,
+  Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
+
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import moment from 'moment';
 import _ from 'lodash';
 import ReactTooltip from 'react-tooltip';
+
 import { getTimeEntriesForWeek, getTimeEntriesForPeriod } from '../../actions/timeEntries';
 import { getUserProfile } from '../../actions/userProfile';
 import { getUserProjects } from '../../actions/userProjects';
@@ -136,7 +122,9 @@ class Timelog extends Component {
   }
 
   startOfWeek(offset) {
+
     return moment()
+      .tz('America/Los_Angeles')
       .startOf('week')
       .subtract(offset, 'weeks')
       .format('YYYY-MM-DD')
@@ -144,9 +132,11 @@ class Timelog extends Component {
 
   endOfWeek(offset) {
     return moment()
+      .tz('America/Los_Angeles')
       .endOf('week')
       .subtract(offset, 'weeks')
       .format('YYYY-MM-DD')
+
   }
 
   generateTimeEntries(data) {
@@ -154,6 +144,7 @@ class Timelog extends Component {
     if (!this.state.projectsSelected.includes('all')) {
       filteredData = data.filter(entry => this.state.projectsSelected.includes(entry.projectId));
     }
+
     return filteredData.map(entry => (
       <TimeEntry
         data={entry}
@@ -203,7 +194,7 @@ class Timelog extends Component {
                   <Row>
                     <Col md={11}>
                       <CardTitle tag="h4">Time Entries &nbsp;
-                            <i
+                        <i
                           className="fa fa-info-circle"
                           data-tip
                           data-for="registerTip"
@@ -212,7 +203,7 @@ class Timelog extends Component {
                         /></CardTitle>
                       <CardSubtitle tag="h6" className="text-muted">
                         Viewing time entries logged in the last 3 weeks
-                    </CardSubtitle>
+                      </CardSubtitle>
                     </Col>
                     <Col md={11}>
                       {isOwner ? (
@@ -229,42 +220,42 @@ class Timelog extends Component {
                               />
                             </Button>
                             <ReactTooltip id="timeEntryTip" place="bottom" effect="solid">
-                              Clicking this button only allows for “Intangible Time” to be added to your time log. <u>You can manually log Intangible Time but it doesn’t <br/>
-                              count towards your weekly time commitment.</u><br/><br/>
-                              
-                              “Tangible Time” is the default for logging time using the timer at the top of the app. It represents all work done on assigned action items <br/>
-                              and is what counts towards a person’s weekly volunteer time commitment. The only way for a volunteer to log Tangible Time is by using the clock<br/>
-                               in/out timer. <br/><br/>
+                              Clicking this button only allows for “Intangible Time” to be added to your time log. <u>You can manually log Intangible Time but it doesn’t <br />
+                                count towards your weekly time commitment.</u><br /><br />
 
-                              Intangible Time is almost always used only by the management team. It is used for weekly Monday night management team calls, monthly management<br/>
-                               team reviews and Welcome Team Calls, and non-action-item related research, classes, and other learning, meetings, etc. that benefit or relate to <br/>
-                               the project but aren’t related to a specific action item on the <a href="https://www.tinyurl.com/oc-os-wbs">One Community Work Breakdown Structure.</a><br/><br/>
+                              “Tangible Time” is the default for logging time using the timer at the top of the app. It represents all work done on assigned action items <br />
+                              and is what counts towards a person’s weekly volunteer time commitment. The only way for a volunteer to log Tangible Time is by using the clock<br />
+                              in/out timer. <br /><br />
 
-                              Intangible Time may also be logged by a volunteer when in the field or for other reasons when the timer wasn’t able to be used. In these cases, the <br/>
-                              volunteer will use this button to log time as “intangible time” and then request that an Admin manually change the log from Intangible to Tangible.<br/><br/>
+                              Intangible Time is almost always used only by the management team. It is used for weekly Monday night management team calls, monthly management<br />
+                              team reviews and Welcome Team Calls, and non-action-item related research, classes, and other learning, meetings, etc. that benefit or relate to <br />
+                              the project but aren’t related to a specific action item on the <a href="https://www.tinyurl.com/oc-os-wbs">One Community Work Breakdown Structure.</a><br /><br />
+
+                              Intangible Time may also be logged by a volunteer when in the field or for other reasons when the timer wasn’t able to be used. In these cases, the <br />
+                              volunteer will use this button to log time as “intangible time” and then request that an Admin manually change the log from Intangible to Tangible.<br /><br />
 
                             </ReactTooltip>
                           </div>
                         </div>
                       ) : (
-                          isAdmin && (
-                            <div className="float-right">
-                              <div>
-                                <Button color="warning" onClick={this.toggle}>
-                                  Add Time Entry {!isOwner && `for ${fullName}`}
-                                </Button>
-                              </div>
-
+                        isAdmin && (
+                          <div className="float-right">
+                            <div>
+                              <Button color="warning" onClick={this.toggle}>
+                                Add Time Entry {!isOwner && `for ${fullName}`}
+                              </Button>
                             </div>
-                          )
-                        )}
+
+                          </div>
+                        )
+                      )}
                       <Modal isOpen={this.state.in} toggle={this.openInfo}>
                         <ModalHeader>Info</ModalHeader>
                         <ModalBody>{this.state.information}</ModalBody>
                         <ModalFooter>
                           <Button onClick={this.openInfo} color="primary">
                             Close
-                        </Button>
+                          </Button>
                           {isAdmin && (
                             <Button onClick={this.openInfo} color="secondary">
                               Edit
@@ -283,7 +274,7 @@ class Timelog extends Component {
                       />
                       <ReactTooltip id="registerTip" place="bottom" effect="solid">
                         Click this icon to learn about the timelog.
-                    </ReactTooltip>
+                      </ReactTooltip>
                     </Col>
                   </Row>
                 </CardHeader>
@@ -299,7 +290,7 @@ class Timelog extends Component {
                         to="#"
                       >
                         Current Week
-                    </NavLink>
+                      </NavLink>
                     </NavItem>
                     <NavItem>
                       <NavLink
@@ -311,7 +302,7 @@ class Timelog extends Component {
                         to="#"
                       >
                         Last Week
-                    </NavLink>
+                      </NavLink>
                     </NavItem>
                     <NavItem>
                       <NavLink
@@ -323,7 +314,7 @@ class Timelog extends Component {
                         to="#"
                       >
                         Week Before Last
-                    </NavLink>
+                      </NavLink>
                     </NavItem>
                     <NavItem>
                       <NavLink
@@ -335,30 +326,28 @@ class Timelog extends Component {
                         to="#"
                       >
                         Search by Date Range
-                    </NavLink>
+                      </NavLink>
                     </NavItem>
                   </Nav>
 
                   <TabContent activeTab={this.state.activeTab}>
                     {this.state.activeTab === 3 ? (
                       <p className="ml-1">
-                        Viewing time Entries from <b>{this.state.fromDate}</b>
-                        {' to '}
-                        <b>{this.state.toDate}</b>
+                        Viewing time Entries from <b>{this.state.fromDate}</b> to <b>{this.state.toDate}</b>
                       </p>
                     ) : (
-                        <p className="ml-1">
-                          Viewing time Entries from <b>{this.startOfWeek(this.state.activeTab)}</b>
-                          {' to '}
-                          <b>{this.endOfWeek(this.state.activeTab)}</b>
-                        </p>
-                      )}
+                      <p className="ml-1">
+                        Viewing time Entries from <b>{this.startOfWeek(this.state.activeTab)}</b>
+                        {' to '}
+                        <b>{this.endOfWeek(this.state.activeTab)}</b>
+                      </p>
+                    )}
                     {this.state.activeTab === 3 && (
                       <Form inline className="mb-2">
                         <FormGroup className="mr-2">
                           <Label for="fromDate" className="mr-2">
                             From
-                        </Label>
+                          </Label>
                           <Input
                             type="date"
                             name="fromDate"
@@ -370,7 +359,7 @@ class Timelog extends Component {
                         <FormGroup>
                           <Label for="toDate" className="mr-2">
                             To
-                        </Label>
+                          </Label>
                           <Input
                             type="date"
                             name="toDate"
@@ -381,14 +370,14 @@ class Timelog extends Component {
                         </FormGroup>
                         <Button color="primary" onClick={this.handleSearch} className="ml-2">
                           Search
-                      </Button>
+                        </Button>
                       </Form>
                     )}
                     <Form inline className="mb-2">
                       <FormGroup>
                         <Label for="projectSelected" className="mr-2 ml-1 mb-5 align-top">
                           Filter Entries by Project:
-                      </Label>
+                        </Label>
                         <Input
                           type="select"
                           name="projectSelected"


### PR DESCRIPTION
High priority 3A and 3B: Fixed issues resulting from differences in local time versus PST

> Entries from the previous week with correct (last week’s) timestamp and descriptions appear in the current week (see 5 hours 6 min in first image). Good news is, in the list of team members it shows the correct time for the current week (0 hours in the second image)

> There’s also an issue with people in other timezones logging time just a few hours before the week closes Saturday night PDT and those hours not counting for their current week… they get logged in the next week. So it seems the timer isn’t 100% synced with Pacific Time.

Summary:

-  When displaying time entries, local time is converted to PST before the times are fetched. So, if you roll over into the next week in your time zone but it’s still last week in PST, you won’t see the next week’s entries until it’s also the next week in PST.

-  When submitting a new time entry, local time is converted to PST for the default date value. If you’re in the next day in your time zone but it’s still yesterday in PST, yesterday is the default date to make sure it lines up with PST.

- The text “Viewing time Entries from xxx-xx-xx to xxxx-xx-xx” on the time log will only roll over to the next week once the next week begins in PST. Previously, local time was used

- The time entries you see are now dependent upon PST, not local time
