### PR TITLE
Yiyun replace confirm window

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -57,6 +57,19 @@ const LeaderBoard = ({
 
   const toggle = () => setOpen((isOpen) => !isOpen);
 
+  // add state hook for the popup the personal's dashboard from leaderboard
+  const [isDashboardOpen, setIsDashboardOpen] = useState(false);
+  const dashboardToggle = () => setIsDashboardOpen((isDashboardOpen) => !isDashboardOpen);
+
+  const showDashboard = (item) => {
+    dashboardToggle();
+    window.open(
+      `/dashboard/${item.personId}`,
+      'Popup',
+      'toolbar=no, location=no, statusbar=no, menubar=no, scrollbars=1, resizable=0, width=580, height=600, top=30',
+    );
+  };
+
   return (
     <div>
       <h3>
@@ -186,18 +199,24 @@ const LeaderBoard = ({
               <tr key={key}>
                 <td
                   className="align-middle"
-                  onClick={() => {
-                    if (
-                      window.confirm(`Are you sure you wish to view this ${item.name} dashboard ?`)
-                    ) {
-                      window.open(
-                        `/dashboard/${item.personId}`,
-                        'Popup',
-                        'toolbar=no, location=no, statusbar=no, menubar=no, scrollbars=1, resizable=0, width=580, height=600, top=30',
-                      );
-                    }
-                  }}
+                  onClick={dashboardToggle}
                 >
+
+                <div>
+                  <Modal isOpen={isDashboardOpen} toggle={dashboardToggle}>
+                    <ModalHeader toggle={dashboardToggle}>Jump to personal Dashboard</ModalHeader>
+                      <ModalBody>
+                        <p>
+                          Are you sure you wish to view this {item.name} dashboard?
+                        </p>
+                      </ModalBody>
+                      <ModalFooter>
+                        <Button variant="primary" onClick={() => {showDashboard(item)}}>Ok</Button>{' '}
+                        <Button variant="secondary" onClick={dashboardToggle}>Cancel</Button>
+                      </ModalFooter>
+                  </Modal>
+                </div>
+
                   {/* <Link to={`/dashboard/${item.personId}`}> */}
                   <div
                     title={`Weekly Committed: ${item.weeklyComittedHours} hours`}

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -59,10 +59,11 @@ const LeaderBoard = ({
 
   // add state hook for the popup the personal's dashboard from leaderboard
   const [isDashboardOpen, setIsDashboardOpen] = useState(false);
-  const dashboardToggle = () => setIsDashboardOpen((isDashboardOpen) => !isDashboardOpen);
-
+  const dashboardToggle = (item) => setIsDashboardOpen(item.personId);
+  const dashboardClose = () => setIsDashboardOpen(false);
+  
   const showDashboard = (item) => {
-    dashboardToggle();
+    dashboardClose();
     window.open(
       `/dashboard/${item.personId}`,
       'Popup',
@@ -199,11 +200,11 @@ const LeaderBoard = ({
               <tr key={key}>
                 <td
                   className="align-middle"
-                  onClick={dashboardToggle}
+                  onClick={() => dashboardToggle(item)}
                 >
 
                 <div>
-                  <Modal isOpen={isDashboardOpen} toggle={dashboardToggle}>
+                  <Modal isOpen={isDashboardOpen === item.personId} toggle={dashboardToggle}>
                     <ModalHeader toggle={dashboardToggle}>Jump to personal Dashboard</ModalHeader>
                       <ModalBody>
                         <p>
@@ -211,7 +212,7 @@ const LeaderBoard = ({
                         </p>
                       </ModalBody>
                       <ModalFooter>
-                        <Button variant="primary" onClick={() => {showDashboard(item)}}>Ok</Button>{' '}
+                        <Button variant="primary" onClick={() => showDashboard(item)}>Ok</Button>{' '}
                         <Button variant="secondary" onClick={dashboardToggle}>Cancel</Button>
                       </ModalFooter>
                   </Modal>


### PR DESCRIPTION
Dashboard > Leaderboard > Circle on the left of a person’s name (WIP Yiyun)
Change popup from window.confirm() to a react-strap modal
This is to remove this from the top of the popup: “https://hgnapplication_react_dev.surge.sh/ says:”