### PR TITLE
Leaderboard centering of data and active green icon sizing

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -5,53 +5,57 @@ import { Link } from 'react-router-dom'
 import { Table, Progress, Modal, ModalBody, ModalFooter, ModalHeader, Button } from 'reactstrap'
 
 function useDeepEffect(effectFunc, deps) {
-  const isFirst = useRef(true);
-  const prevDeps= useRef(deps);
-  useEffect(()=>{
+  const isFirst = useRef(true)
+  const prevDeps = useRef(deps)
+  useEffect(() => {
     const isSame = prevDeps.current.every((obj, index) => {
       let isItEqual = _.isEqual(obj, deps[index])
       return isItEqual
-    });
+    })
     if (isFirst.current || !isSame) {
-      effectFunc();
+      effectFunc()
     }
 
-    isFirst.current = false;
-    prevDeps.current = deps;
-
-  }, deps);
+    isFirst.current = false
+    prevDeps.current = deps
+  }, deps)
 }
 
-const LeaderBoard = ({getLeaderboardData, getOrgData, leaderBoardData, loggedInUser, organizationData, timeEntries, asUser}) => {
-  const userId = asUser ? asUser : loggedInUser.userId;
+const LeaderBoard = ({
+  getLeaderboardData,
+  getOrgData,
+  leaderBoardData,
+  loggedInUser,
+  organizationData,
+  timeEntries,
+  asUser,
+}) => {
+  const userId = asUser ? asUser : loggedInUser.userId
 
   useDeepEffect(() => {
-    getLeaderboardData(userId);
-    getOrgData();
-  }, [timeEntries]);
+    getLeaderboardData(userId)
+    getOrgData()
+  }, [timeEntries])
 
   useEffect(() => {
     try {
-
       if (window.screen.width < 540) {
-        const scrollWindow = document.getElementById('leaderboard');
+        const scrollWindow = document.getElementById('leaderboard')
         if (scrollWindow) {
-          const elem = document.getElementById(`id${userId}`); //
+          const elem = document.getElementById(`id${userId}`) //
 
           if (elem) {
-            const topPos = elem.offsetTop;
-            scrollWindow.scrollTo(0, (topPos - 100) < 100 ? 0 : (topPos - 100));
+            const topPos = elem.offsetTop
+            scrollWindow.scrollTo(0, topPos - 100 < 100 ? 0 : topPos - 100)
           }
         }
       }
-    } catch {
+    } catch {}
+  }, [])
 
-    }
-  }, []);
+  const [isOpen, setOpen] = useState(false)
 
