### PR TITLE
Fixed weekly summaries

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -78,7 +78,7 @@ const FormattedReport = ({ summaries, weekIndex }) => {
     <>
       {alphabetize(summaries).map((summary, index) => {
 
-        const hoursLogged = (summary.totalSeconds / 3600 || 0);
+        const hoursLogged = ((summary.totalSeconds[weekIndex] || 0) / 3600);
 
         return (
           <div

--- a/src/components/WeeklySummariesReport/GeneratePdfReport.jsx
+++ b/src/components/WeeklySummariesReport/GeneratePdfReport.jsx
@@ -26,7 +26,7 @@ const GeneratePdfReport = ({ summaries, weekIndex, weekDates }) => {
 
       const { firstName, lastName, weeklySummaries, mediaUrl, weeklySummariesCount, weeklyComittedHours, totalSeconds } = eachSummary;
 
-      const hoursLogged = totalSeconds / 3600;
+      const hoursLogged = (totalSeconds[weekIndex] || 0) / 3600;
 
       if(eachSummary.email !== undefined && eachSummary.email !== null) {
         emails.push(eachSummary.email);


### PR DESCRIPTION
**Due to the nature of the changes in this PR, the corresponding back-end PR (https://github.com/OneCommunityGlobal/HGNRest/pull/88) needs to be integrated at the same time.**
Fixes issue:
> Jae: Admin User Class: Dashboard → Reports → Weekly Summaries Report → Tangible Hours for the week are wrong for everyone (WIP: Cameron)
Everyone who completed their hours is at least double their actual logged time.  
I see a person who logged zero hours last week showing as having logged 10 too. He was the guy who was supposed to be paused though (see bug #3 above). But one other who was short shows the correct number and another who was short and got a blue square shows what looks like double his actual hours.  
Below is my example. Screenshot below the first one is my actual time worked. Not sure what the correlation between the two is. 
