### PR TITLE
Fix to remove HTML tags and &nsbp; being displayed in red bell diff

### DIFF
--- a/src/components/TeamMemberTasks/components/TaskDifferenceModal.jsx
+++ b/src/components/TeamMemberTasks/components/TaskDifferenceModal.jsx
@@ -36,7 +36,8 @@ const trimParagraphTags = (str) => {
   if (str == null) {
     return "";
   }
-  return str.replace(/(<p[^>]+?>|<p>|<\/p>)/img, "");
+  const regex = /(<([^>]+)>)/ig;
+  return str.replace(regex, '').replace(/(<p[^>]+?>|<p>|<\/p>)/img, "").replace(/&nbsp;/g, '');
 }
 
 const datetimeToDate = (datetime) => {


### PR DESCRIPTION
Copy and pasting text would sometimes include HTML tags and nbsp in the text being displayed when clicking on the red bell to open the modal.