### PR TITLE
Fixed invalid profile icon in header

### DIFF
--- a/src/__tests__/__snapshots__/FormattedReport.test.js.snap
+++ b/src/__tests__/__snapshots__/FormattedReport.test.js.snap
@@ -130,7 +130,7 @@ exports[`FormattedReport Component Snapshot with mocked data 1`] = `
     </b>
      (for the week ending on
     <b>
-      2021-Aug-15
+      2021-Aug-16
     </b>
     ):
     <div

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -68,6 +68,7 @@ export class Header extends React.Component {
   }
 
   render() {
+
     const { isAuthenticated, user, firstName, profilePic } = this.props.auth
     return (
       <div>
@@ -159,7 +160,7 @@ export class Header extends React.Component {
                 <NavItem>
                   <NavLink tag={Link} to={`/userprofile/${user.userid}`}>
                     <img
-                      src={`${profilePic}`}
+                      src={`${profilePic || 'https://www.pngfind.com/pngs/m/676-6764065_default-profile-picture-transparent-hd-png-download.png'}`}
                       alt=""
                       height="35"
                       width="40"


### PR DESCRIPTION
Fixed the invalid profile picture error by linking to an external, generic profile photo until we have a custom one made. 

![https://i.imgur.com/3tAgv5c.png](https://i.imgur.com/3tAgv5c.png)