### PR TITLE
fix WBS table showing column mismatch

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -174,7 +174,7 @@ const WBSTasks = (props) => {
               <th scope="col" data-tip="Action" colSpan="2">
                 Action
               </th>
-              <th scope="col" data-tip="WBS ID" colSpan="2">
+              <th scope="col" data-tip="WBS ID" colSpan="1">
                 #
               </th>
               <th scope="col" data-tip="Task Name" className="task-name">


### PR DESCRIPTION
Before: 
<img width="1874" alt="wbs table column before fix" src="https://user-images.githubusercontent.com/5071040/167948884-97cca5ce-6a72-4f21-85bc-ee99afcc3cee.png">

After: 
<img width="1888" alt="wbs table column after fix" src="https://user-images.githubusercontent.com/5071040/167948900-e04755c4-1b26-4a03-8911-ae9e03605834.png">
