### PR TITLE
user role now is working properly

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -8,10 +8,10 @@ import { SET_CURRENT_USER, SET_HEADER_DATA } from '../constants/auth';
 
 const { tokenKey } = config;
 
-export const loginUser = (credentials) => (dispatch) => {
+export const loginUser = credentials => dispatch => {
   return httpService
     .post(ENDPOINTS.LOGIN, credentials)
-    .then((res) => {
+    .then(res => {
       if (res.data.new) {
         dispatch(setCurrentUser({ new: true, userId: res.data.userId }));
       } else {
@@ -21,7 +21,7 @@ export const loginUser = (credentials) => (dispatch) => {
         dispatch(setCurrentUser(decoded));
       }
     })
-    .catch((err) => {
+    .catch(err => {
       if (err.response && err.response.status === 403) {
         const errors = { email: err.response.data.message };
         dispatch({
@@ -32,9 +32,9 @@ export const loginUser = (credentials) => (dispatch) => {
     });
 };
 
-export const getHeaderData = (userId) => {
+export const getHeaderData = userId => {
   const url = ENDPOINTS.USER_PROFILE(userId);
-  return async (dispatch) => {
+  return async dispatch => {
     const res = await axios.get(url);
     console.log('userrprofie', res);
 
@@ -47,18 +47,31 @@ export const getHeaderData = (userId) => {
   };
 };
 
-export const logoutUser = () => (dispatch) => {
+export const logoutUser = () => dispatch => {
   localStorage.removeItem(tokenKey);
   httpService.setjwt(false);
   dispatch(setCurrentUser(null));
 };
 
-export const setCurrentUser = (decoded) => ({
+export const refreshToken = userId => {
+  return async dispatch => {
+    const res = await axios.get(ENDPOINTS.USER_REFRESH_TOKEN(userId));
+    if (res.status === 200) {
+      localStorage.setItem(tokenKey, res.data.refreshToken);
+      httpService.setjwt(res.data.refreshToken);
+      const decoded = jwtDecode(res.data.refreshToken);
+      dispatch(setCurrentUser(decoded));
+    }
+    return res.status;
+  };
+};
+
+export const setCurrentUser = decoded => ({
   type: SET_CURRENT_USER,
   payload: decoded,
 });
 
-export const setHeaderData = (data) => ({
+export const setHeaderData = data => ({
   type: SET_HEADER_DATA,
   payload: data,
 });

--- a/src/components/UserProfile/UserProfile.container.jsx
+++ b/src/components/UserProfile/UserProfile.container.jsx
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { updateUserProfile, clearUserProfile } from 'actions/userProfile';
 import { updateTask } from 'actions/task';
 import { getTimeEntriesForWeek, getTimeEntriesForPeriod } from '../../actions/timeEntries';
-
+import { refreshToken } from '../../actions/authActions';
 import { getUserProjects } from '../../actions/userProjects';
 import UserProfile from './UserProfile';
 
@@ -25,4 +25,5 @@ export default connect(mapStateToProps, {
   getTimeEntriesForPeriod,
   getUserProjects,
   updateTask,
+  refreshToken,
 })(UserProfile);

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -290,6 +290,7 @@ const UserProfile = props => {
     }
     try {
       await props.updateUserProfile(props.match.params.userId, userProfile);
+      props.refreshToken(userProfile._id);
       await loadUserProfile();
 
       await loadUserTasks();

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -290,7 +290,7 @@ const UserProfile = props => {
     }
     try {
       await props.updateUserProfile(props.match.params.userId, userProfile);
-      props.refreshToken(userProfile._id);
+      await props.refreshToken(userProfile._id);
       await loadUserProfile();
 
       await loadUserTasks();

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -9,6 +9,7 @@ export const ENDPOINTS = {
   USER_PROFILES: `${APIEndpoint}/userprofile/`,
   USER_PROFILE_BY_NAME: userName => `${APIEndpoint}/userProfile/name/${userName}`,
   USER_TEAM: userId => `${APIEndpoint}/userprofile/teammembers/${userId}`,
+  USER_REFRESH_TOKEN: userId => `${APIEndpoint}/refreshToken/${userId}`,
   LOGIN: `${APIEndpoint}/login`,
   PROJECTS: `${APIEndpoint}/projects`,
   TEAM: `${APIEndpoint}/team`,


### PR DESCRIPTION
# Description
Fixes bug number 3 (bug list medium USER PROFILE COMPONENT)
Changing the role from user profile gets saved and updated on profiles page but doesn’t reflect on other pages/privileges.
## Related PRS (if any):
This frontend PR is related to the (https://github.com/OneCommunityGlobal/HGNRest/pull/270) backend PR.

…

## Mainly changes explained:
1- A new API endpoint   `USER_REFRESH_TOKEN: userId => ${APIEndpoint}/refreshToken/${userId}`, in the URL's file
2 - a new function called  `refreshToken( )` was created in the file  `/src/actions/authAction.js` , this function is responsible to update the `JWT` token  with the new informations when the user change his own role, because before the user was changing his own role this was being saved in the database but wasn't being reflected in privilegies of the new user role, because the token wasn't being updated. 
…

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
log as any  user role,  Admin, volunteer etc..
go to Welcome, Username→ View Profile→ Basic Information Tab→ Go to Role → change from Admin to Volunteer or Vice Versa.
Then verify that some privilegies are changing, for example if you Loged as admin you can Atribute a BlueSquare  for yourself, but if you change the role for Volunteer the button to set BlueSquare won't be avaliable. 


## Screenshots or videos of changes:

![Captura de Tela (156)](https://user-images.githubusercontent.com/39320057/212779624-86ad376a-b003-41b8-a3f1-794fc7d9bf80.png)

![Captura de Tela (153)](https://user-images.githubusercontent.com/39320057/212779634-5eab0d55-c324-4fbf-9a27-54ffa30f075b.png)
