### PR TITLE
Rearrange the bottom three button

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -591,40 +591,40 @@ const UserProfile = props => {
         <Row>
           <Col md="4"></Col>
           <Col md="8">
-            {hasPermission(requestorRole, 'resetPasswordOthers') && canEdit && !isUserSelf && (
-              <ResetPasswordButton className="mr-1" user={userProfile} />
-            )}
-            {isUserSelf && (activeTab == '1' || hasPermission(requestorRole, 'editUserProfile')) && (
-              <div className="profileEditButtonContainer">
+            <div className="profileEditButtonContainer">
+              {hasPermission(requestorRole, 'resetPasswordOthers') && canEdit && !isUserSelf && (
+                <ResetPasswordButton className="mr-1" user={userProfile} />
+              )}
+              {isUserSelf && (activeTab == '1' || hasPermission(requestorRole, 'editUserProfile')) && (
                 <Link to={`/updatepassword/${userProfile._id}`}>
                   <Button className="mr-1" color="primary">
                     {' '}
                     Update Password
                   </Button>
                 </Link>
-              </div>
-            )}
-            {canEdit && (activeTab == '1' || hasPermission(requestorRole, 'editUserProfile')) && (
-              <>
-                <span
-                  onClick={() => {
-                    setUserProfile(originalUserProfile);
-                    setChanged(false);
-                  }}
-                  className="btn btn-outline-danger mr-1"
-                >
-                  Cancel
-                </span>
-                <SaveButton
-                  className="mr-1"
-                  handleSubmit={handleSubmit}
-                  disabled={
-                    !formValid.firstName || !formValid.lastName || !formValid.email || !changed
-                  }
-                  userProfile={userProfile}
-                />
-              </>
-            )}
+              )}
+              {canEdit && (activeTab == '1' || hasPermission(requestorRole, 'editUserProfile')) && (
+                <>
+                  <span
+                    onClick={() => {
+                      setUserProfile(originalUserProfile);
+                      setChanged(false);
+                    }}
+                    className="btn btn-outline-danger mr-1"
+                  >
+                    Cancel
+                  </span>
+                  <SaveButton
+                    className="mr-1"
+                    handleSubmit={handleSubmit}
+                    disabled={
+                      !formValid.firstName || !formValid.lastName || !formValid.email || !changed
+                    }
+                    userProfile={userProfile}
+                  />
+                </>
+              )}
+            </div>
           </Col>
         </Row>
       </Container>

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -593,11 +593,11 @@ const UserProfile = props => {
           <Col md="8">
             <div className="profileEditButtonContainer">
               {hasPermission(requestorRole, 'resetPasswordOthers') && canEdit && !isUserSelf && (
-                <ResetPasswordButton className="mr-1" user={userProfile} />
+                <ResetPasswordButton className="mr-1 btn-bottom" user={userProfile} />
               )}
               {isUserSelf && (activeTab == '1' || hasPermission(requestorRole, 'editUserProfile')) && (
                 <Link to={`/updatepassword/${userProfile._id}`}>
-                  <Button className="mr-1" color="primary">
+                  <Button className="mr-1 btn-bottom" color="primary">
                     {' '}
                     Update Password
                   </Button>
@@ -605,23 +605,23 @@ const UserProfile = props => {
               )}
               {canEdit && (activeTab == '1' || hasPermission(requestorRole, 'editUserProfile')) && (
                 <>
-                  <span
-                    onClick={() => {
-                      setUserProfile(originalUserProfile);
-                      setChanged(false);
-                    }}
-                    className="btn btn-outline-danger mr-1"
-                  >
-                    Cancel
-                  </span>
                   <SaveButton
-                    className="mr-1"
+                    className="mr-1 btn-bottom"
                     handleSubmit={handleSubmit}
                     disabled={
                       !formValid.firstName || !formValid.lastName || !formValid.email || !changed
                     }
                     userProfile={userProfile}
                   />
+                  <span
+                    onClick={() => {
+                      setUserProfile(originalUserProfile);
+                      setChanged(false);
+                    }}
+                    className="btn btn-outline-danger mr-1 btn-bottom"
+                  >
+                    Cancel
+                  </span>
                 </>
               )}
             </div>

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -139,6 +139,11 @@
 //   justify-content: flex-end;
 // }
 
+.btn-bottom {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
 .profilePicture {
   width: 150px;
   height: 150px;


### PR DESCRIPTION
The PR change the layout of the bottom three buttons in user profile.
The followings are layouts according to different situations:
1. Login as owner/admin and look to other's profile.
[PC view]<img src="https://user-images.githubusercontent.com/55512434/171751326-25d8e3bf-fede-4464-84d9-27ea9c932da2.png" width="300">
[Phone view]<img src="https://user-images.githubusercontent.com/55512434/171751923-acb38947-f5a4-4a9d-8e47-7d128071e372.png" width="200">

2. Everyone looks to their own profile
[PC view]<img src="https://user-images.githubusercontent.com/55512434/171752066-a64f7196-c1e7-4a25-b2dd-ec0416a9b912.png" width="300">
[Phone view]<img src="https://user-images.githubusercontent.com/55512434/171752107-155bb737-6347-4cce-a9d8-bdaca705d0d4.png" width="200">
