### PR TITLE
Yiyun hotfix volunteer cannot login

### DIFF
--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -3,10 +3,9 @@ const hasPermission = (role, action, roles, userPermissions) => {
   if (role && roles && roles.length != 0 ) {
     const roleIndex = roles?.findIndex(({roleName}) => roleName === role )
 
-    const permissions = [];
-    if (roleIndex !== -1) {
-      permissions = roles[roleIndex].permissions;
-    }
+    const permissions = roles[roleIndex].permissions
+    
+
 
     let isAllowed;
   if(userPermissions && userPermissions?.includes(action)){

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -3,9 +3,10 @@ const hasPermission = (role, action, roles, userPermissions) => {
   if (role && roles && roles.length != 0 ) {
     const roleIndex = roles?.findIndex(({roleName}) => roleName === role )
 
-    const permissions = roles[roleIndex].permissions
-    
-
+    const permissions = [];
+    if (roleIndex !== -1) {
+      permissions = roles[roleIndex].permissions;
+    }
 
     let isAllowed;
   if(userPermissions && userPermissions?.includes(action)){

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -1,11 +1,10 @@
 const hasPermission = (role, action, roles, userPermissions) => {
-
   if (role && roles && roles.length != 0 ) {
     const roleIndex = roles?.findIndex(({roleName}) => roleName === role )
-
-    const permissions = roles[roleIndex].permissions
-    
-
+    let permissions = [];
+    if (roleIndex !== -1) {
+      permissions = roles[roleIndex].permissions;
+    }
 
     let isAllowed;
   if(userPermissions && userPermissions?.includes(action)){


### PR DESCRIPTION
**The bug is: volunteer users cannot login on DEV and local.**

<img width="947" alt="image (1)" src="https://user-images.githubusercontent.com/5071040/205414100-0d5c10a5-d4a1-40ca-82cc-bdad7a43755e.png">


**The reason is the role of users should be `Volunteer`, but somehow from frontend it shows `Volunteer Leader` instead.**
<img width="700" alt="page emtpy reason" src="https://user-images.githubusercontent.com/5071040/205413935-288c7f63-41cb-4310-a4b9-f7b3bdec24bd.png">
So the `roleIndex` = -1 and `permissions` is undefined, that causes the render error.
<img width="488" alt="image" src="https://user-images.githubusercontent.com/5071040/205414049-2ef63ec4-194b-4e70-bd3e-d9072091fed9.png">

This PR add a check for `roleIndex` to avoid issue.

**Things to do after this PR:**
Figure out the root cause why the user role is `Volunteer Leader`.