### PR TITLE
update delete badge message

### DIFF
--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -201,7 +201,7 @@ const BadgeReport = (props) => {
   }
 
   const deletedBadge = (badge, index) => {
-    if (window.confirm("Are you sure you want to delete this badge? Note even if you click ok, this won't be fully deleted until you click the save button below.")) {
+    if (window.confirm("Woah, easy tiger! Are you sure you want to delete this badge ? ")) {
       let newBadges = sortBadges.slice();
       newBadges.splice(index, 1);
       setSortBadges(newBadges);


### PR DESCRIPTION
Other Links → Badge Management → Assign Badge → Confirm
Doing the above should be all that is needed. Currently it then requires a person to hit “Submit” next for changes to take place. This is confusing and inefficient. I’d like “Confirm” to be all that is needed. 

Update the Message as require.
