### PR TITLE
Hotfixes

### DIFF
--- a/src/__tests__/__snapshots__/FormattedReport.test.js.snap
+++ b/src/__tests__/__snapshots__/FormattedReport.test.js.snap
@@ -130,7 +130,7 @@ exports[`FormattedReport Component Snapshot with mocked data 1`] = `
     </b>
      (for the week ending on
     <b>
-      2021-Aug-15
+      2021-Aug-16
     </b>
     ):
     <div

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -356,7 +356,6 @@ const TimeEntryForm = props => {
     if (closed) {
       //make sure form clears before close
       setInputs({ ...initialFormValues })
-      setClose(true)
     }
     setInputs({ ...initialFormValues })
     setReminder({ ...initialReminder })

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -53,7 +53,7 @@ const TotalCommittedHours = (props) => {
       id="totalTangibleHours"
       value={props.userProfile.totalTangibleHrs}
       onChange={props.handleUserProfile}
-      placeholder="Total Committed Hours"
+      placeholder="Total Tangible Time Logged"
       invalid={!props.isUserAdmin}
     />
   );


### PR DESCRIPTION
- Time Entry Form no longer closes when clicking "Clear Form"
- Fixed following issue:
> Please change the background text (when empty) from “Total Committed Hours” to “Total Tangible Time Logged” 