### PR TITLE
window reload

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -258,6 +258,7 @@ const EditTaskModal = (props) => {
 
     if (props.tasks.error === 'none') {
       toggle();
+      window.location.reload();
     }
   };
 


### PR DESCRIPTION
This PR is a quick fix when editing tasks, if the task updated successfully, the page (singleTaskPage or WBSwholeTasksPage) will refresh automatically.

How to test:
Choose the task from MD, click the "edit" button
Or Choose the task from projects-> wbs, click the "edit" button