### PR TITLE
Fix TimeZone problem for finalday and add a 5s notfication banner aft…

### DIFF
--- a/src/components/UserManagement/SetUpFinalDayButton.jsx
+++ b/src/components/UserManagement/SetUpFinalDayButton.jsx
@@ -25,8 +25,10 @@ const SetUpFinalDayButton = (props) => {
     if (isSet) {
       updateUserFinalDayStatus(props.userProfile,"Active",undefined)(dispatch)
       setIsSet(!isSet);
-      toast.success("This user's final day has been set.");
-      window.location.reload();      
+      toast.success("This user's final day has been delete.");
+      setTimeout(function(){
+        window.location.reload();
+     }, 5000);
     } else {
       setFinalDayDateOpen(true);
     } 
@@ -40,8 +42,10 @@ const SetUpFinalDayButton = (props) => {
     updateUserFinalDayStatus(props.userProfile, "Active", finalDayDate)(dispatch);
     setIsSet(true);
     setFinalDayDateOpen(false);
-    toast.success("This user's final day has been deleted.");
-    window.location.reload();
+    toast.success("This user's final day has been set.");
+    setTimeout(function(){
+      window.location.reload();
+   }, 5000);
   };
 
   return (

--- a/src/components/UserManagement/SetUpFinalDayPopUp.jsx
+++ b/src/components/UserManagement/SetUpFinalDayPopUp.jsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import React, { useState } from 'react';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Input, Alert } from 'reactstrap';
 
@@ -12,9 +13,9 @@ const SetUpFinalDayPopUp= React.memo((props) => {
   const closePopup = (e) => {
     props.onClose();
   };
-
+  
   const deactiveUser = () => {
-    if (Date.parse(finalDayDate) > Date.now()) {
+    if (moment().isBefore(moment(finalDayDate))) {
       props.onSave(finalDayDate);
     } else {
       setDateError(true);

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -566,7 +566,7 @@ const BasicInformationTab = (props) => {
           <Label>
             {
             userProfile.endDate
-            ? 'End Date ' + moment(userProfile.endDate).format('YYYY-MM-DD')
+            ? 'End Date ' + userProfile.endDate.toLocaleString().split('T')[0]
             : 'End Date '+ 'N/A'}
             </Label>
           


### PR DESCRIPTION
There are two goals for this PR:
1) Fix the bug for being unable to set a final day when the final day is tomorrow 
2) Create a 5 seconds notification banner when setting or deleting the final day:

Fix bug for unable to set a final day when the last day is tomorrow 

1) In the past, it could not set a final day tomorrow due to the different time zone. Therefore i use moment().isBefore(moment(finalDayDate) to keep time in the same time zone;

Another change for this PR is to give a notification banner when setting or deleting the final day:

It used to direct reload the page when clicking the saves button or delete button, but now I write a function with "toast" toast.success("This user's final day has been deleted.")/toast.success("This user's final day has been set.") to offer a 5 seconds notification - 
<img width="778" alt="Screen Shot 2022-09-14 at 10 09 25 PM" src="https://user-images.githubusercontent.com/108507783/190319638-43134a53-6e25-432c-9ca1-58c3d2b3c2ed.png">

