### PR TITLE
dropdown with default classification when adding a new task

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -80,6 +80,17 @@ const AddTaskModal = (props) => {
   const [endstateInfo, setEndstateInfo] = useState('');
 
   // Classification
+  const classificationOptions = [
+    {value:"Food",label:"Food"},
+    {value:"Energy",label:"Energy"},
+    {value:"Housing",label:"Housing"},
+    {value:"Education",label:"Education"},
+    {value:"Soceity",label:"Soceity"},
+    {value:"Economics",label:"Economics"},
+    {value:"Stewardship",label:"Stewardship"},
+    {value:"Other",label:"Other"}
+  ]
+  const [projectCategory, setProjectCategory] = useState('');
   const [classification, setClassification] = useState('');
 
   // Warning
@@ -340,6 +351,13 @@ const AddTaskModal = (props) => {
 
   useEffect(() => {}, [tasks]);
 
+  useEffect(() =>{
+    const res = props.allProjects.projects.filter(obj => obj._id === props.projectId)[0];
+    if (res){
+      setProjectCategory(res.category);
+    }
+  })
+
   getNewNum();
 
   return (
@@ -584,11 +602,11 @@ const AddTaskModal = (props) => {
               <tr>
                 <td scope="col">Classification</td>
                 <td scope="col">
-                  <input
-                    type="text"
-                    value={classification}
-                    onChange={(e) => setClassification(e.target.value)}
-                  />
+                  <select defaultValue={projectCategory} onChange={e => setClassification(e.target.value)}>
+                    {classificationOptions.map(cla =>{
+                      return <option value={cla.value} key={cla.value}>{cla.label}</option>
+                    })}
+                  </select>
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
# Description
Fix bug (PRIORITY - MEDIUM) 12 
Jae: If you save a task, then go back and edit it, the dropdown is there and this field can be added and saved. We should be able to add it when creating the task though.
Would also like it to default fill with the category that the WBS Project is in. I should still be able to choose a different one, but almost always the category is the same as the Project the WBS is in (see Dashboard→ Other Links → Projects → Category)

## Mainly changes explained:
1. replace the text input box with a select dropdown
2. introduce a new state variable "projectCategory" as the default value of the select element

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. Dashboard→ Other Links → Projects → choose project WBS → Add Task → “Classification” field
<img width="1136" alt="Screen Shot 2022-12-21 at 6 25 52 AM" src="https://user-images.githubusercontent.com/9314962/209005094-ccccf76b-7ca4-4d08-aa20-a04c9c893330.png">
<img width="540" alt="Screen Shot 2022-12-21 at 6 26 25 AM" src="https://user-images.githubusercontent.com/9314962/209005150-93f6e2b1-e2bc-40b5-9133-736740bf110d.png">

## Note:
I found the save/ add new task functionality wasn't completed here and there are a few problems in this file. To make sure one PR focuses on one bug, I will register them as a new bug to fix.
<img width="698" alt="Screen Shot 2022-12-21 at 6 28 13 AM" src="https://user-images.githubusercontent.com/9314962/209005509-40e27c6f-ee59-4be3-a6b1-a4b5f0204bc0.png">
