### PR TITLE
Cherrypick Eiki's Task Edit Suggestions Part 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12687,7 +12687,7 @@
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true
     },
     "lodash.memoize": {

--- a/src/components/TaskEditSuggestions/Components/TaskEditSuggestionRow.jsx
+++ b/src/components/TaskEditSuggestions/Components/TaskEditSuggestionRow.jsx
@@ -1,0 +1,14 @@
+import React, { useEffect, useState } from 'react';
+import { datetimeToDate } from 'components/TeamMemberTasks/components/TaskDifferenceModal';
+
+export const TaskEditSuggestionRow = ({taskEditSuggestion, handleToggleTaskEditSuggestionModal}) => {
+
+
+  return (
+    <tr onClick={() => handleToggleTaskEditSuggestionModal(taskEditSuggestion)}>
+      <td>{datetimeToDate(taskEditSuggestion.dateSuggested)}</td>
+      <td>{taskEditSuggestion.user}</td>
+      <td>{taskEditSuggestion.oldTask.taskName}</td>
+    </tr>
+  );
+}

--- a/src/components/TaskEditSuggestions/Components/TaskEditSuggestionsModal.jsx
+++ b/src/components/TaskEditSuggestions/Components/TaskEditSuggestionsModal.jsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { Modal, ModalHeader, ModalBody, ModalFooter, Row, Col, Button  } from 'reactstrap';
+import { resourcesToString, booleanToString, numberToString, arrayToString, trimParagraphTags, datetimeToDate } from "components/TeamMemberTasks/components/TaskDifferenceModal";
+import DiffedText from 'components/TeamMemberTasks/components/DiffedText';
+
+export const TaskEditSuggestionsModal = ({isTaskEditSuggestionModalOpen, taskEditSuggestion, handleToggleTaskEditSuggestionModal}) => {
+  return (
+    <Modal size="xl" isOpen={isTaskEditSuggestionModalOpen} toggle={() => handleToggleTaskEditSuggestionModal()}>
+    <ModalHeader toggle={() => handleToggleTaskEditSuggestionModal()}>Suggested Changes</ModalHeader>
+    <ModalBody>
+      {
+        taskEditSuggestion &&
+        <div style={{textAlign: 'center'}}>
+        <div>
+            <span style={ {color: 'black', fontWeight: 'bold'} }>Black Bold = No Changes</span>
+            <span style={ {color: 'red', textDecorationLine: 'line-through', marginLeft: '30px'} }>Red Strikethrough = Deleted</span>
+            <span style={ {color: 'green', marginLeft: '30px'} }>Green = Added</span>
+          </div>
+          <table className="table table-bordered">
+            <tbody>
+              <tr>
+                <td scope="col" data-tip="WBS ID">
+                  WBS #
+                </td>
+                <td scope="col">{taskEditSuggestion.oldTask.num}</td>
+              </tr>
+              <tr>
+                <td scope="col">Task Name</td>
+                <td scope="col">
+                  <DiffedText oldText={taskEditSuggestion.oldTask.taskName} newText={taskEditSuggestion.newTask.taskName}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col">Priority</td>
+                <td scope="col">
+                <DiffedText oldText={taskEditSuggestion.oldTask.priority} newText={taskEditSuggestion.newTask.priority}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col">Resources</td>
+                <td scope="col">
+                  <DiffedText oldText={resourcesToString(taskEditSuggestion.oldTask.resources)} newText={resourcesToString(taskEditSuggestion.newTask.resources)}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col">Assigned</td>
+                <td scope="col">
+                  <DiffedText oldText={booleanToString(taskEditSuggestion.oldTask.isAssigned)} newText={booleanToString(taskEditSuggestion.newTask.isAssigned)}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col">Status</td>
+                <td scope="col">
+                  <DiffedText oldText={taskEditSuggestion.oldTask.status} newText={taskEditSuggestion.newTask.status}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col" data-tip="Hours - Best-case">
+                  Hours - Best-case
+                </td>
+                <td scope="col" data-tip="Hours - Best-case">
+                  <DiffedText oldText={numberToString(taskEditSuggestion.oldTask.hoursBest)} newText={numberToString(taskEditSuggestion.newTask.hoursBest)}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col" data-tip="Hours - Worst-case">
+                  Hours - Worst-case
+                </td>
+                <td scope="col" data-tip="Hours - Worst-case">
+                  <DiffedText oldText={numberToString(taskEditSuggestion.oldTask.hoursWorst)} newText={numberToString(taskEditSuggestion.newTask.hoursWorst)}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col" data-tip="Hours - Most-case">
+                  Hours - Most-case
+                </td>
+                <td scope="col" data-tip="Hours - Most-case">
+                  <DiffedText oldText={numberToString(taskEditSuggestion.oldTask.hoursMost)} newText={numberToString(taskEditSuggestion.newTask.hoursMost)}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col" data-tip="Estimated Hours">
+                  Estimated Hours
+                </td>
+                <td scope="col" data-tip="Estimated Hours">
+                  <DiffedText oldText={numberToString(taskEditSuggestion.oldTask.estimatedHours)} newText={numberToString(taskEditSuggestion.newTask.estimatedHours)}/>
+                </td>
+              </tr>
+
+              <tr>
+                <td scope="col">Links</td>
+                <td scope="col">
+                  <DiffedText oldText={arrayToString(taskEditSuggestion.oldTask.links)} newText={arrayToString(taskEditSuggestion.newTask.links)}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col">Classification</td>
+                <td scope="col">
+                  <DiffedText oldText={taskEditSuggestion.oldTask.classification} newText={taskEditSuggestion.newTask.classification}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col">
+                  Why this Task is Important
+                </td>
+                <td>
+                  <DiffedText oldText={trimParagraphTags(taskEditSuggestion.oldTask.whyInfo)} newText={trimParagraphTags(taskEditSuggestion.newTask.whyInfo)}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col">
+                  Design Intent
+                </td>
+                <td>
+                  <DiffedText oldText={trimParagraphTags(taskEditSuggestion.oldTask.intentInfo)} newText={trimParagraphTags(taskEditSuggestion.newTask.intentInfo)}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col">
+                  Endstate
+                </td>
+                <td>
+                  <DiffedText oldText={trimParagraphTags(taskEditSuggestion.oldTask.endstateInfo)} newText={trimParagraphTags(taskEditSuggestion.newTask.endstateInfo)}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col">Start Date</td>
+                <td scope="col">
+                  <DiffedText oldText={datetimeToDate(taskEditSuggestion.oldTask.startedDatetime)} newText={datetimeToDate(taskEditSuggestion.newTask.startedDatetime)}/>
+                </td>
+              </tr>
+              <tr>
+                <td scope="col">End Date</td>
+                <td scope="col">
+                  <DiffedText oldText={datetimeToDate(taskEditSuggestion.oldTask.dueDatetime)} newText={datetimeToDate(taskEditSuggestion.newTask.dueDatetime)}/>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      }
+    </ModalBody>
+    <ModalFooter>
+      <Row>
+        <Col>
+          <Button color="success">Approve</Button>
+        </Col>
+        <Col style={{display: "flex"}}>
+          <Button color="danger" style={{marginLeft: "auto"}}>Reject</Button>
+        </Col>
+      </Row>
+    </ModalFooter>
+  </Modal>
+  );
+}

--- a/src/components/TaskEditSuggestions/TaskEditSuggestions.jsx
+++ b/src/components/TaskEditSuggestions/TaskEditSuggestions.jsx
@@ -1,0 +1,319 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Table } from 'reactstrap';
+import { TaskEditSuggestionRow } from './Components/TaskEditSuggestionRow';
+import { TaskEditSuggestionsModal } from './Components/TaskEditSuggestionsModal';
+
+const taskEditSuggestionsInitial = [
+  {
+    _id: 1,
+    user: "EK Example",
+    dateSuggested: "2022-07-12T16:25:26.837Z",
+    newTask: {
+			_id:"62c9b82d11575257acb95f5f",
+			taskId:"62a382a44ee5b0299c5ff212",
+			userId:"627985bfe2896b87a47b99aa",
+			__v:0,
+			dateCreated:"2022-07-09T16:25:26.837Z",
+			isAcknowleged:0,
+			priority:"Primary",
+			isAssigned:true,
+			status:"Started",
+			hoursBest:0,
+			hoursWorst:0,
+			hoursMost:0,
+			estimatedHours:0,
+			links:null,
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        }
+      ],
+			taskName:"EK Example Task 1",
+			startedDatetime:null,
+			dueDatetime:null,
+			whyInfo:"",
+			intentInfo:"",
+			endstateInfo:"",
+			classification:"",
+    },
+    oldTask: {
+      _id:"62a382a44ee5b0299c5ff212",
+      priority:"Primary",
+      isAssigned:true,
+      status:"Started",
+      hoursBest:0,
+      hoursWorst:0,
+      hoursMost:0,
+      estimatedHours:0,
+      links:null,
+      parentId1:null,
+      parentId2:null,
+      parentId3:null,
+      mother:null,
+      isActive:true,
+      hasChild:false,
+      modifiedDatetime:"2022-07-09T17:17:33.649Z",
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        },
+        {
+          _id:"62c9b82d11575257acb95f5c",
+          userID:"62798679e2896b87a47b99bd",
+          name:"EK Admin",
+        },
+      ],
+      wbsId:"62799b53f8ff455aec1737a9",
+      taskName:"Red Bell Test 13",
+      num:"25",
+      level:1,
+      startedDatetime:null,
+      dueDatetime:null,
+      position:24,
+      createdDatetime:"2022-06-10T17:43:00.009Z",
+      whyInfo:"",
+      intentInfo:"",
+      endstateInfo:"",
+      classification:"",
+    }
+  },
+  {
+    _id: 2,
+    user: "EK Example",
+    dateSuggested: "2022-07-11T16:25:26.837Z",
+    newTask: {
+			_id:"62c9b82d11575257acb95f5f",
+			taskId:"62a382a44ee5b0299c5ff212",
+			userId:"627985bfe2896b87a47b99aa",
+			__v:0,
+			dateCreated:"2022-07-09T16:25:26.837Z",
+			isAcknowleged:0,
+			priority:"Primary",
+			isAssigned:true,
+			status:"Started",
+			hoursBest:0,
+			hoursWorst:0,
+			hoursMost:0,
+			estimatedHours:0,
+			links:null,
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        }
+      ],
+			taskName:"EK Example Task 2",
+			startedDatetime:null,
+			dueDatetime:null,
+			whyInfo:"",
+			intentInfo:"",
+			endstateInfo:"",
+			classification:"",
+    },
+    oldTask: {
+      _id:"62a382a44ee5b0299c5ff212",
+      priority:"Primary",
+      isAssigned:true,
+      status:"Started",
+      hoursBest:0,
+      hoursWorst:0,
+      hoursMost:0,
+      estimatedHours:0,
+      links:null,
+      parentId1:null,
+      parentId2:null,
+      parentId3:null,
+      mother:null,
+      isActive:true,
+      hasChild:false,
+      modifiedDatetime:"2022-07-09T17:17:33.649Z",
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        },
+        {
+          _id:"62c9b82d11575257acb95f5c",
+          userID:"62798679e2896b87a47b99bd",
+          name:"EK Admin",
+        },
+      ],
+      wbsId:"62799b53f8ff455aec1737a9",
+      taskName:"Red Bell Test 13",
+      num:"25",
+      level:1,
+      startedDatetime:null,
+      dueDatetime:null,
+      position:24,
+      createdDatetime:"2022-06-10T17:43:00.009Z",
+      whyInfo:"",
+      intentInfo:"",
+      endstateInfo:"",
+      classification:"",
+    }
+  },
+  {
+    _id: 3,
+    user: "AAA",
+    dateSuggested: "2022-07-10T16:25:26.837Z",
+    newTask: {
+			_id:"62c9b82d11575257acb95f5f",
+			taskId:"62a382a44ee5b0299c5ff212",
+			userId:"627985bfe2896b87a47b99aa",
+			__v:0,
+			dateCreated:"2022-07-09T16:25:26.837Z",
+			isAcknowleged:0,
+			priority:"Primary",
+			isAssigned:true,
+			status:"Started",
+			hoursBest:0,
+			hoursWorst:0,
+			hoursMost:0,
+			estimatedHours:0,
+			links:null,
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        }
+      ],
+			taskName:"AAA Task 1",
+			startedDatetime:null,
+			dueDatetime:null,
+			whyInfo:"",
+			intentInfo:"",
+			endstateInfo:"",
+			classification:"",
+    },
+    oldTask: {
+      _id:"62a382a44ee5b0299c5ff212",
+      priority:"Primary",
+      isAssigned:true,
+      status:"Started",
+      hoursBest:0,
+      hoursWorst:0,
+      hoursMost:0,
+      estimatedHours:0,
+      links:null,
+      parentId1:null,
+      parentId2:null,
+      parentId3:null,
+      mother:null,
+      isActive:true,
+      hasChild:false,
+      modifiedDatetime:"2022-07-09T17:17:33.649Z",
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        },
+        {
+          _id:"62c9b82d11575257acb95f5c",
+          userID:"62798679e2896b87a47b99bd",
+          name:"EK Admin",
+        },
+      ],
+      wbsId:"62799b53f8ff455aec1737a9",
+      taskName:"Red Bell Test 13",
+      num:"25",
+      level:1,
+      startedDatetime:null,
+      dueDatetime:null,
+      position:24,
+      createdDatetime:"2022-06-10T17:43:00.009Z",
+      whyInfo:"",
+      intentInfo:"",
+      endstateInfo:"",
+      classification:"",
+    }
+  },
+];
+
+export const TaskEditSuggestions = () => {
+
+  const[taskEditSuggestions, setTaskEditSuggestions] = useState([]);
+  const [isTaskEditSuggestionModalOpen, setIsTaskEditSuggestionModalOpen] = useState(false);
+  const [currentTaskEditSuggestion, setCurrentTaskEditSuggestion] = useState();
+  
+  const [userSortDirection, setUserSortDirection] = useState();
+  const [dateSuggestedSortDirection, setDateSuggestedSortDirection] = useState("desc");
+
+  useEffect(() => setTaskEditSuggestions(taskEditSuggestionsInitial.sort((tes1, tes2) => tes2.dateSuggested.localeCompare(tes1.dateSuggested))), []);
+
+  const handleToggleTaskEditSuggestionModal = (currentTaskEditSuggestion) => {
+    setCurrentTaskEditSuggestion(currentTaskEditSuggestion);
+    setIsTaskEditSuggestionModalOpen(!isTaskEditSuggestionModalOpen);
+  };
+
+  const SortArrow = ({sortDirection}) => {
+    if (sortDirection === "asc") {
+      return <i class="fa fa-arrow-up"></i>;
+    } else if (sortDirection === "desc") {
+      return <i class="fa fa-arrow-down"></i>;
+    } else {
+      return <></>;
+    }
+  };
+
+  const toggleDateSuggestedSortDirection = () => {
+    setUserSortDirection();
+    if (dateSuggestedSortDirection == null || dateSuggestedSortDirection == "asc") {
+      setTaskEditSuggestions([...taskEditSuggestions].sort((tes1, tes2) => tes2.dateSuggested.localeCompare(tes1.dateSuggested)));
+      setDateSuggestedSortDirection("desc");
+    } else if (dateSuggestedSortDirection == "desc") {
+      setTaskEditSuggestions([...taskEditSuggestions].sort((tes1, tes2) => tes1.dateSuggested.localeCompare(tes2.dateSuggested)));
+      setDateSuggestedSortDirection("asc");
+    }
+  };
+
+  const toggleUserSortDirection = () => {
+    setDateSuggestedSortDirection();
+    if (userSortDirection == null || userSortDirection == "asc") {
+      setTaskEditSuggestions([...taskEditSuggestions].sort((tes1, tes2) => tes1.user.localeCompare(tes2.user)));
+      setUserSortDirection("desc");
+    } else if (userSortDirection == "desc") {
+      setTaskEditSuggestions([...taskEditSuggestions].sort((tes1, tes2) => tes2.user.localeCompare(tes1.user)));
+      setUserSortDirection("asc");
+    }
+  };
+
+  return (
+    <Container>
+      <h1>Task Edit Suggestions</h1>
+      <Table>
+        <thead>
+          <tr>
+            <th onClick={toggleDateSuggestedSortDirection}>Date Suggested <SortArrow sortDirection={dateSuggestedSortDirection}/></th>
+            <th onClick={toggleUserSortDirection}>User <SortArrow sortDirection={userSortDirection}/></th>
+            <th>Task</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            taskEditSuggestions.map((taskEditSuggestion) => 
+            <TaskEditSuggestionRow
+              key={taskEditSuggestion._id}
+              taskEditSuggestion={taskEditSuggestion}
+              handleToggleTaskEditSuggestionModal={handleToggleTaskEditSuggestionModal}
+            />)
+          }
+        </tbody>
+      </Table>
+      <TaskEditSuggestionsModal 
+        isTaskEditSuggestionModalOpen={isTaskEditSuggestionModalOpen}
+        taskEditSuggestion={currentTaskEditSuggestion}
+        handleToggleTaskEditSuggestionModal={handleToggleTaskEditSuggestionModal}
+        // onApprove={handleTaskNotificationRead}
+        // loggedInUserId={props.auth.user.userid}
+      />
+    </Container>
+  );
+}

