### PR TITLE
give different users different views

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -25,6 +25,8 @@ const TeamMemberTasks = props => {
   const [taskNotificationModal, setTaskNotificationModal] = useState(false);
   const [currentTaskNotifications, setCurrentTaskNotifications] = useState([]);
 
+  const userRole = props.auth.user.role;
+
   const setTaskNotifications = taskNotifications => {
     setCurrentTaskNotifications(taskNotifications);
   };
@@ -272,7 +274,19 @@ const TeamMemberTasks = props => {
 
   let teamsList = [];
   if (teams && teams.length > 0) {
-    teamsList = teams.map((member, index) => (
+    // give different users different views
+    const filteredMembers = teams.filter(member => {
+      if (userRole === "Volunteer" || userRole === "Core Team") {
+        return member.role === "Volunteer" || member.role === "Core Team";
+      } else if (userRole === "Manager" || userRole === "Mentor") {
+        return member.role === "Volunteer" || member.role === "Core Team" || 
+        member.role === "Manager" || member.role === "Mentor";
+      } else {
+        return member;
+      }
+    })
+
+    teamsList = filteredMembers.map((member, index) => (
       <tr key={index}>
         {/* green if member has met committed hours for the week, red if not */}
         <td>


### PR DESCRIPTION
This PR is working for implement different views for different role users. 
More details:
- owner/admin can see all members in the system
- manager/mentor can see all members in the same teams as him
- volunteer/core team can see limited members(whose role is also volunteer or core team) in the same teams as him

Results see below images:
image 1 is the manager view, while image 2 is the volunteer view
<img width="455" alt="image" src="https://user-images.githubusercontent.com/5071040/172264167-3f3a0352-34cb-49b9-8b16-7a7cdb5d3a02.png">
<img width="451" alt="image" src="https://user-images.githubusercontent.com/5071040/172264412-5ef1f850-54c4-47e2-babc-0e96a62fed57.png">
