### PR TITLE
Raul fix header menu displaying behind content on small screens

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -74,7 +74,7 @@ export const Header = props => {
 
   return (
     <div className="header-wrapper">
-      <Navbar className="py-3 mb-3" color="dark" dark expand="lg">
+      <Navbar className="py-3 mb-3" color="dark" dark expand="lg" style={{ zIndex:'10' }}>
         {/**
          * <NavbarBrand tag={Link} to="/" className="d-none d-md-block">
           {LOGO}

--- a/src/components/SummaryBar/SummaryBar.css
+++ b/src/components/SummaryBar/SummaryBar.css
@@ -73,7 +73,7 @@
 }
 
 .redBackgroup {
-  z-index: 10;
+  z-index: 1;
   bottom: 0;
   right: 0;
   position: absolute;


### PR DESCRIPTION
# Description
(HEADER COMPONENT - PRIORITY LOW) 

> (PRIORITY LOW) Raul: (WIP Raul) Header menu displays behind content when opened. How to test:
> a. Use a smartphone or a tablet. Must be something with a small screen. You can also decrease browser window size.
> b. Then, open the menu clicking on the header burguer(top right). 


## Mainly changes explained:
In Header.jsx, was added a 'z-index: 10' to the Navbar, so it cannot be overlapped by page content on small screens anymore.

## How to test:
1. git checkout raul_fix_menu_displaying_behind_content
2. npm install
3. npm run start:local
4. log in with any user
5. Verify if the header menu is being overlapped by content on small screens after clicking on the dropdown button (you can test it by changing the resolutions with the inspection resource on Chrome). The proper resolutions to test are **between 425px and 991 px**.

### Here are two videos to help you:

1. Dropdown behavior (BEFORE):

https://user-images.githubusercontent.com/29555732/217062841-a1253109-7349-485d-970e-fbc522d16f12.mp4

2. Dropdown behavior (AFTER):

https://user-images.githubusercontent.com/29555732/217063827-cbb6c176-8e16-40cb-a5a5-3c18994e9a27.mp4

