### PR TITLE
Issue 5 Fixed by removing the disable functionality

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -542,7 +542,8 @@ const TimeEntryForm = props => {
             {' '}
             Clear Form{' '}
           </Button>
-          <Button color="primary" disabled={isSubmitting || (data.hours === inputs.hours && data.minutes === inputs.minutes && data.notes === inputs.notes)} onClick={handleSubmit}>
+          {/* <Button color="primary" disabled={isSubmitting || (data.hours === inputs.hours && data.minutes === inputs.minutes && data.notes === inputs.notes)} onClick={handleSubmit}> */}
+          <Button color="primary"  onClick={handleSubmit}>
             {edit ? 'Save' : 'Submit'}
           </Button>
         </ModalFooter>


### PR DESCRIPTION
 Admin Functionality → Edit user date for past date—  (Navya : Completed)
When I try to edit a user’s date for a past date (not an entry with today’s date), the “save” button stays greyed out. As a workaround, I can edit the text too, and that makes the “save’ button active. Save button should be active for any edit made though. 


Fixed the above issue by removing the disable functionality ,for that modified in  src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
line 546 ,removed disabled function previously written by other developer ,so just commented the old code and kept new code by removing the disable function so that in future if we need we can integrate the changes.