### PR TITLE
Fixed improper number rounding on Volunteering tab of profile page

### DIFF
--- a/src/__tests__/__snapshots__/FormattedReport.test.js.snap
+++ b/src/__tests__/__snapshots__/FormattedReport.test.js.snap
@@ -130,7 +130,7 @@ exports[`FormattedReport Component Snapshot with mocked data 1`] = `
     </b>
      (for the week ending on
     <b>
-      2021-Aug-15
+      2021-Aug-16
     </b>
     ):
     <div

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -267,7 +267,7 @@ const ViewTab = (props) => {
       </Row>
       <Row>
         <Col md="6">
-          <Label>Total Other Category Hours </Label>
+          <Label>Total Unassigned Category Hours </Label>
         </Col>
 
         <Col md="6">

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -25,6 +25,7 @@ const StartDate = (props) => {
   );
 };
 const WeeklyCommitedHours = (props) => {
+
   if (!props.isUserAdmin) {
     return <p>{props.userProfile.weeklyComittedHours}</p>;
   }
@@ -51,7 +52,7 @@ const TotalCommittedHours = (props) => {
       type="number"
       name="totalTangibleHours"
       id="totalTangibleHours"
-      value={props.userProfile.totalTangibleHrs}
+      value={props.userProfile.totalTangibleHrs?.toFixed(2)}
       onChange={props.handleUserProfile}
       placeholder="Total Committed Hours"
       invalid={!props.isUserAdmin}
@@ -130,7 +131,7 @@ const TotalCategoryHours = (props) => {
       type="number"
       name={`total${props.category}CategoryHours`}
       id={`${props.category}CategoryHours`}
-      value={props?.userProfile?.categoryTangibleHrs[index]?.hrs}
+      value={props?.userProfile?.categoryTangibleHrs[index]?.hrs?.toFixed(2)}
       onChange={props.handleUserProfile}
       placeholder={`Total ${props.category} Tangible Hours`}
       invalid={!props.isUserAdmin}


### PR DESCRIPTION
Fixes issues:
> Please make any number in this field round to the nearest 100th (E.g. 10.76 vs 10.756666) (8/15: Still not working for me)

> Please change “Total Other Category Hours” to “Total Unassigned Category Hours”
