### PR TITLE
onDeleteTeamMember alert text updated

### DIFF
--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -347,7 +347,7 @@ class Teams extends React.PureComponent {
     */
   onDeleteTeamMember = (deletedUserId) => {
     this.props.deleteTeamMember(this.state.selectedTeamId, deletedUserId);
-    alert('Deleted Succefully');
+    alert('Team member successfully deleted! Ryunosuke Satoro famously said, “Individually we are one drop, together we are an ocean.” Through the action you just took, this ocean is now one drop smaller.');
   }
 }
 const mapStateToProps = state => ({ state });


### PR DESCRIPTION
Other Links → Teams → Members → Input name → Add → then Delete the person 

When I do this, the popup has a spelling error (see below). I’d like to make that popup more interesting too. Please update this text to say: 

Team member successfully deleted! Ryunosuke Satoro famously said, “Individually we are one drop, together we are an ocean.” Through the action you just took, this ocean is now one drop smaller.  
