### PR TITLE
Fixed to badges not updating immediately on the user profile screen when deleting or assigned badges.

### DIFF
--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -224,13 +224,18 @@ const BadgeReport = (props) => {
   };
 
   const saveChanges = async () => {
-    let newBadgeCollection = sortBadges.slice();
+    let newBadgeCollection = JSON.parse(JSON.stringify(sortBadges));  
     for (let i = 0; i < newBadgeCollection.length; i++) {
       newBadgeCollection[i].badge = newBadgeCollection[i].badge._id;
-    }
+    }  
     console.log(newBadgeCollection);
     await props.changeBadgesByUserID(props.userId, newBadgeCollection);
     await props.getUserProfile(props.userId);
+    
+    props.setUserProfile(prevProfile => {
+      return {...prevProfile, badgeCollection: sortBadges }
+    });
+    props.handleSubmit();
     //close the modal
     props.close();
     //Reload the view profile page with updated bages

--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -217,7 +217,10 @@ const BadgeReport = (props) => {
 
   const deleteBadge = () => {
     let newBadges = sortBadges.slice();
-    newBadges.splice(badgeToDelete, 1);
+    const deletedBadge = newBadges.splice(badgeToDelete, 1);  
+    if (deletedBadge[0].featured) {
+      setNumFeatured(--numFeatured);
+    } 
     setSortBadges(newBadges);
     setShowModal(false);
     setBadgeToDelete(null);

--- a/src/components/UserProfile/AssignBadgePopup.jsx
+++ b/src/components/UserProfile/AssignBadgePopup.jsx
@@ -28,6 +28,7 @@ const AssignBadgePopup = (props) => {
     } catch (e) {
       //TODO: Proper error handling.
     }
+    props.handleSubmit();
     props.close();
   };
 

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -60,6 +60,8 @@ const Badges = (props) => {
                   firstName={props.userProfile.firstName}
                   lastName={props.userProfile.lastName}
                   close={toggle}
+                  setUserProfile={props.setUserProfile}
+                  handleSubmit={props.handleSubmit}
                 />
               </ModalBody>
             </Modal>
@@ -82,7 +84,7 @@ const Badges = (props) => {
               </>
             )}
           </CardTitle>
-          <FeaturedBadges badges={props.userProfile.badgeCollection} />
+          <FeaturedBadges badges={props.userProfile.badgeCollection}  />
           <CardText
             style={{
               fontWeight: 'bold',

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -78,6 +78,7 @@ const Badges = (props) => {
                       userProfile={props.userProfile}
                       setUserProfile={props.setUserProfile}
                       close={assignToggle}
+                      handleSubmit={props.handleSubmit}
                     />
                   </ModalBody>
                 </Modal>

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -466,6 +466,7 @@ const UserProfile = props => {
               setUserProfile={setUserProfile}
               role={requestorRole}
               canEdit={canEdit}
+              handleSubmit={handleSubmit}
             />
           </Col>
         </Row>


### PR DESCRIPTION
Per bug request - fixed:
a: Badge doesn’t actually delete.

- On the Main it deleted, then came back. I was able to make them come back by using the “Assign Badges” button and assigning a badge. Then going back into the “Select Featured” and there all the deleted ones were.  
b: If I delete a badge that is checked, then try and select a new badge, I get the warning that says I can only select 5 badges 
c: Assigning badges also doesn’t save: Profile → Featured Badges → Assign Badges → Select → Save Changes_

- Badge list doesn’t update


