### PR TITLE
Time warnings

### DIFF
--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -25,8 +25,11 @@ const TimeEntry = ({ data, displayYear, userProfile }) => {
   const dispatch = useDispatch();
 
   const toggleTangability = () => {
-    
-    const newData = {...data,
+
+    if (!isAdmin) return;
+
+    const newData = {
+      ...data,
       isTangible: !data.isTangible,
       timeSpent: `${data.hours}:${data.minutes}:00`
     };
@@ -56,7 +59,7 @@ const TimeEntry = ({ data, displayYear, userProfile }) => {
           <div className="text-muted">Project/Task:</div>
           <h6> {data.projectName} </h6>
           <span className="text-muted">Tangible:&nbsp;</span>
-          <input type="checkbox" name="isTangible" checked={data.isTangible} readOnly={!isAdmin} onChange={() => toggleTangability(data)}/>
+          <input type="checkbox" name="isTangible" checked={data.isTangible} onChange={() => toggleTangability(data)} />
         </Col>
         <Col md={5} className="pl-2 pr-0">
           <div className="text-muted">Notes:</div>

--- a/src/components/Timelog/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm.jsx
@@ -36,8 +36,7 @@ const TimeEntryForm = ({ userId, edit, data, isOpen, toggle, timer, userProfile,
     minutes: 0,
     projectId: '',
     notes: '',
-    isTangible: isInTangible ? false : true,
-
+    isTangible: !isInTangible,
   };
 
   const initialReminder = {
@@ -219,7 +218,7 @@ const TimeEntryForm = ({ userId, edit, data, isOpen, toggle, timer, userProfile,
       result.notes = 'Description and reference link are required';
     }
 
-    if (!isAdmin && edit && reminder.edit_notice && edittime) {
+    if (!isAdmin && inputs.isTangible && edit && reminder.edit_notice && edittime) {
       openModal();
       setReminder(reminder => ({
         ...reminder,
@@ -262,7 +261,7 @@ const TimeEntryForm = ({ userId, edit, data, isOpen, toggle, timer, userProfile,
 
     let status;
     if (edit) {
-      if (edittime && !isAdmin) {
+      if (edittime && !isAdmin && inputs.isTangible) {
         timeEntry.editCount = reminder.edit_count + 1;
       }
       timeEntry.hours = hours;

--- a/src/components/Timelog/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm.jsx
@@ -41,7 +41,7 @@ const TimeEntryForm = ({
   };
   const initialReminder = {
     notification: false,
-    has_link: data && data.notes && data.notes.includes('http') ?  true : false,
+    has_link: data && data.notes && data.notes.includes('http') ? true : false,
     remind: '',
     num_words: data && data.notes && data.notes.split(' ').length > 10 ? 10 : 0,
     edit_count: data ? data.editCount : 0,
@@ -70,7 +70,7 @@ const TimeEntryForm = ({
     if (close && inputs.projectId == '') {
       //double make sure close is set to false to stop form from reclosing on open
       close = false;
-      setClose((close)=>{
+      setClose((close) => {
         setTimeout(function myfunc() {
           toggle();
         }, 100);
@@ -80,7 +80,7 @@ const TimeEntryForm = ({
   }, [close, inputs])
 
   useEffect(() => {
-    
+
   }, [inputs])
 
   const openModal = () => setReminder(reminder => ({
@@ -312,7 +312,7 @@ const TimeEntryForm = ({
     //   totalComittedHours: totalTime,
     // };
     //await dispatch(updateUserProfile(userProfile._id, updatedUserprofile));
-    
+
     if (fromTimer) {
       if (status === 200) {
         const timerStatus = await dispatch(stopTimer(userId));
@@ -388,14 +388,14 @@ const TimeEntryForm = ({
     }));
   };
 
-  const clearForm = (closed) => {
+  const clearForm = (closed = false) => {
     if (closed) {
       //make sure form clears before close
-      inputs = {...initialState};
+      inputs = { ...initialState };
       setClose(true);
     }
-    setInputs({...initialState});
-    setReminder({...initialReminder});
+    setInputs({ ...initialState });
+    setReminder({ ...initialReminder });
     setErrors({});
   };
 
@@ -434,14 +434,14 @@ const TimeEntryForm = ({
                 onChange={handleInputChange}
               />
             ) : (
-                <Input
-                  type="date"
-                  name="dateOfWork"
-                  id="dateOfWork"
-                  value={inputs.dateOfWork}
-                  disabled
-                />
-              )}
+              <Input
+                type="date"
+                name="dateOfWork"
+                id="dateOfWork"
+                value={inputs.dateOfWork}
+                disabled
+              />
+            )}
             {'dateOfWork' in errors && (
               <div className="text-danger">
                 <small>{errors.dateOfWork}</small>
@@ -542,8 +542,8 @@ const TimeEntryForm = ({
                   onChange={handleCheckboxChange}
                 />
               ) : (
-                  <Input type="checkbox" name="isTangible" checked={inputs.isTangible} disabled />
-                )}{' '}
+                <Input type="checkbox" name="isTangible" checked={inputs.isTangible} disabled />
+              )}{' '}
               Tangible&nbsp;<i
                 className="fa fa-info-circle"
                 data-tip
@@ -605,10 +605,8 @@ const TimeEntryForm = ({
       </ModalBody>
       <ModalFooter>
         <small className="mr-auto text-secondary">* All the fields are required</small>
-        <Button onClick={clearForm} color="danger">
-          {' '}
+        <Button onClick={() => clearForm(false)} color="danger">
           Clear Form
-          {' '}
         </Button>
         <Button onClick={handleSubmit} color="primary" disabled={submitDisabled}>
           {edit ? 'Save' : 'Submit'}


### PR DESCRIPTION
Fixes medium priority bug # 7:

> Admin editing a person’s time should not contribute to their time-edit count towards blue squares. I did this on Malathi and got an email notice. The email notice is good, but I’d like it not to contribute to their blue square count… and for the message to say that it doesn’t contribute to it. 

Summary:

- Admins are no longer warned about editing time entries
- The edit count of time entries is not increased when edited by an admin
- Fixed bug allowing non-admins to change the tangibility of their time entries (PR #183)
- Warnings are no longer issued when editing **intangible** time, nor does editing intangible time increment the edit count.
- Pressing "Clear Form" when creating or editing a time entry no longer closes the menu due to a truthy type check (accidentally included from PR #182)
