### PR TITLE
Admins can edit a user's tangible hours

### DIFF
--- a/src/__tests__/UserProfile/VolunteeringTimesTab.test.js
+++ b/src/__tests__/UserProfile/VolunteeringTimesTab.test.js
@@ -94,7 +94,7 @@ describe('volunteering times tab user as not admin', () => {
       expect(screen.getByText(`${userProfileMock.weeklyComittedHours}`)).toBeInTheDocument();
     });
     it('should render correct total committed hours value', () => {
-      expect(screen.getByText(`${userProfileMock.totalComittedHours}`)).toBeInTheDocument();
+      expect(screen.getByText(`${userProfileMock.totalTangibleHrs}`)).toBeInTheDocument();
     });
     // it('should render the correct start date', () => {
     //   expect(screen.getByText(`${userProfileMock.createdDate}`)).toBeInTheDocument();

--- a/src/__tests__/mockStates.js
+++ b/src/__tests__/mockStates.js
@@ -438,7 +438,7 @@ export const timerMock = {
 };
 export const userProfileMock = {
   isActive: true,
-  totalComittedHours: 15,
+  totalTangibleHrs: 15,
   phoneNumber: [
     '1112223333',
   ],

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -336,8 +336,8 @@ class UserProfile extends Component {
   }
 
   handleSubmit = async event => {
-    const { updateUserProfile, match } = this.props
-    const { userProfile, formValid } = this.state
+    const { updateUserProfile, match } = this.props;
+    const { userProfile, formValid } = this.state;
     const submitResult = await updateUserProfile(match.params.userId, userProfile)
     this.setState({ showSaveWarning: false })
   }
@@ -475,11 +475,11 @@ class UserProfile extends Component {
           },
         })
         break
-      case 'totalComittedHours':
+      case 'totalTangibleHours':
         this.setState({
           userProfile: {
             ...userProfile,
-            totalComittedHours: event.target.value,
+            totalTangibleHrs: event.target.value,
           },
         })
         break

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -41,21 +41,23 @@ const WeeklyCommitedHours = (props) => {
 };
 
 const TotalCommittedHours = (props) => {
+
   if (!props.isUserAdmin) {
-    return <p>{props.userProfile.totalComittedHours}</p>;
+    return <p>{props.userProfile.totalTangibleHrs}</p>;
   }
   return (
     <Input
       type="number"
-      name="totalComittedHours"
-      id="totalComittedHours"
-      value={props.userProfile.totalComittedHours}
+      name="totalTangibleHours"
+      id="totalTangibleHours"
+      value={props.userProfile.totalTangibleHrs}
       onChange={props.handleUserProfile}
       placeholder="Total Committed Hours"
       invalid={!props.isUserAdmin}
     />
   );
 };
+
 const ViewTab = (props) => {
   const {
     userProfile,
@@ -103,7 +105,7 @@ const ViewTab = (props) => {
       </Row>
       <Row>
         <Col md="6">
-          <Label>Total Hours </Label>
+          <Label>Total Tangible Hours </Label>
         </Col>
 
         <Col md="6">


### PR DESCRIPTION
Backed component of fixing low severity issue 2a and 2b:

> Should show total tangible hours the volunteer has contributed - currently not showing anything 
Should be editable by an Admin

Summary:
- A user's total tangible hours now display properly and can be edited by an admin
![](https://i.imgur.com/ns6QSBy.png)
