### PR TITLE
fix white page when filter "complete"

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -140,6 +140,12 @@ const WBSTasks = props => {
           return taskItem;
         }
       });
+    }else if (filter === 'complete') {
+      return allTaskItems.filter(taskItem => {
+        if (taskItem.status === 'Complete') {
+          return taskItem;
+        }
+      });
     }
   };
 


### PR DESCRIPTION
### Description
Fix PROJECTS/TASKS/WBS COMPONENT bug 4 (PRIORITY MEDIUM)
White page displayed upon clicking “Complete” on WBS list page.
On DEV: Administrator → Other links → Projects → Click on WBS icon for any project → Click on any name from the list → Click on “Complete” from top right corner → Empty white page is displayed

### Mainly changes explained:
Add filter to return the tasks whose status is "complete".
**Note: It works well when the tasks are loaded and its status has been updated to "Complete".** However, occasionally a sub task under a parent task will not be saved and loaded correctly(it is possible that it relates to bug PRIORITY URGENT 4: Some (but not all) tasks are not saving my updates). Thus that task isn't shown under the complete filter. That situation is beyond the target of this bug fix and should be fixed by another update.

go to Projects → project JL Testing→ JL wbs1
<img width="1229" alt="all" src="https://user-images.githubusercontent.com/9314962/211928082-d399d2c1-c747-4594-95ac-eda1054b94e1.png">
Click on “Complete” from top right corner
<img width="1222" alt="after" src="https://user-images.githubusercontent.com/9314962/211928067-2e16deaf-bfa2-4b07-8216-8b0deda731ce.png">

### How to test:
check into current branch
do npm install and ... to run this PR locally
Administrator → Other links → Projects → Click on WBS icon for any project → Click on any name from the list → Click on “Complete” from top right corner → return required tasks and the overall layout remains the same.