### PR TITLE
Added Boostrap Grid to Badge component, evened out the Badge box with Timelog Box

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import {
+  Container,
+  Row, 
+  Col,
   Card,
   CardText,
   CardBody,
@@ -66,42 +69,48 @@ const Badge = props => {
   const permissionsUser = props.userProfile?.permissions?.frontPermissions;
   return (
     <>
-      <Card style={{ backgroundColor: '#fafafa', borderRadius: 0 }} id="badgesearned">
-        <CardHeader tag="h3">
-          Badges <i className="fa fa-info-circle" id="BadgeInfo" onClick={toggleTypes} />
-        </CardHeader>
-        <CardBody>
-          <NewBadges badges={props.userProfile.badgeCollection || []} />
-          <OldBadges badges={props.userProfile.badgeCollection || []} />
-          <CardText
-            style={{
-              fontWeight: 'bold',
-              fontSize: 18,
-              color: '#285739',
-            }}
-          >
-            Bravo! You Earned {totalBadge} Badges!{' '}
-            <i className="fa fa-info-circle" id="CountInfo" />
-          </CardText>
-          <Button className="btn--dark-sea-green float-right" onClick={toggle}>
-            Badge Report
-          </Button>
-          <Modal size={'lg'} isOpen={isOpen} toggle={toggle}>
-            <ModalHeader toggle={toggle}>Full View of Badge History</ModalHeader>
-            <ModalBody>
-              <BadgeReport
-                badges={props.userProfile.badgeCollection || []}
-                userId={props.userId}
-                firstName={props.userProfile.firstName}
-                lastName={props.userProfile.lastName}
-                role={props.role}
-                close={toggle}
-                permissionsUser={permissionsUser}
-              />
-            </ModalBody>
-          </Modal>
-        </CardBody>
-      </Card>
+    <Container>
+      <Row>
+        <Col md={12}>
+          <Card style={{ backgroundColor: '#fafafa', borderRadius: 0 }} id="badgesearned">
+            <CardHeader tag="h3">
+              Badges <i className="fa fa-info-circle" id="BadgeInfo" onClick={toggleTypes} />
+            </CardHeader>
+            <CardBody>
+              <NewBadges badges={props.userProfile.badgeCollection || []} />
+              <OldBadges badges={props.userProfile.badgeCollection || []} />
+              <CardText
+                style={{
+                  fontWeight: 'bold',
+                  fontSize: 18,
+                  color: '#285739',
+                }}
+              >
+                Bravo! You Earned {totalBadge} Badges!{' '}
+                <i className="fa fa-info-circle" id="CountInfo" />
+              </CardText>
+              <Button className="btn--dark-sea-green float-right" onClick={toggle}>
+                Badge Report
+              </Button>
+              <Modal size={'lg'} isOpen={isOpen} toggle={toggle}>
+                <ModalHeader toggle={toggle}>Full View of Badge History</ModalHeader>
+                <ModalBody>
+                  <BadgeReport
+                    badges={props.userProfile.badgeCollection || []}
+                    userId={props.userId}
+                    firstName={props.userProfile.firstName}
+                    lastName={props.userProfile.lastName}
+                    role={props.role}
+                    close={toggle}
+                    permissionsUser={permissionsUser}
+                  />
+                </ModalBody>
+              </Modal>
+            </CardBody>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
       <UncontrolledTooltip
         placement="auto"
         target="CountInfo"

--- a/src/components/Badge/OldBadges.jsx
+++ b/src/components/Badge/OldBadges.jsx
@@ -69,3 +69,5 @@ const OldBadges = (props) => {
 };
 
 export default OldBadges;
+
+


### PR DESCRIPTION
BUG: Fix formatting of badges box below the Time Log so that it is the same width as the time log window. See below how they are different.  

FIX: Added Grid system to Badge component, was able to make Badge container a little thinner and put in line with Timelog container. 


