### PR TITLE
Swapped order of team and project tabs on the create user menu

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -274,7 +274,7 @@ class AddUserProfile extends Component {
                         this.toggleTab('1')
                       }}
                     >
-                      Team
+                      Project
                     </NavLink>
                   </NavItem>
                   <NavItem>
@@ -284,7 +284,7 @@ class AddUserProfile extends Component {
                         this.toggleTab('2')
                       }}
                     >
-                      Project
+                      Team
                     </NavLink>
                   </NavItem>
                 </Nav>
@@ -296,21 +296,21 @@ class AddUserProfile extends Component {
                 style={{ border: 0 }}
               >
                 <TabPane tabId="1">
-                  <TeamsTab
-                    userTeams={this.state.teams}
-                    teamsData={this.props ? this.props.allTeams.allTeamsData : []}
-                    onAssignTeam={this.onAssignTeam}
-                    onDeleteteam={this.onDeleteTeam}
-                    isUserAdmin={true}
-                    edit
-                  />
-                </TabPane>
-                <TabPane tabId="2">
                   <ProjectsTab
                     userProjects={this.state.projects}
                     projectsData={this.props ? this.props.allProjects.projects : []}
                     onAssignProject={this.onAssignProject}
                     onDeleteProject={this.onDeleteProject}
+                    isUserAdmin={true}
+                    edit
+                  />
+                </TabPane>
+                <TabPane tabId="2">
+                  <TeamsTab
+                    userTeams={this.state.teams}
+                    teamsData={this.props ? this.props.allTeams.allTeamsData : []}
+                    onAssignTeam={this.onAssignTeam}
+                    onDeleteteam={this.onDeleteTeam}
                     isUserAdmin={true}
                     edit
                   />


### PR DESCRIPTION
Solves issue:
> Jae: Other Links → User Management → Create New User
Please switch the Team and Project locations at the bottom so that “Project” is first and shown by default. This is wanted because every person is assigned projects but only some people are assigned teams. So switching these will reduce clicks and save me time.
