### PR TITLE
After adding a new member to a team, the search bar now clears itself.

### DIFF
--- a/src/components/Teams/MembersAutoComplete.jsx
+++ b/src/components/Teams/MembersAutoComplete.jsx
@@ -4,7 +4,7 @@ import {
 } from 'reactstrap';
 
 const MemberAutoComplete = (props) => {
-  const [searchText, onInputChange] = useState('');
+
   const [isOpen, toggle] = useState(false);
 
   return (
@@ -15,14 +15,14 @@ const MemberAutoComplete = (props) => {
     >
       <Input
         type="text"
-        value={searchText}
+        value={props.searchText}
         onChange={(e) => {
-          onInputChange(e.target.value);
+          props.setSearchText(e.target.value);
           toggle(true);
         }}
       />
 
-      {(searchText !== '' && props.userProfileData && props.userProfileData.userProfiles.length > 0)
+      {(props.searchText !== '' && props.userProfileData && props.userProfileData.userProfiles.length > 0)
         ? (
           <div
             tabIndex="-1"
@@ -32,15 +32,15 @@ const MemberAutoComplete = (props) => {
             style={{ marginTop: '0px', width: '100%' }}
           >
             {props.userProfileData.userProfiles.filter((user) => {
-              if (user.firstName.toLowerCase().indexOf(searchText.toLowerCase()) > -1
-                || user.lastName.toLowerCase().indexOf(searchText.toLowerCase()) > -1) {
+              if (user.firstName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1
+                || user.lastName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1) {
                 return user;
               }
             }).slice(0, 10).map((item) => (
               <div
                 className="user-auto-cpmplete"
                 onClick={() => {
-                  onInputChange(`${item.firstName} ${item.lastName}`);
+                  props.setSearchText(`${item.firstName} ${item.lastName}`);
                   toggle(false);
                   props.onAddUser(item);
                 }}

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -11,9 +11,12 @@ const TeamMembersPopup = React.memo((props) => {
   const closePopup = () => { props.onClose(); };
   const [selectedUser, onSelectUser] = useState(undefined);
   const [isValidUser, onValidation] = useState(true);
+  const [searchText, setSearchText] = useState('');
+
   const onAddUser = () => {
     if (selectedUser && !props.members.teamMembers.some((x) => x._id === selectedUser._id)) {
       props.onAddUser(selectedUser);
+      setSearchText('')
     } else {
       onValidation(false);
     }
@@ -38,6 +41,8 @@ const TeamMembersPopup = React.memo((props) => {
             <MembersAutoComplete
               userProfileData={props.usersdata}
               onAddUser={selectUser}
+              searchText={searchText}
+              setSearchText={setSearchText}
             />
             <Button
               color="primary"


### PR DESCRIPTION
Solves issue:
> Jae: Other Links → Teams → Members → Input name → Add
When I click the “add” button, the name should clear in the field so it is ready for me to type another name vs. having to clear the existing name before choosing a new one
