### PR TITLE
Fix the blue squares cannot be edited/assigned/deleted problem

### DIFF
--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -35,7 +35,7 @@ const BlueSquareLayout = props => {
         </div>
 
         <BlueSquare
-          blueSquares={userProfile?.infringments || userProfile?.infringements}
+          blueSquares={userProfile?.infringements}
           handleBlueSquare={handleBlueSquare}
           role={role}
           roles={roles}
@@ -52,7 +52,7 @@ const BlueSquareLayout = props => {
         <div>
           <p>BLUE SQUARES</p>
           <BlueSquare
-            blueSquares={userProfile?.infringments || userProfile?.infringments}
+            blueSquares={userProfile?.infringements}
             handleBlueSquare={handleBlueSquare}
             role={role}
           />


### PR DESCRIPTION
# Description
Urgent bug #4
<img width="526" alt="image" src="https://user-images.githubusercontent.com/5071040/207985769-ffe6ba01-e869-4c77-a35a-b2a05827c396.png">
✅ This PR will solve the "blue squares cannot be edited/assigned/deleted" problem
❓ Not sure if it can also solve "add blue squares should send an email" problem 

## Mainly changes explained:
Before changes, `userProfile?.infringments || userProfile?.infringements` will only show all `infringments` instead of `infringements ` if it is not null, so `infringements` will be totally ignored.

## How did I find it:
1. I tried to add blue squares on DEV, it did save newly added blue squares on database. See blow image as an example
<img width="802" alt="blue squares can be added but not show up" src="https://user-images.githubusercontent.com/5071040/207986633-97e4cdfa-af51-4de2-9737-922888f67c79.png">

2. I found the frontend props of useProfile also contained the blue squares I added
4. I found the blueSquareLayout only show old `infringments` data and ignore all new `infringements` data
5. I found `userProfile?.infringments || userProfile?.infringements` will only show all `infringments` instead of `infringements ` if it is not null, so `infringements` will be totally ignored.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin/owner user
4. go to a user's profile page
5. try edit/assign/remove blue squares

## Note:
1. ~~To get rid of future bugs, I'll move the previous `infringments` records under `infringements` for all active users on our BETA database.~~ Already modified on BETA database.
2. When you test, please ignore the below popup error. It already files as urgent bug 10 and not introduced by this PR.
<img width="385" alt="image" src="https://user-images.githubusercontent.com/5071040/207988457-13bcb089-0210-48d3-a39d-021afa6e64ce.png">

