### PR TITLE
Admin Create New User: auto add 'Orientation and Initial Setup' for the new user

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -381,6 +381,12 @@ class AddUserProfile extends Component {
       timeZone
     } = that.state.userProfile
 
+    const initalUserProject = that.props.allProjects.projects.filter((project) => {
+      if (project.projectName === 'Orientation and Initial Setup'){
+        return project;
+      }
+    });
+
     const userData = {
       password: '123Welcome!',
       role: role,
@@ -393,7 +399,7 @@ class AddUserProfile extends Component {
       personalLinks: [],
       adminLinks: [],
       teams: this.state.teams,
-      projects: this.state.projects,
+      projects: [...this.state.projects, ...initalUserProject],
       email: email,
       privacySettings: privacySettings,
       collaborationPreference: collaborationPreference,


### PR DESCRIPTION
**Functionality Required:** Add 'Orientation and Initial Setup' project to each new user created by admin.

**Changes:** 
- Fetch project named 'Orientation and Initial Setup' from state and store it in `initialUserProject`
- Modified `userData` to store projects added by admin as well as `initialUserProject`

**Screenshot of Admin Creating a new user:** 
![Screen Shot 2021-10-01 at 9 12 21 PM](https://user-images.githubusercontent.com/20497587/135703276-95bc5d69-ab74-4e17-bf56-74e50c1aa4c5.png)

**Screenshot of New User Profile added with additional project 'Orientation and Initial Setup':**
![Screen Shot 2021-10-01 at 9 12 38 PM](https://user-images.githubusercontent.com/20497587/135703277-9cb9d6ec-1eb9-4da5-a625-a5f439b1a259.png)
