### PR TITLE
Yiyun create single task component

### DIFF
--- a/src/components/Projects/WBS/SingleTask/SingleTask.js
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.js
@@ -1,11 +1,119 @@
+import React from "react";
+import { useState, useEffect } from "react";
+import ReactTooltip from "react-tooltip";
+import axios from 'axios';
+import { NavItem, Button } from "reactstrap";
+import { Link } from "react-router-dom";
+import { ENDPOINTS } from 'utils/URL';
 
 const SingleTask = (props) => {
   console.log("single task props is: ", props)
   const taskId = props.match.params.taskId;
   console.log("task id is: ", taskId)
 
-  return (
-    <p>Hello world</p>
+  const [task, setTask] = useState({});
+
+  useEffect(() => {
+    axios
+      .get(ENDPOINTS.GET_TASK(taskId))
+      .then((res) => {
+        setTask(res?.data || {})
+      })
+      .catch(err => console.log(err));
+  }, []);
+
+  console.log("get task is: ", task)
+
+  return ( 
+    <React.Fragment>
+      <ReactTooltip />
+      <div className="container-single-task">
+        <nav aria-label="breadcrumb">
+          <ol className="breadcrumb">
+            <NavItem tag={Link} to={`/project/wbs/{task.wbsId}`}>
+              <Button type="button" className="btn btn-secondary">
+                <i className="fa fa-chevron-circle-left" aria-hidden="true"></i>
+              </Button>
+            </NavItem>
+            <div id="single_task_name">{task.taskName}</div>
+          </ol>
+        </nav>
+
+        <table className="table table-bordered tasks-table">
+        <thead>
+          <tr>
+            <th scope="col" data-tip="task-num" colSpan="1">
+              #
+            </th>
+            <th scope="col" data-tip="Task Name" className="task-name">
+              Task Name
+            </th>
+            <th scope="col" data-tip="Priority">
+              <i className="fa fa-star" aria-hidden="true"></i>
+            </th>
+            <th className="desktop-view" scope="col" data-tip="Resources">
+              <i className="fa fa-users" aria-hidden="true"></i>
+            </th>
+            <th scope="col" data-tip="Assigned">
+              <i className="fa fa-user-circle-o" aria-hidden="true"></i>
+            </th>
+            <th className="desktop-view" scope="col" data-tip="Status">
+              <i className="fa fa-tasks" aria-hidden="true"></i>
+            </th>
+            <th className="desktop-view" scope="col" data-tip="Hours-Best">
+              <i className="fa fa-hourglass-start" aria-hidden="true"></i>
+            </th>
+            <th className="desktop-view" scope="col" data-tip="Hours-Worst">
+              <i className="fa fa-hourglass" aria-hidden="true"></i>
+            </th>
+            <th className="desktop-view" scope="col" data-tip="Hours-Most">
+              <i className="fa fa-hourglass-half" aria-hidden="true"></i>
+            </th>
+            <th className="desktop-view" scope="col" data-tip="Estimated Hours">
+              <i className="fa fa-clock-o" aria-hidden="true"></i>
+            </th>
+            <th className="desktop-view" scope="col" data-tip="Hours-Logged">
+            <i className="fa fa-clock-o" aria-hidden="true"></i>
+            </th>
+            <th className="desktop-view" scope="col" data-tip="Start Date">
+              <i className="fa fa-calendar-check-o" aria-hidden="true"></i> Start
+            </th>
+            <th className="desktop-view" scope="col" data-tip="Due Date">
+              <i className="fa fa-calendar-times-o" aria-hidden="true"></i> End
+            </th>
+            <th className="desktop-view" scope="col" data-tip="Links">
+              <i className="fa fa-link" aria-hidden="true"></i>
+            </th>
+            <th className="desktop-view" scope="col" data-tip="Details">
+              <i className="fa fa-question" aria-hidden="true"></i>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">{task.num}</th>
+            <td>{task.taskName}</td>
+            <td>{task.priority}</td>
+            <td>need more work</td>
+            <td>{task.isAssigned}</td>
+            <td>{task.isActive}</td>
+            <td>{task.hoursBest}</td>
+            <td>{task.hoursWorst}</td>
+            <td>{task.hoursMost}</td>
+            <td>{task.estimatedHours}</td>
+            <td>{task.hoursLogged}</td>
+            <td>{task.startedDatetime}</td>
+            <td>{task.dueDatetime}</td>
+            <td>{task.links}</td>
+            <td>need more work</td>
+          </tr>
+        </tbody>
+
+        </table>
+
+      </div>
+      
+    </React.Fragment>
   );
 
 }

--- a/src/components/Projects/WBS/SingleTask/SingleTask.js
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.js
@@ -9,10 +9,7 @@ import { Link } from "react-router-dom";
 import { ENDPOINTS } from 'utils/URL';
 
 const SingleTask = (props) => {
-  console.log("single task props is: ", props)
   const taskId = props.match.params.taskId;
-  console.log("task id is: ", taskId)
-
   const [task, setTask] = useState({});
   const [modal, setModal] = useState(false);
   const toggleModel = () => setModal(!modal);
@@ -25,8 +22,6 @@ const SingleTask = (props) => {
       })
       .catch(err => console.log(err));
   }, []);
