### PR TITLE
hot fix blue squares cannot be deleted on Main

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -265,13 +265,12 @@ const UserProfile = props => {
       setShowModal(false);
       setUserProfile({ ...userProfile, infringements: currentBlueSquares });
     } else if (operation === 'delete') {
-      const newInfringements = [];
-      userProfile.infringements?.forEach(infringement => {
-        if (infringement._id !== id) newInfringements.push(infringement);
-      });
-
-      setUserProfile({ ...userProfile, infringements: newInfringements });
-      setShowModal(false);
+      let newInfringements = [...userProfile?.infringements] || [];
+      if (newInfringements !== []) {
+        newInfringements = newInfringements.filter(infringement => infringement._id !== id)
+        setUserProfile({ ...userProfile, infringements: newInfringements });
+        setShowModal(false);
+      }
     }
     setBlueSquareChanged(true);
   };


### PR DESCRIPTION
# Description
<img width="539" alt="image" src="https://user-images.githubusercontent.com/5071040/208549165-9f658d6e-49c0-4198-896d-7fd6b77fb4dc.png">

## Mainly changes explained:
<img width="516" alt="image" src="https://user-images.githubusercontent.com/5071040/209028638-64fa85b1-24a7-427a-a759-5e9010b00b4c.png">
I was thinking, the delete action doesn't work on Main, because of line 269 get `infringements` as an empty array first, so line 270 `infrigement._id` is undefined, so that `newInfringements` has all items from `infringements`. That turns out no items are deleted. 

## How to test:
Since I cannot reproduce them on Dev, I cannot guarantee they are fixed on Beta. 

## Note:
This hotfix PR just like #600 