### PR TITLE
Urgent Priority 1: Clicking people’s time log loads my timelog data before theirs

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -81,7 +81,7 @@ class Timelog extends Component {
     toDate: this.endOfWeek(0),
     in: false,
     information: '',
-    isTimeEntriesLoading: false,
+    isTimeEntriesLoading: true,
   };
 
   state = this.initialState;


### PR DESCRIPTION
Jae's Issue video : https://www.dropbox.com/s/dq3d4l9o6376ymx/Wrong%20Data%20Loading%20on%20Timelogs%20Page.mov?dl=0

Fix: 
To avoid the glitching/wrong data being shown in the tasks/timelog as part of dashboard, I have fixed the code to show "Loading symbol/image/gif" unless the correct data is loaded. You can check in the video below. This will be utilized in timelog page as well.

https://user-images.githubusercontent.com/16258136/211631296-0d467c78-5d23-448b-934a-92197e94e285.mov

Code changes:
The loading gif was already in place. However the initial state was set to false which did not allow it to be displayed. So updated the initial state as true and on component mount, have set it to false.

NOTE: 
1. Improving the timelog to load faster is a separate concern
2. "Loading" shown instead of summary bar in timelog page is handled in a separate PR.

