### PR TITLE
Made the authentication system more secure and follow established sta…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16970,6 +16970,12 @@
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -17998,6 +18004,13 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^3.4.0",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "sockjs-client": {
@@ -19598,11 +19611,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -20484,6 +20492,11 @@
           "version": "3.2.4",
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
           "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -16,6 +16,7 @@ export const loginUser = credentials => dispatch => {
         dispatch(setCurrentUser({ new: true, userId: res.data.userId }))
       } else {
         localStorage.setItem(tokenKey, res.data.token)
+        localStorage.setItem('refreshToken', JSON.stringify(res.data.refreshToken))
         httpService.setjwt(res.data.token)
         const decoded = jwtDecode(res.data.token)
         dispatch(setCurrentUser(decoded))
@@ -47,6 +48,7 @@ export const getHeaderData = userId => {
 
 export const logoutUser = () => dispatch => {
   localStorage.removeItem(tokenKey)
+  localStorage.removeItem('refreshToken')
   httpService.setjwt(false)
   dispatch(setCurrentUser(null))
 };

--- a/src/actions/leaderBoardData.js
+++ b/src/actions/leaderBoardData.js
@@ -7,10 +7,8 @@ export const getLeaderboardData = userId => {
 
 	return async dispatch => {
 		const url = ENDPOINTS.LEADER_BOARD(userId)
-		//console.log(url)
 		const res = await httpService.get(url)
 
-		//console.log('LeaderBoardData is ',s res.data)
 
 		await dispatch(getLeaderBoardDataActionCreator(res.data))
 	}

--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -11,20 +11,18 @@ import { ENDPOINTS } from '../utils/URL';
 
 
 export const getUserProfile = (userId) => {
-  const url = ENDPOINTS.USER_PROFILE(userId);
+
   return async (dispatch) => {
-    let loggedOut = false;
-    const res = await axios.get(url).catch((error)=>{
-      if (error.status === 401) {
-        //logout error
-        loggedOut = true;
-      }
-    });
-    // console.log('GET user profile: response:', res)
-    if (!loggedOut) {
-      await dispatch(getUserProfileActionCreator(res.data));
+
+    try {
+      const res = await axios.get(ENDPOINTS.USER_PROFILE(userId))
+      await dispatch(getUserProfileActionCreator(res.data))
+    } catch (err) {
+      console.log("ERR")
     }
+
   };
+
 };
 
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,51 +1,21 @@
 import React, { useState, useEffect } from "react";
-import routes from '../routes'
-import logger from "../services/logService";
-
-import httpService from "../services/httpService";
-import jwtDecode from 'jwt-decode';
-import { setCurrentUser, logoutUser } from "../actions/authActions"
-import moment from 'moment-timezone'
-
-import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import axios from 'axios'
+import moment from 'moment-timezone'
+import jwtDecode from 'jwt-decode';
+
+import routes from '../routes'
+import httpService from "../services/httpService";
+import { setCurrentUser, logoutUser } from "../actions/authActions"
 import configureStore from '../store';
 import { PersistGate } from 'redux-persist/integration/react';
 import Loading from './common/Loading'
-
-import { tokenKey } from "../config.json";
-import "../App.css";
 import { ENDPOINTS } from "utils/URL";
-import axios from 'axios'
+
+import "../App.css";
 
 const { persistor, store } = configureStore();
-
-const SECOND = 1
-const HOUR = 60 * SECOND
-const DAY = 24 * HOUR
-
-const TOKEN_LIFETIME_BUFFER = 2 * DAY;
-
-/***********/
-if (localStorage.getItem(tokenKey)) {
-
-  const decoded = jwtDecode(localStorage.getItem(tokenKey));
-
-  const currentTime = Date.now() / 1000;
-  const expiryTime = new Date(decoded.expiryTimestamp).getTime() / 1000;
-
-  if (expiryTime - TOKEN_LIFETIME_BUFFER < currentTime) {
-
-    store.dispatch(logoutUser());
-  }
-  else {
-    httpService.setjwt(localStorage.getItem(tokenKey));
-    store.dispatch(setCurrentUser(decoded));
-  }
-}
-/***********/
-
-
 
 const App = () => {
 
@@ -66,6 +36,8 @@ const App = () => {
     const refreshTokenExpirationDate = moment(new Date(refreshToken.expirationDate))
     const now = moment();
 
+    // If the token has expired or is going to expire within 15 minutes,
+    // log the user out.
     if(now.diff(refreshTokenExpirationDate, 'minutes') > -15) {
       store.dispatch(logoutUser());
       setInitialized(true);

--- a/src/components/RefreshTokenManager.jsx
+++ b/src/components/RefreshTokenManager.jsx
@@ -4,6 +4,7 @@ import { useDispatch } from "react-redux";
 import httpService from "services/httpService";
 import { ENDPOINTS } from "utils/URL";
 import { logoutUser } from "actions/authActions";
+import { tokenKey } from 'config.json'
 
 const SECOND = 1000;
 
@@ -13,7 +14,7 @@ const useRefreshToken = async () => {
         refreshToken: JSON.parse(localStorage.getItem('refreshToken')).token
     })
 
-    localStorage.setItem('token', res.data.token);
+    localStorage.setItem(tokenKey, res.data.token);
     localStorage.setItem('refreshToken', JSON.stringify(res.data.refreshToken))
     httpService.setjwt(res.data.token)
 
@@ -21,7 +22,7 @@ const useRefreshToken = async () => {
 
 const onLoop = async (dispatch) => {
         
-    const base64AccessToken = localStorage.getItem('token');
+    const base64AccessToken = localStorage.getItem(tokenKey);
     if(!base64AccessToken) return;
   
     const splits = base64AccessToken.split('.');

--- a/src/components/RefreshTokenManager.jsx
+++ b/src/components/RefreshTokenManager.jsx
@@ -4,7 +4,6 @@ import httpService from "services/httpService";
 import { ENDPOINTS } from "utils/URL";
 
 const SECOND = 1000;
-const MINUTE = SECOND * 60;
 
 const useRefreshToken = async () => {
 

--- a/src/components/RefreshTokenManager.jsx
+++ b/src/components/RefreshTokenManager.jsx
@@ -1,0 +1,66 @@
+import axios from "axios"
+import { useEffect, useState } from "react"
+import httpService from "services/httpService";
+import { ENDPOINTS } from "utils/URL";
+
+const SECOND = 1000;
+const MINUTE = SECOND * 60;
+
+const useRefreshToken = async () => {
+
+    const res = await axios.post(ENDPOINTS.REFRESH_TOKEN(), {
+        refreshToken: JSON.parse(localStorage.getItem('refreshToken')).token
+    })
+
+    localStorage.setItem('token', res.data.token);
+    localStorage.setItem('refreshToken', JSON.stringify(res.data.refreshToken))
+    httpService.setjwt(res.data.token)
+
+}
+
+const onLoop = async () => {
+        
+    const base64AccessToken = localStorage.getItem('token');
+    if(!base64AccessToken) return;
+  
+    const splits = base64AccessToken.split('.');
+  
+    const payloadString = Buffer.from(splits[1], 'base64').toString('utf-8')
+    const payload = JSON.parse(payloadString);
+  
+    const accessTokenExpirationDate = new Date(payload.exp * SECOND);
+    const currentDate = new Date();
+    const isAccessTokenExpired = true || (accessTokenExpirationDate.valueOf() - currentDate.valueOf() <= 60 * SECOND);
+  
+    if(isAccessTokenExpired) {
+      try {
+        await useRefreshToken();
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  
+}
+
+/**
+ * Automat
+ * @returns 
+ */
+const RefreshTokenManager = () => {
+
+    const [loopInterval, setLoopInterval] = useState(setInterval(onLoop, 15 * SECOND))
+
+    useEffect(() => {
+        return () => {
+            clearInterval(loopInterval);
+        }
+    }, [])
+
+    return (
+        <>
+        </>
+    )
+
+}
+
+export default RefreshTokenManager

--- a/src/components/RefreshTokenManager.jsx
+++ b/src/components/RefreshTokenManager.jsx
@@ -30,7 +30,7 @@ const onLoop = async () => {
   
     const accessTokenExpirationDate = new Date(payload.exp * SECOND);
     const currentDate = new Date();
-    const isAccessTokenExpired = true || (accessTokenExpirationDate.valueOf() - currentDate.valueOf() <= 60 * SECOND);
+    const isAccessTokenExpired = (accessTokenExpirationDate.valueOf() - currentDate.valueOf() <= 60 * SECOND);
   
     if(isAccessTokenExpired) {
       try {

--- a/src/components/RefreshTokenManager.jsx
+++ b/src/components/RefreshTokenManager.jsx
@@ -1,7 +1,9 @@
 import axios from "axios"
 import { useEffect, useState } from "react"
+import { useDispatch } from "react-redux";
 import httpService from "services/httpService";
 import { ENDPOINTS } from "utils/URL";
+import { logoutUser } from "actions/authActions";
 
 const SECOND = 1000;
 
@@ -17,7 +19,7 @@ const useRefreshToken = async () => {
 
 }
 
-const onLoop = async () => {
+const onLoop = async (dispatch) => {
         
     const base64AccessToken = localStorage.getItem('token');
     if(!base64AccessToken) return;
@@ -35,7 +37,9 @@ const onLoop = async () => {
       try {
         await useRefreshToken();
       } catch (err) {
-        console.log(err);
+        alert('An error occurred that forced us to log you out. If the problem persists, please contact technical support.')
+        logoutUser()(dispatch)
+        return;
       }
     }
   
@@ -47,7 +51,8 @@ const onLoop = async () => {
  */
 const RefreshTokenManager = () => {
 
-    const [loopInterval, setLoopInterval] = useState(setInterval(onLoop, 15 * SECOND))
+    const [loopInterval, setLoopInterval] = useState(setInterval(() => onLoop(dispatch), 15 * SECOND))
+    const dispatch = useDispatch();
 
     useEffect(() => {
         return () => {

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -513,6 +513,15 @@ const UserProfile = props => {
               <h5 style={{ display: 'inline-block', marginRight: 10 }}>
                 {`${firstName} ${lastName}`}
               </h5>
+              <i
+                data-toggle="tooltip"
+                data-placement="right"
+                title="Click for more information"
+                style={{ fontSize: 24, cursor: 'pointer' }}
+                aria-hidden="true"
+                className="fa fa-info-circle"
+                onClick={toggleInfoModal}
+              />{' '}
               {
                 isUserAdmin && (
                   <>
@@ -528,15 +537,6 @@ const UserProfile = props => {
                   </>
                 )
               }
-              <i
-                data-toggle="tooltip"
-                data-placement="right"
-                title="Click for more information"
-                style={{ fontSize: 24, cursor: 'pointer' }}
-                aria-hidden="true"
-                className="fa fa-info-circle"
-                onClick={toggleInfoModal}
-              />{' '}
               {isUserAdmin && (
                 <i
                   data-toggle="tooltip"

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/App';
 import registerServiceWorker from './registerServiceWorker';
-// import $ from 'jquery';
-// import popper from 'popper.js';
 import 'bootstrap/dist/css/bootstrap.css';
-// import 'bootstrap/dist/js/bootstrap.js';
 import 'font-awesome/css/font-awesome.css';
 import logService from './services/logService';
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -29,10 +29,12 @@ import TeamReport from './components/Reports/TeamReport'
 import Inventory from './components/Inventory'
 import BadgeManagement from "./components/Badge/BadgeManagement"
 import AutoUpdate from 'components/AutoUpdate'
+import RefreshTokenManager from 'components/RefreshTokenManager'
 
 export default (
   <React.Fragment>
     <Header />
+    <RefreshTokenManager/>
     <AutoUpdate />
     <ToastContainer />
     <Switch>

--- a/src/services/httpService.js
+++ b/src/services/httpService.js
@@ -2,9 +2,19 @@ import axios from 'axios';
 import { toast } from 'react-toastify';
 import logService from './logService';
 
+/**
+ * Sets the 
+ * @param {*} jwt 
+ */
+const setjwt = (jwt) => {
+  if (jwt){
+    axios.defaults.headers.common.Authorization = `Bearer ${jwt}`;
+  } else {
+    delete axios.defaults.headers.common['Authorization'];
+  }
+}
 
 axios.defaults.headers.post['Content-Type'] = 'application/json';
-
 
 axios.interceptors.response.use(null, (error) => {
   if (!(error.response && error.response.status >= 400 && error.response.status <= 500)) {
@@ -13,15 +23,6 @@ axios.interceptors.response.use(null, (error) => {
   }
   return Promise.reject(error);
 });
-
-function setjwt(jwt) {
-  if (jwt){
-    axios.defaults.headers.common.Authorization = jwt;
-  }
-  else {
-    delete axios.defaults.headers.common['Authorization'];
-  }
-}
 
 export default {
   get: axios.get,

--- a/src/services/httpService.js
+++ b/src/services/httpService.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { toast } from 'react-toastify';
 import logService from './logService';
+import { tokenKey } from 'config.json'
 
 /**
  * Sets the 
@@ -22,6 +23,13 @@ axios.interceptors.response.use(null, (error) => {
     toast.error('Unexpected error');
   }
   return Promise.reject(error);
+});
+
+axios.interceptors.request.use((config) => {
+  const jwt = localStorage.getItem(tokenKey)
+  if(!jwt) return config;
+  setjwt(jwt)
+  return config;
 });
 
 export default {

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -55,6 +55,7 @@ export const ENDPOINTS = {
   BADGE: () => `${APIEndpoint}/badge`,
   BADGE_ASSIGN: userId => `${APIEndpoint}/badge/assign/${userId}`,
   BADGE_BY_ID: badgeId => `${APIEndpoint}/badge/${badgeId}`,
+  REFRESH_TOKEN: () => `${APIEndpoint}/refreshToken`
 };
 
 export const ApiEndpoint = APIEndpoint;


### PR DESCRIPTION
# Authentication Mechanism Overhual

**WARNING**: Both the front-end PR and the back-end PR for these changes are breaking changes. All logged in users at the time of this update will likely recieve numerous errors. Additionally, both the front-end and back-end PR must be deployed at the same time to avoid problems. Corresponding back-end PR: https://github.com/OneCommunityGlobal/HGNRest/pull/98

## Motivation 

The server and client previously used a JWT-only authentication flow. The server signed a JWT with a lifespan of **10 days** and the client provided it every request until it expired. This is far beyond the recommended lifespan for a JWT which is usually only a few minutes (5 - 15), or upwards or 24 hours for more benign oAuth 2 use cases. 

The main issue with a JWT-only system is that user access to the system fundamentally cannot be revoked, at least not in a timely fashion. This is because in this kind of a system, a message that has been signed will always be valid unless the private key it was signed with changed. Until now, there was no secure way to respond to the following scenarios:

- User's permissions need to be downgraded
- User's account is hijacked (hijacker could of have access for up to 10 days)
- User needs to be blocked / banned from system
- User's old sessions need to be invalidated (like during a password reset)

The JWT-only system was replaced with a new system that uses a combination of JWT's and rotating refresh tokens as described in the next section.

## Solution

JWT's issued by the server now last for only 15 minutes (hard coded). The environment variables that previously described the duration of the JWT's have been repurposed and now describe the lifetime of refresh tokens. 

A refresh token is a **revokable** token that can be exchanged for both a new refresh token and a new access token (JWT). Each time a refresh token is used, it becomes invalid and the client is given a new refresh token to replace it. This scheme is referred to as a **rotating refresh token**.

Now, every 15 seconds, the client checks if it's access token will expire within the next 60 seconds. If that's the case, the client exchanges its refresh token for a new access token and a new refresh token.  

## Implications

- Access to the system can now be properly revoked

- Because of the rotating refresh token scheme, users never have to sign into the application again unless they remain inactive for more than 10 days. Each time a refresh token is used, the new token granted in response has a new expiration date 10 days in the future. 

## Technical Summary 

- Added 'Bearer' prefix to HTTP Authorization header

- Replaced non-standard 'expiryTimestamp' field of the JWT payload with the standard 'exp' field

- The JWT's issued by the server now only last 15 minutes and they are renewed using a refresh token.

- New authentication scheme is compatible with a an isolated authentication service
