### PR TITLE
Fixed centering of timer button

### DIFF
--- a/src/__tests__/__snapshots__/FormattedReport.test.js.snap
+++ b/src/__tests__/__snapshots__/FormattedReport.test.js.snap
@@ -117,7 +117,7 @@ exports[`FormattedReport Component Snapshot with mocked data 1`] = `
       <b>
         Weekly Summary
       </b>
-       (2021-Aug-23):
+       (2021-Aug-24):
     </p>
     <span
       style="color: red;"

--- a/src/__tests__/__snapshots__/FormattedReport.test.js.snap
+++ b/src/__tests__/__snapshots__/FormattedReport.test.js.snap
@@ -117,7 +117,7 @@ exports[`FormattedReport Component Snapshot with mocked data 1`] = `
       <b>
         Weekly Summary
       </b>
-       (2021-Aug-19):
+       (2021-Aug-21):
     </p>
     <span
       style="color: red;"

--- a/src/__tests__/__snapshots__/FormattedReport.test.js.snap
+++ b/src/__tests__/__snapshots__/FormattedReport.test.js.snap
@@ -117,7 +117,7 @@ exports[`FormattedReport Component Snapshot with mocked data 1`] = `
       <b>
         Weekly Summary
       </b>
-       (2021-Aug-21):
+       (2021-Aug-23):
     </p>
     <span
       style="color: red;"

--- a/src/components/Timer/Timer.css
+++ b/src/components/Timer/Timer.css
@@ -1,5 +1,5 @@
 .timer button {
-  width: 3.75rem;
+  min-width: 3.75rem;
   box-shadow: none !important;
 }
 

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -77,8 +77,7 @@
   border-bottom: 2px solid #0062cc;
 }
 .profile-work {
-  padding: 14%;
-  margin-top: -15%;
+  padding: 5% 14% 14% 14%;
 }
 .profile-work p {
   font-size: 12px;


### PR DESCRIPTION
Solves issue:

> Jae: Dashboard → Timer Appearance: Please center the word “Pause”. “Clear” looks like it may be off center too. 
