### PR TITLE
Fixed incorrect times being displayed on time entry edit histories

### DIFF
--- a/src/components/UserProfile/TimeEntryEditHistory.jsx
+++ b/src/components/UserProfile/TimeEntryEditHistory.jsx
@@ -60,7 +60,7 @@ const TimeEntryEditHistory = props => {
           {editHistory.map(item => {
             return (
               <tr key={`edit-history-${item._id}`}>
-                <td>{moment(item.date).format('YYYY-MM-DD HH:MM:SS')}</td>
+                <td>{moment(item.date).tz('America/Los_Angeles').format('YYYY-MM-DD HH:MM:SS')}</td>
                 <td>{secondsToHms(item.initialSeconds)}</td>
                 <td>{secondsToHms(item.newSeconds)}</td>
                 {props.isAdmin === true && (


### PR DESCRIPTION
Fixes issue:
> 9/1: Time stamp for edits is off. See image below. These three edits were made one right after another at approximately 17:46 PDT. Note that the last one somehow logged in before the middle one. None of them are the right time