### PR TITLE
add tasks as options when log time

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -26,7 +26,7 @@ import AboutModal from './AboutModal';
 import TangibleInfoModal from './TangibleInfoModal';
 import ReminderModal from './ReminderModal';
 import axios from 'axios';
-import { ApiEndpoint } from '../../../utils/URL';
+import { ENDPOINTS } from '../../../utils/URL';
 import hasPermission from 'utils/permissions';
 import { getTimeEntryFormData } from './selectors';
 
@@ -102,20 +102,20 @@ const TimeEntryForm = (props) => {
 
   useEffect(() => {
     axios
-      .get(`${ApiEndpoint}/userprofile/${userId}`)
+      .get(ENDPOINTS.USER_PROFILE(userId))
       .then((res) => {
         setProjects(res?.data?.projects || []);
       })
-      .catch((err) => {});
+      .catch(err => console.log(err));
   }, []);
 
   useEffect(() => {
     axios
-      .get(`${ApiEndpoint}/tasks/userProfile?members=${userId}`)
+      .get(ENDPOINTS.TASKS_BY_USERID(userId))
       .then((res) => {
         setTasks(res?.data || []); 
       })
-      .catch((err) => {});
+      .catch(err => console.log(err));
   }, []);
 
   const openModal = () =>

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -74,6 +74,7 @@ const TimeEntryForm = (props) => {
   const [isTangibleInfoModalVisible, setTangibleInfoModalVisibleModalVisible] = useState(false);
   const [isInfoModalVisible, setInfoModalVisible] = useState(false);
   const [projects, setProjects] = useState([]);
+  const [tasks, setTasks] = useState([]);
 
   const fromTimer = !_.isEmpty(timer);
   const { userProfile, currentUserRole } = useSelector(getTimeEntryFormData);
@@ -108,6 +109,15 @@ const TimeEntryForm = (props) => {
       .catch((err) => {});
   }, []);
 
+  useEffect(() => {
+    axios
+      .get(`${ApiEndpoint}/tasks/userProfile?members=${userId}`)
+      .then((res) => {
+        setTasks(res?.data || []); 
+      })
+      .catch((err) => {});
+  }, []);
+
   const openModal = () =>
     setReminder((reminder) => ({
       ...reminder,
@@ -134,16 +144,24 @@ const TimeEntryForm = (props) => {
     setInputs({ ...inputs, ...timer });
   }, [timer]);
 
-  const projectOptions = projects.map((project) => (
+  const projectOrTaskOptions = projects.map((project) => (
     <option value={project._id} key={project._id}>
       {project.projectName}
     </option>
   ));
-  projectOptions.unshift(
+  projectOrTaskOptions.unshift(
     <option value="" key="none" disabled>
       Select Project/Task
     </option>,
   );
+
+  const taskOptions = tasks.map((task) => (
+    <option value={task._id} key={task._id}>
+      {task.taskName}
+    </option>
+  ));
+
+  projectOrTaskOptions.push(taskOptions)
 
   const getEditMessage = () => {
     let editCount = 0;
@@ -478,7 +496,7 @@ const TimeEntryForm = (props) => {
                 value={inputs.projectId}
                 onChange={handleInputChange}
               >
-                {projectOptions}
+                {projectOrTaskOptions}
               </Input>
               {'projectId' in errors && (
                 <div className="text-danger">

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -219,7 +219,7 @@ class Timelog extends Component {
     ));
     projectOptions.unshift(
       <option value="all" key="all">
-        All Projects (Default)
+        All Projects and Tasks (Default)
       </option>,
     );
 
@@ -484,7 +484,7 @@ class Timelog extends Component {
                       <Form inline className="mb-2">
                         <FormGroup>
                           <Label for="projectSelected" className="mr-1 ml-1 mb-1 align-top">
-                            Filter Entries by Project:
+                            Filter Entries by Project and Task:
                           </Label>
                           <Input
                             type="select"


### PR DESCRIPTION
Create the ability to log time for tasks (currently we can only log time for projects)
**This PR is the first part of changes for above feature, only UI changes. Backend/database changes and related "Time Log listing table" changes will come into next PR**.

The below images show log tangible/intangible time the popup table, they do have tasks assigned to current user as dropdown options
<img width="341" alt="image" src="https://user-images.githubusercontent.com/5071040/173686137-fceec79d-919c-45dd-9319-4660adb8e922.png">
<img width="360" alt="image" src="https://user-images.githubusercontent.com/5071040/173686600-9db7ea19-cf8a-4d08-8381-8f77a609d040.png">
