### PR TITLE
Fix task placement and hours wrapping

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -325,7 +325,7 @@ const TeamMemberTasks = props => {
                 {member.tasks &&
                 member.tasks.map((task, index) => (
                 <tr key={`${task._id}${index}`} className='task-break'>
-                  <td>
+                  <td className='task-align'>
                     <p>
                       <Link
                         key={index}

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -314,7 +314,7 @@ const TeamMemberTasks = props => {
           <td>
             <Link to={`/userprofile/${member._id}`}>{`${member.firstName} ${member.lastName}`}</Link>
           </td>
-          <td>
+          <td className='team-clocks'>
             <u>{member.weeklyCommittedHours}</u> / 
             <font color="green"> {Math.round(totalHoursLogged)}</font> / 
             <font color="red"> {Math.round(totalHoursRemaining)}</font>
@@ -460,7 +460,7 @@ const TeamMemberTasks = props => {
               {/* Empty column header for hours completed icon */}
               <th />
               <th className='team-member-tasks-headers'>Team Member</th>
-              <th width="100px" className='team-member-tasks-headers'>
+              <th className='team-member-tasks-headers team-clocks team-clocks-header'>
                 <FontAwesomeIcon icon={faClock} title="Weekly Committed Hours" />
                 /
                 <FontAwesomeIcon

--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -26,3 +26,7 @@
 .task-break:last-of-type {
   border-bottom: none;
 } 
+
+.task-align {
+  text-align: left;
+}

--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -30,3 +30,13 @@
 .task-align {
   text-align: left;
 }
+
+.team-clocks {
+  display: flex;
+  justify-content: space-around;
+}
+
+.team-clocks-header {
+  height: 73.5px;
+  align-items: center;
+}


### PR DESCRIPTION
This PR is to fix some UI presentation issues related to the 'Team Member Tasks' table.

1. Alignment of task names - currently set to center. Set to left alignment.
![image](https://user-images.githubusercontent.com/19660966/177080966-a8b97f38-883d-4163-80ed-3d53a43e136e.png)


2. Red clock hours wrapping - red clock hours wrap if there are too many digits. Need hours not to wrap when having 3-digit hours for green and red clock. Since green clock hour functionality not currently in place yet, tested successfully using black and red clock with cumulative 9-digits total (4-black, 1-green, 4-red). Also aligned the clock to the relevant hours for each task.

Before:
![image](https://user-images.githubusercontent.com/19660966/177080877-71ce4fc3-aa36-4066-a898-f25950a4cda9.png)


After:
![image](https://user-images.githubusercontent.com/19660966/177080914-039952dd-0652-4954-9c79-a92584be1f98.png)


