### PR TITLE
Change three buttons 'update password', 'cancel', 'save change' display logic

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -331,15 +331,13 @@ const UserProfile = props => {
   // const isUserAdmin = requestorRole === 'Administrator';
   // const canEdit = hasPermission(requestorRole, 'editUserProfile') || isUserSelf;
   let canEdit;
-  if(userProfile.role !== 'Owner'){
+  if (userProfile.role !== 'Owner') {
     canEdit = hasPermission(requestorRole, 'editUserProfile') || isUserSelf;
   } else {
     canEdit = hasPermission(requestorRole, 'addDeleteEditOwners') || isUserSelf;
   }
 
-
   return (
-
     <div>
       {showModal && (
         <UserProfileModal
@@ -596,7 +594,7 @@ const UserProfile = props => {
             {hasPermission(requestorRole, 'resetPasswordOthers') && canEdit && !isUserSelf && (
               <ResetPasswordButton className="mr-1" user={userProfile} />
             )}
-            {isUserSelf && (
+            {isUserSelf && (activeTab == '1' || hasPermission(requestorRole, 'editUserProfile')) && (
               <div className="profileEditButtonContainer">
                 <Link to={`/updatepassword/${userProfile._id}`}>
                   <Button className="mr-1" color="primary">
@@ -606,23 +604,25 @@ const UserProfile = props => {
                 </Link>
               </div>
             )}
-            {canEdit && (
+            {isUserSelf && (activeTab == '1' || hasPermission(requestorRole, 'editUserProfile')) && (
               <>
-              <span
-                onClick={() => {
-                  setUserProfile(originalUserProfile);
-                  setChanged(false);
-                }}
-                className="btn btn-outline-danger mr-1"
-              >
-                Cancel
-              </span>      
-              <SaveButton
-                className="mr-1"
-                handleSubmit={handleSubmit}
-                disabled={!formValid.firstName || !formValid.lastName || !formValid.email || !changed}
-                userProfile={userProfile}
-              />
+                <span
+                  onClick={() => {
+                    setUserProfile(originalUserProfile);
+                    setChanged(false);
+                  }}
+                  className="btn btn-outline-danger mr-1"
+                >
+                  Cancel
+                </span>
+                <SaveButton
+                  className="mr-1"
+                  handleSubmit={handleSubmit}
+                  disabled={
+                    !formValid.firstName || !formValid.lastName || !formValid.email || !changed
+                  }
+                  userProfile={userProfile}
+                />
               </>
             )}
           </Col>

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -331,7 +331,7 @@ const UserProfile = props => {
   // const isUserAdmin = requestorRole === 'Administrator';
   // const canEdit = hasPermission(requestorRole, 'editUserProfile') || isUserSelf;
   let canEdit;
-  if (userProfile.role !== 'Owner') {
+  if (requestorRole !== 'Owner') {
     canEdit = hasPermission(requestorRole, 'editUserProfile') || isUserSelf;
   } else {
     canEdit = hasPermission(requestorRole, 'addDeleteEditOwners') || isUserSelf;
@@ -604,7 +604,7 @@ const UserProfile = props => {
                 </Link>
               </div>
             )}
-            {isUserSelf && (activeTab == '1' || hasPermission(requestorRole, 'editUserProfile')) && (
+            {canEdit && (activeTab == '1' || hasPermission(requestorRole, 'editUserProfile')) && (
               <>
                 <span
                   onClick={() => {


### PR DESCRIPTION
To the reviewer:

This PR changes the display logic of the three buttons 'update password', 'cancel', and 'save change' on the User Profile page.
When non-Admin users view their own profile, these three buttons should only exist when they are on the "Basic Information" tab.
And when admin users view everyone's profile,  these three buttons should exist on every tab.
<img src="https://user-images.githubusercontent.com/55512434/171313195-fbccf198-476a-4e08-af17-b2a7f0825e92.png" width="400" >
<img src="https://user-images.githubusercontent.com/55512434/171313222-f66af418-a66c-483e-b683-4ef89e48ef1a.png" width="400" >