### PR TITLE
add scrollbar and change display order of blue squares

### DIFF
--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -29,7 +29,7 @@
 }
 
 .blueSquareContainer {
-  /* display: flex; */
+  display: flex;
   text-decoration: none;
   justify-content: center;
   /* margin: 10px; */
@@ -37,9 +37,11 @@
 
 .blueSquares {
   width: 100%;
+  max-height: 450px;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  overflow: auto;
   /* justify-content: center; */
 }
 

--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -37,7 +37,7 @@
 
 .blueSquares {
   width: 100%;
-  max-height: 450px;
+  max-height: 120px;
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import './BlueSquare.css';
 import hasPermission from 'utils/permissions';
 const BlueSquare = ({ blueSquares, handleBlueSquare, role }) => {
-  console.log(blueSquares);
   return (
     <div className="blueSquareContainer">
       <div className="blueSquares">

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -1,48 +1,59 @@
 import React from 'react';
 import './BlueSquare.css';
 import hasPermission from 'utils/permissions';
-
 const BlueSquare = ({ blueSquares, handleBlueSquare, role }) => {
+  console.log(blueSquares);
   return (
     <div className="blueSquareContainer">
       <div className="blueSquares">
-        {blueSquares.map((blueSquare, index) => (
+        {(hasPermission(role, 'editUserProfile') ||
+          hasPermission(role, 'assignOnlyBlueSquares')) && (
           <div
-            key={index}
-            role="button"
-            id="wrapper"
-            data-testid="blueSquare"
-            className="blueSquareButton"
             onClick={() => {
-              if (!blueSquare._id) {
-                handleBlueSquare(hasPermission(role, 'handleBlueSquare'), 'message', 'none');
-              } else if (hasPermission(role, 'handleBlueSquare')) {
-                handleBlueSquare(hasPermission(role, 'handleBlueSquare'), 'modBlueSquare', blueSquare._id);
-              } else {
-                handleBlueSquare(!hasPermission(role, 'handleBlueSquare'), 'viewBlueSquare', blueSquare._id);
-              }
+              handleBlueSquare(true, 'addBlueSquare', '');
             }}
+            className="blueSquareButton"
+            color="primary"
+            data-testid="addBlueSquare"
           >
-            <div className="report" data-testid="report">
-              <div className="title">{blueSquare.date}</div>
-              <div className="summary">{blueSquare.description}</div>
-            </div>
+            +
           </div>
-        ))}
+        )}
+        {blueSquares
+          .sort((bs1, bs2) => new Date(bs2.date) - new Date(bs1.date))
+          .map((blueSquare, index) => (
+            <div
+              key={index}
+              role="button"
+              id="wrapper"
+              data-testid="blueSquare"
+              className="blueSquareButton"
+              onClick={() => {
+                if (!blueSquare._id) {
+                  handleBlueSquare(hasPermission(role, 'handleBlueSquare'), 'message', 'none');
+                } else if (hasPermission(role, 'handleBlueSquare')) {
+                  handleBlueSquare(
+                    hasPermission(role, 'handleBlueSquare'),
+                    'modBlueSquare',
+                    blueSquare._id,
+                  );
+                } else {
+                  handleBlueSquare(
+                    !hasPermission(role, 'handleBlueSquare'),
+                    'viewBlueSquare',
+                    blueSquare._id,
+                  );
+                }
+              }}
+            >
+              <div className="report" data-testid="report">
+                <div className="title">{blueSquare.date}</div>
+                <div className="summary">{blueSquare.description}</div>
+              </div>
+            </div>
+          ))}
       </div>
 
-      {(hasPermission(role, 'editUserProfile') || hasPermission(role, 'assignOnlyBlueSquares'))  && (
-        <div
-          onClick={() => {
-            handleBlueSquare(true, 'addBlueSquare', '');
-          }}
-          className="blueSquareButton"
-          color="primary"
-          data-testid="addBlueSquare"
-        >
-          +
-        </div>
-      )}
       <br />
     </div>
   );


### PR DESCRIPTION
In this PR, I added a scrollbar to the blue square area and moved the "add blue square" button to the first place. Also, I reversed the order of the blue square. Now the newest one will show first. So, the admin can directly find/edit the newest blue square without scrolling to the very end.
![image](https://user-images.githubusercontent.com/55512434/172730234-314ab88a-ff9d-4f3b-8724-bca4b52cf829.png)
