### PR TITLE
impl single task wbs page

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -23,6 +23,10 @@ const WBSTasks = (props) => {
   const wbsId = props.match.params.wbsId;
   const projectId = props.match.params.projectId;
   const wbsName = props.match.params.wbsName;
+  // when passing from management-dashboard, wbsName is the taskId of the single task
+  const taskId = props.match.params.wbsName;
+
+  const WBSItems = props.state.wbs.WBSItems;
   const [isShowImport, setIsShowImport] = useState(false);
 
   const [selectedId, setSelectedId] = useState(null);
@@ -149,6 +153,30 @@ const WBSTasks = (props) => {
 
   let filteredTasks = filterTasks(props.state.tasks.taskItems, filterState);
 
+  // looking for the single task object by its id which clicked on management-dashboard 
+  const filterTaskById = (allTaskItems, id) => {
+    return allTaskItems.filter((taskItem) => {
+      if (taskItem._id === id) {
+        return taskItem;
+      }
+    });
+  }
+  let filteredTaskById = filterTaskById(props.state.tasks.taskItems, taskId);
+  let singleTaskName = filteredTaskById[0]? filteredTaskById[0].taskName : "";
+  
+  // if showSingleTask is true, means showing the single task version WBS
+  // otherwise, showing the whole tasks on the WBS
+  let showSingleTask = true;
+  for (let wbsitem of WBSItems) {
+    if (wbsName === wbsitem.wbsName) {
+      showSingleTask = false;
+      break;
+    }
+  }
+  if (showSingleTask === true) {
+    filteredTasks = filteredTaskById
+  }
+
   return (
     <React.Fragment>
       <ReactTooltip />
@@ -160,8 +188,8 @@ const WBSTasks = (props) => {
                 <i className="fa fa-chevron-circle-left" aria-hidden="true"></i>
               </button>
             </NavItem>
-
-            <div id="member_project__name">{wbsName}</div>
+            {showSingleTask === false && <div id="member_project__name">{wbsName}</div>}
+            {showSingleTask === true && <div id="member_project__name">{singleTaskName}</div>}
           </ol>
         </nav>
 

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -293,7 +293,7 @@ const TeamMemberTasks = props => {
               <p key={`${task._id}${index}`}>
                 <Link
                   key={index}
-                  to={task.projectId ? `/wbs/tasks/${task.wbsId}/${task.projectId}` : '/'}
+                  to={task.projectId ? `/wbs/tasks/${task.wbsId}/${task.projectId}/${task._id}` : '/'}
                 >
                   <span>{`${task.num} ${task.taskName}`}</span>
                 </Link>

--- a/src/routes.js
+++ b/src/routes.js
@@ -73,6 +73,7 @@ export default (
       />
       <ProtectedRoute path="/project/wbs/:projectId" component={WBS} />
       <ProtectedRoute path="/wbs/tasks/:wbsId/:projectId" component={WBSDetail} />
+      <ProtectedRoute path="/wbs/tasks/:wbsId/:projectId/:taskId" component={WBSDetail} />
       <ProtectedRoute
         path="/usermanagement"
         exact


### PR DESCRIPTION
Implement clicking the task on dashboard, will lead to the pettier WBS page with only the task's details.
 
The below image is after clicking the "HGN Software Development" task from management-dashboard.
<img width="946" alt="image" src="https://user-images.githubusercontent.com/5071040/171745269-f8bd37f9-c4bd-4b6b-9a62-121d272be2c9.png">

**Note:**
**1. The left-up back button function is still need to be discussed
2. Now this PR only works for level-1 tasks on management-dashboard**

