### PR TITLE
Added in regions section along with enableLongNumbers

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -176,8 +176,7 @@ class AddUserProfile extends Component {
                   <Col md="6">
                     <FormGroup>
                     <PhoneInput
-                        country="US"
-                        enableLongNumbers = 'true'
+                        country="US
                         regions={['america','europe','asia','oceania','africa']}
                         value={phoneNumber}
                         onChange={phone => this.phoneChange(phone)}

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -176,8 +176,9 @@ class AddUserProfile extends Component {
                   <Col md="6">
                     <FormGroup>
                     <PhoneInput
-                        country="US
+                        country="US"
                         regions={['america','europe','asia','oceania','africa']}
+                        limitMaxLength= 'true'
                         value={phoneNumber}
                         onChange={phone => this.phoneChange(phone)}
                       />

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -37,7 +37,6 @@ import { fetchAllProjects } from 'actions/projects';
 
 import PhoneInput from 'react-phone-input-2';
 import 'react-phone-input-2/lib/style.css';
-
 import classnames from 'classnames';
 import TimeZoneDropDown from '../TimeZoneDropDown';
 import { getUserTimeZone } from 'services/timezoneApiService';
@@ -176,8 +175,10 @@ class AddUserProfile extends Component {
                   </Col>
                   <Col md="6">
                     <FormGroup>
-                      <PhoneInput
-                        country={'us'}
+                    <PhoneInput
+                        country="US"
+                        enableLongNumbers = 'true'
+                        regions={['america','europe','asia','oceania','africa']}
                         value={phoneNumber}
                         onChange={phone => this.phoneChange(phone)}
                       />


### PR DESCRIPTION
BUG:  (WIP SHAUN) App not allowing me to create new users with foreign phone numbers
Other Links → User Management → Create New User → input foreign number like the example below → Gives error shown below and won’t allow me to save


FIX: Added in "enableLongNumbers" and "regions" keys to the PhoneInput section, all international numbers should now be able to be entered without issue