### PR TITLE
Set final day button for front-end ui.

### DIFF
--- a/src/actions/userManagement.js
+++ b/src/actions/userManagement.js
@@ -7,8 +7,9 @@ import {
   USER_PROFILE_DELETE,
 } from '../constants/userManagement';
 import { ENDPOINTS } from '../utils/URL';
-import { UserStatus } from '../utils/enums';
+import { UserFinalDayStatus, UserStatus } from '../utils/enums';
 import moment from 'moment';
+
 
 /**
  * fetching all user profiles
@@ -32,9 +33,10 @@ export const getAllUserProfile = () => {
  * @param {*} user - the user to be updated
  * @param {*} status  - Active/InActive
  */
+
 export const updateUserStatus = (user, status, reactivationDate) => {
   const userProfile = Object.assign({}, user);
-  userProfile.isActive = status === UserStatus.Active;
+  userProfile.isActive = (status === UserStatus.Active);
   userProfile.reactivationDate = reactivationDate;
   const patchData = { status: status, reactivationDate: reactivationDate };
   if (status === UserStatus.InActive) {
@@ -44,14 +46,18 @@ export const updateUserStatus = (user, status, reactivationDate) => {
     patchData.endDate = undefined;
     userProfile.endDate = undefined;
   }
-
-  const updateProfilePromise = axios.patch(ENDPOINTS.USER_PROFILE(user._id), patchData);
+  const updateProfilePromise = axios.patch(ENDPOINTS.USER_PROFILE(user._id), patchData)
+  .then(function (response) {
+   return response.data})
+    .catch(function (error) {
+    console.log(error);});
   return async (dispatch) => {
     updateProfilePromise.then((res) => {
       dispatch(userProfileUpdateAction(userProfile));
     });
   };
 };
+
 
 /**
  * delete an existing user
@@ -125,4 +131,30 @@ export const userProfileDeleteAction = (user) => {
     type: USER_PROFILE_DELETE,
     user,
   };
+};
+/**
+ * update the user profile
+ * @param {*} user - the user to be updated
+ * @param {*} finalDate  - the date to be inactive
+ */
+export const updateUserFinalDayStatus = (user,status,finalDayDate) => {
+  const userProfile = Object.assign({}, user);
+  userProfile.endDate = finalDayDate;
+  userProfile.isActive = status === "Active";
+  const patchData = {status: status, endDate: finalDayDate}
+  if(finalDayDate == undefined){
+    patchData.endDate = undefined;
+    userProfile.endDate = undefined;
+  }else{
+    userProfile.endDate = moment(finalDayDate).format('YYYY-MM-DD');
+    patchData.endDate = moment(finalDayDate).format('YYYY-MM-DD');
+  }
+  const updateProfilePromise = axios.patch(ENDPOINTS.USER_PROFILE(user._id), patchData);
+  
+  return async (dispatch) => {
+    updateProfilePromise.then((res) => {
+      dispatch(userProfileUpdateAction(userProfile)); 
+    });
+  };
+  
 };

--- a/src/actions/userManagement.js
+++ b/src/actions/userManagement.js
@@ -7,9 +7,8 @@ import {
   USER_PROFILE_DELETE,
 } from '../constants/userManagement';
 import { ENDPOINTS } from '../utils/URL';
-import { UserFinalDayStatus, UserStatus } from '../utils/enums';
+import { UserStatus } from '../utils/enums';
 import moment from 'moment';
-
 
 /**
  * fetching all user profiles
@@ -33,7 +32,6 @@ export const getAllUserProfile = () => {
  * @param {*} user - the user to be updated
  * @param {*} status  - Active/InActive
  */
-
 export const updateUserStatus = (user, status, reactivationDate) => {
   const userProfile = Object.assign({}, user);
   userProfile.isActive = (status === UserStatus.Active);
@@ -46,18 +44,14 @@ export const updateUserStatus = (user, status, reactivationDate) => {
     patchData.endDate = undefined;
     userProfile.endDate = undefined;
   }
-  const updateProfilePromise = axios.patch(ENDPOINTS.USER_PROFILE(user._id), patchData)
-  .then(function (response) {
-   return response.data})
-    .catch(function (error) {
-    console.log(error);});
+
+  const updateProfilePromise = axios.patch(ENDPOINTS.USER_PROFILE(user._id), patchData);
   return async (dispatch) => {
     updateProfilePromise.then((res) => {
       dispatch(userProfileUpdateAction(userProfile));
     });
   };
 };
-
 
 /**
  * delete an existing user
@@ -132,29 +126,29 @@ export const userProfileDeleteAction = (user) => {
     user,
   };
 };
+
 /**
- * update the user profile
+ * update the user final day status
  * @param {*} user - the user to be updated
  * @param {*} finalDate  - the date to be inactive
  */
-export const updateUserFinalDayStatus = (user,status,finalDayDate) => {
+export const updateUserFinalDayStatus = (user, status, finalDayDate) => {
   const userProfile = Object.assign({}, user);
   userProfile.endDate = finalDayDate;
   userProfile.isActive = status === "Active";
-  const patchData = {status: status, endDate: finalDayDate}
-  if(finalDayDate == undefined){
+  const patchData = { status: status, endDate: finalDayDate };
+  if (finalDayDate === undefined) {
     patchData.endDate = undefined;
     userProfile.endDate = undefined;
-  }else{
+  }else {
     userProfile.endDate = moment(finalDayDate).format('YYYY-MM-DD');
     patchData.endDate = moment(finalDayDate).format('YYYY-MM-DD');
   }
+
   const updateProfilePromise = axios.patch(ENDPOINTS.USER_PROFILE(user._id), patchData);
-  
   return async (dispatch) => {
     updateProfilePromise.then((res) => {
       dispatch(userProfileUpdateAction(userProfile)); 
     });
   };
-  
 };

--- a/src/components/UserManagement/SetUpFinalDayButton.jsx
+++ b/src/components/UserManagement/SetUpFinalDayButton.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { Button } from 'reactstrap';
+import { SET_FINAL_DAY, CANCEL } from '../../languages/en/ui';
+import SetUpFinalDayPopUp from './SetUpFinalDayPopUp';
+import { updateUserFinalDayStatus } from 'actions/userManagement';
+import axios from 'axios';
+import { ENDPOINTS } from 'utils/URL';
+import { toast } from 'react-toastify';
+/**
+ * @param {*} props
+ * @param {Boolean} props.isBigBtn
+ * @param {*} props.userProfile.isSet
+ * @returns
+ */
+const SetUpFinalDayButton = (props) => {
+  const[isSet, setIsSet] = useState(false);  
+  const[finalDayDateOpen, setFinalDayDateOpen] = useState(false);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (props.userProfile?.endDate !== undefined)
+      setIsSet(true);
+  }, [setIsSet]);
+  
+  const onFinalDayClick = (user, status) => {
+    if(isSet){
+      updateUserFinalDayStatus(props.userProfile,"Active",undefined)(dispatch)
+      setIsSet(!isSet);
+      toast.success('Your Final Day has been set.');
+      window.location.reload();
+      
+    }else{
+      setFinalDayDateOpen(true);
+    }
+    
+  };
+  const setUpFinalDayPopupClose = () => {
+    setFinalDayDateOpen(false);
+  };
+    
+  const deactiveUser = (finalDayDate) => {
+    updateUserFinalDayStatus(props.userProfile, "Active", finalDayDate)(dispatch);
+    setIsSet(true);
+    setFinalDayDateOpen(false);
+    toast.success('Your Final Day has been deleted.');
+    window.location.reload();
+  }
+
+  return (
+    <React.Fragment>
+       <SetUpFinalDayPopUp
+        open={finalDayDateOpen}
+        onClose={setUpFinalDayPopupClose}
+        onSave={deactiveUser}
+      />
+      <Button
+        outline
+        color="primary"
+        className={`btn btn-outline-${isSet ? 'warning':'success'} ${
+          props.isBigBtn ? '' : 'btn-sm'
+        }  mr-1`}
+        onClick={(e) => {
+          onFinalDayClick(props.userProfile, isSet);
+        }}
+      >
+        {isSet ? CANCEL : SET_FINAL_DAY}
+      </Button>
+      
+    </React.Fragment>
+    
+  );
+};
+export default SetUpFinalDayButton;

--- a/src/components/UserManagement/SetUpFinalDayButton.jsx
+++ b/src/components/UserManagement/SetUpFinalDayButton.jsx
@@ -4,9 +4,8 @@ import { Button } from 'reactstrap';
 import { SET_FINAL_DAY, CANCEL } from '../../languages/en/ui';
 import SetUpFinalDayPopUp from './SetUpFinalDayPopUp';
 import { updateUserFinalDayStatus } from 'actions/userManagement';
-import axios from 'axios';
-import { ENDPOINTS } from 'utils/URL';
 import { toast } from 'react-toastify';
+
 /**
  * @param {*} props
  * @param {Boolean} props.isBigBtn
@@ -19,22 +18,20 @@ const SetUpFinalDayButton = (props) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (props.userProfile?.endDate !== undefined)
-      setIsSet(true);
-  }, [setIsSet]);
+    if (props.userProfile?.endDate !== undefined) setIsSet(true);
+  }, []);
   
   const onFinalDayClick = (user, status) => {
-    if(isSet){
+    if (isSet) {
       updateUserFinalDayStatus(props.userProfile,"Active",undefined)(dispatch)
       setIsSet(!isSet);
-      toast.success('Your Final Day has been set.');
-      window.location.reload();
-      
-    }else{
+      toast.success("This user's final day has been set.");
+      window.location.reload();      
+    } else {
       setFinalDayDateOpen(true);
-    }
-    
+    } 
   };
+
   const setUpFinalDayPopupClose = () => {
     setFinalDayDateOpen(false);
   };
@@ -43,13 +40,13 @@ const SetUpFinalDayButton = (props) => {
     updateUserFinalDayStatus(props.userProfile, "Active", finalDayDate)(dispatch);
     setIsSet(true);
     setFinalDayDateOpen(false);
-    toast.success('Your Final Day has been deleted.');
+    toast.success("This user's final day has been deleted.");
     window.location.reload();
-  }
+  };
 
   return (
     <React.Fragment>
-       <SetUpFinalDayPopUp
+      <SetUpFinalDayPopUp
         open={finalDayDateOpen}
         onClose={setUpFinalDayPopupClose}
         onSave={deactiveUser}
@@ -57,7 +54,7 @@ const SetUpFinalDayButton = (props) => {
       <Button
         outline
         color="primary"
-        className={`btn btn-outline-${isSet ? 'warning':'success'} ${
+        className={`btn btn-outline-${isSet ? 'warning' : 'success'} ${
           props.isBigBtn ? '' : 'btn-sm'
         }  mr-1`}
         onClick={(e) => {
@@ -65,10 +62,8 @@ const SetUpFinalDayButton = (props) => {
         }}
       >
         {isSet ? CANCEL : SET_FINAL_DAY}
-      </Button>
-      
-    </React.Fragment>
-    
+      </Button>  
+    </React.Fragment> 
   );
 };
 export default SetUpFinalDayButton;

--- a/src/components/UserManagement/SetUpFinalDayPopUp.jsx
+++ b/src/components/UserManagement/SetUpFinalDayPopUp.jsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { toast } from 'react-toastify';
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Input, Alert } from 'reactstrap';
+import store from 'store';
+
+/**
+ * Modal popup to show the user profile in create mode
+ */
+const SetUpFinalDayPopUp= React.memo((props) => {
+ 
+  const [finalDayDate, onDateChange] = useState(Date.now());
+  const [dateError, setDateError] = useState(false);
+
+  const closePopup = (e) => {
+    props.onClose();
+  };
+  const deactiveUser = () => {
+    if (Date.parse(finalDayDate) > Date.now()) {
+      props.onSave(finalDayDate);
+      //toast.success('Your Final Day has been set.');
+    } else {
+      setDateError(true);
+    }
+    
+  };
+
+  return (
+    <Modal isOpen={props.open} toggle={closePopup}>
+      <ModalHeader toggle={closePopup}>Set Your Final Day</ModalHeader>
+      <ModalBody>
+        <Input
+          type="date"
+          name="inactiveDate"
+          id="inactiveDate"
+          value={finalDayDate}
+          onChange={(event) => {
+            setDateError(false);
+            onDateChange(event.target.value);
+          }}
+          data-testid="date-input"
+        />
+        {dateError && <Alert color="danger">{'Please choose a future date.'}</Alert>}
+      </ModalBody>
+      <ModalFooter>
+        <Button color="primary" onClick={deactiveUser}>
+          Save 
+        </Button>
+        <Button color="secondary" onClick={closePopup}>
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+});
+
+export default SetUpFinalDayPopUp;

--- a/src/components/UserManagement/SetUpFinalDayPopUp.jsx
+++ b/src/components/UserManagement/SetUpFinalDayPopUp.jsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { toast } from 'react-toastify';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Input, Alert } from 'reactstrap';
-import store from 'store';
 
 /**
  * Modal popup to show the user profile in create mode
@@ -14,14 +12,13 @@ const SetUpFinalDayPopUp= React.memo((props) => {
   const closePopup = (e) => {
     props.onClose();
   };
+
   const deactiveUser = () => {
     if (Date.parse(finalDayDate) > Date.now()) {
       props.onSave(finalDayDate);
-      //toast.success('Your Final Day has been set.');
     } else {
       setDateError(true);
-    }
-    
+    } 
   };
 
   return (
@@ -52,5 +49,4 @@ const SetUpFinalDayPopUp= React.memo((props) => {
     </Modal>
   );
 });
-
 export default SetUpFinalDayPopUp;

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -5,13 +5,13 @@ import moment from 'moment';
 
 import PhoneInput from 'react-phone-input-2';
 import 'react-phone-input-2/lib/style.css';
-
 import PauseAndResumeButton from 'components/UserManagement/PauseAndResumeButton';
-
 import TimeZoneDropDown from '../TimeZoneDropDown';
 import { useSelector } from 'react-redux';
 import { getUserTimeZone } from 'services/timezoneApiService';
 import hasPermission from 'utils/permissions';
+import SetUpFinalDayButton from 'components/UserManagement/SetUpFinalDayButton';
+import ActiveCell from 'components/UserManagement/ActiveCell';
 
 const Name = props => {
   const {
@@ -563,6 +563,22 @@ const BasicInformationTab = (props) => {
           {canEdit && <PauseAndResumeButton isBigBtn={true} userProfile={userProfile} />}
         </Col>
       </Row>
+      <Row style={{ marginBottom: '10px' }}>
+        <Col>
+          <Label>
+            {
+            userProfile.endDate
+            ? 'End Date ' + moment(userProfile.endDate).format('YYYY-MM-DD')
+            : 'End Date '+ 'N/A'}
+            </Label>
+          
+        </Col>
+        <Col md="6">
+          {canEdit && <SetUpFinalDayButton isBigBtn={true} userProfile={userProfile} />}
+        </Col>
+      </Row >
+      
+      
     </div>
   );
 };

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Row, Label, Input, Col, FormFeedback, FormGroup, Button } from 'reactstrap';
 import ToggleSwitch from '../UserProfileEdit/ToggleSwitch';
 import moment from 'moment';
-
 import PhoneInput from 'react-phone-input-2';
 import 'react-phone-input-2/lib/style.css';
 import PauseAndResumeButton from 'components/UserManagement/PauseAndResumeButton';
@@ -11,7 +10,6 @@ import { useSelector } from 'react-redux';
 import { getUserTimeZone } from 'services/timezoneApiService';
 import hasPermission from 'utils/permissions';
 import SetUpFinalDayButton from 'components/UserManagement/SetUpFinalDayButton';
-import ActiveCell from 'components/UserManagement/ActiveCell';
 
 const Name = props => {
   const {

--- a/src/languages/en/ui.js
+++ b/src/languages/en/ui.js
@@ -46,3 +46,5 @@ export const TOTAL_TEAMS = 'Teams';
 export const ACTIVE_TEAMS = 'Active Teams';
 export const ADMIN = 'Admin';
 export const POPUP_MANAGEMENT = 'Popup Management';
+export const CANCEL = 'Delete Final Day';
+export const SET_FINAL_DAY = 'Set Final Day';


### PR DESCRIPTION
Task: 
create a button on the user profile page to set up the final day;

Current functions: 
1) After clicking the set final day button, it pops up a date picker(name setUpFinalDayPopUp), which is possible to select a final day.
2) The set final day button could be changed to deleted final day button if the user profile end date has been set; 
3) If click the delete the final day button, the user profile end date could be deleted, and the end date could become NA

About code:

Related component : 
1) BasicInformationTab->  2)SetUpFinalDayButton -> 3) SetUpFinalDayPopUp

Related action: 
userManagement.js (it uses Axios to patch endDate to REST API)

General logical about SetUpFinalDayButton : 
use react hook - 
1) useState(const[isSet, setIsSet]) to record if there is a final day set and
2) useState (const[finalDayDateOpen, setFinalDayDateOpen]) to control the SetUpFinalDayPopUp open or not; 

General logical about UserManager : 
it is related to controller - UserProfileController-change user status; 
React route : path="/userprofile/:userId" function :patch(controller.changeUserStatus);

For the next step: if reach out on the final day, the user will automatically change from active status to inactive and send an email to the admin to notify. 
