### PR TITLE
pause and resume bugfix.

### DIFF
--- a/src/components/UserManagement/ActivationDatePopup.jsx
+++ b/src/components/UserManagement/ActivationDatePopup.jsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import React, { useState } from 'react';
 import { toast } from 'react-toastify';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Input, Alert } from 'reactstrap';
@@ -13,7 +14,7 @@ const ActivationDatePopup = React.memo(props => {
     props.onClose();
   };
   const pauseUser = () => {
-    if (Date.parse(activationDate) > Date.now()) {
+    if (moment().isBefore(moment(activationDate))) {
       props.onPause(activationDate);
       toast.success('Your Changes were saved successfully.');
       setTimeout(function() {

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -554,7 +554,7 @@ const BasicInformationTab = props => {
             {userProfile.isActive
               ? 'Active'
               : userProfile.reactivationDate
-              ? 'Paused until ' + moment(userProfile.reactivationDate).format('YYYY-MM-DD')
+              ? 'Paused through ' + moment(userProfile.reactivationDate).format('MM-DD-YYYY')
               : 'Inactive'}
           </Label>
           &nbsp;


### PR DESCRIPTION
The Pause and resume buttons can not be set the tomorrow as the reactivation date after 16:00 o'clock.
<img width="428" alt="image" src="https://user-images.githubusercontent.com/108507783/214491781-b519dc89-725b-4ec0-a7a3-6b5f8759bfd1.png">
For example:

Today is Tue 24 January 2023, 21:48:12 in PTS 
 if I select 1/25 as the reactivation date, if use the old code;
The reactivates day is  UTC timezone (Wed Jan 25, 2023, 00:00:00), local Time Zone(Tue 24 January 2023 16:00:00, Milliseconds is 1674604800000, 
And the current time is UTC timezone (Wed Jan 25, 2023, 05:48:12), local Time Zone(Tue 24 January 2023 21:48:12), Milliseconds is 1674625692694
And the Date. parse(activation date) < Date. now(), therefore it is impossible to select the tomorrow as reactivate date.
Reason to cause that: In a world, it is different timezone problem.
Method:
False:
The reactivates day is  UTC timezone (Wed Jan 25, 2023, 00:00:00), local Time Zone(Tue 24 January 202316:00:00, Milliseconds is 1674604800000
True:
The reactivates day is  UTC timezone (Wed Jan 25 2023 08:00:00), local Time Zone(Wed Jan 25, 2023, 00:00:00), Milliseconds is 1674633600000

Above effect can achieve by package moment()
moment(date), moment() is local time compare to local time.





