### PR TITLE
Low priority 1a: Search UX

### DIFF
--- a/src/components/Projects/Members/Members.jsx
+++ b/src/components/Projects/Members/Members.jsx
@@ -15,19 +15,12 @@ import './members.css'
 
 const Members = (props) => {
   const [role] = useState(props.state ? props.state.auth.user.role : null);
-  let [keyword, setKeyword] = useState('');
   const projectId = props.match.params.projectId;
 
 
   useEffect(() => {
     props.fetchAllMembers(projectId);
   }, [projectId]);
-
-  const pressEnter = (event, keyword) => {
-    if (event.key === "Enter") {
-      props.findUserProfiles(keyword);
-    }
-  }
 
   const assignAll = () => {
     const allUsers = props.state.projectMembers.foundUsers.filter(user => user.assigned === false);
@@ -62,14 +55,12 @@ const Members = (props) => {
             </div>
 
             <input type="text" className="form-control" aria-label="Search user" placeholder="Name"
-              onChange={(e) => setKeyword(e.target.value)}
-              onKeyPress={(e) => pressEnter(e, keyword)}
+              onChange={(e) => {
+                props.findUserProfiles(e.target.value);
+              }}
             />
             <div className="input-group-append">
-              <button className="btn btn-outline-primary" type="button"
-                onClick={(e) => props.findUserProfiles(keyword)}>
-                <i className="fa fa-search" aria-hidden="true"></i>
-              </button>
+
               <button className="btn btn-outline-primary" type="button"
                 onClick={(e) => props.getAllUserProfiles()}>
                 All


### PR DESCRIPTION
Solves low priority 1a: 

> This should auto-populate the list with all active options. Right now you have to type a name and hit “enter”, which is way less efficient and user friendly.  

![](https://i.imgur.com/KLFA9jU.png)

Summary: 

- Magnifying glass search button removed as it was made redundant
- Search results now auto-populate as you type