### PR TITLE
Timelog shows correct time and week before last works

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -84,24 +84,28 @@ const TeamMemberTasks = props => {
 
       //find currentUser
       const currentUser = filteredMembers.find(user => user.personId === userId);
-      //conditional variable for moving current user up front.
-      let moveCurrentUserFront = false;
+      // if current user doesn't have any task, the currentUser cannot be found
 
-      console.log('filteredMembers', filteredMembers);
+      if (currentUser) {
+        //conditional variable for moving current user up front.
+        let moveCurrentUserFront = false;
 
-      //Does the user has at least one task with project Id and task id assigned. Then set the current user up front.
-      for (const task of currentUser.tasks) {
-        if (task.wbsId && task.projectId) {
-          moveCurrentUserFront = true;
-          break;
+        console.log('filteredMembers', filteredMembers);
+
+        //Does the user has at least one task with project Id and task id assigned. Then set the current user up front.
+        for (const task of currentUser.tasks) {
+          if (task.wbsId && task.projectId) {
+            moveCurrentUserFront = true;
+            break;
+          }
         }
-      }
-      //if needs to move current user up front, first remove current user from filterMembers. Then put the current user on top of the list.
-      if (moveCurrentUserFront) {
-        //removed currentUser
-        filteredMembers = filteredMembers.filter(user => user.personId !== userId);
-        //push currentUser on top of the array.
-        filteredMembers.unshift(currentUser);
+        //if needs to move current user up front, first remove current user from filterMembers. Then put the current user on top of the list.
+        if (moveCurrentUserFront) {
+          //removed currentUser
+          filteredMembers = filteredMembers.filter(user => user.personId !== userId);
+          //push currentUser on top of the array.
+          filteredMembers.unshift(currentUser);
+        }
       }
 
       teamsList = filteredMembers.map((user, index) => {

--- a/src/components/Timelog/EffortBar.jsx
+++ b/src/components/Timelog/EffortBar.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 const EffortBar = ({ activeTab, projectsSelected }) => {
   const data = useSelector(state =>
-    activeTab === 4 ? state.timeEntries.period : state.timeEntries.weeks[activeTab],
+    activeTab === 4 ? state.timeEntries.period : state.timeEntries.weeks[activeTab - 1],
   );
 
   const calculateTotalTime = (data, isTangible) => {


### PR DESCRIPTION
Hi,

I realize that I forget to adjust the data transferred to Effort Bar needs to be corrected. Previously there are 4 tabs, but however there are 5 tabs now and the first tab(tab 0) is the Tasks tab. Therefore all other tabs 1,2,3,4 used to be tabs 0,1,2,3. To adjust the change, I subtract -1 in timeEntries week as state.timeEntries.weeks[activeTab -1].

The week before last seems to be working now but please let me know if you can click on week before last with no errors
![Capture](https://user-images.githubusercontent.com/83194014/194332120-0492e5d4-16ca-43a1-a898-3e76b4db820e.PNG)
