### PR TITLE
Fixed issues with editing time entries

### DIFF
--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -18,7 +18,8 @@ const TimeEntry = ({ data, displayYear, userProfile }) => {
   const dateOfWork = moment(data.dateOfWork);
   const { user } = useSelector((state) => state.auth);
   const isOwner = data.personId === user.userid;
-  const isSameDay = moment().isSame(data.dateOfWork, 'day');
+
+  const isSameDay = moment().tz('America/Los_Angeles').format('YYYY-MM-DD') === data.dateOfWork
   const isAdmin = user.role === 'Administrator';
 
   const dispatch = useDispatch();

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -154,8 +154,8 @@ const TimeEntryForm = props => {
         editCount += 1;
       }
     });
-    return `If you edit your time entries 6 times or more within the span of a year,
-    you will be issued a blue square and will recieve an additional blue square for each edit beyond the 6th.
+    return `If you edit your time entries 5 times or more within the span of a year,
+    you will be issued a blue square and will recieve an additional blue square for each edit beyond the 5th.
     Currently, you have edited your time entries ${editCount} times within the last 365 days. Do you wish to continue?`
   }
 
@@ -292,7 +292,7 @@ const TimeEntryForm = props => {
     if(fromTimer) clearForm()
     setReminder(initialReminder);
 
-    setInputs(initialFormValues)
+    if(!props.edit) setInputs(initialFormValues)
 
     await getUserProfile(userId)(dispatch);
 


### PR DESCRIPTION
Related back-end PR: https://github.com/OneCommunityGlobal/HGNRest/pull/79

Fixes issues:

> The popup says 6 or more times gives blue squares (see pic below) and it actually gives them after 5 or more times. See pic below that shows 7 edits and 3 blue squares >> Please update the text to say "5 or more".  >> I also did not get an email notifying me that a blue square was issued for this. I'm guessing they wouldn't have either.

> If they edit the same time repeatedly, it looks like it the warning pops up but it doesn't add the time to their log for me to delete their edits... it DOES still issue them a blue square though for too many edits. And this leaves me with no way to fix this, since I can't see the edits showing up in their editable list for me. 