### PR TITLE
Added a new verification

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -291,9 +291,9 @@ const UserProfile = props => {
     try {
       await props.updateUserProfile(props.match.params.userId, userProfile);
 
-      if (userProfile._id == props.auth.user.userid) {
-        await props.refreshToken(userProfile._id);
-      }
+        if (userProfile._id == props.auth.user.userid && props.auth.user.role !== userProfile.role) {
+          await props.refreshToken(userProfile._id);
+        }
       await loadUserProfile();
 
       await loadUserTasks();

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -290,7 +290,10 @@ const UserProfile = props => {
     }
     try {
       await props.updateUserProfile(props.match.params.userId, userProfile);
-      await props.refreshToken(userProfile._id);
+
+      if (userProfile._id == props.auth.user.userid) {
+        await props.refreshToken(userProfile._id);
+      }
       await loadUserProfile();
 
       await loadUserTasks();

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -291,7 +291,7 @@ const UserProfile = props => {
     try {
       await props.updateUserProfile(props.match.params.userId, userProfile);
 
-        if (userProfile._id == props.auth.user.userid && props.auth.user.role !== userProfile.role) {
+        if (userProfile._id === props.auth.user.userid && props.auth.user.role !== userProfile.role) {
           await props.refreshToken(userProfile._id);
         }
       await loadUserProfile();


### PR DESCRIPTION
# Description
Fixes bug number 3 (bug list medium USER PROFILE COMPONENT)
Changing the role from user profile gets saved and updated on profiles page but doesn’t reflect on other pages/privileges.


## Mainly changes explained:
1-Was added a new verification  in the `userProfile.jsx`:
`  if (userProfile._id == props.auth.user.userid) {
        await props.refreshToken(userProfile._id);
      }`

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
log as volunteer user
go to Welcome, Username→ View Profile→ Basic Information Tab→ Go to Role → change from Admin to Volunteer or Vice Versa.
Then verify that some privilegies are changing, for example if you Loged as admin you can Atribute a BlueSquare for yourself, but if you change the role for Volunteer the button to set BlueSquare won't be avaliable.
Now change your role to admin go to the Dashboard -> Leaderboard -> choose any user(not your own user) -> change some information for this user -> save changes. You will see that you will continue to be logged in with your username, which was not the case before. 


## Note:
This PR is to fix an error from another  PR that I created and  has already be merged.
[OTHER PR](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/656)
The Backend for this PR was already merged please update your backend repository to test this PR.
