### PR TITLE
revert the order and layout of blue squares

### DIFF
--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -29,19 +29,19 @@
 }
 
 .blueSquareContainer {
-  display: flex;
+  /* display: flex; */
   text-decoration: none;
   justify-content: center;
   /* margin: 10px; */
+  max-height: 120px;
+  overflow: auto;
 }
 
 .blueSquares {
   width: 100%;
-  max-height: 120px;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  overflow: auto;
   /* justify-content: center; */
 }
 

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -5,54 +5,50 @@ const BlueSquare = ({ blueSquares, handleBlueSquare, role }) => {
   return (
     <div className="blueSquareContainer">
       <div className="blueSquares">
-        {(hasPermission(role, 'editUserProfile') ||
-          hasPermission(role, 'assignOnlyBlueSquares')) && (
+        {blueSquares.map((blueSquare, index) => (
           <div
-            onClick={() => {
-              handleBlueSquare(true, 'addBlueSquare', '');
-            }}
+            key={index}
+            role="button"
+            id="wrapper"
+            data-testid="blueSquare"
             className="blueSquareButton"
-            color="primary"
-            data-testid="addBlueSquare"
+            onClick={() => {
+              if (!blueSquare._id) {
+                handleBlueSquare(hasPermission(role, 'handleBlueSquare'), 'message', 'none');
+              } else if (hasPermission(role, 'handleBlueSquare')) {
+                handleBlueSquare(
+                  hasPermission(role, 'handleBlueSquare'),
+                  'modBlueSquare',
+                  blueSquare._id,
+                );
+              } else {
+                handleBlueSquare(
+                  !hasPermission(role, 'handleBlueSquare'),
+                  'viewBlueSquare',
+                  blueSquare._id,
+                );
+              }
+            }}
           >
-            +
-          </div>
-        )}
-        {blueSquares
-          .sort((bs1, bs2) => new Date(bs2.date) - new Date(bs1.date))
-          .map((blueSquare, index) => (
-            <div
-              key={index}
-              role="button"
-              id="wrapper"
-              data-testid="blueSquare"
-              className="blueSquareButton"
-              onClick={() => {
-                if (!blueSquare._id) {
-                  handleBlueSquare(hasPermission(role, 'handleBlueSquare'), 'message', 'none');
-                } else if (hasPermission(role, 'handleBlueSquare')) {
-                  handleBlueSquare(
-                    hasPermission(role, 'handleBlueSquare'),
-                    'modBlueSquare',
-                    blueSquare._id,
-                  );
-                } else {
-                  handleBlueSquare(
-                    !hasPermission(role, 'handleBlueSquare'),
-                    'viewBlueSquare',
-                    blueSquare._id,
-                  );
-                }
-              }}
-            >
-              <div className="report" data-testid="report">
-                <div className="title">{blueSquare.date}</div>
-                <div className="summary">{blueSquare.description}</div>
-              </div>
+            <div className="report" data-testid="report">
+              <div className="title">{blueSquare.date}</div>
+              <div className="summary">{blueSquare.description}</div>
             </div>
-          ))}
+          </div>
+        ))}
       </div>
-
+      {(hasPermission(role, 'editUserProfile') || hasPermission(role, 'assignOnlyBlueSquares')) && (
+        <div
+          onClick={() => {
+            handleBlueSquare(true, 'addBlueSquare', '');
+          }}
+          className="blueSquareButton"
+          color="primary"
+          data-testid="addBlueSquare"
+        >
+          +
+        </div>
+      )}
       <br />
     </div>
   );


### PR DESCRIPTION
This PR reverts the order of blue squares to its original order(oldest to newest) and the add button is moved to the end of the section.
![image](https://user-images.githubusercontent.com/55512434/173261842-c2ac6636-7303-40ae-b722-bcd7252110bf.png)