--- a/src/components/TaskEditSuggestions/actions.js
+++ b/src/components/TaskEditSuggestions/actions.js
@@ -1,0 +1,5 @@
+import { createAction } from "redux-actions";
+
+export const fetchTaskEditSuggestionsBegin = createAction("FETCH_TASK_EDIT_SUGGESTIONS_BEGIN");
+export const fetchTaskEditSuggestionsSuccess = createAction("FETCH_TASK_EDIT_SUGGESTIONS_SUCESS");
+export const fetchTaskEditSuggestionsError = createAction("FETCH_TASK_EDIT_SUGGESTIONS_ERROR");

--- a/src/components/TaskEditSuggestions/reducer.js
+++ b/src/components/TaskEditSuggestions/reducer.js
@@ -1,0 +1,253 @@
+
+const initialState = {
+  isLoading: false,
+  taskEditSuggestions: taskEditSuggestionsInitial, // TODO: change to []
+};
+
+export const taskEditSuggestionsReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case "FETCH_TASK_EDIT_SUGGESTIONS_BEGIN":
+      return { ...state, isLoading: true} ;
+    case "FETCH_TASK_EDIT_SUGGESTIONS_SUCESS":
+      return { ...state, isLoading: false, taskEditSuggestions: [...action.payload]};
+    case "FETCH_TASK_EDIT_SUGGESTIONS_ERROR":
+      return { ...state, isLoading: false };
+    default:
+      return state;
+  }
+};
+
+// TODO: Delete
+const taskEditSuggestionsInitial = [
+  {
+    _id: 1,
+    user: "EK Example",
+    dateSuggested: "2022-07-12T16:25:26.837Z",
+    newTask: {
+			_id:"62c9b82d11575257acb95f5f",
+			taskId:"62a382a44ee5b0299c5ff212",
+			userId:"627985bfe2896b87a47b99aa",
+			__v:0,
+			dateCreated:"2022-07-09T16:25:26.837Z",
+			isAcknowleged:0,
+			priority:"Primary",
+			isAssigned:true,
+			status:"Started",
+			hoursBest:0,
+			hoursWorst:0,
+			hoursMost:0,
+			estimatedHours:0,
+			links:null,
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        }
+      ],
+			taskName:"EK Example Task 1",
+			startedDatetime:null,
+			dueDatetime:null,
+			whyInfo:"",
+			intentInfo:"",
+			endstateInfo:"",
+			classification:"",
+    },
+    oldTask: {
+      _id:"62a382a44ee5b0299c5ff212",
+      priority:"Primary",
+      isAssigned:true,
+      status:"Started",
+      hoursBest:0,
+      hoursWorst:0,
+      hoursMost:0,
+      estimatedHours:0,
+      links:null,
+      parentId1:null,
+      parentId2:null,
+      parentId3:null,
+      mother:null,
+      isActive:true,
+      hasChild:false,
+      modifiedDatetime:"2022-07-09T17:17:33.649Z",
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        },
+        {
+          _id:"62c9b82d11575257acb95f5c",
+          userID:"62798679e2896b87a47b99bd",
+          name:"EK Admin",
+        },
+      ],
+      wbsId:"62799b53f8ff455aec1737a9",
+      taskName:"Red Bell Test 13",
+      num:"25",
+      level:1,
+      startedDatetime:null,
+      dueDatetime:null,
+      position:24,
+      createdDatetime:"2022-06-10T17:43:00.009Z",
+      whyInfo:"",
+      intentInfo:"",
+      endstateInfo:"",
+      classification:"",
+    }
+  },
+  {
+    _id: 2,
+    user: "EK Example",
+    dateSuggested: "2022-07-11T16:25:26.837Z",
+    newTask: {
+			_id:"62c9b82d11575257acb95f5f",
+			taskId:"62a382a44ee5b0299c5ff212",
+			userId:"627985bfe2896b87a47b99aa",
+			__v:0,
+			dateCreated:"2022-07-09T16:25:26.837Z",
+			isAcknowleged:0,
+			priority:"Primary",
+			isAssigned:true,
+			status:"Started",
+			hoursBest:0,
+			hoursWorst:0,
+			hoursMost:0,
+			estimatedHours:0,
+			links:null,
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        }
+      ],
+			taskName:"EK Example Task 2",
+			startedDatetime:null,
+			dueDatetime:null,
+			whyInfo:"",
+			intentInfo:"",
+			endstateInfo:"",
+			classification:"",
+    },
+    oldTask: {
+      _id:"62a382a44ee5b0299c5ff212",
+      priority:"Primary",
+      isAssigned:true,
+      status:"Started",
+      hoursBest:0,
+      hoursWorst:0,
+      hoursMost:0,
+      estimatedHours:0,
+      links:null,
+      parentId1:null,
+      parentId2:null,
+      parentId3:null,
+      mother:null,
+      isActive:true,
+      hasChild:false,
+      modifiedDatetime:"2022-07-09T17:17:33.649Z",
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        },
+        {
+          _id:"62c9b82d11575257acb95f5c",
+          userID:"62798679e2896b87a47b99bd",
+          name:"EK Admin",
+        },
+      ],
+      wbsId:"62799b53f8ff455aec1737a9",
+      taskName:"Red Bell Test 13",
+      num:"25",
+      level:1,
+      startedDatetime:null,
+      dueDatetime:null,
+      position:24,
+      createdDatetime:"2022-06-10T17:43:00.009Z",
+      whyInfo:"",
+      intentInfo:"",
+      endstateInfo:"",
+      classification:"",
+    }
+  },
+  {
+    _id: 3,
+    user: "AAA",
+    dateSuggested: "2022-07-10T16:25:26.837Z",
+    newTask: {
+			_id:"62c9b82d11575257acb95f5f",
+			taskId:"62a382a44ee5b0299c5ff212",
+			userId:"627985bfe2896b87a47b99aa",
+			__v:0,
+			dateCreated:"2022-07-09T16:25:26.837Z",
+			isAcknowleged:0,
+			priority:"Primary",
+			isAssigned:true,
+			status:"Started",
+			hoursBest:0,
+			hoursWorst:0,
+			hoursMost:0,
+			estimatedHours:0,
+			links:null,
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        }
+      ],
+			taskName:"AAA Task 1",
+			startedDatetime:null,
+			dueDatetime:null,
+			whyInfo:"",
+			intentInfo:"",
+			endstateInfo:"",
+			classification:"",
+    },
+    oldTask: {
+      _id:"62a382a44ee5b0299c5ff212",
+      priority:"Primary",
+      isAssigned:true,
+      status:"Started",
+      hoursBest:0,
+      hoursWorst:0,
+      hoursMost:0,
+      estimatedHours:0,
+      links:null,
+      parentId1:null,
+      parentId2:null,
+      parentId3:null,
+      mother:null,
+      isActive:true,
+      hasChild:false,
+      modifiedDatetime:"2022-07-09T17:17:33.649Z",
+      resources: [
+        {
+          _id:"62a382a44ee5b0299c5ff213",
+          userID:"627985bfe2896b87a47b99aa",
+          name:"EK Volunteer",
+        },
+        {
+          _id:"62c9b82d11575257acb95f5c",
+          userID:"62798679e2896b87a47b99bd",
+          name:"EK Admin",
+        },
+      ],
+      wbsId:"62799b53f8ff455aec1737a9",
+      taskName:"Red Bell Test 13",
+      num:"25",
+      level:1,
+      startedDatetime:null,
+      dueDatetime:null,
+      position:24,
+      createdDatetime:"2022-06-10T17:43:00.009Z",
+      whyInfo:"",
+      intentInfo:"",
+      endstateInfo:"",
+      classification:"",
+    }
+  },
+];

