### PR TITLE
open all task folders in one click

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -37,10 +37,11 @@ const Task = props => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [isLoad, setIsLoad] = useState(false);
   const toggle = () => setDropdownOpen(prevState => !prevState);
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(props.isOpen);
   const [isCopied, setIsCopied] = useState(false);
   const [tableColNum, setTableColNum] = useState(16);
   const tableRowRef = createRef();
+
   useEffect(() => {
     if (tableRowRef.current) {
       const spanColNum = tableRowRef.current.cells.length;
@@ -67,28 +68,22 @@ const Task = props => {
     props.selectTask(id);
   }; */
 
-  const toggleGroups = (num, id, level) => {
-    if (!isLoad) {
-      props.fetchAllTasks(props.wbsId, level, props.id);
-      setIsLoad(true);
-    }
-
+  const toggleGroups = id => {
     if (isOpen) {
       const allItems = [
-        ...document.getElementsByClassName(`parentId1_${props.id}`),
-        ...document.getElementsByClassName(`parentId2_${props.id}`),
-        ...document.getElementsByClassName(`parentId3_${props.id}`),
+        ...document.getElementsByClassName(`parentId1_${id}`),
+        ...document.getElementsByClassName(`parentId2_${id}`),
+        ...document.getElementsByClassName(`parentId3_${id}`),
       ];
       for (let i = 0; i < allItems.length; i++) {
         allItems[i].style.display = 'none';
       }
     } else {
-      const allItems = [...document.getElementsByClassName(`mother_${props.id}`)];
+      const allItems = [...document.getElementsByClassName(`mother_${id}`)];
       for (let i = 0; i < allItems.length; i++) {
         allItems[i].style.display = 'table-row';
       }
     }
-
     setIsOpen(!isOpen);
   };
 
@@ -178,7 +173,7 @@ const Task = props => {
               className="taskNum"
               onClick={() => {
                 /* selectTask(props.id); */
-                toggleGroups(props.num, props.id, props.level);
+                toggleGroups(props.id);
               }}
             >
               {props.num.split('.0').join('')}
@@ -187,7 +182,7 @@ const Task = props => {
               {props.level === 1 ? (
                 <div className="level-space-1" data-tip="Level 1">
                   <span
-                    onClick={e => toggleGroups(props.num, props.id, props.level)}
+                    onClick={e => toggleGroups(props.id)}
                     id={`task_name_${props.id}`}
                     className={props.hasChildren ? 'has_children' : ''}
                   >
@@ -206,7 +201,7 @@ const Task = props => {
               {props.level === 2 ? (
                 <div className="level-space-2" data-tip="Level 2">
                   <span
-                    onClick={e => toggleGroups(props.num, props.id, props.level)}
+                    onClick={e => toggleGroups(props.id)}
                     id={`task_name_${props.id}`}
                     className={props.hasChildren ? 'has_children' : ''}
                   >
@@ -225,7 +220,7 @@ const Task = props => {
               {props.level === 3 ? (
                 <div className="level-space-3" data-tip="Level 3">
                   <span
-                    onClick={e => toggleGroups(props.num, props.id, props.level)}
+                    onClick={e => toggleGroups(props.id)}
                     id={`task_name_${props.id}`}
                     className={props.hasChildren ? 'has_children' : ''}
                   >
@@ -244,7 +239,7 @@ const Task = props => {
               {props.level === 4 ? (
                 <div className="level-space-4" data-tip="Level 4">
                   <span
-                    onClick={e => toggleGroups(props.num, props.id, props.level)}
+                    onClick={e => toggleGroups(props.id)}
                     id={`task_name_${props.id}`}
                     className={props.hasChildren ? 'has_children' : ''}
                   >

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -32,10 +32,8 @@ const WBSTasks = props => {
   const [openAll, setOpenAll] = useState(false);
 
   const load = async()=>{
-    await props.fetchAllTasks(wbsId, 0);
-    await props.fetchAllTasks(wbsId, 1);
-    await props.fetchAllTasks(wbsId, 2);
-    await props.fetchAllTasks(wbsId, 3);
+    const le = [0,1,2,3,4];
+    await Promise.all(le.map(l => props.fetchAllTasks(wbsId, l)));
     AutoOpenAll(false);
   }
 

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -29,11 +29,16 @@ const WBSTasks = props => {
   const [isShowImport, setIsShowImport] = useState(false);
   const [selectedId, setSelectedId] = useState(null);
   const [filterState, setFilterState] = useState('all');
+  const [openAll, setOpenAll] = useState('');
 
   useEffect(() => {
     props.fetchAllTasks(wbsId, 0);
+    props.fetchAllTasks(wbsId, 1);
+    props.fetchAllTasks(wbsId, 2);
+    props.fetchAllTasks(wbsId, 3);
     props.fetchAllMembers(projectId);
-    setIsShowImport(true);
+    setTimeout(() => setIsShowImport(true), 1000);
+    setTimeout(() => setOpenAll(false), 1000);
   }, [wbsId, projectId]);
 
   const refresh = () => {
@@ -41,9 +46,36 @@ const WBSTasks = props => {
     props.fetchAllTasks(wbsId, -1);
     setTimeout(() => {
       props.fetchAllTasks(wbsId, 0);
+      props.fetchAllTasks(wbsId, 1);
+      props.fetchAllTasks(wbsId, 2);
+      props.fetchAllTasks(wbsId, 3);
+    }, 100);
+    setTimeout(() => setIsShowImport(true), 1500);
+    setTimeout(() => AutoOpenAll(false), 1500);
+  };
 
-      setTimeout(() => setIsShowImport(true), 1000);
-    }, 1000);
+  useEffect(() => {
+    AutoOpenAll(openAll);
+  }, [openAll]);
+
+  const AutoOpenAll = openflag => {
+    if (openflag) {
+      //console.log('open the folder');
+      for (let i = 2; i < 5; i++) {
+        const subItems = [...document.getElementsByClassName(`lv_${i}`)];
+        for (let i = 0; i < subItems.length; i++) {
+          subItems[i].style.display = 'table-row';
+        }
+      }
+    } else {
+      //console.log('close the folder');
+      for (let i = 2; i < 5; i++) {
+        const subItems = [...document.getElementsByClassName(`lv_${i}`)];
+        for (let i = 0; i < subItems.length; i++) {
+          subItems[i].style.display = 'none';
+        }
+      }
+    }
   };
 
   const selectTaskFunc = id => {
@@ -140,7 +172,7 @@ const WBSTasks = props => {
           return taskItem;
         }
       });
-    }else if (filter === 'complete') {
+    } else if (filter === 'complete') {
       return allTaskItems.filter(taskItem => {
         if (taskItem.status === 'Complete') {
           return taskItem;
@@ -149,7 +181,10 @@ const WBSTasks = props => {
     }
   };
 
-  let filteredTasks = filterTasks(props.state.tasks.taskItems, filterState);
+  const LoadTasks = props.state.tasks.taskItems
+    .slice(0)
+    .sort((a, b) => a.num.split('.').join('') - b.num.split('.').join(''));
+  const filteredTasks = filterTasks(LoadTasks, filterState);
 
   return (
     <React.Fragment>
@@ -179,12 +214,26 @@ const WBSTasks = props => {
         {props.state.tasks.taskItems.length === 0 && isShowImport === true ? (
           <ImportTask wbsId={wbsId} projectId={projectId} />
         ) : null}
-        <Button color="primary" className="btn-success" size="sm" onClick={() => refresh()}>
+        <Button
+          color="primary"
+          className="btn-success"
+          size="sm"
+          onClick={() => {
+            refresh();
+          }}
+        >
           Refresh{' '}
         </Button>
 
         <div className="toggle-all">
-          <Button color="primary" size="sm" onClick={() => setFilterState('all')}>
+          <Button
+            color="primary"
+            size="sm"
+            onClick={() => {
+              setFilterState('all');
+              setOpenAll(!openAll);
+            }}
+          >
             All
           </Button>
           <Button color="secondary" size="sm" onClick={() => setFilterState('assigned')}>
@@ -285,7 +334,7 @@ const WBSTasks = props => {
                 parentId2={task.parentId2}
                 parentId3={task.parentId3}
                 mother={task.mother}
-                isOpen={true}
+                isOpen={openAll}
                 drop={dropTask}
                 drag={dragTask}
                 deleteTask={deleteTask}

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -30,11 +30,13 @@ const WBSTasks = props => {
   const [selectedId, setSelectedId] = useState(null);
   const [filterState, setFilterState] = useState('all');
   const [openAll, setOpenAll] = useState(false);
+  const [loadAll, setLoadAll] = useState(false);
 
   const load = async()=>{
-    const le = [0,1,2,3,4];
-    await Promise.all(le.map(l => props.fetchAllTasks(wbsId, l)));
+    const levelList = [0,1,2,3,4];
+    await Promise.all(levelList.map(level => props.fetchAllTasks(wbsId, level)));
     AutoOpenAll(false);
+    setLoadAll(true);
   }
 
   useEffect(() => {
@@ -44,6 +46,7 @@ const WBSTasks = props => {
   }, [wbsId, projectId]);
 
   const refresh = () => {
+    setLoadAll(false);
     setIsShowImport(false);
     props.fetchAllTasks(wbsId, -1);
     setTimeout(() => {
@@ -222,6 +225,10 @@ const WBSTasks = props => {
         >
           Refresh{' '}
         </Button>
+
+        {loadAll === false? (
+        <Button color="warning" size="sm">  Task Loading......  </Button>
+        ) : null}
 
         <div className="toggle-all">
           <Button

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -184,7 +184,17 @@ const WBSTasks = props => {
 
   const LoadTasks = props.state.tasks.taskItems
     .slice(0)
-    .sort((a, b) => a.num.split('.').join('') - b.num.split('.').join(''));
+    .sort((a, b) => {
+      var former = a.num.split('.');
+      var latter = b.num.split('.');
+      for(var i = 0; i< 4; i++){
+        var _former = +former[i] || 0;
+        var _latter = +latter[i] || 0;
+        if(_former === _latter) continue;
+        else return _former > _latter ? 1: -1
+      }
+      return 0;
+    });
   const filteredTasks = filterTasks(LoadTasks, filterState);
 
   return (

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -29,29 +29,29 @@ const WBSTasks = props => {
   const [isShowImport, setIsShowImport] = useState(false);
   const [selectedId, setSelectedId] = useState(null);
   const [filterState, setFilterState] = useState('all');
-  const [openAll, setOpenAll] = useState('');
+  const [openAll, setOpenAll] = useState(false);
+
+  const load = async()=>{
+    await props.fetchAllTasks(wbsId, 0);
+    await props.fetchAllTasks(wbsId, 1);
+    await props.fetchAllTasks(wbsId, 2);
+    await props.fetchAllTasks(wbsId, 3);
+    AutoOpenAll(false);
+  }
 
   useEffect(() => {
-    props.fetchAllTasks(wbsId, 0);
-    props.fetchAllTasks(wbsId, 1);
-    props.fetchAllTasks(wbsId, 2);
-    props.fetchAllTasks(wbsId, 3);
+    load().then(setOpenAll(false));
     props.fetchAllMembers(projectId);
     setTimeout(() => setIsShowImport(true), 1000);
-    setTimeout(() => setOpenAll(false), 1000);
   }, [wbsId, projectId]);
 
   const refresh = () => {
     setIsShowImport(false);
     props.fetchAllTasks(wbsId, -1);
     setTimeout(() => {
-      props.fetchAllTasks(wbsId, 0);
-      props.fetchAllTasks(wbsId, 1);
-      props.fetchAllTasks(wbsId, 2);
-      props.fetchAllTasks(wbsId, 3);
+      load().then(setOpenAll(false));
     }, 100);
-    setTimeout(() => setIsShowImport(true), 1500);
-    setTimeout(() => AutoOpenAll(false), 1500);
+    setTimeout(() => setIsShowImport(true), 1000);
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Description
Fixes bug priority low 7 of PROJECTS/TASKS/WBS COMPONENT:
Make clicking “All” on a WBS open all folders to show all tasks

### Mainly changes explained:
Load all tasks of the WBS when open the WBS task page but don't show the sub tasks in the initial state. Open all folders when the filterstate is set to 'all' by clicking the 'all' button.
https://user-images.githubusercontent.com/9314962/215760671-45b37427-eb5e-4f02-a904-dcc90c51e969.mov

### How to test:
check into current branch
do npm install and ... to run this PR locally
Logged in as Amin → Other Links → Projects → AAA USE THIS PROJECT → Click WBS Icon → Choose a WBS → Click “all”
<img width="1203" alt="img" src="https://user-images.githubusercontent.com/9314962/215760351-05cc2d34-6fc4-4ea4-966c-3509b9a82728.png">