### PR TITLE
Fixed problem with newly added blue squares displaying improperly

### DIFF
--- a/src/__tests__/__snapshots__/FormattedReport.test.js.snap
+++ b/src/__tests__/__snapshots__/FormattedReport.test.js.snap
@@ -130,7 +130,7 @@ exports[`FormattedReport Component Snapshot with mocked data 1`] = `
     </b>
      (for the week ending on
     <b>
-      2021-Aug-18
+      2021-Aug-19
     </b>
     ):
     <div

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -6,25 +6,25 @@ const BlueSquare = ({blueSquares, handleBlueSquare, isUserAdmin}) => {
   return (
     <div className="blueSquareContainer">
       <div className="blueSquares">
-        {blueSquares.map((current, index) => (
+        {blueSquares.map((blueSquare, index) => (
           <div
             key={index}
             role="button"
             id="wrapper"
             className="blueSquareButton"
             onClick={() => {
-              if (!current._id) {
+              if (!blueSquare._id) {
                 handleBlueSquare(isUserAdmin, 'message', 'none')
               } else if (isUserAdmin) {
-                handleBlueSquare(isUserAdmin, 'modBlueSquare', current._id)
+                handleBlueSquare(isUserAdmin, 'modBlueSquare', blueSquare._id)
               } else {
-                handleBlueSquare(!isUserAdmin, 'viewBlueSquare', current._id)
+                handleBlueSquare(!isUserAdmin, 'viewBlueSquare', blueSquare._id)
               }
             }}
           >
             <div className="report" data-testid="report">
-              <div className="title">{current.date}</div>
-              <div className="summary">{current.description}</div>
+              <div className="title">{blueSquare.date}</div>
+              <div className="summary">{blueSquare.description}</div>
             </div>
           </div>
         ))}

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -35,8 +35,11 @@ import PauseAndResumeButton from '../UserManagement/PauseAndResumeButton'
 import Badges from './Badges'
 
 import axios from 'axios'
+import { getUserProfile } from 'actions/userProfile'
+import { useDispatch } from 'react-redux'
 
 const UserProfile = props => {
+
   const initialHoursByCategory = {
     housing: 0,
     food: 0,
@@ -66,19 +69,35 @@ const UserProfile = props => {
   const [type, setType] = useState('')
   const [showModal, setShowModal] = useState(false)
   const [modalTitle, setModalTitle] = useState('')
-  const [modalMessage, setModalMessgae] = useState('')
+  const [modalMessage, setModalMessage] = useState('')
   const [hoursByCategory, setHoursByCategory] = useState(initialHoursByCategory)
+  const [shouldRefresh, setShouldRefresh] = useState(false);
+
+  const dispatch = useDispatch();
 
   useEffect(() => {
     componentDidMount()
     calculateHoursByCategory()
   }, [])
 
+  // The following useEffect callback is a convoluted workaround that's required given
+  // how the userProfile object is stored inside the global store. Sometimes, the global userProfile object
+  // doesn't match the user profile currently being viewed for some reason, meaning that when it's
+  // passed down as a prop, it doesn't always match. 
+
+  // Another factor making this necessary is that some changes to the
+  // user profile object are not submitted immediately and are instead stored
+  // in memory before finally being submittied. This means that the userProfile hook
+  // Can't simply be replaced with props.userProfile as changes would be erased before
+  // they could be submitted.
+
+  //Because of this, we only use setUserProfile when the ID is different or when shouldRefresh is true. 
   useEffect(() => {
-    if (props.userProfile._id !== userProfile._id) {
+    if (props.userProfile._id !== userProfile._id || shouldRefresh === true) {
       setUserProfile(props.userProfile)
+      setShouldRefresh(false);
     }
-  }, [props.userProfile])
+  }, [props.userProfile, shouldRefresh])
 
   useEffect(() => {
     if (blueSquareChanged) {
@@ -199,7 +218,7 @@ const UserProfile = props => {
       setIsValid(false)
       setShowModal(true)
       setModalTitle('Profile Pic Error')
-      setModalMessgae(errorMessage)
+      setModalMessage(errorMessage)
 
       return
     }
@@ -213,20 +232,18 @@ const UserProfile = props => {
   }
 
   const handleBlueSquare = (status = true, type = 'message', blueSquareID = '') => {
+
     setType(type)
     setShowModal(status)
 
     if (type === 'addBlueSquare') {
       setModalTitle('Blue Square')
-    } else if (type === 'modBlueSquare') {
-      setModalTitle('Blue Square')
-      setId(blueSquareID)
-    } else if (type === 'viewBlueSquare') {
+    } else if (type === 'viewBlueSquare' || type === 'modBlueSquare') {
       setModalTitle('Blue Square')
       setId(blueSquareID)
     } else if (blueSquareID === 'none') {
       setModalTitle('Save & Refresh')
-      setModalMessgae('')
+      setModalMessage('')
     }
   }
 
@@ -238,6 +255,7 @@ const UserProfile = props => {
    * @param {String} operation 'add' | 'update' | 'delete'
    */
   const modifyBlueSquares = (id, dateStamp, summary, operation) => {
+
     if (operation === 'add') {
       const newBlueSquare = { date: dateStamp, description: summary }
       setShowModal(false)
@@ -245,6 +263,7 @@ const UserProfile = props => {
         ...userProfile,
         infringments: userProfile.infringments.concat(newBlueSquare),
       })
+      setModalTitle('Blue Square')
     } else if (operation === 'update') {
       const currentBlueSquares = [...userProfile.infringments]
       if (dateStamp != null) {
@@ -272,10 +291,12 @@ const UserProfile = props => {
     const { updateUserProfile, match } = props
     try {
       await updateUserProfile(match.params.userId, userProfile)
+      await getUserProfile(match.params.userId)(dispatch)
       setShowSaveWarning(false)
     } catch (err) {
       alert('An error occurred while attempting to save this profile.')
     }
+    setShouldRefresh(true);
   }
 
   const toggleInfoModal = () => {

--- a/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
@@ -49,8 +49,8 @@ const UserProfileModal = props => {
   const [adminLinkName, setAdminLinkName] = useState('')
   const [adminLinkURL, setAdminLinkURL] = useState('')
 
-  const [dateStamp, setDateStamp] = useState(id != null ? blueSquare[0].date : '')
-  const [summary, setSummary] = useState(id != null ? blueSquare[0].description : '')
+  const [dateStamp, setDateStamp] = useState(blueSquare[0]?.date || '')
+  const [summary, setSummary] = useState(blueSquare[0]?.description || '')
 
   const [addButton, setAddButton] = useState(true)
   const [summaryFieldView, setSummaryFieldView] = useState(true)
@@ -148,8 +148,6 @@ const UserProfileModal = props => {
       setAddButton(true)
     }
   }
-
-  //const buttonDisabled = !(linkName && linkURL)
 
   return (
     <Modal isOpen={isOpen} toggle={closeModal}>


### PR DESCRIPTION
Fixes issue:
> When you add a blue square then try to modify it afterwards without refreshing, the newly added information doesn’t show up.