--- a/src/components/TaskEditSuggestions/selectors.js
+++ b/src/components/TaskEditSuggestions/selectors.js
@@ -1,0 +1,4 @@
+export const getTeamMemberTasksData = (state) => ({
+  isLoading: state.teamMemberTasks.isLoading,
+  usersWithTasks: state.teamMemberTasks.usersWithTasks
+});

--- a/src/components/TaskEditSuggestions/thunks.js
+++ b/src/components/TaskEditSuggestions/thunks.js
@@ -1,0 +1,14 @@
+const selectFetchTeamMembersTaskData = (state) => state.auth.user.userid;
+const selectUpdateTaskData = (state, taskId) => state.tasks.taskItems.find(({_id}) => _id === taskId);
+
+export const fetchTaskEditSuggestions = () => async (dispatch, getState) => {
+  try {
+    const state = getState();
+    const userId = selectFetchTeamMembersTaskData(state);
+    dispatch(fetchTeamMembersTaskBegin());
+    const response = await axios.get(ENDPOINTS.TEAM_MEMBER_TASKS(userId));
+    dispatch(fetchTeamMembersTaskSuccess(response.data));
+  } catch (error) {
+    dispatch(fetchTeamMembersTaskError());
+  }
+};

--- a/src/components/TeamMemberTasks/components/TaskDifferenceModal.jsx
+++ b/src/components/TeamMemberTasks/components/TaskDifferenceModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Table } from 'reactstrap';
 import DiffedText from './DiffedText';
 
