### PR TITLE
Alan create new user duplicate name fix

### DIFF
--- a/src/components/UserManagement/DuplicateNamePopup.jsx
+++ b/src/components/UserManagement/DuplicateNamePopup.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+
+/**
+ * Modal popup to delete the user profile
+ */
+const DuplicateNamePopup = React.memo(props => {
+  const closePopup = e => {
+    props.onClose();
+  };
+
+  return (
+    <Modal isOpen={props.open} toggle={closePopup}>
+      <ModalHeader toggle={closePopup}>Duplicate Names</ModalHeader>
+      <ModalBody>
+        <p>There is already a user with the same name.</p>
+        <p>Do you wish to proceed and have duplicate names?</p>
+        <div style={{ textAlign: 'center', paddingTop: '10px' }}>
+          <Button
+            color="primary btn-danger"
+            onClick={() => {
+              props.setAllowDuplicateName(true);
+              closePopup();
+            }}
+          >
+            Yes
+          </Button>
+          <DivSpacer />
+          <Button color="primary btn-warning" onClick={closePopup}>
+            No
+          </Button>
+          <DivSpacer />
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="secondary" onClick={closePopup}>
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+});
+
+const DivSpacer = React.memo(() => {
+  return <div style={{ padding: '5px' }}></div>;
+});
+
+export default DuplicateNamePopup;

--- a/src/components/UserManagement/DuplicateNamePopup.jsx
+++ b/src/components/UserManagement/DuplicateNamePopup.jsx
@@ -24,7 +24,7 @@ const DuplicateNamePopup = React.memo(props => {
             }}
           >
             Confirm
-          </Button>{' '}
+          </Button>
           <Button onClick={() => props.onClose()}>Cancel</Button>
         </ModalFooter>
       </ModalBody>

--- a/src/components/UserManagement/DuplicateNamePopup.jsx
+++ b/src/components/UserManagement/DuplicateNamePopup.jsx
@@ -15,40 +15,19 @@ const DuplicateNamePopup = React.memo(props => {
       <ModalBody>
         <p>There is already a user with the same name.</p>
         <p>Do you wish to proceed and have duplicate names?</p>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-evenly',
-            textAlign: 'center',
-            paddingTop: '10px',
-          }}
-        >
+        <ModalFooter>
           <Button
-            color="primary btn-danger"
-            style={{ width: '30%' }}
+            color="primary"
             onClick={() => {
               props.createUserProfile(true);
               props.onClose();
             }}
           >
-            Yes
-          </Button>
-          <DivSpacer />
-          <Button
-            color="primary btn-warning"
-            style={{ width: '30%' }}
-            onClick={() => props.onClose()}
-          >
-            No
-          </Button>
-          <DivSpacer />
-        </div>
+            Confirm
+          </Button>{' '}
+          <Button onClick={() => props.onClose()}>Cancel</Button>
+        </ModalFooter>
       </ModalBody>
-      <ModalFooter>
-        <Button color="secondary" onClick={closePopup}>
-          Close
-        </Button>
-      </ModalFooter>
     </Modal>
   );
 });

