### PR TITLE
update bar value in leadershipboard

### DIFF
--- a/src/components/LeaderBoard/LeaderBoard.container.jsx
+++ b/src/components/LeaderBoard/LeaderBoard.container.jsx
@@ -1,7 +1,7 @@
 import { getLeaderboardData, getOrgData } from '../../actions/leaderBoardData';
 import { connect } from 'react-redux';
 import Leaderboard from './Leaderboard';
-import { getcolor, getprogress } from '../../utils/effortColors';
+import { getcolor, getprogress, getProgressValue } from '../../utils/effortColors';
 import _ from 'lodash';
 
 const mapStateToProps = (state) => {
@@ -23,7 +23,7 @@ const mapStateToProps = (state) => {
       element.intangibletimewidth = _.round((element.totalintangibletime_hrs * 100) / maxTotal, 0);
 
       element.barcolor = getcolor(element.totaltangibletime_hrs);
-      element.barprogress = getprogress(element.totaltangibletime_hrs);
+      element.barprogress = getProgressValue(element.totaltangibletime_hrs,40);
       element.totaltime = _.round(element.totaltime_hrs, 2);
 
       return element;


### PR DESCRIPTION
### Description
Fixes bug priority low 19.
Fix LEADERBOARD task bar lengths to be proportionate up to 40 hours.
<img width="624" alt="image" src="https://user-images.githubusercontent.com/9314962/210260666-81b88c1b-a275-4597-acdb-4961b20413ee.png">


### Mainly changes explained:
Change the bar value of individuals to proportionate up to 40 hours.
<img width="559" alt="img" src="https://user-images.githubusercontent.com/9314962/210260774-6309e664-2d5e-41db-921a-fc5410a70d68.png">


### How to test:
check into current branch
do `npm install` and ... to run this PR locally
go to dashboard