### PR TITLE
Fix/display end date volunteering time tab

### DIFF
--- a/src/actions/userManagement.js
+++ b/src/actions/userManagement.js
@@ -8,6 +8,7 @@ import {
 } from '../constants/userManagement'
 import { ENDPOINTS } from '../utils/URL'
 import { UserStatus } from '../utils/enums'
+import moment from 'moment'
 
 /**
  * fetching all user profiles
@@ -34,6 +35,14 @@ export const updateUserStatus = (user, status, reactivationDate) => {
   userProfile.isActive = (status === UserStatus.Active);
   userProfile.reactivationDate = reactivationDate;
   const patchData = { status: status, reactivationDate: reactivationDate };
+  if (status === UserStatus.InActive) {
+    patchData.endDate = moment().tz(userProfile.timeZone);
+    userProfile.endDate = moment().tz(userProfile.timeZone)
+  }else {
+    patchData.endDate = undefined;
+    userProfile.endDate = undefined;
+  }
+
   const updateProfilePromise = axios.patch(ENDPOINTS.USER_PROFILE(user._id), patchData)
   return async dispatch => {
     updateProfilePromise.then(res => {

--- a/src/actions/userManagement.js
+++ b/src/actions/userManagement.js
@@ -8,7 +8,7 @@ import {
 } from '../constants/userManagement'
 import { ENDPOINTS } from '../utils/URL'
 import { UserStatus } from '../utils/enums'
-import moment from 'moment'
+import moment from 'moment-timezone'
 
 /**
  * fetching all user profiles

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -352,6 +352,12 @@ const UserProfile = props => {
           createdDate: event.target.value,
         })
         break
+      case 'endDate':
+        setUserProfile({
+          ...userProfile,
+          endDate: event.target.value,
+        })
+        break
       case 'totalTangibleHours':
         setUserProfile({
           ...userProfile,

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -24,6 +24,23 @@ const StartDate = props => {
   )
 }
 
+const EndDate = props => {
+  if (!props.isUserAdmin) {
+    return <p>{props.userProfile.endDate ? moment(props.userProfile.endDate).format('YYYY-MM-DD') : 'N/A'}</p>
+  }
+  return (
+    <Input
+      type="date"
+      name="EndDate"
+      id="endDate"
+      value={props.userProfile.endDate ? moment(props.userProfile.endDate).format('YYYY-MM-DD') : ''}
+      onChange={props.handleUserProfile}
+      placeholder="End Date"
+      invalid={!props.isUserAdmin}
+    />
+  )
+}
+
 const WeeklyCommitedHours = props => {
   if (!props.isUserAdmin) {
     return <p>{props.userProfile.weeklyComittedHours}</p>
@@ -133,7 +150,11 @@ const ViewTab = props => {
           <Label>End Date</Label>
         </Col>
         <Col md="6">
-          <p>{userProfile.endDate ? moment(userProfile.endDate).format('YYYY-MM-DD') : 'N/A'}</p>
+          <EndDate
+            isUserAdmin={isUserAdmin}
+            userProfile={userProfile}
+            handleUserProfile={handleUserProfile}
+          />
         </Col>
       </Row>
 


### PR DESCRIPTION
Bug title: Jae: Profile → Volunteering Times → Start Date/End Date

Added an editable input in the volunteering time tab for admin to edit end date. The endDate field will be added to Mongo if the date is valid and when the user is paused at the Basic Information tab with current date as the endDate or at the Volunteering tab by adding an endDate.

![image](https://user-images.githubusercontent.com/31672796/132287337-4e4c8e47-623a-42cf-8c62-194e141e6bae.png)
 