### PR TITLE
Fixed Wrapping issue by adding a media query + overscroll-x property …

### DIFF
--- a/src/components/UserProfile/Badge.css
+++ b/src/components/UserProfile/Badge.css
@@ -88,7 +88,7 @@
 
 .badge_featured_container {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: none;
   overflow-y: none;
 }
 
@@ -128,4 +128,12 @@
 
 .badge_info_icon_text {
   text-align: left;
+}
+
+@media (max-width: 1199px) {
+  .badge_featured_container {
+    flex-wrap: none;
+    overflow-y: hidden;
+    overflow-x: scroll;
+  }
 }

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -35,7 +35,7 @@ const Badges = (props) => {
 
   return (
     <>
-      <Card style={{ backgroundColor: '#f6f6f3', marginTop: 20, marginBottom: 20 }}>
+      <Card style={{ backgroundColor: '#f6f6f3', marginTop: 20, marginBottom: 20, minWidth: 477 }}>
         <CardBody>
           <CardTitle
             style={{


### PR DESCRIPTION
…when page size shrinks to a certain point.

The following changes now trigger a scrollbar when the page would normally wrap. Please see the attached image below.

![overflow-x](https://user-images.githubusercontent.com/76860289/168972915-219c3bb0-0cdb-4a20-8b4b-15b0a18a8699.png)
 