### PR TITLE
update opened week time entries after editing a time entry

### DIFF
--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -67,12 +67,12 @@ export const postTimeEntry = (timeEntry) => {
   };
 };
 
-export const editTimeEntry = (timeEntryId, timeEntry) => {
+export const editTimeEntry = (timeEntryId, timeEntry, oldDateOfWork) => {
   const url = ENDPOINTS.TIME_ENTRY_CHANGE(timeEntryId);
   return async (dispatch) => {
     try {
       const res = await axios.put(url, timeEntry);
-      dispatch(updateTimeEntries(timeEntry));
+      dispatch(updateTimeEntries(timeEntry, oldDateOfWork));
       return res.status;
     } catch (e) {
       return e.response.status;
@@ -93,11 +93,17 @@ export const deleteTimeEntry = (timeEntry) => {
   };
 };
 
-const updateTimeEntries = (timeEntry) => {
+const updateTimeEntries = (timeEntry, oldDateOfWork) => {
   const startOfWeek = moment().startOf('week');
-  const offset = Math.ceil(startOfWeek.diff(timeEntry.dateOfWork, 'week', true));
 
   return async (dispatch) => {
+    if (oldDateOfWork) {
+      const oldOffset = Math.ceil(startOfWeek.diff(oldDateOfWork, 'week', true));
+      dispatch(getTimeEntriesForWeek(timeEntry.personId, oldOffset));
+    }
+
+    const offset = Math.ceil(startOfWeek.diff(timeEntry.dateOfWork, 'week', true));
+
     if (offset <= 2 && offset >= 0) {
       dispatch(getTimeEntriesForWeek(timeEntry.personId, offset));
     }

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -255,7 +255,7 @@ const TimeEntryForm = (props) => {
 
     if (edit) {
       if (!reminder.notice) {
-        timeEntryStatus = await dispatch(editTimeEntry(data._id, timeEntry));
+        timeEntryStatus = await dispatch(editTimeEntry(data._id, timeEntry, data.dateOfWork));
       }
     } else {
       timeEntryStatus = await dispatch(postTimeEntry(timeEntry));


### PR DESCRIPTION
The PR fixes the bug that appears when you edit a time entry and change the date so the time entry must move to another week. 
The wrong behavior was that the edited time entry was moved to another week, but did not disappear from the edited week's entry list until the page was refreshed. Now it works without refreshing. 