### PR TITLE
Added activity toggle to user profile

### DIFF
--- a/src/components/UserManagement/ActiveCell.jsx
+++ b/src/components/UserManagement/ActiveCell.jsx
@@ -1,0 +1,20 @@
+/**
+ * Reusable component that enables the toggling of a user's active / inactive status
+ * @param {bool} props.isActive
+ * @param {int} props.index Used when rendering this component using the .map function
+ * @param {func} props.onClick
+ */
+const ActiveCell = props => {
+  return (
+    <span
+      className={props.isActive ? 'isActive' : 'isNotActive'}
+      id={props.index === undefined ? undefined : `active_cell_${props.index}`}
+      title="Click here to change the user status"
+      onClick={props.onClick}
+    >
+      <i className="fa fa-circle" aria-hidden="true" />
+    </span>
+  )
+}
+
+export default ActiveCell

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -3,6 +3,7 @@ import ResetPasswordButton from './ResetPasswordButton';
 import { DELETE, PAUSE, RESUME } from '../../languages/en/ui';
 import { UserStatus } from '../../utils/enums';
 import { useHistory } from 'react-router-dom';
+import ActiveCell from './ActiveCell';
 
 /**
  * The body row of the user table
@@ -18,10 +19,6 @@ const UserTableData = React.memo((props) => {
     onReset(false);
   }, [props.isActive, props.resetLoading]);
 
-  const onActiveInactiveClick = (user) => {
-    props.onActiveInactiveClick(user);
-  };
-
   return (
     <tr className="usermanagement__tr" id={`tr_user_${props.index}`}>
       <td className="usermanagement__active--input">
@@ -29,8 +26,7 @@ const UserTableData = React.memo((props) => {
           isActive={props.isActive}
           key={`active_cell${props.index}`}
           index={props.index}
-          user={props.user}
-          onActiveInactiveClick={onActiveInactiveClick}
+          onClick={() => props.onActiveInactiveClick(props.user)}
         />
       </td>
       <td>
@@ -86,21 +82,5 @@ const UserTableData = React.memo((props) => {
     </tr>
   );
 });
-
-/**
- * Component to show the active status in the
- */
-const ActiveCell = React.memo(props => (
-  <div
-    className={props.isActive ? 'isActive' : 'isNotActive'}
-    id={`active_cell_${props.index}`}
-    title="Click here to change the user status"
-    onClick={() => {
-      props.onActiveInactiveClick(props.user);
-    }}
-  >
-    <i className="fa fa-circle" aria-hidden="true" />
-  </div>
-));
 
 export default UserTableData;

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -34,9 +34,10 @@ import ResetPasswordButton from '../UserManagement/ResetPasswordButton'
 import Badges from './Badges'
 import TimeEntryEditHistory from './TimeEntryEditHistory.jsx'
 
-import axios from 'axios'
 import { getUserProfile } from 'actions/userProfile'
 import { useDispatch } from 'react-redux'
+
+import ActiveCell from 'components/UserManagement/ActiveCell'
 
 const UserProfile = props => {
   const initialFormValid = {
@@ -512,6 +513,21 @@ const UserProfile = props => {
               <h5 style={{ display: 'inline-block', marginRight: 10 }}>
                 {`${firstName} ${lastName}`}
               </h5>
+              {
+                isUserAdmin && (
+                  <>
+                    <ActiveCell
+                      isActive={userProfile.isActive}
+                      user={userProfile}
+                      onClick={() => {
+                        setChanged(true);
+                        setUserProfile({...userProfile, isActive: !userProfile.isActive})
+                      }}
+                    />
+                    &nbsp;
+                  </>
+                )
+              }
               <i
                 data-toggle="tooltip"
                 data-placement="right"


### PR DESCRIPTION
Fixues issue:
> I’d like that section to include the option for Admins to make a person “inactive” also please (not to be confused with “paused”). Should bring up the same popup I see when clicking the green dot to do this on the User Management page. 

![https://i.imgur.com/vsOmTxW.png](https://i.imgur.com/vsOmTxW.png)

![https://i.imgur.com/9DfsDiG.png](https://i.imgur.com/9DfsDiG.png)