### PR TITLE
Raul implement opening a new tab by ctrl-clicking on the name in the user management

### DIFF
--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -22,14 +22,6 @@ const UserTableData = React.memo(props => {
     onReset(false);
   }, [props.isActive, props.resetLoading]);
 
-  function handleClickName(event) {
-    e.preventDefault();
-            
-    event.ctrlKey 
-      ? window.open(`/userprofile/${props.user._id}`, "_blank")
-      : history.push(`/userprofile/${props.user._id}`);
-  }
-
   return (
     <tr className="usermanagement__tr" id={`tr_user_${props.index}`}>
       <td className="usermanagement__active--input">
@@ -43,7 +35,6 @@ const UserTableData = React.memo(props => {
       <td>
         <a
           href={`/userprofile/${props.user._id}`}
-          onClick={handleClickName}
         >
           {props.user.firstName}
         </a>
@@ -51,7 +42,6 @@ const UserTableData = React.memo(props => {
       <td>
         <a
           href={`/userprofile/${props.user._id}`}
-          onClick={handleClickName}
         >
           {props.user.lastName}
         </a>

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -22,6 +22,14 @@ const UserTableData = React.memo(props => {
     onReset(false);
   }, [props.isActive, props.resetLoading]);
 
+  function handleClickName(event) {
+    e.preventDefault();
+            
+    event.ctrlKey 
+      ? window.open(`/userprofile/${props.user._id}`, "_blank")
+      : history.push(`/userprofile/${props.user._id}`);
+  }
+
   return (
     <tr className="usermanagement__tr" id={`tr_user_${props.index}`}>
       <td className="usermanagement__active--input">
@@ -35,10 +43,7 @@ const UserTableData = React.memo(props => {
       <td>
         <a
           href={`/userprofile/${props.user._id}`}
-          onClick={e => {
-            e.preventDefault();
-            history.push('/userprofile/' + props.user._id);
-          }}
+          onClick={handleClickName}
         >
           {props.user.firstName}
         </a>
@@ -46,10 +51,7 @@ const UserTableData = React.memo(props => {
       <td>
         <a
           href={`/userprofile/${props.user._id}`}
-          onClick={e => {
-            e.preventDefault();
-            history.push('/userprofile/' + props.user._id);
-          }}
+          onClick={handleClickName}
         >
           {props.user.lastName}
         </a>


### PR DESCRIPTION
# Description
(USER MANAGEMENT COMPONENT - PRIORITY LOW) 

> Jae: Make Names Command(Mac)/Control(PC) Clickable :
> a. Admin Login → Other Links → User Management
> b. The clickable names in the Team Management page won’t allow me to Command(Mac)/Control(PC) click to open them in a new tab

## Mainly changes explained:
The old opening function was deleted and a new one was created. Now, besides the opening at the same tab by clicking, if the user clicks pressing the ctrl/command, the profile opens in a new tab.

## How to test:
1. git checkout raul_impl_opennewtab_ctrlclicking_name
2. npm install
3. npm run start:local
4. log as an admin user
5. go to Other Links -> User Management
6. click any name by pressing the ctrl and make sure that the name's profile will open in a new tab.

Here is a video of my testing below:

https://user-images.githubusercontent.com/29555732/213498874-02996a6c-dc7c-433c-9f12-0c187afbd287.mov


