### PR TITLE
fix zoom as default value of video call

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -58,6 +58,7 @@ class AddUserProfile extends Component {
         email: '',
         phoneNumber: null,
         weeklyCommittedHours: 10,
+        collaborationPreference: 'Zoom',
         role: 'Volunteer',
         privacySettings: { blueSquares: true, email: true, phoneNumber: true },
         jobTitle: '',


### PR DESCRIPTION
This PR is fixing create new user -> video call preference, set "Zoom“ as default value when creating new user and could also be edited.
![details_of_video_call_bug](https://user-images.githubusercontent.com/98206107/201212476-543c7b6b-9499-47a5-92b7-48d2af03ddb7.JPG)
![fix_video_call_preference](https://user-images.githubusercontent.com/98206107/201212499-4ce4e18e-7016-46f5-b071-aeb84279910f.JPG)
