### PR TITLE
fix the progress bar

### DIFF
--- a/src/components/LeaderBoard/LeaderBoard.container.jsx
+++ b/src/components/LeaderBoard/LeaderBoard.container.jsx
@@ -22,8 +22,8 @@ const mapStateToProps = (state) => {
 
       element.intangibletimewidth = _.round((element.totalintangibletime_hrs * 100) / maxTotal, 0);
 
-      element.barcolor = getcolor(element.totaltangibletime_hrs,element.weeklyComittedHours);
-      element.barprogress = getprogress(element.totaltangibletime_hrs,element.weeklyComittedHours);
+      element.barcolor = getcolor(element.totaltangibletime_hrs);
+      element.barprogress = getprogress(element.totaltangibletime_hrs);
       element.totaltime = _.round(element.totaltime_hrs, 2);
 
       return element;
@@ -38,11 +38,11 @@ const mapStateToProps = (state) => {
   orgData.intangibletime = _.round(orgData.totalintangibletime_hrs, 2);
   orgData.weeklyComittedHours = _.round(orgData.totalWeeklyComittedHours, 2);
 
-  //const tenPTotalOrgTime = orgData.weeklyComittedHours * 0.1;
-  //const orgTangibleColorTime = orgData.totaltime < tenPTotalOrgTime * 2 ? 0 : 5;
+  const tenPTotalOrgTime = orgData.weeklyComittedHours * 0.1;
+  const orgTangibleColorTime = orgData.totaltime < tenPTotalOrgTime * 2 ? 0 : 5;
 
-  orgData.barcolor = getcolor(orgData.totaltime,orgData.totalWeeklyComittedHours);
-  orgData.barprogress = getprogress(orgData.totaltime,orgData.totalWeeklyComittedHours);
+  orgData.barcolor = getcolor(orgTangibleColorTime);
+  orgData.barprogress = getprogress(orgTangibleColorTime);
 
   return {
     isAuthenticated: _.get(state, 'auth.isAuthenticated', false),

--- a/src/components/LeaderBoard/LeaderBoard.container.jsx
+++ b/src/components/LeaderBoard/LeaderBoard.container.jsx
@@ -22,8 +22,8 @@ const mapStateToProps = (state) => {
 
       element.intangibletimewidth = _.round((element.totalintangibletime_hrs * 100) / maxTotal, 0);
 
-      element.barcolor = getcolor(element.totaltangibletime_hrs);
-      element.barprogress = getprogress(element.totaltangibletime_hrs);
+      element.barcolor = getcolor(element.totaltangibletime_hrs,element.weeklyComittedHours);
+      element.barprogress = getprogress(element.totaltangibletime_hrs,element.weeklyComittedHours);
       element.totaltime = _.round(element.totaltime_hrs, 2);
 
       return element;
@@ -38,11 +38,11 @@ const mapStateToProps = (state) => {
   orgData.intangibletime = _.round(orgData.totalintangibletime_hrs, 2);
   orgData.weeklyComittedHours = _.round(orgData.totalWeeklyComittedHours, 2);
 
-  const tenPTotalOrgTime = orgData.weeklyComittedHours * 0.1;
-  const orgTangibleColorTime = orgData.totaltime < tenPTotalOrgTime * 2 ? 0 : 5;
+  //const tenPTotalOrgTime = orgData.weeklyComittedHours * 0.1;
+  //const orgTangibleColorTime = orgData.totaltime < tenPTotalOrgTime * 2 ? 0 : 5;
 
-  orgData.barcolor = getcolor(orgTangibleColorTime);
-  orgData.barprogress = getprogress(orgTangibleColorTime);
+  orgData.barcolor = getcolor(orgData.totaltime,orgData.totalWeeklyComittedHours);
+  orgData.barprogress = getprogress(orgData.totaltime,orgData.totalWeeklyComittedHours);
 
   return {
     isAuthenticated: _.get(state, 'auth.isAuthenticated', false),

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -116,8 +116,8 @@ const LeaderBoard = ({
                 system, how many volunteer hours they are collectively committed to, and how many
                 tangible and total hours they have completed. The color and length of that bar
                 changes based on what percentage of the total committed hours for the week have been
-                completed: >10%: Red, 10-50%: Orange, 50-60% hrs: Green, 60-70%: Blue, 70-80%:
-                Indigo, 80-100%: Violet, and More than 100%: Purple.
+                completed: 0-20%: Red, 20-40%: Orange, 40-60% hrs: Green, 60-80%: Blue, 80-100%:
+                Indigo, and Equal or More than 100%: Purple.
               </li>
               <li>
                 The red/green dot shows whether or not a person has completed their “tangible” hours
@@ -130,7 +130,7 @@ const LeaderBoard = ({
                 completed hours for the week rank you compared to other people on your team.
                 Clicking a person’s time bar will take you to the time log section on their/your
                 dashboard. This bar also changes color based on how many tangible hours you have
-                completed: >5 hrs: Red, 5-10 hrs: Orange, 10-20 hrs: Green, 20-30 hrs: Blue, 30-40
+                completed: 5 hrs: Red, 5-10 hrs: Orange, 10-20 hrs: Green, 20-30 hrs: Blue, 30-40
                 hrs: Indigo, 40-50 hrs: Violet, and 50+ hrs: Purple
               </li>
               <li>Clicking a person’s name will lead to their/your profile page.</li>

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -114,10 +114,11 @@ const LeaderBoard = ({
               <li>
                 The HGN Totals at the top shows how many volunteers are currently active in the
                 system, how many volunteer hours they are collectively committed to, and how many
-                tangible and total hours they have completed. The color and length of that bar
+                tangible and total hours they have completed. 
+                {/*The color and length of that bar
                 changes based on what percentage of the total committed hours for the week have been
-                completed: 0-20%: Red, 20-40%: Orange, 40-60% hrs: Green, 60-80%: Blue, 80-100%:
-                Indigo, and Equal or More than 100%: Purple.
+                completed: 0-20%: Red, 20-40%: Orange, 40-60% hrs: Green, 60-80%: Blue, 80-100%:Indigo, 
+                and Equal or More than 100%: Purple.*/}
               </li>
               <li>
                 The red/green dot shows whether or not a person has completed their “tangible” hours
@@ -130,7 +131,7 @@ const LeaderBoard = ({
                 completed hours for the week rank you compared to other people on your team.
                 Clicking a person’s time bar will take you to the time log section on their/your
                 dashboard. This bar also changes color based on how many tangible hours you have
-                completed: 5 hrs: Red, 5-10 hrs: Orange, 10-20 hrs: Green, 20-30 hrs: Blue, 30-40
+                completed: 0-5 hrs: Red, 5-10 hrs: Orange, 10-20 hrs: Green, 20-30 hrs: Blue, 30-40
                 hrs: Indigo, 40-50 hrs: Violet, and 50+ hrs: Purple
               </li>
               <li>Clicking a person’s name will lead to their/your profile page.</li>

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -29,6 +29,7 @@ import { ENDPOINTS } from 'utils/URL';
 import axios from 'axios';
 import { ApiEndpoint } from 'utils/URL';
 import hasPermission from 'utils/permissions';
+import { getcolor, getprogress } from '../../utils/effortColors';
 
 const SummaryBar = props => {
   const { asUser, role, leaderData } = props;
@@ -169,38 +170,6 @@ const SummaryBar = props => {
   //   await this.props.getWeeklySummaries(this.props.currentUser.userid);
   //   const { weeklySummariesCount } = this.props.summaries;}
 
-  const getBarColor = hours => {
-    if (hours < 5) {
-      return 'red';
-    }
-    if (hours < 10) {
-      return 'orange';
-    }
-    if (hours < 20) {
-      return 'green';
-    }
-    if (hours < 30) {
-      return 'blue';
-    }
-    if (hours < 40) {
-      return 'indigo';
-    }
-    if (hours < 50) {
-      return 'violet';
-    }
-    return 'purple';
-  };
-
-  const getBarValue = hours => {
-    if (hours <= 40) {
-      return hours * 2;
-    }
-    if (hours <= 50) {
-      return (hours - 40) * 1.5 + 80;
-    }
-    return ((hours - 50) * 5) / 40 + 95;
-  };
-
   const onTaskClick = () => {
     window.location.hash = '#tasks';
   };
@@ -289,8 +258,8 @@ const SummaryBar = props => {
                   <div className="text--black align-items-center med_text_summary">
                     Current Week : {totalEffort.toFixed(2)} / {weeklyCommittedHours}
                     <Progress
-                      value={getBarValue(totalEffort)}
-                      className={getBarColor(totalEffort)}
+                      value={getprogress(totalEffort,weeklyCommittedHours)}
+                      color={getcolor(totalEffort,weeklyCommittedHours)}
                       striped={totalEffort < weeklyCommittedHours}
                     />
                   </div>

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -29,7 +29,7 @@ import { ENDPOINTS } from 'utils/URL';
 import axios from 'axios';
 import { ApiEndpoint } from 'utils/URL';
 import hasPermission from 'utils/permissions';
-import { getcolor, getprogress } from '../../utils/effortColors';
+import { getProgressColor, getProgressValue } from '../../utils/effortColors';
 
 const SummaryBar = props => {
   const { asUser, role, leaderData } = props;
@@ -258,8 +258,8 @@ const SummaryBar = props => {
                   <div className="text--black align-items-center med_text_summary">
                     Current Week : {totalEffort.toFixed(2)} / {weeklyCommittedHours}
                     <Progress
-                      value={getprogress(totalEffort,weeklyCommittedHours)}
-                      color={getcolor(totalEffort,weeklyCommittedHours)}
+                      value={getProgressValue(totalEffort,weeklyCommittedHours)}
+                      color={getProgressColor(totalEffort,weeklyCommittedHours)}
                       striped={totalEffort < weeklyCommittedHours}
                     />
                   </div>

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -15,7 +15,7 @@ import { TaskDifferenceModal } from './components/TaskDifferenceModal';
 import { getTeamMemberTasksData } from './selectors';
 import { getUserProfile } from '../../actions/userProfile';
 import './style.css';
-import { getcolor } from '../../utils/effortColors';
+import { getcolor, getprogress } from '../../utils/effortColors';
 import { fetchAllManagingTeams } from '../../actions/team';
 import EffortBar from 'components/Timelog/EffortBar';
 import TimeEntry from 'components/Timelog/TimeEntry';
@@ -90,7 +90,7 @@ const TeamMemberTasks = props => {
         //conditional variable for moving current user up front.
         let moveCurrentUserFront = false;
 
-        console.log('filteredMembers', filteredMembers);
+        //console.log('filteredMembers', filteredMembers);
 
         //Does the user has at least one task with project Id and task id assigned. Then set the current user up front.
         for (const task of currentUser.tasks) {
@@ -202,12 +202,8 @@ const TeamMemberTasks = props => {
                                 ${parseFloat(task.estimatedHours.toFixed(2))}`}
                                   </span>
                                   <Progress
-                                    color={
-                                      task.hoursLogged > task.estimatedHours
-                                        ? getcolor(0)
-                                        : getcolor(task.estimatedHours - task.hoursLogged)
-                                    }
-                                    value={(task.hoursLogged / task.estimatedHours) * 100}
+                                    color = {getcolor(task.hoursLogged,task.estimatedHours)}
+                                    value = {getprogress(task.hoursLogged,task.estimatedHours)}
                                   />
                                 </div>
                               </td>

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -15,7 +15,7 @@ import { TaskDifferenceModal } from './components/TaskDifferenceModal';
 import { getTeamMemberTasksData } from './selectors';
 import { getUserProfile } from '../../actions/userProfile';
 import './style.css';
-import { getcolor, getprogress } from '../../utils/effortColors';
+import { getProgressColor, getProgressValue } from '../../utils/effortColors';
 import { fetchAllManagingTeams } from '../../actions/team';
 import EffortBar from 'components/Timelog/EffortBar';
 import TimeEntry from 'components/Timelog/TimeEntry';
@@ -202,8 +202,8 @@ const TeamMemberTasks = props => {
                                 ${parseFloat(task.estimatedHours.toFixed(2))}`}
                                   </span>
                                   <Progress
-                                    color = {getcolor(task.hoursLogged,task.estimatedHours)}
-                                    value = {getprogress(task.hoursLogged,task.estimatedHours)}
+                                    color = {getProgressColor(task.hoursLogged,task.estimatedHours)}
+                                    value = {getProgressValue(task.hoursLogged,task.estimatedHours)}
                                   />
                                 </div>
                               </td>

--- a/src/components/Timelog/TimelogNavbar.jsx
+++ b/src/components/Timelog/TimelogNavbar.jsx
@@ -11,6 +11,7 @@ import {
   NavLink,
 } from 'reactstrap';
 import { useSelector } from 'react-redux';
+import { getcolor, getprogress } from '../../utils/effortColors';
 
 const TimelogNavbar = ({ userId }) => {
   const { firstName, lastName } = useSelector(state => state.userProfile);
@@ -22,38 +23,6 @@ const TimelogNavbar = ({ userId }) => {
   const reducer = (total, entry) => total + parseInt(entry.hours) + parseInt(entry.minutes) / 60;
   const totalEffort = timeEntries.reduce(reducer, 0);
   const weeklyComittedHours = useSelector(state => state.userProfile.weeklyComittedHours);
-
-  const getBarColor = hours => {
-    if (hours < 5) {
-      return 'red';
-    }
-    if (hours < 10) {
-      return 'orange';
-    }
-    if (hours < 20) {
-      return 'green';
-    }
-    if (hours < 30) {
-      return 'blue';
-    }
-    if (hours < 40) {
-      return 'indigo';
-    }
-    if (hours < 50) {
-      return 'violet';
-    }
-    return 'purple';
-  };
-
-  const getBarValue = hours => {
-    if (hours <= 40) {
-      return hours * 2;
-    }
-    if (hours <= 50) {
-      return (hours - 40) * 1.5 + 80;
-    }
-    return ((hours - 50) * 5) / 40 + 95;
-  };
 
   return (
     <div>
@@ -69,15 +38,9 @@ const TimelogNavbar = ({ userId }) => {
               <div>
                 Current Week : {totalEffort.toFixed(2)} / {weeklyComittedHours}
               </div>
-              {/* <Progress striped value={progressPercentage} color={
-                  progressPercentage < 30 ?
-                  "danger" :
-                  progressPercentage < 90 ?
-                  "warning" : "success"}
-                /> */}
               <Progress
-                value={getBarValue(totalEffort)}
-                className={getBarColor(totalEffort)}
+                value={getprogress(totalEffort,weeklyComittedHours)}
+                color={getcolor(totalEffort,weeklyComittedHours)}
                 striped={totalEffort < weeklyComittedHours}
               />
             </NavItem>

--- a/src/components/Timelog/TimelogNavbar.jsx
+++ b/src/components/Timelog/TimelogNavbar.jsx
@@ -11,7 +11,7 @@ import {
   NavLink,
 } from 'reactstrap';
 import { useSelector } from 'react-redux';
-import { getcolor, getprogress } from '../../utils/effortColors';
+import { getProgressColor, getProgressValue } from '../../utils/effortColors';
 
 const TimelogNavbar = ({ userId }) => {
   const { firstName, lastName } = useSelector(state => state.userProfile);
@@ -39,8 +39,8 @@ const TimelogNavbar = ({ userId }) => {
                 Current Week : {totalEffort.toFixed(2)} / {weeklyComittedHours}
               </div>
               <Progress
-                value={getprogress(totalEffort,weeklyComittedHours)}
-                color={getcolor(totalEffort,weeklyComittedHours)}
+                value={getProgressValue(totalEffort,weeklyComittedHours)}
+                color={getProgressColor(totalEffort,weeklyComittedHours)}
                 striped={totalEffort < weeklyComittedHours}
               />
             </NavItem>

--- a/src/utils/effortColors.js
+++ b/src/utils/effortColors.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-export const getcolor = (effort,commit) => {
+export const getProgressColor = (effort,commit) => {
   let color = 'white';
   let percentage = 0;
   if (commit>0){
@@ -15,7 +15,18 @@ export const getcolor = (effort,commit) => {
   return color;
 };
 
-export const getprogress = (effort,commit) => {
+export const getcolor = (effort) => {
+  let color = 'super-awesome'; //purple
+  if (_.inRange(effort, 0, 5)) color = 'danger'; //red
+  if (_.inRange(effort, 5, 10)) color = 'orange'; //orange
+  if (_.inRange(effort, 10, 20)) color = 'success'; //green
+  if (_.inRange(effort, 20, 30)) color = 'primary'; //blue
+  if (_.inRange(effort, 30, 40)) color = 'super'; //indigo
+  if (_.inRange(effort, 40, 50)) color = 'awesome'; //violet
+  return color;
+};
+
+export const getProgressValue = (effort,commit) => {
   let percentage = 0;
   if (commit>0){
     percentage = Math.round(effort*100/commit)
@@ -24,4 +35,18 @@ export const getprogress = (effort,commit) => {
   return percentage;
 };
 
-export default getcolor;
+export const getprogress = (effort) => {
+  let progress = 92;
+  if (_.inRange(effort, 0, 5)) progress = 5 + Math.round(5 * (effort / 5));
+  else if (_.inRange(effort, 5, 10)) progress = 12 + Math.round(5 * ((effort - 5) / 5));
+  else if (_.inRange(effort, 10, 20)) progress = 20 + Math.round(20 * ((effort - 10) / 10));
+  else if (_.inRange(effort, 20, 30)) progress = 45 + Math.round(10 * ((effort - 20) / 10));
+  else if (_.inRange(effort, 30, 40)) progress = 60 + Math.round(15 * ((effort - 30) / 10));
+  else if (_.inRange(effort, 40, 50)) progress = 80 + Math.round(10 * ((effort - 30) / 10));
+  else if (_.inRange(effort, 60, 70)) progress = 95;
+  else if (effort > 70) progress = 98;
+
+  return progress;
+};
+
+export default {getProgressColor,getcolor};

--- a/src/utils/effortColors.js
+++ b/src/utils/effortColors.js
@@ -1,27 +1,27 @@
 import _ from 'lodash';
-export const getcolor = (effort) => {
-  let color = 'super-awesome'; //purple
-  if (_.inRange(effort, 0, 5)) color = 'danger'; //red
-  if (_.inRange(effort, 5, 10)) color = 'orange'; //orange
-  if (_.inRange(effort, 10, 20)) color = 'success'; //green
-  if (_.inRange(effort, 20, 30)) color = 'primary'; //blue
-  if (_.inRange(effort, 30, 40)) color = 'super'; //indigo
-  if (_.inRange(effort, 40, 50)) color = 'awesome'; //violet
+export const getcolor = (effort,commit) => {
+  let color = 'white';
+  let percentage = 0;
+  if (commit>0){
+    percentage = Math.round(effort*100/commit);
+  }
+  if (_.inRange(percentage, 0, 20)) color = 'danger'; //red
+  if (_.inRange(percentage, 20, 40)) color = 'orange'; //orange
+  if (_.inRange(percentage, 40, 60)) color = 'success'; //green
+  if (_.inRange(percentage, 60, 80)) color = 'primary'; //blue
+  if (_.inRange(percentage, 80, 100)) color = 'super'; //indigo
+  //if (_.inRange(percentage, 40, 50)) color = 'awesome'; //violet
+  if (percentage >= 100) color = 'super-awesome'; //purple
   return color;
 };
 
-export const getprogress = (effort) => {
-  let progress = 92;
-  if (_.inRange(effort, 0, 5)) progress = 5 + Math.round(5 * (effort / 5));
-  else if (_.inRange(effort, 5, 10)) progress = 12 + Math.round(5 * ((effort - 5) / 5));
-  else if (_.inRange(effort, 10, 20)) progress = 20 + Math.round(20 * ((effort - 10) / 10));
-  else if (_.inRange(effort, 20, 30)) progress = 45 + Math.round(10 * ((effort - 20) / 10));
-  else if (_.inRange(effort, 30, 40)) progress = 60 + Math.round(15 * ((effort - 30) / 10));
-  else if (_.inRange(effort, 40, 50)) progress = 80 + Math.round(10 * ((effort - 30) / 10));
-  else if (_.inRange(effort, 60, 70)) progress = 95;
-  else if (effort > 70) progress = 98;
-
-  return progress;
+export const getprogress = (effort,commit) => {
+  let percentage = 0;
+  if (commit>0){
+    percentage = Math.round(effort*100/commit)
+    if (percentage>100) percentage = 100;
+  }
+  return percentage;
 };
 
 export default getcolor;

--- a/src/utils/effortColors.js
+++ b/src/utils/effortColors.js
@@ -1,4 +1,6 @@
 import _ from 'lodash';
+
+//For progress bar that shows the percentage of the completion
 export const getProgressColor = (effort,commit) => {
   let color = 'white';
   let percentage = 0;
@@ -15,6 +17,7 @@ export const getProgressColor = (effort,commit) => {
   return color;
 };
 
+//For (progress) bar that is designed for the exact hours in LEADERBOARD
 export const getcolor = (effort) => {
   let color = 'super-awesome'; //purple
   if (_.inRange(effort, 0, 5)) color = 'danger'; //red
@@ -26,6 +29,7 @@ export const getcolor = (effort) => {
   return color;
 };
 
+//For progress bar that shows the percentage of the completion
 export const getProgressValue = (effort,commit) => {
   let percentage = 0;
   if (commit>0){
@@ -35,6 +39,7 @@ export const getProgressValue = (effort,commit) => {
   return percentage;
 };
 
+//For (progress) bar that is designed for the exact hours in LEADERBOARD
 export const getprogress = (effort) => {
   let progress = 92;
   if (_.inRange(effort, 0, 5)) progress = 5 + Math.round(5 * (effort / 5));
@@ -48,5 +53,3 @@ export const getprogress = (effort) => {
 
   return progress;
 };
-
-export default {getProgressColor,getcolor};


### PR DESCRIPTION
# Description
Fixes bug priority low 16.
Currently the color and value of progress bar shown in the summary bar and task list are incorrect and inconsistent, they should reflect the percentage of the total committed hours for the week that have been completed, instead of exact hour counts.
**2nd commit note:** Changes made for the leaderboard has been undo and the info description has been updated.

## Mainly changes explained:
1. Color: 0-20%: Red, 20-40%: Orange, 40-60% hrs: Green, 60-80%: Blue, 80-100%:Indigo, and Equal or More than 100%: Purple. The value of the progress bar is set to reflect its percentage.
2. Update progress bars in the summary bar, leaderboard and team member tasks list.
<img width="735" alt="Screen Shot1" src="https://user-images.githubusercontent.com/9314962/209359146-f929f631-e7f4-4ef5-a3e9-eee482a53335.png">
<img width="932" alt="Screen Shot3" src="https://user-images.githubusercontent.com/9314962/209359168-70988059-28aa-46ae-beef-15fe810011d5.png">

## How to test:
1. check into current branch
4. do `npm install` and `...` to run this PR locally
5. go to dashboard→ Tasks
