### PR TITLE
sortby names for people reports

### DIFF
--- a/src/components/Reports/PeopleTable.js
+++ b/src/components/Reports/PeopleTable.js
@@ -7,7 +7,8 @@ import moment from 'moment';
 const PeopleTable = props => {
   let PeopleList = [];
   if (props.userProfiles.length > 0) {
-    PeopleList = props.userProfiles.map((person, index) => (
+    PeopleList = props.userProfiles.sort((a, b) =>
+    a.firstName.localeCompare(b.firstName) ).map((person, index) => (
       <tr className="teams__tr" id={`tr_${person._id}`} key={person._id}>
         <th className="teams__order--input" scope="row">
           <div>{index + 1}</div>


### PR DESCRIPTION
Bug :Alphabetize people on reports page(WIP Navya)
Reports → People → Choose Active, Inactive, or All
Whichever you choose, the list should be alphabetized
Implemented sorting for name.
How to test : 
Reports → People → Choose Active, Inactive, or All
Whichever you choose, the list should be alphabetized