-
-  console.log("get task is: ", task)
 
   return ( 
     <React.Fragment>
@@ -100,70 +95,36 @@ const SingleTask = (props) => {
               <td>{task.priority}</td>
               <td className="desktop-view">
                 {task.resources
-                  ? task.resources.map((elm, i) => {
-                    if (i < 2) {
-                      try {
-                        if (!elm.profilePic) {
-                          return (
-                            <a
-                              key={`res_${i}`}
-                              data-tip={elm.name}
-                              className="name"
-                              href={`/userprofile/${elm.userID}`}
-                              target="_blank"
-                            >
-                              <span className="dot">{elm.name.substring(0, 2)}</span>
-                            </a>
-                          );
-                        }
+                  ? task.resources.map((elem, i) => {
+                    try {
+                      if (elem.profilePic) {
                         return (
                           <a
                             key={`res_${i}`}
-                            data-tip={elm.name}
+                            data-tip={elem.name}
                             className="name"
-                            href={`/userprofile/${elm.userID}`}
+                            href={`/userprofile/${elem.userID}`}
                             target="_blank"
                           >
-                            <img className="img-circle" src={elm.profilePic} />
+                            <img className="img-circle" src={elem.profilePic} />
                           </a>
                         );
-                      } catch (err) {}
-                    }
-                  })
-                : null}
-
-                <div id={`res-${task.id}`} className="resourceMore">
-                  {task.resources
-                    ? task.resources.map((elm, i) => {
-                      if (i >= 2) {
-                        if (!elm.profilePic) {
-                          return (
-                            <a
-                              data-tip={elm.name}
-                              className="name"
-                              key={i}
-                              href={`/userprofile/${elm.userID}`}
-                              target="_blank"
-                            >
-                              <span className="dot">{elm.name.substring(0, 2)}</span>
-                            </a>
-                          );
-                        }
+                      } else {
                         return (
                           <a
-                            data-tip={elm.name}
+                            key={`res_${i}`}
+                            data-tip={elem.name}
                             className="name"
-                            key={i}
-                            href={`/userprofile/${elm.userID}`}
+                            href={`/userprofile/${elem.userID}`}
                             target="_blank"
                           >
-                            <img className="img-circle" src={elm.profilePic} />
+                            <span className="dot">{elem.name.substring(0, 2)}</span>
                           </a>
                         );
                       }
-                    })
-                    : null}
-                </div>
+                    } catch (err) {}
+                  })
+                : null}
               </td>
               <td>
                 {task.isAssigned ? (
@@ -176,8 +137,8 @@ const SingleTask = (props) => {
               <td>{task.hoursBest}</td>
               <td>{task.hoursWorst}</td>
               <td>{task.hoursMost}</td>
-              <td>{parseInt(task.estimatedHours).toFixed(2)}</td>
-              <td>{task.hoursLogged}</td>
+              <td>{parseFloat(task.estimatedHours).toFixed(2)}</td>
+              <td>{parseFloat(task.hoursLogged).toFixed(2)}</td>
               <td>{task.startedDatetime ? task.startedDatetime.slice(0,10) : "N/A" }</td>
               <td>{task.dueDatetime ? task.dueDatetime.slice(0,10) : "N/A"}</td>
               <td>{task.links}</td>

--- a/src/components/Projects/WBS/SingleTask/SingleTask.js
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.js
@@ -94,8 +94,8 @@ const SingleTask = (props) => {
               <td>{task.taskName}</td>
               <td>{task.priority}</td>
               <td className="desktop-view">
-                {task.resources
-                  ? task.resources.map((elem, i) => {
+                {task?.resources && 
+                  task.resources.map((elem, i) => {
                     try {
                       if (elem.profilePic) {
                         return (
@@ -124,7 +124,7 @@ const SingleTask = (props) => {
                       }
                     } catch (err) {}
                   })
-                : null}
+                }
               </td>
               <td>
                 {task.isAssigned ? (

--- a/src/components/Projects/WBS/SingleTask/SingleTask.js
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.js
@@ -3,6 +3,8 @@ import { useState, useEffect } from "react";
 import ReactTooltip from "react-tooltip";
 import axios from 'axios';
 import { NavItem, Button } from "reactstrap";
+import { Modal, ModalBody, } from 'reactstrap';
+import { Editor } from '@tinymce/tinymce-react';
 import { Link } from "react-router-dom";
 import { ENDPOINTS } from 'utils/URL';
 
@@ -12,6 +14,8 @@ const SingleTask = (props) => {
   console.log("task id is: ", taskId)
 
   const [task, setTask] = useState({});
+  const [modal, setModal] = useState(false);
+  const toggleModel = () => setModal(!modal);
 
   useEffect(() => {
     axios
@@ -40,78 +44,196 @@ const SingleTask = (props) => {
         </nav>
 
         <table className="table table-bordered tasks-table">
-        <thead>
-          <tr>
-            <th scope="col" data-tip="task-num" colSpan="1">
-              #
-            </th>
-            <th scope="col" data-tip="Task Name" className="task-name">
-              Task Name
-            </th>
-            <th scope="col" data-tip="Priority">
-              <i className="fa fa-star" aria-hidden="true"></i>
-            </th>
-            <th className="desktop-view" scope="col" data-tip="Resources">
-              <i className="fa fa-users" aria-hidden="true"></i>
-            </th>
-            <th scope="col" data-tip="Assigned">
-              <i className="fa fa-user-circle-o" aria-hidden="true"></i>
-            </th>
-            <th className="desktop-view" scope="col" data-tip="Status">
-              <i className="fa fa-tasks" aria-hidden="true"></i>
-            </th>
-            <th className="desktop-view" scope="col" data-tip="Hours-Best">
-              <i className="fa fa-hourglass-start" aria-hidden="true"></i>
-            </th>
-            <th className="desktop-view" scope="col" data-tip="Hours-Worst">
-              <i className="fa fa-hourglass" aria-hidden="true"></i>
-            </th>
-            <th className="desktop-view" scope="col" data-tip="Hours-Most">
-              <i className="fa fa-hourglass-half" aria-hidden="true"></i>
-            </th>
-            <th className="desktop-view" scope="col" data-tip="Estimated Hours">
-              <i className="fa fa-clock-o" aria-hidden="true"></i>
-            </th>
-            <th className="desktop-view" scope="col" data-tip="Hours-Logged">
-            <i className="fa fa-clock-o" aria-hidden="true"></i>
-            </th>
-            <th className="desktop-view" scope="col" data-tip="Start Date">
-              <i className="fa fa-calendar-check-o" aria-hidden="true"></i> Start
-            </th>
-            <th className="desktop-view" scope="col" data-tip="Due Date">
-              <i className="fa fa-calendar-times-o" aria-hidden="true"></i> End
-            </th>
-            <th className="desktop-view" scope="col" data-tip="Links">
-              <i className="fa fa-link" aria-hidden="true"></i>
-            </th>
-            <th className="desktop-view" scope="col" data-tip="Details">
-              <i className="fa fa-question" aria-hidden="true"></i>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{task.num}</th>
-            <td>{task.taskName}</td>
-            <td>{task.priority}</td>
-            <td>need more work</td>
-            <td>{task.isAssigned}</td>
-            <td>{task.isActive}</td>
-            <td>{task.hoursBest}</td>
-            <td>{task.hoursWorst}</td>
-            <td>{task.hoursMost}</td>
-            <td>{task.estimatedHours}</td>
-            <td>{task.hoursLogged}</td>
-            <td>{task.startedDatetime}</td>
-            <td>{task.dueDatetime}</td>
-            <td>{task.links}</td>
-            <td>need more work</td>
-          </tr>
-        </tbody>
+          <thead>
+            <tr>
+              <th scope="col" data-tip="task-num" colSpan="1">
+                #
+              </th>
+              <th scope="col" data-tip="Task Name" className="task-name">
+                Task Name
+              </th>
+              <th scope="col" data-tip="Priority">
+                <i className="fa fa-star" aria-hidden="true"></i>
+              </th>
+              <th className="desktop-view" scope="col" data-tip="Resources">
+                <i className="fa fa-users" aria-hidden="true"></i>
+              </th>
+              <th scope="col" data-tip="Assigned">
+                <i className="fa fa-user-circle-o" aria-hidden="true"></i>
+              </th>
+              <th className="desktop-view" scope="col" data-tip="Status">
+                <i className="fa fa-tasks" aria-hidden="true"></i>
+              </th>
+              <th className="desktop-view" scope="col" data-tip="Hours-Best">
+                <i className="fa fa-hourglass-start" aria-hidden="true"></i>
+              </th>
+              <th className="desktop-view" scope="col" data-tip="Hours-Worst">
+                <i className="fa fa-hourglass" aria-hidden="true"></i>
+              </th>
+              <th className="desktop-view" scope="col" data-tip="Hours-Most">
+                <i className="fa fa-hourglass-half" aria-hidden="true"></i>
+              </th>
+              <th className="desktop-view" scope="col" data-tip="Estimated Hours">
+                <i className="fa fa-clock-o" aria-hidden="true"></i>
+              </th>
+              <th className="desktop-view" scope="col" data-tip="Hours-Logged">
+              <i className="fa fa-hourglass-end" aria-hidden="true"></i>
+              </th>
+              <th className="desktop-view" scope="col" data-tip="Start Date">
+                <i className="fa fa-calendar-check-o" aria-hidden="true"></i> Start
+              </th>
+              <th className="desktop-view" scope="col" data-tip="Due Date">
+                <i className="fa fa-calendar-times-o" aria-hidden="true"></i> End
+              </th>
+              <th className="desktop-view" scope="col" data-tip="Links">
+                <i className="fa fa-link" aria-hidden="true"></i>
+              </th>
+              <th className="desktop-view" scope="col" data-tip="Details">
+                <i className="fa fa-question" aria-hidden="true"></i>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">{task.num}</th>
+              <td>{task.taskName}</td>
+              <td>{task.priority}</td>
+              <td className="desktop-view">
+                {task.resources
+                  ? task.resources.map((elm, i) => {
+                    if (i < 2) {
+                      try {
+                        if (!elm.profilePic) {
+                          return (
+                            <a
+                              key={`res_${i}`}
+                              data-tip={elm.name}
+                              className="name"
+                              href={`/userprofile/${elm.userID}`}
+                              target="_blank"
+                            >
+                              <span className="dot">{elm.name.substring(0, 2)}</span>
+                            </a>
+                          );
+                        }
+                        return (
+                          <a
+                            key={`res_${i}`}
+                            data-tip={elm.name}
+                            className="name"
+                            href={`/userprofile/${elm.userID}`}
+                            target="_blank"
+                          >
+                            <img className="img-circle" src={elm.profilePic} />
+                          </a>
+                        );
+                      } catch (err) {}
+                    }
+                  })
+                : null}
 
+                <div id={`res-${task.id}`} className="resourceMore">
+                  {task.resources
+                    ? task.resources.map((elm, i) => {
+                      if (i >= 2) {
+                        if (!elm.profilePic) {
+                          return (
+                            <a
+                              data-tip={elm.name}
+                              className="name"
+                              key={i}
+                              href={`/userprofile/${elm.userID}`}
+                              target="_blank"
+                            >
+                              <span className="dot">{elm.name.substring(0, 2)}</span>
+                            </a>
+                          );
+                        }
+                        return (
+                          <a
+                            data-tip={elm.name}
+                            className="name"
+                            key={i}
+                            href={`/userprofile/${elm.userID}`}
+                            target="_blank"
+                          >
+                            <img className="img-circle" src={elm.profilePic} />
+                          </a>
+                        );
+                      }
+                    })
+                    : null}
+                </div>
+              </td>
+              <td>
+                {task.isAssigned ? (
+                  <i data-tip="Assigned" className="fa fa-check-square" aria-hidden="true"></i>
+                ) : (
+                  <i data-tip="Not Assigned" className="fa fa-square-o" aria-hidden="true"></i>
+                )}
+              </td>
+              <td>{task.status}</td>
+              <td>{task.hoursBest}</td>
+              <td>{task.hoursWorst}</td>
+              <td>{task.hoursMost}</td>
+              <td>{parseInt(task.estimatedHours).toFixed(2)}</td>
+              <td>{task.hoursLogged}</td>
+              <td>{task.startedDatetime ? task.startedDatetime.slice(0,10) : "N/A" }</td>
+              <td>{task.dueDatetime ? task.dueDatetime.slice(0,10) : "N/A"}</td>
+              <td>{task.links}</td>
+              <td className="desktop-view" onClick={toggleModel}>
+                <i className="fa fa-book" aria-hidden="true"></i>
+              </td>
+            </tr>
+          </tbody>
         </table>
-
       </div>
+
+      <Modal isOpen={modal} toggle={toggleModel}>
+        <ModalBody>
+          <h6>WHY THIS TASK IS IMPORTANT:</h6>
+          <Editor
+            init={{
+              menubar: false,
+              toolbar: false,
+              branding: false,
+              min_height: 80,
+              max_height: 300,
+              autoresize_bottom_margin: 1,
+            }}
+            disabled={true}
+            value={task.whyInfo}
+          />
+
+          <h6>THE DESIGN INTENT:</h6>
+          <Editor
+            init={{
+              menubar: false,
+              toolbar: false,
+              branding: false,
+              min_height: 80,
+              max_height: 300,
+              autoresize_bottom_margin: 1,
+            }}
+            disabled={true}
+            value={task.intentInfo}
+          />
+
+          <h6>ENDSTATE:</h6>
+          <Editor
+            init={{
+              menubar: false,
+              toolbar: false,
+              branding: false,
+              min_height: 80,
+              max_height: 300,
+              autoresize_bottom_margin: 1,
+            }}
+            disabled={true}
+            value={task.endstateInfo}
+          />
+        </ModalBody>
+      </Modal>
       
     </React.Fragment>
   );

--- a/src/components/Projects/WBS/SingleTask/SingleTask.js
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.js
@@ -1,0 +1,13 @@
+
+const SingleTask = (props) => {
+  console.log("single task props is: ", props)
+  const taskId = props.match.params.taskId;
+  console.log("task id is: ", taskId)
+
+  return (
+    <p>Hello world</p>
+  );
+
+}
+
+export default SingleTask;

--- a/src/components/Projects/WBS/SingleTask/index.js
+++ b/src/components/Projects/WBS/SingleTask/index.js
@@ -1,0 +1,1 @@
+export { default } from './SingleTask';

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -16,7 +16,6 @@ import ReactTooltip from 'react-tooltip';
 import hasPermission from 'utils/permissions';
 
 const WBSTasks = (props) => {
-  console.log("WBStask props: ", props);
   // modal
   const [modal, setModal] = useState(false);
   const toggle = () => setModal(!modal);

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -24,12 +24,8 @@ const WBSTasks = (props) => {
   const wbsId = props.match.params.wbsId;
   const projectId = props.match.params.projectId;
   const wbsName = props.match.params.wbsName;
-  // when passing from management-dashboard, wbsName is the taskId of the single task
-  const taskId = props.match.params.wbsName;
 
-  const WBSItems = props.state.wbs.WBSItems;
   const [isShowImport, setIsShowImport] = useState(false);
-
   const [selectedId, setSelectedId] = useState(null);
   const [filterState, setFilterState] = useState('all');
 
@@ -154,30 +150,6 @@ const WBSTasks = (props) => {
 
   let filteredTasks = filterTasks(props.state.tasks.taskItems, filterState);
 
-  // looking for the single task object by its id which clicked on management-dashboard 
-  const filterTaskById = (allTaskItems, id) => {
-    return allTaskItems.filter((taskItem) => {
-      if (taskItem._id === id) {
-        return taskItem;
-      }
-    });
-  }
-  let filteredTaskById = filterTaskById(props.state.tasks.taskItems, taskId);
-  let singleTaskName = filteredTaskById[0]? filteredTaskById[0].taskName : "";
-  
-  // if showSingleTask is true, means showing the single task version WBS
-  // otherwise, showing the whole tasks on the WBS
-  let showSingleTask = true;
-  for (let wbsitem of WBSItems) {
-    if (wbsName === wbsitem.wbsName) {
-      showSingleTask = false;
-      break;
-    }
-  }
-  if (showSingleTask === true) {
-    filteredTasks = filteredTaskById
-  }
-
   return (
     <React.Fragment>
       <ReactTooltip />
@@ -189,8 +161,7 @@ const WBSTasks = (props) => {
                 <i className="fa fa-chevron-circle-left" aria-hidden="true"></i>
               </button>
             </NavItem>
-            {showSingleTask === false && <div id="member_project__name">{wbsName}</div>}
-            {showSingleTask === true && <div id="member_project__name">{singleTaskName}</div>}
+            <div id="member_project__name">{wbsName}</div>
           </ol>
         </nav>
 

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -16,6 +16,7 @@ import ReactTooltip from 'react-tooltip';
 import hasPermission from 'utils/permissions';
 
 const WBSTasks = (props) => {
+  console.log("WBStask props: ", props);
   // modal
   const [modal, setModal] = useState(false);
   const toggle = () => setModal(!modal);

--- a/src/components/Projects/WBS/wbs.jsx
+++ b/src/components/Projects/WBS/wbs.jsx
@@ -12,7 +12,6 @@ import AddWBS from './AddWBS';
 import WBSItem from './WBSItem/WBSItem';
 
 const WBS = (props) => {
-  console.log("WBS props is: ", props)
   const projectId = props.match.params.projectId;
 
   useEffect(() => {

--- a/src/components/Projects/WBS/wbs.jsx
+++ b/src/components/Projects/WBS/wbs.jsx
@@ -12,6 +12,7 @@ import AddWBS from './AddWBS';
 import WBSItem from './WBSItem/WBSItem';
 
 const WBS = (props) => {
+  console.log("WBS props is: ", props)
   const projectId = props.match.params.projectId;
 
   useEffect(() => {

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -122,7 +122,7 @@ const TeamMemberTasks = (props) => {
                   <tr key={`${task._id}${index}`} className='task-break'>
                     <td className='task-align'>
                       <p>
-                        <Link to={task.projectId ? `/wbs/tasks/${task.wbsId}/${task.projectId}/${task._id}` : '/'}>
+                        <Link to={task.projectId ? `/wbs/tasks/${task._id}` : '/'}>
                           <span>{`${task.num} ${task.taskName}`} </span>
                         </Link>
                         {

--- a/src/routes.js
+++ b/src/routes.js
@@ -18,6 +18,7 @@ import UserManagement from './components/UserManagement';
 import Members from './components/Projects/Members';
 import WBS from './components/Projects/WBS';
 import WBSDetail from './components/Projects/WBS/WBSDetail';
+import SingleTask from './components/Projects/WBS/SingleTask';
 import WeeklySummariesReport from './components/WeeklySummariesReport';
 import Admin from './components/Admin';
 import 'react-toastify/dist/ReactToastify.css';
@@ -73,7 +74,7 @@ export default (
       />
       <ProtectedRoute path="/project/wbs/:projectId" component={WBS} />
       <ProtectedRoute path="/wbs/tasks/:wbsId/:projectId" component={WBSDetail} />
-      <ProtectedRoute path="/wbs/tasks/:wbsId/:projectId/:taskId" component={WBSDetail} />
+      <ProtectedRoute path="/wbs/tasks/:taskId" component={SingleTask} />
       <ProtectedRoute
         path="/usermanagement"
         exact


### PR DESCRIPTION
This PR is implementing "click a task from Management-Dashboard would jump to its detail page".

This functionality was implemented for only level 1 tasks before by filtering the task from whole WBS tasks page. This PR is creating a new component called "SingleTask", which contains all needed detail info of a task. 
Take the "2.4 Finish Tree House Village Book Edits" assigned to "Jae Test" for example. See below images, the first one is before, second one is after.
<img width="944" alt="image" src="https://user-images.githubusercontent.com/5071040/183765531-91e14739-d7d4-40ee-ae67-08e64b2813e6.png">
<img width="956" alt="image" src="https://user-images.githubusercontent.com/5071040/183764130-c643f877-b1e7-4f5a-a962-da7e4a80b08a.png">

**Main changes of this PR:**
1. create "SingleTask" component and use it
2. revert the temporary implementation of showing task in `src/components/Projects/WBS/WBSDetail/WBSTasks.jsx`

**Note this PR is only for the jumping and showing details of task, below features are not included and will come in next PRs:**
1. Click the top left ◀️ button will jump a page contains all tasks in the same folder of current one
3. Admin/Owner users can directly edit this task or add a new task on "Single Task page" (still need to be discussed before implementing)