### PR TITLE
extend WBS tasks filters from three to six

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -351,6 +351,7 @@ const EditTaskModal = (props) => {
                   <select id="Status" onChange={(e) => setStatus(e.target.value)}>
                     <option value="Started">Started</option>
                     <option value="Not Started">Not Started</option>
+                    <option value="Complete">Complete</option>
                   </select>
                 </td>
               </tr>

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -114,18 +114,36 @@ const WBSTasks = (props) => {
   const filterTasks = (allTaskItems, filter) => {
     if (filter === "all") {
       return allTaskItems;
-    } else if (filter === "open") {
+    } else if (filter === "assigned") {
+      return allTaskItems.filter((taskItem) => {
+        if (taskItem.isAssigned === true) {
+          return taskItem;
+        } 
+      });
+    } else if (filter === "unassigned") {
+      return allTaskItems.filter((taskItem) => {
+        if (taskItem.isAssigned === false) {
+          return taskItem;
+        } 
+      });
+    } else if (filter === "active") {
       return allTaskItems.filter((taskItem) => {
         if (taskItem.status === "Active" || taskItem.status === "Started") {
           return taskItem;
         } 
       });
-    } else if (filter === "close") {
+    } else if (filter === "inactive") {
       return allTaskItems.filter((taskItem) => {
-        if (taskItem.status === "Complete" || taskItem.status === "Not Started") {
+        if (taskItem.status === "Not Started") {
           return taskItem;
         } 
       });
+    } else if (filter === "complete") {
+      return allTaskItems.filter((taskItem) => {
+        if (taskItem.status === "Complete") {
+          return taskItem;
+        }
+      })
     }
   }
 
@@ -165,14 +183,23 @@ const WBSTasks = (props) => {
         </Button>
 
         <div className="toggle-all">
-          <Button color="light" size="sm" onClick={() => setFilterState('open')}>
-            Open
-          </Button>
-          <Button color="dark" size="sm" onClick={() => setFilterState("close")}>
-            Close
-          </Button>
-          <Button color="grey" size="sm" onClick={() => setFilterState("all")}>
+          <Button color="primary" size="sm" onClick={() => setFilterState("all")}>
             All
+          </Button>
+          <Button color="secondary" size="sm" onClick={() => setFilterState("assigned")}>
+            Assigned
+          </Button>
+          <Button color="success" size="sm" onClick={() => setFilterState("unassigned")}>
+            Unasigned
+          </Button>
+          <Button color="info" size="sm" onClick={() => setFilterState("active")}>
+            Active
+          </Button>
+          <Button color="warning" size="sm" onClick={() => setFilterState("inactive")}>
+            Inactive
+          </Button>
+          <Button color="danger" size="sm" onClick={() => setFilterState("complete")}>
+            Complete
           </Button>
         </div>
 


### PR DESCRIPTION
This PR is a follow-up for [PR#416](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/416)
Per Jae's comments: 
<img width="521" alt="image" src="https://user-images.githubusercontent.com/5071040/170140263-4834e43c-5b62-4940-b5ad-4bfe64d4cfbc.png">


- Extend the WBS tasks filter from (All, open, close) to (All, assigned, unassigned, active, inactive)
<img width="639" alt="image" src="https://user-images.githubusercontent.com/5071040/170139361-692bed5e-8b84-4358-b53b-1bfce6bb2ac8.png">

- Add "complete" as a choice when editing one task's status
<img width="350" alt="image" src="https://user-images.githubusercontent.com/5071040/170139440-03fdccab-323f-426c-ae9d-9f9ac00ec894.png">
