### PR TITLE
UP1: Jae: Clicking people’s time log loads my timelog data before theirs

### DIFF
--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -159,19 +159,22 @@ export class Login extends Form {
             label: 'Password:',
             type: 'password',
           })}
-          {this.renderButton('Submit')}
-          <Link to="forgotpassword">
-            <span
-              style={{
-                color: 'blue',
-                textDecorationLine: 'underline',
-                marginLeft: '240px',
-                cursor: 'pointer',
-              }}
-            >
-              forgot password?
-            </span>
-          </Link>
+          <div>
+            {this.renderButton('Submit')}
+            <Link to="forgotpassword">
+              <span
+                style={{
+                  color: 'blue',
+                  textDecorationLine: 'underline',
+                  lineHeight: '50px',
+                  float: 'right',
+                  cursor: 'pointer',
+                }}
+              >
+                forgot password?
+              </span>
+            </Link>
+          </div>
         </form>
       </div>
     );

--- a/src/components/SummaryBar/SummaryBar.css
+++ b/src/components/SummaryBar/SummaryBar.css
@@ -163,6 +163,11 @@
   font-size: 1rem;
 }
 
+.disabled-bar{
+  opacity: 0.4;
+  filter: alpha(opacity=40); /* msie */
+}
+
 /* XLarge devices (landscape phones, 544px and down) */
 @media (max-width: 1200px) {
   .med_text_summary {

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -59,7 +59,6 @@ const SummaryBar = props => {
     try {
       const response = await axios.get(ENDPOINTS.USER_PROFILE(userId));
       const newUserProfile = response.data;
-      console.log('User Profile loaded', newUserProfile);
       setUserProfile(newUserProfile);
     } catch (err) {
       console.log('User Profile not loaded.');
@@ -73,8 +72,6 @@ const SummaryBar = props => {
     try {
       const response = await axios.get(ENDPOINTS.TASKS_BY_USERID(userId));
       const newUserTasks = response.data;
-      console.log('User Tasks loaded');
-      console.log(newUserTasks.length);
       setTasks(newUserTasks.length);
     } catch (err) {
       console.log('User Tasks not loaded.');
@@ -86,23 +83,7 @@ const SummaryBar = props => {
     getUserTask();
   }, [leaderData]);
 
-  const calculateTotalTime = (data, isTangible) => {
-    const filteredData = data.filter(entry => entry.isTangible === isTangible);
 
-    const reducer = (total, entry) => total + parseInt(entry.hours) + parseInt(entry.minutes) / 60;
-    return filteredData.reduce(reducer, 0);
-  };
-  // const weeklySummary = useSelector(state => {
-  //   let summaries = state.userProfile?.weeklySummaries;
-  //   if (summaries && Array.isArray(summaries) && summaries[0] && summaries[0].summary) {
-  //     console.log('Yes weeklySummary');
-  //     console.log(summaries[0].summary);
-  //     return summaries[0].summary;
-  //   } else {
-  //     console.log('No weeklySummary');
-  //     return '';
-  //   }
-  // });
 
   //Get infringement count from userProfile
   const getInfringements = user => {
@@ -199,13 +180,12 @@ const SummaryBar = props => {
   if (userProfile !== undefined && leaderData !== undefined) {
     const infringements = getInfringements(userProfile);
     const badges = getBadges(userProfile);
-    console.log(tasks);
     const { firstName, lastName, email, _id } = userProfile;
     let totalEffort = parseFloat(leaderData.find(x => x.personId === asUser).tangibletime);
     const weeklyCommittedHours = userProfile.weeklyComittedHours;
     const weeklySummary = getWeeklySummary(userProfile);
     return (
-      <Container fluid className="px-lg-0 bg--bar">
+      <Container fluid className={matchUser ? "px-lg-0 bg--bar" : "px-lg-0 bg--bar disabled-bar"}>
         <Row className="no-gutters row-eq-height">
           <Col
             className="d-flex justify-content-center align-items-center col-lg-2 col-12 text-list"
@@ -308,12 +288,6 @@ const SummaryBar = props => {
                 </div>
               )}
 
-              {/* <div className="border-green col-sm-4 bg--dark-green" align="center">
-                <div className="py-1"> </div>
-                <h1 align="center">✓</h1>
-                <font size="3">SUMMARY</font>
-                <div className="py-2"> </div>
-              </div> */}
               <div
                 className="col-8 border-black bg--white-smoke d-flex align-items-center"
                 align="center"
@@ -332,12 +306,6 @@ const SummaryBar = props => {
               </div>
             </Row>
           </Col>
-          {/* {isSubmitted && (<font className="text--black" align="center" size="3">
-              You have completed weekly summary.
-            </font>)}
-            {!isSubmitted && (<font className="text--black" align="center" size="3">
-              You still need to complete the weekly summary.
-            </font>)} */}
 
           <Col className="m-auto mt-2 col-lg-4 col-12 badge-list">
             <div className="d-flex justify-content-around no-gutters">
@@ -346,31 +314,48 @@ const SummaryBar = props => {
                 <div className="redBackgroup">
                   <span>{tasks}</span>
                 </div>
-
+                {matchUser ?
                 <img className="sum_img" src={task_icon} alt="" onClick={onTaskClick}></img>
+                :
+                <img className="sum_img" src={task_icon} alt=""></img>
+                }
               </div>
               &nbsp;&nbsp;
               <div className="image_frame">
-                <img className="sum_img" src={badges_icon} alt="" onClick={onBadgeClick} />
+                {matchUser ?
+                <img className="sum_img" src={badges_icon} alt="" onClick={onBadgeClick} /> 
+                :
+                <img className="sum_img" src={badges_icon} alt="" />}
                 <div className="redBackgroup">
                   <span>{badges}</span>
                 </div>
               </div>
               &nbsp;&nbsp;
               <div className="image_frame">
+                {
+                matchUser ?
                 <Link to={`/userprofile/${_id}#bluesquare`}>
                   <img className="sum_img" src={bluesquare_icon} alt="" />
                   <div className="redBackgroup">
                     <span>{infringements}</span>
                   </div>
+                </Link> 
+                :
+                <Link>
+                  <img className="sum_img" src={bluesquare_icon} alt="" />
+                  <div className="redBackgroup">
+                    <span>{infringements}</span>
+                  </div>
                 </Link>
+                }
               </div>
               &nbsp;&nbsp;
               <div className="image_frame">
+                {matchUser ?
                 <img className="sum_img" src={report_icon} alt="" onClick={openReport} />
-                {/* <div className="blackBackgroup">
-                <i className="fa fa-exclamation" aria-hidden="true" />
-              </div> */}
+                :
+                <img className="sum_img" src={report_icon} alt="" />
+                }
               </div>
             </div>
           </Col>

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -297,9 +297,15 @@ const SummaryBar = props => {
                     {weeklySummary || props.submittedSummary ? (
                       'You have submitted your weekly summary.'
                     ) : (
-                      <span className="summary-toggle" onClick={props.toggleSubmitForm}>
-                        You still need to complete the weekly summary. Click here to submit it.
-                      </span>
+                          matchUser ? (
+                            <span className="summary-toggle" onClick={props.toggleSubmitForm}>
+                            You still need to complete the weekly summary. Click here to submit it.
+                            </span>
+                          ) : (
+                            <span className="summary-toggle">
+                            You still need to complete the weekly summary. Click here to submit it.
+                            </span>
+                          )
                     )}
                   </font>
                 </div>
@@ -341,12 +347,12 @@ const SummaryBar = props => {
                   </div>
                 </Link> 
                 :
-                <Link>
+                <div>
                   <img className="sum_img" src={bluesquare_icon} alt="" />
                   <div className="redBackgroup">
                     <span>{infringements}</span>
                   </div>
-                </Link>
+                </div>
                 }
               </div>
               &nbsp;&nbsp;

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -107,12 +107,13 @@ class Timelog extends Component {
     if (!this.props.match) return;
 
     if (
-      prevProps.match?.params?.userId !== this.props.match.params.userId
-      || prevProps.asUser !== this.props.asUser
+      prevProps.match?.params?.userId !== this.props.match.params.userId ||
+      prevProps.asUser !== this.props.asUser
     ) {
       this.setState(this.initialState);
 
-      const userId = this.props.match?.params?.userId || this.props.asUser || this.props.auth.user.userid;
+      const userId =
+        this.props.match?.params?.userId || this.props.asUser || this.props.auth.user.userid;
       await this.props.getUserProfile(userId);
 
       this.userProfile = this.props.userProfile;
@@ -179,9 +180,10 @@ class Timelog extends Component {
 
   handleSearch(e) {
     e.preventDefault();
-    const userId = this.props.match && this.props.match.params.userId
-      ? this.props.match.params.userId
-      : this.props.asUser || this.props.auth.user.userid;
+    const userId =
+      this.props.match && this.props.match.params.userId
+        ? this.props.match.params.userId
+        : this.props.asUser || this.props.auth.user.userid;
     this.props.getTimeEntriesForPeriod(userId, this.state.fromDate, this.state.toDate);
   }
 
@@ -206,9 +208,7 @@ class Timelog extends Component {
   }
 
   calculateTotalTime(data, isTangible) {
-    const filteredData = data.filter(
-      (entry) => entry.isTangible === isTangible,
-    );
+    const filteredData = data.filter(entry => entry.isTangible === isTangible);
 
     const reducer = (total, entry) => total + parseInt(entry.hours) + parseInt(entry.minutes) / 60;
     return filteredData.reduce(reducer, 0);
@@ -216,12 +216,12 @@ class Timelog extends Component {
 
   generateTimeEntries(data) {
     if (!this.state.projectsSelected.includes('all')) {
-      data = data.filter((entry) => this.state.projectsSelected.includes(entry.projectId));
+      data = data.filter(entry => this.state.projectsSelected.includes(entry.projectId));
     } else {
       this.state.currentWeekEffort = this.calculateTotalTime(data, true);
     }
 
-    return data.map((entry) => (
+    return data.map(entry => (
       <TimeEntry data={entry} displayYear={false} key={entry._id} userProfile={this.userProfile} />
     ));
   }
@@ -229,18 +229,16 @@ class Timelog extends Component {
   renderViewingTimeEntriesFrom() {
     if (this.state.activeTab === 0) {
       return <></>;
-    } 
-    else if (this.state.activeTab === 4) {
+    } else if (this.state.activeTab === 4) {
       return (
         <p className="ml-1">
           Viewing time Entries from <b>{this.state.fromDate}</b> to <b>{this.state.toDate}</b>
         </p>
       );
-    } 
-    else {
+    } else {
       return (
         <p className="ml-1">
-            Viewing time Entries from <b>{this.startOfWeek(this.state.activeTab - 1)}</b> to{' '}
+          Viewing time Entries from <b>{this.startOfWeek(this.state.activeTab - 1)}</b> to{' '}
           <b>{this.endOfWeek(this.state.activeTab - 1)}</b>
         </p>
       );
@@ -252,9 +250,10 @@ class Timelog extends Component {
     const lastWeekEntries = this.generateTimeEntries(this.props.timeEntries.weeks[1]);
     const beforeLastEntries = this.generateTimeEntries(this.props.timeEntries.weeks[2]);
     const periodEntries = this.generateTimeEntries(this.props.timeEntries.period);
-    const userId = this.props.match && this.props.match.params.userId
-      ? this.props.match.params.userId
-      : this.props.asUser || this.props.auth.user.userid;
+    const userId =
+      this.props.match && this.props.match.params.userId
+        ? this.props.match.params.userId
+        : this.props.asUser || this.props.auth.user.userid;
     const { role } = this.props.auth.user;
     const userPermissions = this.props.auth.user?.permissions?.frontPermissions;
 
@@ -265,11 +264,10 @@ class Timelog extends Component {
     if (!_.isEmpty(this.props.userProjects.projects)) {
       projects = this.props.userProjects.projects;
     }
-    const projectOrTaskOptions = projects.map((project) => (
+    const projectOrTaskOptions = projects.map(project => (
       <option value={project.projectId} key={project.projectId}>
         {' '}
-        {project.projectName}
-        {' '}
+        {project.projectName}{' '}
       </option>
     ));
     projectOrTaskOptions.unshift(
@@ -295,27 +293,23 @@ class Timelog extends Component {
 
     return (
       <div>
-        {
-          !this.props.isDashboard
-            ? (this.state.isTimeEntriesLoading ? (
-              'Loading...'
-            )
-            : (
-              <Container fluid>
-                <SummaryBar
-                  asUser={userId}
-                  toggleSubmitForm={() => this.showSummary(isOwner)}
-                  role={role}
-                  leaderData={leaderData}
-                />
-                <br />
-              </Container>
-            )
+        {!this.props.isDashboard ? (
+          this.state.isTimeEntriesLoading ? (
+            'Loading...'
+          ) : (
+            <Container fluid>
+              <SummaryBar
+                asUser={userId}
+                toggleSubmitForm={() => this.showSummary(isOwner)}
+                role={role}
+                leaderData={leaderData}
+              />
+              <br />
+            </Container>
           )
-          : (
-            ''
-          )
-        }
+        ) : (
+          ''
+        )}
         {this.state.isTimeEntriesLoading ? (
           <Loading />
         ) : (
@@ -346,9 +340,10 @@ class Timelog extends Component {
                             isActive={this.props.userProfile.isActive}
                             user={this.props.userProfile}
                             onClick={() => {
-                              const userId = this.props.match?.params?.userId
-                                || this.props.asUser
-                                || this.props.auth.user.userid;
+                              const userId =
+                                this.props.match?.params?.userId ||
+                                this.props.asUser ||
+                                this.props.auth.user.userid;
                               this.props.updateUserProfile(userId, {
                                 ...this.props.userProfile,
                                 isActive: !this.props.userProfile.isActive,
@@ -361,9 +356,9 @@ class Timelog extends Component {
                           />
                           <ProfileNavDot
                             userId={
-                              this.props.match?.params?.userId
-                              || this.props.asUser
-                              || this.props.auth.user.userid
+                              this.props.match?.params?.userId ||
+                              this.props.asUser ||
+                              this.props.auth.user.userid
                             }
                           />
                         </CardTitle>
@@ -388,8 +383,7 @@ class Timelog extends Component {
                               </Button>
                               <ReactTooltip id="timeEntryTip" place="bottom" effect="solid">
                                 Clicking this button only allows for “Intangible Time” to be added
-                                to your time log.
-                                {' '}
+                                to your time log.{' '}
                                 <u>
                                   You can manually log Intangible Time but it doesn’t
                                   {' '}
@@ -472,7 +466,7 @@ class Timelog extends Component {
                               <Button onClick={this.openInfo} color="secondary">
                                 Edit
                               </Button>
-                              ) : null}
+                            ) : null}
                           </ModalFooter>
                         </Modal>
                         <TimeEntryForm
@@ -600,12 +594,14 @@ class Timelog extends Component {
                               id="projectSelected"
                               value={this.state.projectsSelected}
                               title="Ctrl + Click to select multiple projects and tasks to filter."
-                              onChange={(e) => this.setState({
-                                projectsSelected: Array.from(
-                                  e.target.selectedOptions,
-                                  (option) => option.value,
-                                ),
-                              })}
+                              onChange={e =>
+                                this.setState({
+                                  projectsSelected: Array.from(
+                                    e.target.selectedOptions,
+                                    option => option.value,
+                                  ),
+                                })
+                              }
                               multiple
                             >
                               {projectOrTaskOptions}
@@ -622,7 +618,9 @@ class Timelog extends Component {
                           projectsSelected={this.state.projectsSelected}
                         />
                       )}
-                      <TabPane tabId={0}><TeamMemberTasks asUser={this.props.asUser} /></TabPane>
+                      <TabPane tabId={0}>
+                        <TeamMemberTasks asUser={this.props.asUser} />
+                      </TabPane>
                       <TabPane tabId={1}>{currentWeekEntries}</TabPane>
                       <TabPane tabId={2}>{lastWeekEntries}</TabPane>
                       <TabPane tabId={3}>{beforeLastEntries}</TabPane>
@@ -640,7 +638,7 @@ class Timelog extends Component {
   }
 }
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   auth: state.auth,
   userProfile: state.userProfile,
   timeEntries: state.timeEntries,

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -31,6 +31,9 @@ import moment from 'moment';
 import _ from 'lodash';
 import ReactTooltip from 'react-tooltip';
 
+import ActiveCell from 'components/UserManagement/ActiveCell';
+import { ProfileNavDot } from 'components/UserManagement/ProfileNavDot';
+import TeamMemberTasks from 'components/TeamMemberTasks';
 import { getTimeEntriesForWeek, getTimeEntriesForPeriod } from '../../actions/timeEntries';
 import { getUserProfile, updateUserProfile, getUserTask } from '../../actions/userProfile';
 import { getUserProjects } from '../../actions/userProjects';
@@ -40,12 +43,8 @@ import TimeEntry from './TimeEntry';
 import EffortBar from './EffortBar';
 import SummaryBar from '../SummaryBar/SummaryBar';
 import WeeklySummary from '../WeeklySummary/WeeklySummary';
-import ActiveCell from 'components/UserManagement/ActiveCell';
-import { ProfileNavDot } from 'components/UserManagement/ProfileNavDot';
 import Loading from '../common/Loading';
 import hasPermission from '../../utils/permissions';
-
-import TeamMemberTasks from 'components/TeamMemberTasks';
 
 class Timelog extends Component {
   constructor(props) {
@@ -57,7 +56,7 @@ class Timelog extends Component {
     this.handleSearch = this.handleSearch.bind(this);
     this.openInfo = this.openInfo.bind(this);
     this.calculateTotalTime = this.calculateTotalTime.bind(this);
-    //renderViewingTimeEntriesFrom
+
     this.renderViewingTimeEntriesFrom = this.renderViewingTimeEntriesFrom.bind(this);
     this.data = {
       disabled: !hasPermission(
@@ -82,7 +81,7 @@ class Timelog extends Component {
     toDate: this.endOfWeek(0),
     in: false,
     information: '',
-    currentWeekEffort : 0,
+    currentWeekEffort: 0,
     isTimeEntriesLoading: true,
   };
 
@@ -104,17 +103,16 @@ class Timelog extends Component {
   }
 
   async componentDidUpdate(prevProps) {
-    //Don't run function on first render
+    // Don't run function on first render
     if (!this.props.match) return;
 
     if (
-      prevProps.match?.params?.userId !== this.props.match.params.userId ||
-      prevProps.asUser !== this.props.asUser
+      prevProps.match?.params?.userId !== this.props.match.params.userId
+      || prevProps.asUser !== this.props.asUser
     ) {
       this.setState(this.initialState);
 
-      const userId =
-        this.props.match?.params?.userId || this.props.asUser || this.props.auth.user.userid;
+      const userId = this.props.match?.params?.userId || this.props.asUser || this.props.auth.user.userid;
       await this.props.getUserProfile(userId);
 
       this.userProfile = this.props.userProfile;
@@ -146,7 +144,7 @@ class Timelog extends Component {
         summary: !this.state.summary,
       });
       setTimeout(() => {
-        let elem = document.getElementById('weeklySum');
+        const elem = document.getElementById('weeklySum');
         if (elem) {
           elem.scrollIntoView();
         }
@@ -181,15 +179,14 @@ class Timelog extends Component {
 
   handleSearch(e) {
     e.preventDefault();
-    const userId =
-      this.props.match && this.props.match.params.userId
-        ? this.props.match.params.userId
-        : this.props.asUser || this.props.auth.user.userid;
+    const userId = this.props.match && this.props.match.params.userId
+      ? this.props.match.params.userId
+      : this.props.asUser || this.props.auth.user.userid;
     this.props.getTimeEntriesForPeriod(userId, this.state.fromDate, this.state.toDate);
   }
 
-  //startOfWeek returns the date of the start of the week based on offset. Offset is the number of weeks before.
-  //For example, if offset is 0, returns the start of this week. If offset is 1, returns the start of last week.
+  // startOfWeek returns the date of the start of the week based on offset. Offset is the number of weeks before.
+  // For example, if offset is 0, returns the start of this week. If offset is 1, returns the start of last week.
   startOfWeek(offset) {
     return moment()
       .tz('America/Los_Angeles')
@@ -198,8 +195,8 @@ class Timelog extends Component {
       .format('YYYY-MM-DD');
   }
 
-  //endOfWeek returns the date of the end of the week based on offset. Offset is the number of weeks before.
-  //For example, if offset is 0, returns the end of this week. If offset is 1, returns the end of last week.
+  // endOfWeek returns the date of the end of the week based on offset. Offset is the number of weeks before.
+  // For example, if offset is 0, returns the end of this week. If offset is 1, returns the end of last week.
   endOfWeek(offset) {
     return moment()
       .tz('America/Los_Angeles')
@@ -210,25 +207,21 @@ class Timelog extends Component {
 
   calculateTotalTime(data, isTangible) {
     const filteredData = data.filter(
-      entry =>
-        entry.isTangible === isTangible &&
-        (this.state.projectsSelected.includes('all') || this.state.projectsSelected.includes(entry.projectId)),
+      (entry) => entry.isTangible === isTangible,
     );
 
     const reducer = (total, entry) => total + parseInt(entry.hours) + parseInt(entry.minutes) / 60;
     return filteredData.reduce(reducer, 0);
-  };
+  }
 
   generateTimeEntries(data) {
-    let filteredData = data;
     if (!this.state.projectsSelected.includes('all')) {
-      filteredData = data.filter(entry => this.state.projectsSelected.includes(entry.projectId));
-    }
-    else {
+      data = data.filter((entry) => this.state.projectsSelected.includes(entry.projectId));
+    } else {
       this.state.currentWeekEffort = this.calculateTotalTime(data, true);
     }
 
-    return filteredData.map(entry => (
+    return data.map((entry) => (
       <TimeEntry data={entry} displayYear={false} key={entry._id} userProfile={this.userProfile} />
     ));
   }
@@ -236,16 +229,18 @@ class Timelog extends Component {
   renderViewingTimeEntriesFrom() {
     if (this.state.activeTab === 0) {
       return <></>;
-    } else if (this.state.activeTab === 4) {
+    } 
+    else if (this.state.activeTab === 4) {
       return (
         <p className="ml-1">
           Viewing time Entries from <b>{this.state.fromDate}</b> to <b>{this.state.toDate}</b>
         </p>
       );
-    } else {
+    } 
+    else {
       return (
         <p className="ml-1">
-          Viewing time Entries from <b>{this.startOfWeek(this.state.activeTab - 1)}</b> to{' '}
+            Viewing time Entries from <b>{this.startOfWeek(this.state.activeTab - 1)}</b> to{' '}
           <b>{this.endOfWeek(this.state.activeTab - 1)}</b>
         </p>
       );
@@ -257,24 +252,24 @@ class Timelog extends Component {
     const lastWeekEntries = this.generateTimeEntries(this.props.timeEntries.weeks[1]);
     const beforeLastEntries = this.generateTimeEntries(this.props.timeEntries.weeks[2]);
     const periodEntries = this.generateTimeEntries(this.props.timeEntries.period);
-    const userId =
-      this.props.match && this.props.match.params.userId
-        ? this.props.match.params.userId
-        : this.props.asUser || this.props.auth.user.userid;
-    const role = this.props.auth.user.role;
+    const userId = this.props.match && this.props.match.params.userId
+      ? this.props.match.params.userId
+      : this.props.asUser || this.props.auth.user.userid;
+    const { role } = this.props.auth.user;
     const userPermissions = this.props.auth.user?.permissions?.frontPermissions;
 
     const isOwner = this.props.auth.user.userid === userId;
-    const leaderData = [{ personId : userId, tangibletime : this.state.currentWeekEffort}]
+    const leaderData = [{ personId: userId, tangibletime: this.state.currentWeekEffort }];
     const fullName = `${this.props.userProfile.firstName} ${this.props.userProfile.lastName}`;
     let projects = [];
     if (!_.isEmpty(this.props.userProjects.projects)) {
       projects = this.props.userProjects.projects;
     }
-    const projectOrTaskOptions = projects.map(project => (
+    const projectOrTaskOptions = projects.map((project) => (
       <option value={project.projectId} key={project.projectId}>
         {' '}
-        {project.projectName}{' '}
+        {project.projectName}
+        {' '}
       </option>
     ));
     projectOrTaskOptions.unshift(
@@ -301,22 +296,23 @@ class Timelog extends Component {
     return (
       <div>
         {
-          !this.props.isDashboard ? 
-          (this.state.isTimeEntriesLoading ? (
+          !this.props.isDashboard
+            ? (this.state.isTimeEntriesLoading ? (
               'Loading...'
-            ) : 
-            (
+            )
+            : (
               <Container fluid>
-                <SummaryBar asUser={userId} 
-                            toggleSubmitForm={() => this.showSummary(isOwner)} 
-                            role={role} 
-                            leaderData={leaderData}/>
-                <br/>
+                <SummaryBar
+                  asUser={userId}
+                  toggleSubmitForm={() => this.showSummary(isOwner)}
+                  role={role}
+                  leaderData={leaderData}
+                />
+                <br />
               </Container>
             )
-          ) 
-          : 
-          (
+          )
+          : (
             ''
           )
         }
@@ -350,10 +346,9 @@ class Timelog extends Component {
                             isActive={this.props.userProfile.isActive}
                             user={this.props.userProfile}
                             onClick={() => {
-                              const userId =
-                                this.props.match?.params?.userId ||
-                                this.props.asUser ||
-                                this.props.auth.user.userid;
+                              const userId = this.props.match?.params?.userId
+                                || this.props.asUser
+                                || this.props.auth.user.userid;
                               this.props.updateUserProfile(userId, {
                                 ...this.props.userProfile,
                                 isActive: !this.props.userProfile.isActive,
@@ -366,9 +361,9 @@ class Timelog extends Component {
                           />
                           <ProfileNavDot
                             userId={
-                              this.props.match?.params?.userId ||
-                              this.props.asUser ||
-                              this.props.auth.user.userid
+                              this.props.match?.params?.userId
+                              || this.props.asUser
+                              || this.props.auth.user.userid
                             }
                           />
                         </CardTitle>
@@ -393,21 +388,28 @@ class Timelog extends Component {
                               </Button>
                               <ReactTooltip id="timeEntryTip" place="bottom" effect="solid">
                                 Clicking this button only allows for “Intangible Time” to be added
-                                to your time log.{' '}
+                                to your time log.
+                                {' '}
                                 <u>
-                                  You can manually log Intangible Time but it doesn’t <br />
+                                  You can manually log Intangible Time but it doesn’t
+                                  {' '}
+                                  <br />
                                   count towards your weekly time commitment.
                                 </u>
                                 <br />
                                 <br />
                                 “Tangible Time” is the default for logging time using the timer at
                                 the top of the app. It represents all work done on assigned action
-                                items <br />
+                                items
+                                {' '}
+                                <br />
                                 and is what counts towards a person’s weekly volunteer time
                                 commitment. The only way for a volunteer to log Tangible Time is by
                                 using the clock
                                 <br />
-                                in/out timer. <br />
+                                in/out timer.
+                                {' '}
+                                <br />
                                 <br />
                                 Intangible Time is almost always used only by the management team.
                                 It is used for weekly Monday night management team calls, monthly
@@ -415,8 +417,11 @@ class Timelog extends Component {
                                 <br />
                                 team reviews and Welcome Team Calls, and non-action-item related
                                 research, classes, and other learning, meetings, etc. that benefit
-                                or relate to <br />
-                                the project but aren’t related to a specific action item on the{' '}
+                                or relate to
+                                {' '}
+                                <br />
+                                the project but aren’t related to a specific action item on the
+                                {' '}
                                 <a href="https://www.tinyurl.com/oc-os-wbs">
                                   One Community Work Breakdown Structure.
                                 </a>
@@ -424,7 +429,9 @@ class Timelog extends Component {
                                 <br />
                                 Intangible Time may also be logged by a volunteer when in the field
                                 or for other reasons when the timer wasn’t able to be used. In these
-                                cases, the <br />
+                                cases, the
+                                {' '}
+                                <br />
                                 volunteer will use this button to log time as “intangible time” and
                                 then request that an Admin manually change the log from Intangible
                                 to Tangible.
@@ -465,7 +472,7 @@ class Timelog extends Component {
                               <Button onClick={this.openInfo} color="secondary">
                                 Edit
                               </Button>
-                            ) : null}
+                              ) : null}
                           </ModalFooter>
                         </Modal>
                         <TimeEntryForm
@@ -582,7 +589,7 @@ class Timelog extends Component {
                       {this.state.activeTab === 0 ? (
                         <></>
                       ) : (
-                        <Form inline className="mb-2">
+                        <Form className="mb-2">
                           <FormGroup>
                             <Label for="projectSelected" className="mr-1 ml-1 mb-1 align-top">
                               Filter Entries by Project and Task:
@@ -593,14 +600,12 @@ class Timelog extends Component {
                               id="projectSelected"
                               value={this.state.projectsSelected}
                               title="Ctrl + Click to select multiple projects and tasks to filter."
-                              onChange={e =>
-                                this.setState({
-                                  projectsSelected: Array.from(
-                                    e.target.selectedOptions,
-                                    option => option.value,
-                                  ),
-                                })
-                              }
+                              onChange={(e) => this.setState({
+                                projectsSelected: Array.from(
+                                  e.target.selectedOptions,
+                                  (option) => option.value,
+                                ),
+                              })}
                               multiple
                             >
                               {projectOrTaskOptions}
@@ -617,7 +622,7 @@ class Timelog extends Component {
                           projectsSelected={this.state.projectsSelected}
                         />
                       )}
-                      <TabPane tabId={0}>{<TeamMemberTasks asUser={this.props.asUser} />}</TabPane>
+                      <TabPane tabId={0}><TeamMemberTasks asUser={this.props.asUser} /></TabPane>
                       <TabPane tabId={1}>{currentWeekEntries}</TabPane>
                       <TabPane tabId={2}>{lastWeekEntries}</TabPane>
                       <TabPane tabId={3}>{beforeLastEntries}</TabPane>
@@ -635,7 +640,7 @@ class Timelog extends Component {
   }
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   auth: state.auth,
   userProfile: state.userProfile,
   timeEntries: state.timeEntries,

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -71,7 +71,7 @@ class Timelog extends Component {
     };
     this.userProfile = this.props.userProfile;
   }
-
+  
   initialState = {
     modal: false,
     summary: false,
@@ -209,7 +209,7 @@ class Timelog extends Component {
 
   calculateTotalTime(data, isTangible) {
     const filteredData = data.filter(entry => entry.isTangible === isTangible);
-
+    
     const reducer = (total, entry) => total + parseInt(entry.hours) + parseInt(entry.minutes) / 60;
     return filteredData.reduce(reducer, 0);
   }
@@ -217,8 +217,6 @@ class Timelog extends Component {
   generateTimeEntries(data) {
     if (!this.state.projectsSelected.includes('all')) {
       data = data.filter(entry => this.state.projectsSelected.includes(entry.projectId));
-    } else {
-      this.state.currentWeekEffort = this.calculateTotalTime(data, true);
     }
 
     return data.map(entry => (
@@ -247,6 +245,7 @@ class Timelog extends Component {
 
   render() {
     const currentWeekEntries = this.generateTimeEntries(this.props.timeEntries.weeks[0]);
+    this.state.currentWeekEffort = this.calculateTotalTime(this.props.timeEntries.weeks[0], true);
     const lastWeekEntries = this.generateTimeEntries(this.props.timeEntries.weeks[1]);
     const beforeLastEntries = this.generateTimeEntries(this.props.timeEntries.weeks[2]);
     const periodEntries = this.generateTimeEntries(this.props.timeEntries.period);


### PR DESCRIPTION
What is handled here and things to test:
1. Display of summary bar in timelog page : a) For self : normal just like dashboard summary bar b) other user: disabled summary bar to avoid incorrect summary/error submission
2. Loading to be shown till timelog and summary bar are loaded when navigated to timelog page
3. Effort shown in timelog page - summary bar is calculated from weekly summary data. Not the same logic as in dashboard page which uses leaderboard data to calculate effort. Effort shown in summary bar is just the tangible entries for the current week.
4. Filter Entries by Project and Task and its associated dropdown is displayed in 2 separate lines to avoid overflow of dropdown out of container when task name is too long. (UI changes already confirmed with Jae)
<img width="600" alt="UP_1_project_dropdown_error" src="https://user-images.githubusercontent.com/16258136/214491109-4fea83bf-4fa5-415a-ad72-51d406726894.png">

5. Update timelog - summary bar effort - on toggle of tangible entries (tangible -> intangible and vice versa). 
6. No change in timelog - summary bar effort on change in timelog tabs.
7. ESLint corrections

What is not covered: 
a. Cali is working on the authentication token missing in the API calls on first hit (which resolves on page refresh). This is not handled in this PR.
b. Improving the performance of the page

Output screenshots:
Dropdown correction:
<img width="600" alt="UP_1_dashboard_project_list" src="https://user-images.githubusercontent.com/16258136/214491131-ec9d5496-3320-4fb1-a63a-b9ecc616668f.png">

Other user:
<img width="600" alt="UP_1_timelog_other_user" src="https://user-images.githubusercontent.com/16258136/214491083-bcb94374-e1d8-4e3c-a06d-34d2c25f3b83.png">

Same user:
<img width="600" alt="Screen Shot 2023-01-24 at 9 54 00 PM" src="https://user-images.githubusercontent.com/16258136/214491174-18653540-6b87-4061-82cf-cde9a0371e8b.png">




