### PR TITLE
invert color for progress bar of task

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -76,3 +76,13 @@ body,
 .bg--dark-sea-green {
   background-color: #c9d6c6;
 }
+
+.bg-bright-red {
+  background-color: #FF3300 !important;
+  /*  bright-red */
+}
+
+.bg-almost-red {
+  background-color: #CC3366 !important;
+  /*  90%to100%-red */
+}

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -207,7 +207,7 @@ const TeamMemberTasks = props => {
                                 ${parseFloat(task.estimatedHours.toFixed(2))}`}
                                   </span>
                                   <Progress
-                                    color = {getProgressColor(task.hoursLogged,task.estimatedHours)}
+                                    color = {getProgressColor(task.hoursLogged,task.estimatedHours,true)}
                                     value = {getProgressValue(task.hoursLogged,task.estimatedHours)}
                                   />
                                 </div>

--- a/src/utils/effortColors.js
+++ b/src/utils/effortColors.js
@@ -1,19 +1,29 @@
 import _ from 'lodash';
 
 //For progress bar that shows the percentage of the completion
-export const getProgressColor = (effort,commit) => {
+//Set 'invert' to true when used for the bars of TASK
+export const getProgressColor = (effort,commit,invert=false) => {
   let color = 'white';
   let percentage = 0;
   if (commit>0){
     percentage = Math.round(effort*100/commit);
   }
-  if (_.inRange(percentage, 0, 20)) color = 'danger'; //red
-  if (_.inRange(percentage, 20, 40)) color = 'orange'; //orange
-  if (_.inRange(percentage, 40, 60)) color = 'success'; //green
-  if (_.inRange(percentage, 60, 80)) color = 'primary'; //blue
-  if (_.inRange(percentage, 80, 100)) color = 'super'; //indigo
-  //if (_.inRange(percentage, 40, 50)) color = 'awesome'; //violet
-  if (percentage >= 100) color = 'super-awesome'; //purple
+  if (!invert){
+    if (_.inRange(percentage, 0, 20)) color = 'danger'; //red
+    if (_.inRange(percentage, 20, 40)) color = 'orange'; //orange
+    if (_.inRange(percentage, 40, 60)) color = 'success'; //green
+    if (_.inRange(percentage, 60, 80)) color = 'primary'; //blue
+    if (_.inRange(percentage, 80, 100)) color = 'super'; //indigo
+    if (percentage >= 100) color = 'super-awesome'; //purple
+  }else{
+    if (_.inRange(percentage, 0, 20)) color =  'super-awesome'; //purple 
+    if (_.inRange(percentage, 20, 40)) color = 'super'; //indigo
+    if (_.inRange(percentage, 40, 60)) color = 'primary'; //blue
+    if (_.inRange(percentage, 60, 80)) color = 'success'; //green
+    if (_.inRange(percentage, 80, 90)) color = 'orange'; //orange
+    if (_.inRange(percentage, 90, 100)) color = 'almost-red'; 
+    if (percentage >= 100) color = color = 'bright-red'; //bright red
+  }
   return color;
 };
 


### PR DESCRIPTION
### Description
Update the color of the progress bar (for tasks) as the request below:
<img width="1002" alt="requirement" src="https://user-images.githubusercontent.com/9314962/210078474-a5d4d99f-4aad-4616-92b1-dfe4cea8e18b.png">

### Mainly changes explained:
Introduce an optional parameter` invert `for function `getProgressColor`, so that when called for the task percentage, it shows the color inverted.
<img width="620" alt="example" src="https://user-images.githubusercontent.com/9314962/210078498-eaf3fac2-308b-4902-a36f-f4230c99199c.png">

### How to test:
check into current branch
do npm install and ... to run this PR locally
go to dashboard→ Tasks