-const resourcesToString = (resources) => {
+export const resourcesToString = (resources) => {
   if (!resources) {
     return "";
   }
@@ -11,36 +11,35 @@ const resourcesToString = (resources) => {
   return trimmed;
 };
 
-const booleanToString = (bool) => {
+export const booleanToString = (bool) => {
   if (bool == null) {
     return "";
   }
   return bool ? "Yes" : "No";
 }
 
-const numberToString = (num) => {
+export const numberToString = (num) => {
   if (num == null) {
     return "";
   }
   return num.toString();
 }
 
-const arrayToString = (arr) => {
+export const arrayToString = (arr) => {
   if (arr == null) {
     return "";
   }
   return arr.reduce((acc, ele) => acc + "\n" + ele, "").trim();
 }
 
-const trimParagraphTags = (str) => {
+export const trimParagraphTags = (str) => {
   if (str == null) {
     return "";
   }
-  const regex = /(<([^>]+)>)/ig;
-  return str.replace(regex, '').replace(/(<p[^>]+?>|<p>|<\/p>)/img, "").replace(/&nbsp;/g, '');
+  return str.replace(/(<p[^>]+?>|<p>|<\/p>)/img, "");
 }
 
-const datetimeToDate = (datetime) => {
+export const datetimeToDate = (datetime) => {
   if (datetime == null) {
     return "";
   }

--- a/src/routes.js
+++ b/src/routes.js
@@ -31,6 +31,7 @@ import { TeamReport } from './components/Reports/TeamReport';
 import Inventory from './components/Inventory';
 import BadgeManagement from './components/Badge/BadgeManagement';
 import AutoUpdate from 'components/AutoUpdate';
+import { TaskEditSuggestions } from 'components/TaskEditSuggestions/TaskEditSuggestions'
 
 export default (
   <React.Fragment>
@@ -49,6 +50,7 @@ export default (
       <ProtectedRoute path="/peoplereport/:userId" component={PeopleReport} />
       <ProtectedRoute path="/projectreport/:projectId" component={ProjectReport} />
       <ProtectedRoute path="/teamreport/:teamId" component={TeamReport} />
+      <ProtectedRoute path="/taskeditsuggestions" component={TaskEditSuggestions} />
 
       <ProtectedRoute
         path="/inventory/:projectId"


### PR DESCRIPTION
This PR is the first part of [Eiki's Task Edit Suggestions PR](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/497/commits), due to the large scale of changes and commits, we decided to cherrypick all his changes and split into couple new PRs, which would be more readable and understandable.

This PR is the first one, creating taskEditSuggestion page and mock data.

**Related background knowledge:**
Currently we have 6 types of account in our app. 
Admin/Owner: they can create/delete/edit tasks
Manager/Mentor: they can create a suggestion when they want to create/delete/edit tasks. If admin/owner approve that suggestion, changes would be applied on tasks; if admin/owner reject that suggestion, changes would disappear.
Volunteer/ Core team: they can only view tasks

See our [MD doc](https://docs.google.com/document/d/1dxUjkJ9dZg5T4SnmEgPZwxUzwOO1CqfHe-CN4zY6v3M/edit) page 8.
<img width="548" alt="image" src="https://user-images.githubusercontent.com/5071040/197073095-bfe195fb-9c03-449d-9a8e-918ddb6159b0.png">

**How to test:**
1. check on the [related backend PR](https://github.com/OneCommunityGlobal/HGNRest/pull/186)
2. check on this PR as frontend
3. go to http://localhost:3000/taskeditsuggestions
4. click on the rows on taskEditSuggestions page

**Mainly changes explained:**
- `package-lock.json`: don't know why this happened, but choose to keep it due to the first answer from [this question](https://stackoverflow.com/questions/47638381/why-did-package-lock-json-change-the-integrity-hash-from-sha1-to-sha512)
- `src/components/TaskEditSuggestions/Components/`: create taskEditSuggestion component
- `src/components/TaskEditSuggestions/TaskEditSuggestions.jsx`: mock data shows on taskEditSuggestion page

**Note:** 
Mock data will be deleted in coming PRs.