### PR TITLE
fix userProfile not loading

### DIFF
--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -6,9 +6,18 @@ import './UserProfile.scss';
 import './UserProfileEdit/UserProfileEdit.scss';
 
 const BlueSquareLayout = props => {
-  const { userProfile, handleUserProfile, handleBlueSquare, isUserSelf, role, canEdit } = props;
+  const {
+    userProfile,
+    handleUserProfile,
+    handleBlueSquare,
+    isUserSelf,
+    role,
+    roles,
+    userPermissions,
+    canEdit,
+  } = props;
 
-  const { privacySettings, infringements } = userProfile;
+  const { privacySettings } = userProfile;
 
   if (canEdit) {
     return (
@@ -26,7 +35,7 @@ const BlueSquareLayout = props => {
         </div>
 
         <BlueSquare
-          blueSquares={infringements}
+          blueSquares={userProfile?.infringments || userProfile?.infringements}
           handleBlueSquare={handleBlueSquare}
           role={role}
           roles={roles}
@@ -42,7 +51,11 @@ const BlueSquareLayout = props => {
       ) : (
         <div>
           <p>BLUE SQUARES</p>
-          <BlueSquare blueSquares={infringements} handleBlueSquare={handleBlueSquare} role={role} />
+          <BlueSquare
+            blueSquares={userProfile?.infringments || userProfile?.infringments}
+            handleBlueSquare={handleBlueSquare}
+            role={role}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
UserProfile should work now...

I would say this is a temporary fix to let us load userProfile. 
The reason behind this bug is all the current users have been already created with "infringments" property, but since we've changed all the misspellings of "infringments" to "infringements", it WILL NOT load blue squares correctly on user profile page. 

And notice that once the **[Backend PR](https://github.com/OneCommunityGlobal/HGNRest/pull/220)** of misspellings of "infringments" which Alan is working with is merged, all the new users will be created with "infringements" property. So, for now I just keep both "infringments" and "infringements" on the file `BlueSquareLayout.jsx`.

What I thought is we might experience new bugs in the future when we handle blue squares of users because of the terminology discrepancies. Maybe the best solution for this is to find a way to rename all the "infringments" property to "infringements" in the database. 

Hope this makes sense!

![user_profile_page](https://user-images.githubusercontent.com/98206107/205364765-328db652-4a45-41f1-ac3e-124ab2d58fab.JPG)
