### PR TITLE
Fixed bug preventing the editing of weekly summaries

### DIFF
--- a/src/__tests__/__snapshots__/FormattedReport.test.js.snap
+++ b/src/__tests__/__snapshots__/FormattedReport.test.js.snap
@@ -130,7 +130,7 @@ exports[`FormattedReport Component Snapshot with mocked data 1`] = `
     </b>
      (for the week ending on
     <b>
-      2021-Aug-18
+      2021-Aug-19
     </b>
     ):
     <div

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -42,7 +42,7 @@ export class WeeklySummary extends Component {
   };
 
   async componentDidMount() {
-    await this.props.getWeeklySummaries(this.props.asUser ? this.props.asUser : this.props.currentUser.userid);
+    await this.props.getWeeklySummaries(this.props.asUser || this.props.currentUser.userid);
     const { mediaUrl, weeklySummaries, weeklySummariesCount } = this.props.summaries;
     const summary = weeklySummaries && weeklySummaries[0] && weeklySummaries[0].summary || '';
     const summaryLastWeek = weeklySummaries && weeklySummaries[1] && weeklySummaries[1].summary || '';
@@ -183,7 +183,6 @@ export class WeeklySummary extends Component {
       weeklySummariesCount: this.state.formElements.weeklySummariesCount,
     }
 
-
     const updateWeeklySummaries = this.props.updateWeeklySummaries(this.props.asUser || this.props.currentUser.userid, modifiedWeeklySummaries);
     let saveResult;
     if(updateWeeklySummaries) {
@@ -193,9 +192,13 @@ export class WeeklySummary extends Component {
     if (saveResult === 200) {
       toast.success("✔ The data was saved successfully!", { toastId: toastIdOnSave, pauseOnFocusLoss: false, autoClose: 3000 });
       this.props.getUserProfile(this.props.currentUser.userid);
+      this.props.getWeeklySummaries(this.props.asUser || this.props.currentUser.userid);
     } else {
       toast.error("✘ The data could not be saved!", { toastId: toastIdOnSave, pauseOnFocusLoss: false, autoClose: 3000 });
     }
+
+    
+
   };
 
   render() {
@@ -362,17 +365,18 @@ WeeklySummary.propTypes = {
 }
 
 const mapStateToProps = ({ auth, weeklySummaries }) => ({
-  currentUser: auth.user,
-  summaries: weeklySummaries?.summaries,
-  loading: weeklySummaries.loading,
-  fetchError: weeklySummaries.fetchError,
-});
+    currentUser: auth.user,
+    summaries: weeklySummaries?.summaries,
+    loading: weeklySummaries.loading,
+    fetchError: weeklySummaries.fetchError,
+  });
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    getUserProfile: (userId) => dispatch(getUserProfile(userId)),
     getWeeklySummaries: getWeeklySummaries,
     updateWeeklySummaries: updateWeeklySummaries,
+    getWeeklySummaries: (userId) => getWeeklySummaries(userId)(dispatch),
+    getUserProfile: (userId) => getUserProfile(userId)(dispatch)
   }
 }
 


### PR DESCRIPTION
Fixed high priority bug: 

> If a person saves their summary, and then goes back in and tries to add something to it, their new additions won’t save. It says it saves, but then you return to the page and the new additions aren’t there. Not sure if this bug means a person can’t save their summary the first time or not. This is a much bigger problem if that’s the case