### PR TITLE
Remove "Search For Time Zone" feature in BasicInfo

### DIFF
--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -454,14 +454,14 @@ const BasicInformationTab = (props) => {
         </Col>
       </Row>
       <Row style={{ marginBottom: '10px' }}>
-        <Col>
+        {/* <Col>
           <Label>Search For Time Zone</Label>
         </Col>
         <Col>
           <Input type="text" onChange={(e) => setTimeZoneFilter(e.target.value)} />
         </Col>
       </Row>
-      <Row style={{ marginBottom: '10px' }}>
+      <Row style={{ marginBottom: '10px' }}> */}
         <Col>
           <Label>Status</Label>
         </Col>


### PR DESCRIPTION
Bug:
Profile Page → Basic Information
In addition to the above request, the “Search for Time Zone” field should be removed because the above request would replace this. 
