### PR TITLE
Made it obvious on weekly summary reports when someone who didn't sub…

### DIFF
--- a/src/__tests__/__snapshots__/FormattedReport.test.js.snap
+++ b/src/__tests__/__snapshots__/FormattedReport.test.js.snap
@@ -37,19 +37,13 @@ exports[`FormattedReport Component Snapshot with mocked data 1`] = `
       </b>
        
     </p>
-    <b>
-      Weekly Summary
-    </b>
-     (for the week ending on
-    <b>
-      2020-Jun-27
-    </b>
-    ):
-    <div
-      style="padding: 10px 20px 0px;"
-    >
-      Week 2 summary
-    </div>
+    <p>
+      <b>
+        Weekly Summary
+      </b>
+       (2020-Jun-27):
+    </p>
+    Week 2 summary
   </div>
   <div
     style="padding: 20px 0px; margin-top: 5px; border-bottom: 1px solid #DEE2E6;"
@@ -79,23 +73,17 @@ exports[`FormattedReport Component Snapshot with mocked data 1`] = `
       </b>
        
     </p>
-    <b>
-      Weekly Summary
-    </b>
-     (for the week ending on
-    <b>
-      2020-Jun-27
-    </b>
-    ):
-    <div
-      style="padding: 10px 20px 0px;"
+    <p>
+      <b>
+        Weekly Summary
+      </b>
+       (2020-Jun-27):
+    </p>
+    <span
+      style="color: red;"
     >
-      <span
-        style="color: red;"
-      >
-        Not provided!
-      </span>
-    </div>
+      Not provided!
+    </span>
   </div>
   <div
     style="padding: 20px 0px; margin-top: 5px; border-bottom: 1px solid #DEE2E6;"
@@ -125,23 +113,17 @@ exports[`FormattedReport Component Snapshot with mocked data 1`] = `
       </b>
        
     </p>
-    <b>
-      Weekly Summary
-    </b>
-     (for the week ending on
-    <b>
-      2021-Aug-18
-    </b>
-    ):
-    <div
-      style="padding: 10px 20px 0px;"
+    <p>
+      <b>
+        Weekly Summary
+      </b>
+       (2021-Aug-19):
+    </p>
+    <span
+      style="color: red;"
     >
-      <span
-        style="color: red;"
-      >
-        Not provided!
-      </span>
-    </div>
+      Not provided!
+    </span>
   </div>
   <h4>
     Emails

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -374,6 +374,11 @@ const UserProfile = props => {
           collaborationPreference: event.target.value,
         })
         break
+      case 'weeklySummaryNotReqd':
+        setUserProfile({
+          ...userProfile,
+          weeklySummaryNotReq: !userProfile.weeklySummaryNotReq
+        });
     }
   }
 

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -39,26 +39,30 @@ const FormattedReport = ({ summaries, weekIndex }) => {
   }
 
   const getWeeklySummaryMessage = summary => {
-    if (summary) {
-      return (
-        <>
-          <b>Weekly Summary</b> (for the week ending on
-          <b>
-            {moment(summary.weeklySummaries[weekIndex]?.dueDate)
-              .tz('America/Los_Angeles')
-              .format('YYYY-MMM-DD')}
-          </b>
-          ):
-          <div style={{ padding: '10px 20px 0' }}>{summary?.weeklySummaries[weekIndex]?.summary || <span style={{color: 'red'}}>Not provided!</span> }</div>
-        </>
-      )
-    } else {
-      return (
-        <p>
-          <b>Weekly Summary:</b> Not provided!
-        </p>
-      )
-    }
+
+    if(!summary) return (<p><b>Weekly Summary:</b> Not provided!</p>)
+
+    const summaryText = summary?.weeklySummaries[weekIndex]?.summary;
+
+        return (
+          <>
+            <p>
+              <b>Weekly Summary</b> ({moment(summary.weeklySummaries[weekIndex]?.dueDate).tz('America/Los_Angeles').format('YYYY-MMM-DD')}):
+            </p> 
+
+            {summaryText && ReactHtmlParser(summaryText)}
+
+            {
+            summary.weeklySummaryNotReq === true && !summaryText && 
+            <p style={{color: 'magenta'}}>Not required for this user</p>
+            }
+
+            {!summaryText && !summary.weeklySummaryNotReq && <span style={{color: 'red'}}>Not provided!</span>}
+            
+          </>
+        )
+    
+
   }
 
   const getTotalValidWeeklySummaries = summary => {

--- a/src/components/WeeklySummariesReport/GeneratePdfReport.jsx
+++ b/src/components/WeeklySummariesReport/GeneratePdfReport.jsx
@@ -18,6 +18,7 @@ const GeneratePdfReport = ({ summaries, weekIndex, weekDates }) => {
     <div style="margin-bottom: 20px; color: orange;">From <b>${weekDates.fromDate}</b> to <b>${weekDates.toDate}</b></div>`;
     
     const weeklySummaryNotProvidedMessage = '<div><b>Weekly Summary:</b> <span style="color: red;">Not provided!</span></div>';
+    const weeklySummaryNotRequiredMessage = '<div><b>Weekly Summary:</b> <span style="color: magenta;">Not required for this user</span></div>';
 
     summaries.sort((a, b) => (`${a.firstName} ${a.lastName}`).localeCompare(`${b.firstName} ${b.lastname}`));
 
@@ -27,19 +28,21 @@ const GeneratePdfReport = ({ summaries, weekIndex, weekDates }) => {
         emails.push(eachSummary.email);
       }
 
-      const {
-        firstName, lastName, weeklySummaries,
-        mediaUrl, weeklySummariesCount, weeklyComittedHours
-      } = eachSummary;
+      const { firstName, lastName, weeklySummaries, mediaUrl, weeklySummariesCount, weeklyComittedHours } = eachSummary;
   
       const mediaUrlLink = mediaUrl ? `<a href=${mediaUrl}>Open link to media files</a>` : '<span style="color: red;">Not provided!</span>';
+
       const totalValidWeeklySummaries = weeklySummariesCount || 'No valid submissions yet!';
+
       let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
-      if (Array.isArray(weeklySummaries) && weeklySummaries.length && weeklySummaries[weekIndex]) {
+
+      if (Array.isArray(weeklySummaries) && weeklySummaries[weekIndex]) {
         const { dueDate, summary } = weeklySummaries[weekIndex];
         if (summary) {
           weeklySummaryMessage = `<div><b>Weekly Summary</b> (for the week ending on <b>${moment(dueDate).tz('America/Los_Angeles').format('YYYY-MMM-DD')}</b>):</div>
                                   <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}">${summary}</div>`;
+        } else if (eachSummary.weeklySummaryNotReq === true) {
+          weeklySummaryMessage = weeklySummaryNotRequiredMessage;
         }
       }
   


### PR DESCRIPTION
Corresponding server-side PR: https://github.com/OneCommunityGlobal/HGNRest/pull/75

Solves issue:
 
> Chris added a no-summary-needed function at Profile → Volunteering Times (see below). We need some sort of indicator on the weekly summary reports (emailed, PDFd, and Web-based) that shows when an individual is part of the small group of consultants that don’t need to submit one. Maybe just “Weekly Summary Not Required” in Green, Orange, or Fuschia). This is important so that I’m always remembering each week during my work reviews who the people are that are mentoring and not submitting summaries

## Image Preview

![https://i.imgur.com/LIkpN5g.png](https://i.imgur.com/LIkpN5g.png)

![https://i.imgur.com/QuzDq3v.png](https://i.imgur.com/QuzDq3v.png)