### PR TITLE
Modified CSS to repair the issue with wrapping

### DIFF
--- a/src/components/UserProfile/Badge.css
+++ b/src/components/UserProfile/Badge.css
@@ -88,7 +88,7 @@
 
 .badge_featured_container {
   display: flex;
-  flex-wrap: none;
+  flex-wrap: nowrap;
   overflow-y: none;
 }
 
@@ -130,9 +130,8 @@
   text-align: left;
 }
 
-@media (max-width: 1199px) {
+@media screen and (max-width: 1199px) {
   .badge_featured_container {
-    flex-wrap: none;
     overflow-y: hidden;
     overflow-x: scroll;
   }

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -43,6 +43,7 @@ const Badges = (props) => {
               fontSize: 18,
               color: '#285739',
               marginBottom: 15,
+              minWidth: 446
             }}
           >
             Featured Badges <i className="fa fa-info-circle" id="FeaturedBadgeInfo" />


### PR DESCRIPTION
Changes:

- Corrected issue with flex property for .badge_featured_container in badge.css (was previously flex: none -> is now flex: nowrap)
- Removed flex property from media query. This is likely the reason that there was a conflict.