### PR TITLE
Create new User form: Displays Orientation and Initial Setup project

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -42,10 +42,15 @@ import TimeZoneDropDown from '../TimeZoneDropDown'
 class AddUserProfile extends Component {
   constructor(props) {
     super(props)
+    const initalUserProject = props.allProjects.projects.filter((project) => {
+      if (project.projectName === 'Orientation and Initial Setup'){
+        return project;
+      }
+    });
     this.state = {
       weeklyComittedHours: 10,
       teams: [],
-      projects: [],
+      projects: [...initalUserProject],
       activeTab: '1',
       userProfile: {
         weeklyComittedHours: 10,
@@ -381,12 +386,6 @@ class AddUserProfile extends Component {
       timeZone
     } = that.state.userProfile
 
-    const initalUserProject = that.props.allProjects.projects.filter((project) => {
-      if (project.projectName === 'Orientation and Initial Setup'){
-        return project;
-      }
-    });
-
     const userData = {
       password: '123Welcome!',
       role: role,
@@ -399,7 +398,7 @@ class AddUserProfile extends Component {
       personalLinks: [],
       adminLinks: [],
       teams: this.state.teams,
-      projects: [...this.state.projects, ...initalUserProject],
+      projects: this.state.projects,
       email: email,
       privacySettings: privacySettings,
       collaborationPreference: collaborationPreference,


### PR DESCRIPTION
Functionality Required: Add 'Orientation and Initial Setup' project to each new user created by admin.

Changes:

- Fetch project named 'Orientation and Initial Setup' from state and store it in `initialUserProject`
- Modified constructor to store `initialUserProject` in the initial state.


**Create new user form (with changes):** 
<img width="1138" alt="Fix initial project" src="https://user-images.githubusercontent.com/20497587/136509191-016d5df2-8c5e-4541-a68e-207bdacdbaf5.png">
