### PR TITLE
remove top border for alignment

### DIFF
--- a/src/components/SummaryBar/SummaryBar.css
+++ b/src/components/SummaryBar/SummaryBar.css
@@ -106,6 +106,7 @@
 
 .border-red {
   border-width: 1px;
+  border-top-width: 0px;
   /* border-radius: 10px; */
   border-color: #ff050d;
   border-style: solid;
@@ -113,6 +114,7 @@
 
 .border-black {
   border-width: 1px;
+  border-top-width: 0px;
   /* border-radius: 10px; */
   border-color: #000000;
   border-style: solid;
@@ -120,6 +122,7 @@
 
 .border-green {
   border-width: 1px;
+  border-top-width: 0px;
   /* border-radius: 10px; */
   border-color: #32a518;
   border-style: solid;


### PR DESCRIPTION
### Description
Fix dashboard component bug 1 (priority low)
Fix alignment of top-bar components
If you look closely at the image below, you’ll see that the Hours and Summary boxes are off by a pixel or two from the other boxes there.
<img width="678" alt="bug" src="https://user-images.githubusercontent.com/9314962/211436105-9ca49761-334c-4ea5-9775-e4908bfb773e.png">

### Mainly changes explained:
Set the top border width to 0. So that when the border is black it won't melt into the bar above and cause illusion that there is one pixel off among boxes.
<img width="958" alt="result" src="https://user-images.githubusercontent.com/9314962/211436323-4d2be0ab-e2a5-4813-86aa-b76cfd1b995e.png">

### How to test:
check into current branch
do npm install and ... to run this PR locally
go to dashboard