### PR TITLE
add condition for non tasks for current user

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -84,24 +84,28 @@ const TeamMemberTasks = props => {
 
       //find currentUser
       const currentUser = filteredMembers.find(user => user.personId === userId);
-      //conditional variable for moving current user up front.
-      let moveCurrentUserFront = false;
+      // if current user doesn't have any task, the currentUser cannot be found
 
-      console.log('filteredMembers', filteredMembers);
+      if (currentUser) {
+        //conditional variable for moving current user up front.
+        let moveCurrentUserFront = false;
 
-      //Does the user has at least one task with project Id and task id assigned. Then set the current user up front.
-      for (const task of currentUser.tasks) {
-        if (task.wbsId && task.projectId) {
-          moveCurrentUserFront = true;
-          break;
+        console.log('filteredMembers', filteredMembers);
+
+        //Does the user has at least one task with project Id and task id assigned. Then set the current user up front.
+        for (const task of currentUser.tasks) {
+          if (task.wbsId && task.projectId) {
+            moveCurrentUserFront = true;
+            break;
+          }
         }
-      }
-      //if needs to move current user up front, first remove current user from filterMembers. Then put the current user on top of the list.
-      if (moveCurrentUserFront) {
-        //removed currentUser
-        filteredMembers = filteredMembers.filter(user => user.personId !== userId);
-        //push currentUser on top of the array.
-        filteredMembers.unshift(currentUser);
+        //if needs to move current user up front, first remove current user from filterMembers. Then put the current user on top of the list.
+        if (moveCurrentUserFront) {
+          //removed currentUser
+          filteredMembers = filteredMembers.filter(user => user.personId !== userId);
+          //push currentUser on top of the array.
+          filteredMembers.unshift(currentUser);
+        }
       }
 
       teamsList = filteredMembers.map((user, index) => {


### PR DESCRIPTION
This PR is a fixing for the bug that "non Admin/Owner users cannot login on DEV/local successfully".

The below image is the problem description:
<img width="524" alt="image" src="https://user-images.githubusercontent.com/5071040/194164465-ee4784aa-d870-449a-8bfc-bf1cfe544233.png">

I found that problem came from the `src/components/TeamMemberTasks/TeamMemberTasks.jsx` file. If the the current user doesn't have any tasks, it would hit an error there. So I just add a condition to tell if the `currentUser` existed (new line 89).

**How to test it:**
1. check into my branch
2. test with login/logout with your admin/manager/volunteer accounts