### PR TITLE
Bug fix for: Medium issue 7 : User Profile - Make profile badges fit so bottom scroll bar isn’t showing up.

### DIFF
--- a/src/components/UserProfile/Badge.css
+++ b/src/components/UserProfile/Badge.css
@@ -2,6 +2,8 @@
   background-color: #c9d6c6 !important;
   border-color: #285739 !important;
   color: #285739 !important;
+  /*Spacing between buttons*/
+  margin-right: 10px;
 }
 
 .badge_image_sm > img {
@@ -87,8 +89,11 @@
 
 .badge_featured_container {
   display: flex;
-  flex-wrap: nowrap;
+  /*Wrap on overflow*/
+  flex-wrap: wrap;
   overflow-y: hidden;
+  /*center align content*/
+  justify-content: space-around;
 }
 
 .badge_md_image_container {
@@ -129,8 +134,21 @@
   text-align: left;
 }
 
+/*Aligns the title and the buttons*/
+.badge-header{
+  display:flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+/*Title to occupy more width than buttons*/
+.badge-header-title{
+  flex: 3;
+}
+
+/*To match width of iphone 12 Pro*/
 #badgeCard {
-  min-width: 475px;
+  min-width: 390px;
 }
 
 @media screen and (max-width: 1199px) {

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import {
   Card,
-  CardTitle,
-  CardText,
+  CardHeader,
+  CardFooter,
   CardBody,
   Button,
   Modal,
@@ -37,68 +37,65 @@ const Badges = props => {
   return (
     <>
       <Card id="badgeCard" style={{ backgroundColor: '#f6f6f3', marginTop: 20, marginBottom: 20 }}>
+        <CardHeader>
+          <div className='badge-header'>
+            <span className='badge-header-title'>
+              Featured Badges <i className="fa fa-info-circle" id="FeaturedBadgeInfo" />
+            </span>
+            <div>
+              <Button className="btn--dark-sea-green" onClick={toggle}>
+                Select Featured
+              </Button>
+              <Modal size="lg" isOpen={isOpen} toggle={toggle}>
+                <ModalHeader toggle={toggle}>Full View of Badge History</ModalHeader>
+                <ModalBody>
+                  <BadgeReport
+                    badges={props.userProfile.badgeCollection}
+                    userId={props.userProfile._id}
+                    role={props.role}
+                    firstName={props.userProfile.firstName}
+                    lastName={props.userProfile.lastName}
+                    close={toggle}
+                    setUserProfile={props.setUserProfile}
+                    handleSubmit={props.handleSubmit}
+                    permissionsUser={permissionsUser}
+                  />
+                </ModalBody>
+              </Modal>
+              {props.canEdit && (
+                <>
+                  <Button className="btn--dark-sea-green mr-2" onClick={assignToggle}>
+                    Assign Badges
+                  </Button>
+                  <Modal size="lg" isOpen={isAssignOpen} toggle={assignToggle}>
+                    <ModalHeader toggle={assignToggle}>Assign Badges</ModalHeader>
+                    <ModalBody>
+                      <AssignBadgePopup
+                        allBadgeData={props.allBadgeData}
+                        userProfile={props.userProfile}
+                        setUserProfile={props.setUserProfile}
+                        close={assignToggle}
+                        handleSubmit={props.handleSubmit}
+                      />
+                    </ModalBody>
+                  </Modal>
+                </>
+              )}
+            </div>
+          </div>
+        </CardHeader>
         <CardBody>
-          <CardTitle
-            style={{
-              fontWeight: 'bold',
-              fontSize: 18,
-              color: '#285739',
-              marginBottom: 15,
-              minWidth: 446,
-            }}
-          >
-            Featured Badges <i className="fa fa-info-circle" id="FeaturedBadgeInfo" />
-            <Button className="btn--dark-sea-green float-right" onClick={toggle}>
-              Select Featured
-            </Button>
-            <Modal size="lg" isOpen={isOpen} toggle={toggle}>
-              <ModalHeader toggle={toggle}>Full View of Badge History</ModalHeader>
-              <ModalBody>
-                <BadgeReport
-                  badges={props.userProfile.badgeCollection}
-                  userId={props.userProfile._id}
-                  role={props.role}
-                  firstName={props.userProfile.firstName}
-                  lastName={props.userProfile.lastName}
-                  close={toggle}
-                  setUserProfile={props.setUserProfile}
-                  handleSubmit={props.handleSubmit}
-                  permissionsUser={permissionsUser}
-                />
-              </ModalBody>
-            </Modal>
-            {props.canEdit && (
-              <>
-                <Button className="btn--dark-sea-green float-right mr-2" onClick={assignToggle}>
-                  Assign Badges
-                </Button>
-                <Modal size="lg" isOpen={isAssignOpen} toggle={assignToggle}>
-                  <ModalHeader toggle={assignToggle}>Assign Badges</ModalHeader>
-                  <ModalBody>
-                    <AssignBadgePopup
-                      allBadgeData={props.allBadgeData}
-                      userProfile={props.userProfile}
-                      setUserProfile={props.setUserProfile}
-                      close={assignToggle}
-                      handleSubmit={props.handleSubmit}
-                    />
-                  </ModalBody>
-                </Modal>
-              </>
-            )}
-          </CardTitle>
           <FeaturedBadges badges={props.userProfile.badgeCollection} />
-          <CardText
-            style={{
+        </CardBody>
+        <CardFooter style={{
               fontWeight: 'bold',
               fontSize: 18,
               color: '#285739',
             }}
           >
-            Bravo! You've earned {props.userProfile.badgeCollection.length} badges!{' '}
-            <i className="fa fa-info-circle" id="CountInfo" />
-          </CardText>
-        </CardBody>
+          Bravo! You've earned {props.userProfile.badgeCollection.length} badges!{' '}
+          <i className="fa fa-info-circle" id="CountInfo" />
+        </CardFooter>
       </Card>
       <UncontrolledTooltip
         placement="right"


### PR DESCRIPTION
Bug fix: Medium issue 7 : User Profile Bug: Make profile badges fit so bottom scroll bar isn’t showing up. 
User Profile → Badges Section （WIP RJ)

Confirmed with Jae: Wrap the content of badges section in user profile in case of overflow due to smaller screen sizes (since horizontal scrolling is difficult in mobile phone with the badge info tooltip popping up)

Fixes:
1. Added containers (div/span) around the elements to include flex box design.
2. Flex box properties were set to the containers using CSS classes.
3. Changed from CardTitle to CardHeader and included CardFooter to classify the contents logically.

Please test on local machine for various screen sizes while PR review.

Attaching images for references.

<img width="300" height="300" alt="Screen Shot 2022-12-19 at 9 13 43 PM" src="https://user-images.githubusercontent.com/16258136/208591923-854e448a-bcf0-45d0-a759-6725b1bda97a.png">

<img width="300" height="300" alt="Screen Shot 2022-12-19 at 9 12 57 PM" src="https://user-images.githubusercontent.com/16258136/208592105-e2f404ff-aeb7-4928-9b8b-9e7cc64c23cd.png">

<img width="300" height="300" alt="Screen Shot 2022-12-19 at 9 13 16 PM" src="https://user-images.githubusercontent.com/16258136/208592179-788e5418-c934-4ebd-b5bb-2c55a3b2a8e6.png">
