### PR TITLE
Changed name of 'Other' badge category to 'Unassigned'

### DIFF
--- a/src/components/Badge/CreateNewBadgePopup.jsx
+++ b/src/components/Badge/CreateNewBadgePopup.jsx
@@ -197,7 +197,7 @@ const CreateNewBadgePopup = (props) => {
             <option>Society</option>
             <option>Economics</option>
             <option>Stewardship</option>
-            <option>Other</option>
+            <option>Unassigned</option>
           </Input>
         </FormGroup>
         : ""}

--- a/src/components/Badge/EditBadgePopup.jsx
+++ b/src/components/Badge/EditBadgePopup.jsx
@@ -211,7 +211,7 @@ const EditBadgePopup = (props) => {
                 <option>Society</option>
                 <option>Economics</option>
                 <option>Stewardship</option>
-                <option>Other</option>
+                <option>Unassigned</option>
               </Input>
             </FormGroup>
             : ""}


### PR DESCRIPTION
Changes the name of the "Other" badge category to "Unassigned"

Requires this back-end PR: https://github.com/OneCommunityGlobal/HGNRest/pull/71

> Chris, can we change the “other” in this list to “Unassigned” please