### PR TITLE
implement the open/close filter for tasks

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -342,7 +342,7 @@ const Task = (props) => {
           )}
         </td>
         <td className="desktop-view">
-          {props.status === 'Started' ? (
+          {(props.status === 'Started' || props.status === 'Active') ? (
             <i data-tip="Started" className="fa fa-pause" aria-hidden="true"></i>
           ) : (
             <i data-tip="Not Started" className="fa fa-play" aria-hidden="true"></i>

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -26,6 +26,7 @@ const WBSTasks = (props) => {
   const [isShowImport, setIsShowImport] = useState(false);
 
   const [selectedId, setSelectedId] = useState(null);
+  const [filterState, setFilterState] = useState('all');
 
   useEffect(() => {
     props.fetchAllTasks(wbsId, 0);
@@ -110,20 +111,25 @@ const WBSTasks = (props) => {
     }, 4000);
   };
 
-  const toggleGroups = (open) => {
-    const items2 = document.getElementsByClassName(`lv_2`);
-    const items3 = document.getElementsByClassName(`lv_3`);
-    const items4 = document.getElementsByClassName(`lv_4`);
-    const allItems = [...items2, ...items3, ...items4];
-
-    for (let i = 0; i < allItems.length; i++) {
-      if (!open) {
-        allItems[i].style.display = 'none';
-      } else {
-        allItems[i].style.display = 'table-row';
-      }
+  const filterTasks = (allTaskItems, filter) => {
+    if (filter === "all") {
+      return allTaskItems;
+    } else if (filter === "open") {
+      return allTaskItems.filter((taskItem) => {
+        if (taskItem.status === "Active" || taskItem.status === "Started") {
+          return taskItem;
+        } 
+      });
+    } else if (filter === "close") {
+      return allTaskItems.filter((taskItem) => {
+        if (taskItem.status === "Complete" || taskItem.status === "Not Started") {
+          return taskItem;
+        } 
+      });
     }
-  };
+  }
+
+  let filteredTasks = filterTasks(props.state.tasks.taskItems, filterState);
 
   return (
     <React.Fragment>
@@ -159,11 +165,14 @@ const WBSTasks = (props) => {
         </Button>
 
         <div className="toggle-all">
-          <Button color="light" size="sm" onClick={() => toggleGroups(true)}>
+          <Button color="light" size="sm" onClick={() => setFilterState('open')}>
             Open
           </Button>
-          <Button color="dark" size="sm" onClick={() => toggleGroups(false)}>
+          <Button color="dark" size="sm" onClick={() => setFilterState("close")}>
             Close
+          </Button>
+          <Button color="grey" size="sm" onClick={() => setFilterState("all")}>
+            All
           </Button>
         </div>
 
@@ -222,7 +231,7 @@ const WBSTasks = (props) => {
               <td colSpan={14}></td>
             </tr>
 
-            {props.state.tasks.taskItems.map((task, i) => (
+            {filteredTasks.map((task, i) => (
               <Task
                 key={`${task._id}${i}`}
                 id={task._id}


### PR DESCRIPTION
* This PR implements the open/close/all filter for tasks on WBS page - all changes in `src/components/Projects/WBS/WBSDetail/WBSTasks.jsx` file

image1 - all tasks
<img width="943" alt="image" src="https://user-images.githubusercontent.com/5071040/169416308-df83cf25-2b38-4731-ae61-f3320081b3a4.png">

image2 - open(active+started) tasks
<img width="947" alt="image" src="https://user-images.githubusercontent.com/5071040/169416389-48574497-9449-468a-aaa3-8e182abbab9b.png">

image3 - close(complete+notstarted) tasks
<img width="947" alt="image" src="https://user-images.githubusercontent.com/5071040/169417398-19c30205-1017-4246-bf77-eccd44c41f18.png">


* Fix the inappropriate "status" icon match on WBS page - change in `src/components/Projects/WBS/WBSDetail/Task/Task.jsx` 

How to test this PR:
1. Go to `Yiyun-implement_open_close_filter_for_WBS_tasks` branch
2. Log into the Dev as an Admin → Other Links → Projects → AAA USE THIS PROJECT → WBS Icon → Jae's WBS - USE THIS
3. Test the three buttons on top-right