### PR TITLE
show user name in header when first log in

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -55,7 +55,7 @@ const Badge = props => {
     if (props.userProfile.badgeCollection) {
       console.log('userProfileBadgeCollectionId', props.userProfile._id);
       props.userProfile.badgeCollection.forEach(badge => {
-        //console.log('badge2', badge);
+        console.log('badge2', badge);
         if (badge?.badge?.badgeName === 'Personal Max' || badge?.badge?.type === 'Personal Max') {
           count += 1;
         } else {

--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -55,7 +55,7 @@ const Badge = props => {
     if (props.userProfile.badgeCollection) {
       console.log('userProfileBadgeCollectionId', props.userProfile._id);
       props.userProfile.badgeCollection.forEach(badge => {
-        console.log('badge2', badge);
+        //console.log('badge2', badge);
         if (badge?.badge?.badgeName === 'Personal Max' || badge?.badge?.type === 'Personal Max') {
           count += 1;
         } else {

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -55,7 +55,7 @@ export const Header = props => {
       props.getHeaderData(props.auth.user.userid);
       props.getTimerData(props.auth.user.userid);
     }
-  }, []);
+  }, [props.auth.isAuthenticated]);
 
   useEffect(() => {
     if (roles.length === 0) {

--- a/src/components/Login/ForgotPassword.jsx
+++ b/src/components/Login/ForgotPassword.jsx
@@ -21,7 +21,7 @@ const ForgotPassword = React.memo(() => {
       errors.forEach(err => {
         switch (err.type) {
           case 'any.empty':
-            err.message = 'Last name should not be empty.';
+            err.message = 'First name should not be empty.';
             break;
           default:
             err.message = 'Please enter a valid last name.';
@@ -37,7 +37,7 @@ const ForgotPassword = React.memo(() => {
       errors.forEach(err => {
         switch (err.type) {
           case 'any.empty':
-            err.message = 'First name should not be empty.';
+            err.message = 'Last name should not be empty.';
             break;
           default:
             err.message = 'Please enter a valid first name.';


### PR DESCRIPTION
### Description
Fixes bug 3 of HIGH-PRIORITY BUGS/FUNCTIONS (IN ORDER):
 When you log in your account, the user name is not showing up until you refresh the page.
<img width="634" alt="img" src="https://user-images.githubusercontent.com/9314962/219917649-41ddce74-e85f-4d74-ac65-c769f8de50af.png">

### Mainly changes explained:
In previous version, the `props.auth` won't have the value of `firstName` and `ProfilePic` and the hook to get header data will only run once (before is authenticated) at the very beginning. Now that it will be able to check the change of the status and get the header data when the user first sign in.

A small correction not related to this task:
The warning information of the input on the forgot password page has been corrected.

### How to test:
check into current branch
do npm install and ... to run this PR locally
Log in
<img width="1202" alt="PR" src="https://user-images.githubusercontent.com/9314962/219919581-84314256-5ae8-4220-ac68-f020d5be35cf.png">
