### PR TITLE
Fixed format on time entry edit history tab

### DIFF
--- a/src/components/UserProfile/TimeEntryEditHistory.jsx
+++ b/src/components/UserProfile/TimeEntryEditHistory.jsx
@@ -50,9 +50,9 @@ const TimeEntryEditHistory = props => {
       <Table variant="">
         <thead>
           <tr>
-            <th>Date / Time (Pacific Time)</th>
-            <th>Initial Time (HH:MM:SS)</th>
-            <th>New Time (HH:MM:SS)</th>
+            <th>Date / Time<br/>(Pacific Time)</th>
+            <th>Initial Time<br/>(HH:MM:SS)</th>
+            <th>New Time<br/>(HH:MM:SS)</th>
             {props.isAdmin === true && <th></th>}
           </tr>
         </thead>


### PR DESCRIPTION
Fixes issue:
> Please also move the “(Pacific Time)” below the “Date / Time” so it looks like the other column labels