-  const [isOpen, setOpen] = useState(false);
-
-  const toggle = () => setOpen(isOpen => !isOpen);
+  const toggle = () => setOpen(isOpen => !isOpen)
 
   return (
     <div>
@@ -65,7 +69,7 @@ const LeaderBoard = ({getLeaderboardData, getOrgData, leaderBoardData, loggedInU
           aria-hidden="true"
           className="fa fa-refresh"
           onClick={() => {
-            getLeaderboardData(userId);
+            getLeaderboardData(userId)
           }}
         />
         &nbsp;&nbsp;
@@ -83,21 +87,44 @@ const LeaderBoard = ({getLeaderboardData, getOrgData, leaderBoardData, loggedInU
         <Modal isOpen={isOpen} toggle={toggle}>
           <ModalHeader toggle={toggle}>Leaderboard Info</ModalHeader>
           <ModalBody>
-            <p>This is the One Community Leaderboard! It is used to show how much tangible and total time you’ve contributed, whether or not you’ve achieved your total committed hours for the week, and (in the case of teams) where your completed hours for the week rank you compared to other team members. It can also be used to access key areas of this application.</p>
+            <p>
+              This is the One Community Leaderboard! It is used to show how much tangible and total
+              time you’ve contributed, whether or not you’ve achieved your total committed hours for
+              the week, and (in the case of teams) where your completed hours for the week rank you
+              compared to other team members. It can also be used to access key areas of this
+              application.
+            </p>
             <ul>
-              <li>The HGN Totals at the top shows how many volunteers are currently active in the system, how many volunteer hours they are collectively committed to, and how many tangible and total hours they have completed. The color and length of that bar changes based on what percentage of the total committed hours for the week have been completed: >10%: Red, 10-50%: Orange, 50-60% hrs: Green, 60-70%: Blue, 70-80%: Indigo, 80-100%: Violet, and More than 100%: Purple.</li>
-              <li>The red/green dot shows whether or not a person has completed their “tangible” hours commitment for the week. Green = yes (Great job!), Red = no. Clicking this dot will take you to a person’s tasks section on their/your dashboard. </li>
-              <li>The time bar shows how much tangible and total (tangible + intangible) time you’ve completed so far this week. In the case of teams, it also shows you where your completed hours for the week rank you compared to other people on your team. Clicking a person’s time bar will take you to the time log section on their/your dashboard. This bar also changes color based on how many tangible hours you have completed: >5 hrs: Red, 5-10 hrs: Orange, 10-20 hrs: Green, 20-30 hrs: Blue, 30-40 hrs: Indigo, 40-50 hrs: Violet, and 50+ hrs: Purple</li>
+              <li>
+                The HGN Totals at the top shows how many volunteers are currently active in the
+                system, how many volunteer hours they are collectively committed to, and how many
+                tangible and total hours they have completed. The color and length of that bar
+                changes based on what percentage of the total committed hours for the week have been
+                completed: >10%: Red, 10-50%: Orange, 50-60% hrs: Green, 60-70%: Blue, 70-80%:
+                Indigo, 80-100%: Violet, and More than 100%: Purple.
+              </li>
+              <li>
+                The red/green dot shows whether or not a person has completed their “tangible” hours
+                commitment for the week. Green = yes (Great job!), Red = no. Clicking this dot will
+                take you to a person’s tasks section on their/your dashboard.{' '}
+              </li>
+              <li>
+                The time bar shows how much tangible and total (tangible + intangible) time you’ve
+                completed so far this week. In the case of teams, it also shows you where your
+                completed hours for the week rank you compared to other people on your team.
+                Clicking a person’s time bar will take you to the time log section on their/your
+                dashboard. This bar also changes color based on how many tangible hours you have
+                completed: >5 hrs: Red, 5-10 hrs: Orange, 10-20 hrs: Green, 20-30 hrs: Blue, 30-40
+                hrs: Indigo, 40-50 hrs: Violet, and 50+ hrs: Purple
+              </li>
               <li>Clicking a person’s name will lead to their/your profile page.</li>
             </ul>
             <p>Hovering over any of these areas will tell you how they function too. </p>
-
           </ModalBody>
           <ModalFooter>
             <Button onClick={toggle} color="secondary" className="float-left">
               {' '}
-              Ok
-              {' '}
+              Ok{' '}
             </Button>
           </ModalFooter>
         </Modal>
@@ -121,54 +148,54 @@ const LeaderBoard = ({getLeaderboardData, getOrgData, leaderBoardData, loggedInU
           </thead>
           <tbody className="my-custome-scrollbar">
             <tr>
-              <td>
-              <Link to={`/dashboard/`}>
-                <div
-                  title={`Weekly Committed: ${organizationData.weeklyComittedHours} hours`}
-                  style={{
-                    backgroundColor:
-                    organizationData.tangibletime >= organizationData.weeklyComittedHours
-                      ? 'green'
-                      : 'red',
-                    width: 15,
-                    height: 15,
-                    borderRadius: 7.5,
-                  }}
-                />
+              <td className="align-middle">
+                <Link to={`/dashboard/`}>
+                  <div
+                    title={`Weekly Committed: ${organizationData.weeklyComittedHours} hours`}
+                    style={{
+                      backgroundColor:
+                        organizationData.tangibletime >= organizationData.weeklyComittedHours
+                          ? 'green'
+                          : 'red',
+                      width: 15,
+                      height: 15,
+                      borderRadius: 7.5,
+                      margin: 'auto',
+                    }}
+                  />
                 </Link>
               </td>
               <th scope="row">{organizationData.name}</th>
-              <td>
+              <td className="align-middle">
                 <span title="Tangible time">{organizationData.tangibletime}</span>
               </td>
-              <td>
+              <td className="align-middle">
                 <Progress
                   title={`TangibleEffort: ${organizationData.tangibletime} hours`}
                   value={organizationData.barprogress}
                   color={organizationData.barcolor}
                 />
               </td>
-              <td>
+              <td className="align-middle">
                 <span title="Tangible + Intangible time = Total time">
-                  {organizationData.totaltime}
-                  {' '}
-                  of
-                  {' '}
-                  {organizationData.weeklyComittedHours}
+                  {organizationData.totaltime} of {organizationData.weeklyComittedHours}
                 </span>
               </td>
             </tr>
             {leaderBoardData.map((item, key) => (
               <tr key={key}>
-                <td>
+                <td className="align-middle">
                   <Link to={`/dashboard/${item.personId}`}>
                     <div
                       title={`Weekly Committed: ${item.weeklyComittedHours} hours`}
                       style={{
-                        backgroundColor: item.tangibletime >= item.weeklyComittedHours ? 'green' : 'red',
+                        backgroundColor:
+                          item.tangibletime >= item.weeklyComittedHours ? 'green' : 'red',
                         width: 15,
                         height: 15,
                         borderRadius: 7.5,
+                        margin: 'auto',
+                        verticalAlign: 'middle',
                       }}
                     />
                   </Link>
@@ -178,10 +205,10 @@ const LeaderBoard = ({getLeaderboardData, getOrgData, leaderBoardData, loggedInU
                     {item.name}
                   </Link>
                 </th>
-                <td id={`id${item.personId}`}>
+                <td className="align-middle" id={`id${item.personId}`}>
                   <span title="Tangible time">{item.tangibletime}</span>
                 </td>
-                <td>
+                <td className="align-middle">
                   <Link
                     to={`/timelog/${item.personId}`}
                     title={`TangibleEffort: ${item.tangibletime} hours`}
@@ -189,7 +216,7 @@ const LeaderBoard = ({getLeaderboardData, getOrgData, leaderBoardData, loggedInU
                     <Progress value={item.barprogress} color={item.barcolor} />
                   </Link>
                 </td>
-                <td>
+                <td className="align-middle">
                   <span title="Total time">{item.totaltime}</span>
                 </td>
               </tr>
@@ -198,7 +225,7 @@ const LeaderBoard = ({getLeaderboardData, getOrgData, leaderBoardData, loggedInU
         </Table>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default LeaderBoard;
+export default LeaderBoard

--- a/src/components/UserManagement/ActiveCell.jsx
+++ b/src/components/UserManagement/ActiveCell.jsx
@@ -7,6 +7,7 @@
 const ActiveCell = props => {
   return (
     <span
+      style={{ fontSize: '1.5rem' }}
       className={props.isActive ? 'isActive' : 'isNotActive'}
       id={props.index === undefined ? undefined : `active_cell_${props.index}`}
       title="Click here to change the user status"


### PR DESCRIPTION
Jae: Dashboard → Leaderboard also Admin View → Profile Pages (WIP: Narek)
Admin View → Profile Pages: Please increase the size of the green dot to match the size of the other icons here
<img width="210" alt="Screen Shot 2021-09-05 at 12 30 35 AM" src="https://user-images.githubusercontent.com/45651986/132119155-e0966b50-ffc2-4f8e-accb-9e277f4b763d.png">

Dashboard → Leaderboard: This will make it bigger on the Dashboard too. Right now it is higher than the words there, please also center it vertically (like the name there). Please vertically center everything else in the rows there too. You can see below how only the name is centered vertically in the picture below. Everything else should be centered like that too.
<img width="716" alt="Screen Shot 2021-09-05 at 12 30 49 AM" src="https://user-images.githubusercontent.com/45651986/132119166-c248ac93-279f-4c74-a8c2-ccc080a061e2.png">
