### PR TITLE
resolved intangible spacing issue

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -390,10 +390,9 @@ const TimeEntryForm = (props) => {
             {inputs.isTangible ? (
               'Tangible'
             ) : (
-              <span style={{ textDecoration: 'underline' }}>Intangible</span>
+              <span style={{ color: 'orange' }}>Intangible </span>
             )}
-            Time Entry
-            <i
+            Time Entry <i
               className="fa fa-info-circle"
               data-tip
               data-for="registerTip"


### PR DESCRIPTION
Resolved Intangible Spacing Issue:

_"Text when logging intangible time needs a space at the end of “Intangible” and between the “y” and the information button._

- Changed text decoration property to color because of issues with spaces being underlined. Selected orange to be color blind friendly.
- Input a space between "Intangible" and the next word over.
- Input a space between "Entry" and the "i frame" to the right.