### PR TITLE
show save reminder after the first save

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -140,12 +140,6 @@ const WBSTasks = props => {
           return taskItem;
         }
       });
-    }else if (filter === 'complete') {
-      return allTaskItems.filter(taskItem => {
-        if (taskItem.status === 'Complete') {
-          return taskItem;
-        }
-      });
     }
   };
 

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -291,10 +291,7 @@ const UserProfile = props => {
     try {
       await props.updateUserProfile(props.match.params.userId, userProfile);
       await loadUserProfile();
-
       await loadUserTasks();
-
-      setShowSaveWarning(false);
     } catch (err) {
       alert('An error occurred while attempting to save this profile.');
     }
@@ -304,7 +301,6 @@ const UserProfile = props => {
 
   const toggleInfoModal = () => {
     setInfoModal(!infoModal);
-    setShowSaveWarning(false);
   };
 
   const toggleTab = tab => {

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -264,7 +264,6 @@ const EditLinkModal = props => {
             Cancel
           </Button>
         </ModalFooter>
-        /
       </Modal>
     </React.Fragment>
   );


### PR DESCRIPTION
### Description
Fix USER PROFILE COMPONENT bug 2 (PRIORITY MEDIUM)
When making changes on a user’s profile, the reminder to click the save button has stopped showing AFTER 1 SAVE. It works the first time I make an edit, but not after that/after the auto-refresh when I “save”. It should show for everything that requires that button, ever time. 
<img width="648" alt="img" src="https://user-images.githubusercontent.com/9314962/212435716-0d49ac43-8457-4ed1-8395-e96dcff7e82b.png">

### Mainly changes explained:
Delete the changes made to the state `showSaveWarning` from the function `handleSubmit` and `toggleInfoModal`.
In the code before, the flag/state will be changed to false when the user clicks 'save' or more information icon once. Therefore, no save reminder will be shown even the state `Changed` is updated as true again (new changes made after first save). This `showSaveWarning` should only be set to False when we don't want to show the reminder no matter what value the Changed is. It can be used in the future design but it is not necessary in the current design.

### How to test:
check into current branch
do npm install and ... to run this PR locally
User profile → change any value of the profile → click save → second time change any value of the profile → click save