### PR TITLE
text overflow of dashboard project option

### DIFF
--- a/src/components/Timelog/Timelog.css
+++ b/src/components/Timelog/Timelog.css
@@ -51,3 +51,13 @@
     width: 100%;
   }
 }
+
+#projectSelected {
+  max-width: 100%;
+}
+
+#projectSelected option {
+  overflow:hidden; 
+  white-space:nowrap; 
+  text-overflow:ellipsis;
+}

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -24,6 +24,7 @@ import {
   ModalBody,
   ModalFooter,
 } from 'reactstrap';
+import './Timelog.css';
 
 import classnames from 'classnames';
 import { connect, useSelector } from 'react-redux';


### PR DESCRIPTION
### Description
Fixes bug priority low 9 of LEADERBOARD COMPONENT:
In Current Week Timlog/Last Week/Week Before Last/Search by Date tabs, if the task name is too long, the task box is going outside its parent container. 
<img width="620" alt="image" src="https://user-images.githubusercontent.com/9314962/216786382-e73017cb-be00-4720-9e34-45ccfc3c69aa.png">

### Mainly changes explained:
wrap the text of the option when it is too long with ellipsis and restrict the max width style attribute of the `projectSelected` input element to make sure it will not be wider than its parent container.

### How to test:
check into current branch
do npm install and ... to run this PR locally
Dashboard: Filter Entries by Project and Task
<img width="654" alt="img" src="https://user-images.githubusercontent.com/9314962/216786404-16b6c8ee-0e9a-4941-ba5e-c3be08a0ad88.png">
