### PR TITLE
Medium priority 4A: weekly summaries changes

### DIFF
--- a/src/__tests__/UserProfile/VolunteeringTimesTab.test.js
+++ b/src/__tests__/UserProfile/VolunteeringTimesTab.test.js
@@ -94,7 +94,7 @@ describe('volunteering times tab user as not admin', () => {
       expect(screen.getByText(`${userProfileMock.weeklyComittedHours}`)).toBeInTheDocument();
     });
     it('should render correct total committed hours value', () => {
-      expect(screen.getByText(`${userProfileMock.totalComittedHours}`)).toBeInTheDocument();
+      expect(screen.getByText(`${userProfileMock.totalTangibleHrs}`)).toBeInTheDocument();
     });
     // it('should render the correct start date', () => {
     //   expect(screen.getByText(`${userProfileMock.createdDate}`)).toBeInTheDocument();

--- a/src/__tests__/mockStates.js
+++ b/src/__tests__/mockStates.js
@@ -438,7 +438,7 @@ export const timerMock = {
 };
 export const userProfileMock = {
   isActive: true,
-  totalComittedHours: 15,
+  totalTangibleHrs: 15,
   phoneNumber: [
     '1112223333',
   ],

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -336,8 +336,8 @@ class UserProfile extends Component {
   }
 
   handleSubmit = async event => {
-    const { updateUserProfile, match } = this.props
-    const { userProfile, formValid } = this.state
+    const { updateUserProfile, match } = this.props;
+    const { userProfile, formValid } = this.state;
     const submitResult = await updateUserProfile(match.params.userId, userProfile)
     this.setState({ showSaveWarning: false })
   }
@@ -475,11 +475,11 @@ class UserProfile extends Component {
           },
         })
         break
-      case 'totalComittedHours':
+      case 'totalTangibleHours':
         this.setState({
           userProfile: {
             ...userProfile,
-            totalComittedHours: event.target.value,
+            totalTangibleHrs: event.target.value,
           },
         })
         break

--- a/src/components/UserProfile/UserProfileEdit/UserProfileEdit.jsx
+++ b/src/components/UserProfile/UserProfileEdit/UserProfileEdit.jsx
@@ -37,7 +37,7 @@ import ProjectsTab from '../TeamsAndProjects/ProjectsTab'
 import TeamsTab from '../TeamsAndProjects/TeamsTab'
 
 const styleProfile = {}
