### PR TITLE
fix hours shown in the middle column

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -111,6 +111,7 @@ const TeamMemberTasks = props => {
       teamsList = filteredMembers.map((user, index) => {
         let totalHoursLogged = 0;
         let totalHoursRemaining = 0;
+        const thisWeekHours = user.totaltangibletime_hrs;
 
         if (user.tasks) {
           user.tasks = user.tasks.map(task => {
@@ -147,8 +148,8 @@ const TeamMemberTasks = props => {
                     </td>
                     <td className="team-clocks">
                       <u>{user.weeklyComittedHours ? user.weeklyComittedHours : 0}</u> /
-                      <font color="green"> {Math.round(totalHoursLogged)}</font> /
-                      <font color="red"> {Math.round(totalHoursRemaining)}</font>
+                      <font color="green"> {thisWeekHours?thisWeekHours.toFixed(1):0}</font> /
+                      <font color="red"> {totalHoursRemaining?totalHoursRemaining.toFixed(1):0}</font>
                     </td>
                   </tr>
                   <tr>
@@ -321,7 +322,7 @@ const TeamMemberTasks = props => {
                       <FontAwesomeIcon
                         style={{ color: 'green' }}
                         icon={faClock}
-                        title="Weekly Completed Hours"
+                        title="Total Hours Completed this Week"
                       />
                       /
                       <FontAwesomeIcon


### PR DESCRIPTION
### Description
Fixes bug (priority medium 2)
1. Popup for hours shown for the green clock (see below) should say, “Total Hours Completed this Week”. Please update that label.
<img width="747" alt="image" src="https://user-images.githubusercontent.com/9314962/209886788-f3f722a3-7b19-4dc4-90fa-f6b941b7b335.png">

### Mainly changes explained:
1.popup label changed.
2.The hours shown in the middle column was changed.
It showed the total logged hours of tasks before (no time period or week limitation), the design is to show the hours that are logged this week and related to the tasks. I spent a lot of time rewriting several new functions to load all the time entries logged this week and sum them up by user-task key. However, after looking at the design again, it doesn't need to specify which task the hours belong to and all logged time entries must have project/task when the user adds them into the system. Therefore the hours shown in the middle column are just the total tangible time of this week. Using the data stored in the props instead of recalculating and getting from the server will reduce the work at the front end and some possible errors.
<img width="1476" alt="img" src="https://user-images.githubusercontent.com/9314962/209887562-41aaf47f-28c4-4e3a-98be-bc548c355bf9.png">

### How to test:
check into current branch
run this PR locally
go to `dashboard`→ `Tasks`