### PR TITLE
blusquare sort by date implemented

### DIFF
--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -6,7 +6,8 @@ const BlueSquare = ({ blueSquares, handleBlueSquare, role, roles, userPermission
   return (
     <div className="blueSquareContainer">
       <div className="blueSquares">
-        {blueSquares ? (blueSquares.map((blueSquare, index) => (
+        {blueSquares ? (blueSquares.sort((a,b)=> a.date > b.date ? 1 : -1)
+        .map((blueSquare, index) => (
           <div
             key={index}
             role="button"


### PR DESCRIPTION
Bug : (Navya):: Blue squares on a person’s profile should always be in order by date. Right now they are in the order added. If I add one with a past date, it should show up in the correct order, NOT at the end of the line.

Fix : Implemented sort function,now  bluesquares are sorting by date.