-class EditProfile extends Component {
+class UserProfileEdit extends Component {
   state = {
     showWarning: false,
     isLoading: true,
@@ -1035,4 +1035,4 @@ class EditProfile extends Component {
   }
 }
 
-export default EditProfile
+export default UserProfileEdit

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -41,21 +41,23 @@ const WeeklyCommitedHours = (props) => {
 };
 
 const TotalCommittedHours = (props) => {
+
   if (!props.isUserAdmin) {
-    return <p>{props.userProfile.totalComittedHours}</p>;
+    return <p>{props.userProfile.totalTangibleHrs}</p>;
   }
   return (
     <Input
       type="number"
-      name="totalComittedHours"
-      id="totalComittedHours"
-      value={props.userProfile.totalComittedHours}
+      name="totalTangibleHours"
+      id="totalTangibleHours"
+      value={props.userProfile.totalTangibleHrs}
       onChange={props.handleUserProfile}
       placeholder="Total Committed Hours"
       invalid={!props.isUserAdmin}
     />
   );
 };
+
 const ViewTab = (props) => {
   const {
     userProfile,
@@ -103,7 +105,7 @@ const ViewTab = (props) => {
       </Row>
       <Row>
         <Col md="6">
-          <Label>Total Hours </Label>
+          <Label>Total Tangible Hours </Label>
         </Col>
 
         <Col md="6">

--- a/src/components/WeeklySummariesReport/GeneratePdfReport.jsx
+++ b/src/components/WeeklySummariesReport/GeneratePdfReport.jsx
@@ -3,24 +3,36 @@ import React from 'react';
 import pdfMake from 'pdfmake/build/pdfmake';
 import pdfFonts from 'pdfmake/build/vfs_fonts';
 import htmlToPdfmake from 'html-to-pdfmake';
-import moment from 'moment';
-import 'moment-timezone';
+import moment from 'moment-timezone';
 import { Button } from 'reactstrap';
 
 pdfMake.vfs = pdfFonts.pdfMake.vfs;
 
-
 const GeneratePdfReport = ({ summaries, weekIndex, weekDates }) => {
-  const FormatReportForPdf = () => {
-    let wsReport = `<h3>Weekly Summaries Report</h3>
-    <div style="margin-bottom: 20px; color: orange;">From <b>${weekDates.fromDate}</b> to <b>${weekDates.toDate}</b></div>`;
-    const weeklySummaryNotProvidedMessage = '<div><b>Weekly Summary:</b> Not provided!</div>';
-    summaries.forEach((eachSummary) => {
-      const {
-        firstName, lastName, weeklySummaries, mediaUrl, weeklySummariesCount,
-      } = eachSummary;
 
-      const mediaUrlLink = mediaUrl ? `<a href=${mediaUrl}>Open link to media files</a>` : 'Not provided!';
+  const generateFormattedReport = () => {
+
+    const emails = [];
+
+    let wsReport = `<h1>Weekly Summaries Report</h1>
+    <div style="margin-bottom: 20px; color: orange;">From <b>${weekDates.fromDate}</b> to <b>${weekDates.toDate}</b></div>`;
+    
+    const weeklySummaryNotProvidedMessage = '<div><b>Weekly Summary:</b> <span style="color: red;">Not provided!</span></div>';
+
+    summaries.sort((a, b) => (`${a.firstName} ${a.lastName}`).localeCompare(`${b.firstName} ${b.lastname}`));
+
+    summaries.forEach((eachSummary) => {
+
+      if(eachSummary.email !== undefined && eachSummary.email !== null) {
+        emails.push(eachSummary.email);
+      }
+
+      const {
+        firstName, lastName, weeklySummaries,
+        mediaUrl, weeklySummariesCount, weeklyComittedHours
+      } = eachSummary;
+  
+      const mediaUrlLink = mediaUrl ? `<a href=${mediaUrl}>Open link to media files</a>` : '<span style="color: red;">Not provided!</span>';
       const totalValidWeeklySummaries = weeklySummariesCount || 'No valid submissions yet!';
       let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
       if (Array.isArray(weeklySummaries) && weeklySummaries.length && weeklySummaries[weekIndex]) {
@@ -30,39 +42,49 @@ const GeneratePdfReport = ({ summaries, weekIndex, weekDates }) => {
                                   <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}">${summary}</div>`;
         }
       }
-
+  
       wsReport += `\n
       <div><b>Name:</b> <span class="name">${firstName} ${lastName}</span></div>
       <div><b>Media URL:</b> ${mediaUrlLink}</div>
-      <div><b>Total Valid Weekly Summaries:</b> ${totalValidWeeklySummaries}</div>
+      <div style="${totalValidWeeklySummaries === 8 ? 'text-decoration: underline; color: red;' : ''}"><b>Total valid weekly summaries:</b> ${totalValidWeeklySummaries}</div>
+      <div><b>Committed weekly hours:</b> ${weeklyComittedHours}</div>
       ${weeklySummaryMessage}
       <div style="color:#DEE2E6; margin:10px 0px 20px 0px; text-align:center;">_______________________________________________________________________________________________</div>`;
     });
 
+    wsReport += '<h2>Emails</h2>'
+
+    wsReport += [...(new Set(emails))] //elimiates duplicate entries if they're somehow present
+    .toString()
+    .slice(1, emails.toString().length - 1)
+    .replaceAll(',', ', ');
+    
+
     return wsReport;
   };
-
-  const formattedReport = FormatReportForPdf();
-  const html = htmlToPdfmake(formattedReport);
-
-  const docDefinition = {
-    content: [
-      html,
-    ],
-    styles: {
-      'html-div': { margin: [0, 4, 0, 4] },
-      name: {
-        background: 'yellow',
+  
+  const generateAndDownloadPdf = () => {
+  
+    const html = htmlToPdfmake(generateFormattedReport());
+  
+    const docDefinition = {
+      content: [
+        html,
+      ],
+      styles: {
+        'html-div': { margin: [0, 4, 0, 4] },
+        name: {
+          background: 'yellow',
+        },
       },
-    },
-  };
-
-  const pdfDocGenerator = () => {
+    };
+  
     pdfMake.createPdf(docDefinition).download(`WeeklySummary-${weekDates.fromDate}-to-${weekDates.toDate}`);
+  
   };
 
   return (
-    <Button className="px-5 btn--dark-sea-green float-right" onClick={pdfDocGenerator}>Open PDF</Button>
+    <Button className="px-5 btn--dark-sea-green float-right" onClick={generateAndDownloadPdf}>Open PDF</Button>
   );
 };
 

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -74,7 +74,11 @@ export class WeeklySummariesReport extends Component {
 
     return (
       <Container fluid className="bg--white-smoke py-3 mb-5">
-        <h3 className="mt-3 mb-5">Weekly Summaries Reports page</h3>
+        <Row>
+          <Col lg={{ size: 10, offset: 1 }}>
+            <h3 className="mt-3 mb-5">Weekly Summaries Reports page</h3>
+          </Col>
+        </Row>
         <Row>
           <Col lg={{ size: 10, offset: 1 }}>
             <Nav tabs>


### PR DESCRIPTION
Summary:
- Weekly summary reports are now alphabetically ordered 
- Everyone who contributed a weekly summary report will have their email included at the bottom of the report in a comma separated list
- Each person's weekly commit hours will appear in the report (indicating in the report of the person has fallen short of their commitment is a much more complex change and has been postponed to a future PR)
- When someone reaches 8 weekly summaries, the line indicating this is both red and underlined 
- If a weekly summary is not provided, this is now highlighted in red
![](https://i.imgur.com/5bBWG0y.png)