--- a/src/components/UserManagement/DuplicateNamePopup.jsx
+++ b/src/components/UserManagement/DuplicateNamePopup.jsx
@@ -15,9 +15,17 @@ const DuplicateNamePopup = React.memo(props => {
       <ModalBody>
         <p>There is already a user with the same name.</p>
         <p>Do you wish to proceed and have duplicate names?</p>
-        <div style={{ textAlign: 'center', paddingTop: '10px' }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-evenly',
+            textAlign: 'center',
+            paddingTop: '10px',
+          }}
+        >
           <Button
             color="primary btn-danger"
+            style={{ width: '30%' }}
             onClick={() => {
               props.createUserProfile(true);
               props.onClose();
@@ -26,7 +34,11 @@ const DuplicateNamePopup = React.memo(props => {
             Yes
           </Button>
           <DivSpacer />
-          <Button color="primary btn-warning" onClick={() => props.onClose()}>
+          <Button
+            color="primary btn-warning"
+            style={{ width: '30%' }}
+            onClick={() => props.onClose()}
+          >
             No
           </Button>
           <DivSpacer />

--- a/src/components/UserManagement/DuplicateNamePopup.jsx
+++ b/src/components/UserManagement/DuplicateNamePopup.jsx
@@ -25,7 +25,7 @@ const DuplicateNamePopup = React.memo(props => {
           >
             Confirm
           </Button>
-          <Button onClick={() => props.onClose()}>Cancel</Button>
+          <Button onClick={() => props.popupClose()}>Cancel</Button>
         </ModalFooter>
       </ModalBody>
     </Modal>

--- a/src/components/UserManagement/DuplicateNamePopup.jsx
+++ b/src/components/UserManagement/DuplicateNamePopup.jsx
@@ -25,7 +25,7 @@ const DuplicateNamePopup = React.memo(props => {
           >
             Confirm
           </Button>
-          <Button onClick={() => props.popupClose()}>Cancel</Button>
+          <Button onClick={() => props.popupClose()}>Change name</Button>
         </ModalFooter>
       </ModalBody>
     </Modal>

--- a/src/components/UserManagement/DuplicateNamePopup.jsx
+++ b/src/components/UserManagement/DuplicateNamePopup.jsx
@@ -32,8 +32,4 @@ const DuplicateNamePopup = React.memo(props => {
   );
 });
 
-const DivSpacer = React.memo(() => {
-  return <div style={{ padding: '5px' }}></div>;
-});
-
 export default DuplicateNamePopup;

--- a/src/components/UserManagement/DuplicateNamePopup.jsx
+++ b/src/components/UserManagement/DuplicateNamePopup.jsx
@@ -19,14 +19,14 @@ const DuplicateNamePopup = React.memo(props => {
           <Button
             color="primary btn-danger"
             onClick={() => {
-              props.setAllowDuplicateName(true);
-              closePopup();
+              props.createUserProfile(true);
+              props.onClose();
             }}
           >
             Yes
           </Button>
           <DivSpacer />
-          <Button color="primary btn-warning" onClick={closePopup}>
+          <Button color="primary btn-warning" onClick={() => props.onClose()}>
             No
           </Button>
           <DivSpacer />

--- a/src/components/UserManagement/DuplicateNamePopup.jsx
+++ b/src/components/UserManagement/DuplicateNamePopup.jsx
@@ -10,8 +10,8 @@ const DuplicateNamePopup = React.memo(props => {
   };
 
   return (
-    <Modal isOpen={props.open} toggle={closePopup}>
-      <ModalHeader toggle={closePopup}>Duplicate Names</ModalHeader>
+    <Modal isOpen={props.open} toggle={() => props.popupClose()}>
+      <ModalHeader toggle={() => props.popupClose()}>Duplicate Names</ModalHeader>
       <ModalBody>
         <p>There is already a user with the same name.</p>
         <p>Do you wish to proceed and have duplicate names?</p>

--- a/src/components/UserManagement/NewUserPopup.jsx
+++ b/src/components/UserManagement/NewUserPopup.jsx
@@ -33,6 +33,7 @@ const NewUserPopup = React.memo(props => {
           isAddNewUser={true}
           history={history}
           userCreated={userCreated}
+          userProfiles={props.userProfiles}
         />
 
         {/* Nested Modal that triggers when a first and last name user already exists */}

--- a/src/components/UserManagement/NewUserPopup.jsx
+++ b/src/components/UserManagement/NewUserPopup.jsx
@@ -28,7 +28,12 @@ const NewUserPopup = React.memo(props => {
         Create New User
       </ModalHeader>
       <ModalBody>
-        <AddNewUserProfile isAddNewUser={true} history={history} userCreated={userCreated} />
+        <AddNewUserProfile
+          closePopup={closePopup}
+          isAddNewUser={true}
+          history={history}
+          userCreated={userCreated}
+        />
 
         {/* Nested Modal that triggers when a first and last name user already exists */}
 

--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -235,7 +235,6 @@ class UserManagement extends React.PureComponent {
   userCreated = () => {
     const text = this.state.wildCardSearchText;
     this.props.getAllUserProfile();
-    console.log('text:', text);
     this.setState({
       newUserPopupOpen: false,
       wildCardSearchText: text,

--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -120,6 +120,7 @@ class UserManagement extends React.PureComponent {
         />
         <NewUserPopup
           open={this.state.newUserPopupOpen}
+          userProfiles={this.props.state.allUserProfiles}
           onUserPopupClose={this.onUserPopupClose}
           userCreated={this.userCreated}
         />

--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -70,6 +70,7 @@ class UserManagement extends React.PureComponent {
             {this.popupElements()}
             <UserSearchPanel
               onSearch={this.onWildCardSearch}
+              searchText={this.state.wildCardSearchText}
               onActiveFiter={this.onActiveFiter}
               onNewUserClick={this.onNewUserClick}
             />
@@ -232,9 +233,12 @@ class UserManagement extends React.PureComponent {
    * reload user list and close user creation popup
    */
   userCreated = () => {
+    const text = this.state.wildCardSearchText;
     this.props.getAllUserProfile();
+    console.log('text:', text);
     this.setState({
       newUserPopupOpen: false,
+      wildCardSearchText: text,
     });
   };
 

--- a/src/components/UserManagement/UserSearchPanel.jsx
+++ b/src/components/UserManagement/UserSearchPanel.jsx
@@ -25,6 +25,7 @@ const UserSearchPanel = props => {
         aria-label="Search"
         placeholder="Search Text"
         id="user-profiles-wild-card-search"
+        value={props.searchText}
         onChange={e => {
           props.onSearch(e.target.value);
         }}

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -500,7 +500,7 @@ class AddUserProfile extends Component {
     if (phone === null) {
       toast.error('Phone Number is required');
       return false;
-    } else if (firstLength && lastLength && phone.length > 10) {
+    } else if (firstLength && lastLength && phone.length >= 10) {
       return true;
     } else {
       toast.error('Please fill all the required fields');

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -573,6 +573,15 @@ class AddUserProfile extends Component {
             if (res.data.warning) {
               toast.warn(res.data.warning);
             } else {
+              if (
+                this.checkIfDuplicate(userData.firstName, userData.lastName) &&
+                !allowsDuplicateName
+              ) {
+                this.setState({
+                  popupOpen: true,
+                });
+                return;
+              }
               toast.success('User profile created.');
             }
             this.props.userCreated();

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -509,7 +509,6 @@ class AddUserProfile extends Component {
   };
 
   checkIfDuplicate = (firstName, lastName) => {
-    console.log('userProfiles:', this.state.userProfiles);
     let { userProfiles } = this.state.userProfiles;
 
     const duplicates = userProfiles.filter(user => {
@@ -561,20 +560,13 @@ class AddUserProfile extends Component {
 
     this.setState({ formSubmitted: true });
 
-    if (this.checkIfDuplicate(userData.firstName, userData.lastName) && !allowsDuplicateName) {
-      this.setState({
-        popupOpen: true,
-      });
-      return;
-    }
-
     if (googleDoc) {
       userData.adminLinks.push({ Name: 'Google Doc', Link: googleDoc });
     }
     if (this.fieldsAreValid()) {
       this.setState({ showphone: false });
       if (!email.match(patt)) {
-        toast.error('Email is not valid,Please include @ followed by .com format');
+        toast.error('Email is not valid. Please include @ followed by .com format');
       } else {
         createUser(userData)
           .then(res => {
@@ -613,6 +605,16 @@ class AddUserProfile extends Component {
                     },
                   });
                   break;
+                case 'name':
+                  if (
+                    this.checkIfDuplicate(userData.firstName, userData.lastName) &&
+                    !allowsDuplicateName
+                  ) {
+                    this.setState({
+                      popupOpen: true,
+                    });
+                    return;
+                  }
               }
             }
             toast.error(

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -580,8 +580,9 @@ class AddUserProfile extends Component {
               this.setState({
                 popupOpen: true,
               });
-              toast.success('User profile created.');
               return;
+            } else {
+              toast.success('User profile created.');
             }
             this.props.userCreated();
           })
@@ -621,10 +622,7 @@ class AddUserProfile extends Component {
                     this.setState({
                       popupOpen: true,
                     });
-                    return;
                   }
-                  break;
-                default:
                   break;
               }
             }

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -513,8 +513,8 @@ class AddUserProfile extends Component {
 
     const duplicates = userProfiles.filter(user => {
       return (
-        user.firstName.toLowerCase() == firstName.toLowerCase() &&
-        user.lastName.toLowerCase() == lastName.toLowerCase()
+        user.firstName.toLowerCase() === firstName.toLowerCase() &&
+        user.lastName.toLowerCase() === lastName.toLowerCase()
       );
     });
 
@@ -573,17 +573,15 @@ class AddUserProfile extends Component {
           .then(res => {
             if (res.data.warning) {
               toast.warn(res.data.warning);
-            } else {
-              if (
-                this.checkIfDuplicate(userData.firstName, userData.lastName) &&
-                !allowsDuplicateName
-              ) {
-                this.setState({
-                  popupOpen: true,
-                });
-                return;
-              }
+            } else if (
+              this.checkIfDuplicate(userData.firstName, userData.lastName) &&
+              !allowsDuplicateName
+            ) {
+              this.setState({
+                popupOpen: true,
+              });
               toast.success('User profile created.');
+              return;
             }
             this.props.userCreated();
           })
@@ -625,6 +623,9 @@ class AddUserProfile extends Component {
                     });
                     return;
                   }
+                  break;
+                default:
+                  break;
               }
             }
             toast.error(

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -16,7 +16,7 @@ import {
   NavLink,
   Nav,
 } from 'reactstrap';
-
+import DuplicateNamePopup from 'components/UserManagement/DuplicateNamePopup';
 import ToggleSwitch from '../UserProfileEdit/ToggleSwitch';
 import './UserProfileAdd.scss';
 import { createUser, resetPassword } from '../../../services/userProfileService';
@@ -41,12 +41,15 @@ import classnames from 'classnames';
 import TimeZoneDropDown from '../TimeZoneDropDown';
 import { getUserTimeZone } from 'services/timezoneApiService';
 import hasPermission from 'utils/permissions';
+import NewUserPopup from 'components/UserManagement/NewUserPopup';
 
 const patt = RegExp(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i);
 class AddUserProfile extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      allowsDuplicateName: false,
+      popupOpen: false,
       weeklyCommittedHours: 10,
       teams: [],
       projects: [],
@@ -79,6 +82,18 @@ class AddUserProfile extends Component {
     };
   }
 
+  setAllowDuplicateName = value => {
+    this.setState({
+      allowsDuplicateName: value,
+    });
+  };
+
+  popupClose = () => {
+    this.setState({
+      popupOpen: false,
+    });
+  };
+
   componentDidMount() {
     this.state.showphone = true;
     this.onCreateNewUser();
@@ -91,6 +106,11 @@ class AddUserProfile extends Component {
       this.state.userProfile.phoneNumber.length === 0;
     return (
       <StickyContainer>
+        <DuplicateNamePopup
+          setAllowDuplicateName={this.setAllowDuplicateName}
+          open={this.state.popupOpen}
+          onClose={this.popupClose}
+        />
         <Container className="emp-profile">
           <Row>
             <Col md="12">
@@ -175,10 +195,10 @@ class AddUserProfile extends Component {
                   </Col>
                   <Col md="6">
                     <FormGroup>
-                    <PhoneInput
+                      <PhoneInput
                         country="US"
-                        regions={['america','europe','asia','oceania','africa']}
-                        limitMaxLength= 'true'
+                        regions={['america', 'europe', 'asia', 'oceania', 'africa']}
+                        limitMaxLength="true"
                         value={phoneNumber}
                         onChange={phone => this.phoneChange(phone)}
                       />
@@ -522,6 +542,7 @@ class AddUserProfile extends Component {
       collaborationPreference: collaborationPreference,
       timeZone: timeZone,
       location: location,
+      allowsDuplicateName: this.state.allowsDuplicateName,
     };
 
     this.setState({ formSubmitted: true });
@@ -571,6 +592,10 @@ class AddUserProfile extends Component {
                     },
                   });
                   break;
+                case 'name':
+                  this.setState({
+                    popupOpen: true,
+                  });
               }
             }
             toast.error(

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -500,7 +500,7 @@ class AddUserProfile extends Component {
     if (phone === null) {
       toast.error('Phone Number is required');
       return false;
-    } else if (firstLength && lastLength && phone.length >= 10) {
+    } else if (firstLength && lastLength && phone.length >= 9) {
       return true;
     } else {
       toast.error('Please fill all the required fields');

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -517,7 +517,8 @@ class AddUserProfile extends Component {
         user.lastName.toLowerCase() == lastName.toLowerCase()
       );
     });
-    if (duplicates) return true;
+
+    if (duplicates.length > 0) return true;
     else return false;
   };
 


### PR DESCRIPTION
This is a PR for Other Links → User Management → Create New User ([PR 476](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/476) needs finishing, a “duplicate name created” popup happens after it is created, which is good. Need the rest of the below still though)
Make "user with duplicate name" popup require a person to click to confirm that they want to create a person with a duplicate name 
Make "user with duplicate name" so it is not case sensitive. Currently a user without any caps is not considered a duplicate of the name that includes capitalization of first names. 
The above PR also seems to have broken the auto-refresh for adding a new person… I should see that new person as soon as they are added and now I don’t anymore

How to test:
- With a dev account go to Other Links → User Management → Create New User.
- Create a user with with a name that has been used before (first name + last name).
- Create it with an email that hasn't been used before and also with one that has been used before.
- A new popup should appear asking to confirm if you want to create the user with a duplicate name.
- Check if it behaves the right way.
- Check if the newly created user shows up.