### PR TITLE
Fixed issues with time entry edit emails

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -154,9 +154,10 @@ const TimeEntryForm = props => {
         editCount += 1;
       }
     });
-    return `If you edit your time entries 5 times or more within the span of a year,
-    you will be issued a blue square and will recieve an additional blue square for each edit beyond the 5th.
-    Currently, you have edited your time entries ${editCount} times within the last 365 days. Do you wish to continue?`
+    return `If you edit your time entries 5 times or more within the span of a year, you will be issued a blue square on the 5th time.
+    You will receive an additional blue square for each edit beyond the 5th.
+    Currently, you have edited your time entries ${editCount} times within the last 365 days.
+    Do you wish to continue?`
   }
 
   const validateForm = isTimeModified => {


### PR DESCRIPTION
Fixes issue 

> Bug1) The popup says 6 or more times gives blue squares (see pic below) and it actually gives them after 5 or more times. See pic below that shows 7 edits and 3 blue squares >> Please update the text to say "5 or more".  >> I also did not get an email notifying me that a blue square was issued for this. I'm guessing they wouldn't have either.