### PR TITLE
Fix tangible checkbox

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -80,7 +80,7 @@ const TimeEntryForm = (props) => {
   const { userProfile, currentUserRole } = useSelector(getTimeEntryFormData);
 
   const dispatch = useDispatch();
- 
+
   const tangibleInfoToggle = (e) => {
     e.preventDefault();
     setTangibleInfoModalVisibleModalVisible(!isTangibleInfoModalVisible);
@@ -113,7 +113,7 @@ const TimeEntryForm = (props) => {
     axios
       .get(ENDPOINTS.TASKS_BY_USERID(userId))
       .then((res) => {
-        setTasks(res?.data || []); 
+        setTasks(res?.data || []);
       })
       .catch(err => console.log(err));
   }, []);
@@ -381,8 +381,6 @@ const TimeEntryForm = (props) => {
     if (closed === true && isOpen) toggle();
   };
 
-  // console.log('isTangible', data.isTangible == inputs.isTangible);
-
   return (
     <>
       <TangibleInfoModal
@@ -406,25 +404,12 @@ const TimeEntryForm = (props) => {
         <ModalHeader toggle={toggle}>
           <div>
             {edit ? 'Edit ' : 'Add '}
-            {hasPermission(currentUserRole, 'adminLinks') ? (
-              inputs.isTangible ? (
-                <span style={{ color: 'blue' }}>Tangible </span>
-              ) : (
-                <span style={{ color: 'orange' }}>Intangible </span>
-              )
-              ) : (
-              inputs.isTangible ? (
-                <span style={{ color: 'blue' }}>Tangible </span>
-              ) : (
-                <span style={{ color: 'orange' }}>Intangible </span>
-              )
-              )}  
-              {/* {inputs.isTangible ? (
-                <span style={{ color: 'blue' }}>Tangible </span>
-              ) : (
-                <span style={{ color: 'orange' }}>Intangible </span>
-              )} */}
-              Time Entry <i
+            {inputs.isTangible ? (
+              <span style={{ color: 'blue' }}>Tangible </span>
+            ) : (
+              <span style={{ color: 'orange' }}>Intangible </span>
+            )}
+            Time Entry <i
               className="fa fa-info-circle"
               data-tip
               data-for="registerTip"

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -54,7 +54,8 @@ class Timelog extends Component {
     this.handleSearch = this.handleSearch.bind(this);
     this.openInfo = this.openInfo.bind(this);
     this.data = {
-      disabled: !hasPermission(this.props.auth.user.role, 'disabledDataTimelog') ? false : true
+      disabled: !hasPermission(this.props.auth.user.role, 'disabledDataTimelog') ? false : true,
+      isTangible: false,
     };
     this.userProfile = this.props.userProfile;
   }

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -54,8 +54,7 @@ class Timelog extends Component {
     this.handleSearch = this.handleSearch.bind(this);
     this.openInfo = this.openInfo.bind(this);
     this.data = {
-      disabled: !hasPermission(this.props.auth.user.role, 'disabledDataTimelog') ? false : true,
-      isTangible: hasPermission(this.props.auth.user.role, 'dataIsTangibleTimelog') ? true : false,
+      disabled: !hasPermission(this.props.auth.user.role, 'disabledDataTimelog') ? false : true
     };
     this.userProfile = this.props.userProfile;
   }
@@ -394,7 +393,6 @@ class Timelog extends Component {
                           toggle={this.toggle}
                           isOpen={this.state.modal}
                           userProfile={this.userProfile}
-                          isInTangible={true}
                         />
                         <ReactTooltip id="registerTip" place="bottom" effect="solid">
                           Click this icon to learn about the timelog.

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -1,5 +1,5 @@
 const permissions = {
-    'Administrator' : [
+    'Administrator': [
         'seeWeeklySummaryReports',
         'seeUserManagement',
         'seeBadgeManagement',
@@ -38,7 +38,6 @@ const permissions = {
         'editDeleteTeam',
         'handleBlueSquare',
         'resetPasswordOthers',
-        'dataIsTangibleTimelog',
         'toggleSubmitForm',
     ],
     'Volunteer': [
@@ -96,7 +95,6 @@ const permissions = {
         'seeUserProfileInProjects',
         'handleBlueSquare',
         'resetPasswordOthers',
-        'dataIsTangibleTimelog',
         'addDeleteEditOwners',
         'toggleSubmitForm',
     ],


### PR DESCRIPTION
When Intangible Time is logged by Admins/Owners, the “Tangible time” box was checked but should be unchecked by default. I deleted the `dataIsTangibleTimelog` permission because it isn't needed in any scenario.

![Screenshot_1](https://user-images.githubusercontent.com/22196381/184233560-4ee19d11-f5e2-4827-939d-643d26a61e2c.png)
 