### PR TITLE
Ron intangible admin form fix

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -55,7 +55,7 @@ class Timelog extends Component {
     this.openInfo = this.openInfo.bind(this);
     this.data = {
       disabled: !hasPermission(this.props.auth.user.role, 'disabledDataTimelog') ? false : true,
-      isTangible: hasPermission(this.props.auth.user.role, 'dataIsTangibleTimelog') ? true : false,
+      // isTangible: hasPermission(this.props.auth.user.role, 'dataIsTangibleTimelog') ? true : false,
     };
     this.userProfile = this.props.userProfile;
   }

--- a/src/components/UserProfile/Badge.css
+++ b/src/components/UserProfile/Badge.css
@@ -88,7 +88,7 @@
 
 .badge_featured_container {
   display: flex;
-  flex-wrap: none;
+  flex-wrap: nowrap;
   overflow-y: none;
 }
 
@@ -130,9 +130,8 @@
   text-align: left;
 }
 
-@media (max-width: 1199px) {
+@media screen and (max-width: 1199px) {
   .badge_featured_container {
-    flex-wrap: none;
     overflow-y: hidden;
     overflow-x: scroll;
   }

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -43,6 +43,7 @@ const Badges = (props) => {
               fontSize: 18,
               color: '#285739',
               marginBottom: 15,
+              minWidth: 446
             }}
           >
             Featured Badges <i className="fa fa-info-circle" id="FeaturedBadgeInfo" />


### PR DESCRIPTION
Resolved issue with "Tangible Form pops up as default when logged into Admin Account even if the 'Add Intangible Time Entry Form' is clicked.

Line 58 was commented out and provides a fix for the solution however I did find that there is an alternative solution. We can remove 'dataIsTangibleTimelog' as a permission for the Administrator role in utils/permissions. 

Tested:
- Line 58 in timelog.jsx was commented out
- Add intangible form entry now works when logged into Admin account
- Tangible form entry works when stopping timer
- Intangible and Tangible forms are displaying/trigger correctly and was tested on a 'Volunteer' account.