### PR TITLE
make some tab non-editable to non-admin user

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -572,7 +572,7 @@ const UserProfile = props => {
                   setChanged={setChanged}
                   isUserSelf={isUserSelf}
                   role={requestorRole}
-                  canEdit={canEdit}
+                  canEdit={hasPermission(requestorRole, 'editUserProfile')}
                 />
               </TabPane>
               <TabPane tabId="3">
@@ -581,7 +581,7 @@ const UserProfile = props => {
                   teamsData={props?.allTeams?.allTeamsData || []}
                   onAssignTeam={onAssignTeam}
                   onDeleteteam={onDeleteTeam}
-                  edit={canEdit}
+                  edit={hasPermission(requestorRole, 'editUserProfile')}
                   role={requestorRole}
                 />
               </TabPane>
@@ -591,7 +591,7 @@ const UserProfile = props => {
                   projectsData={props?.allProjects?.projects || []}
                   onAssignProject={onAssignProject}
                   onDeleteProject={onDeleteProject}
-                  edit={canEdit}
+                  edit={hasPermission(requestorRole, 'editUserProfile')}
                   role={requestorRole}
                 />
               </TabPane>


### PR DESCRIPTION
In this PR, I made all tabs non-editable to the non-Admin users except the basic information tab in user profile.
This is an admin view of other's profile. All tabs are editable.
![Capture](https://user-images.githubusercontent.com/55512434/172733376-fe4cdcfe-1596-4650-bf74-1491a31ece31.JPG)


This is non-admin view of other's profile. All tabs are non-editable except Basic Information tab.
![image](https://user-images.githubusercontent.com/55512434/172733522-60de0140-bfa2-4be7-9d00-fe7934f6c1e9.png)
