### PR TITLE
Fixed Issue5 Name field not allowing spaces

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -85,14 +85,14 @@ class AddUserProfile extends Component {
                     <FormGroup> 
                       <Input
                         type="text"
-                        name="firstName"
+                        name="first Name"
                         id="firstName"
                         value={firstName}
                         onChange={this.handleUserProfile}
                         onFocus = {this.handleUserProfile}
                         placeholder="First Name"
                         invalid={this.state.formValid.firstName === undefined ? false : !this.state.formValid.firstName}
-                      />
+                      />                    
                       <FormFeedback>{this.state.formErrors.firstName}</FormFeedback>
                     </FormGroup>
                   </Col>
@@ -145,7 +145,7 @@ class AddUserProfile extends Component {
                         placeholder="Email"
                         invalid={this.state.formValid.email === undefined ? false : !this.state.formValid.email}
                       />
-                      <FormFeedback>{this.state.formErrors.email}</FormFeedback>\
+                      <FormFeedback>{this.state.formErrors.email}</FormFeedback>
                       <ToggleSwitch
                         switchType="email"
                         state={this.state.userProfile.privacySettings?.email}
@@ -559,7 +559,8 @@ class AddUserProfile extends Component {
         this.setState({
           userProfile: {
             ...userProfile,
-            [event.target.id]: event.target.value.trim(),
+            [event.target.id]: event.target.value,
+            // [event.target.id]: event.target.value.trim(),   removed trim to allow space in name field
           },
           formValid: {
             ...formValid,
@@ -575,7 +576,7 @@ class AddUserProfile extends Component {
         this.setState({
           userProfile: {
             ...userProfile,
-            [event.target.id]: event.target.value.trim(),
+            [event.target.id]: event.target.value,
           },
           formValid: {
             ...formValid,


### PR DESCRIPTION
 Admin Functionality → Other Links → User Management → Create New User → Name fields should accept multiple words

Fixed this issue by removing the validation for firstname , lastname fields, previously they are restricting spaces to enter,now i removed this validation.
I just commented the old code and wrote new changes ,so that in future it will be easier to spot the mistakes as I am not aware of the full flow...
changes made in :
 src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx

