### PR TITLE
create folder for tasks with subtasks

### DIFF
--- a/src/actions/task.js
+++ b/src/actions/task.js
@@ -43,6 +43,14 @@ export const deleteTaskNotification = (userId, taskId, taskNotificationId) => as
     //dispatch(deleteTaskNotificationError());
   }
 };
+export const deleteChildrenTasks = taskId => async (dispatch, getState) => {
+  let status = 200;
+  try {
+    await axios.post(ENDPOINTS.DELETE_CHILDREN(taskId));
+  } catch (error) {
+    console.log(error);
+  }
+};
 
 export const addNewTask = (newTask, wbsId) => async (dispatch, getState) => {
   let status = 200;

--- a/src/components/Projects/WBS/SingleTask/SingleTask.js
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.js
@@ -13,6 +13,7 @@ import hasPermission from 'utils/permissions';
 
 const SingleTask = props => {
   const taskId = props.match.params.taskId;
+  console.log('TASK ID PARAM', typeof taskId);
   const { user } = props.auth;
   const userPermissions = props.auth.user?.permissions?.frontPermissions;
   const roles = useSelector(state => state.role.roles);
@@ -31,6 +32,8 @@ const SingleTask = props => {
     };
     fetchTaskData();
   }, []);
+
+  console.log(task);
 
   return (
     <React.Fragment>

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -3,7 +3,7 @@ import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import { connect } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
 import { fetchAllTasks } from './../../../../../actions/task';
-import { addNewTask } from './../../../../../actions/task';
+import { addNewTask, updateTask } from './../../../../../actions/task';
 import { DUE_DATE_MUST_GREATER_THAN_START_DATE } from './../../../../../languages/en/messages';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
 import 'react-day-picker/lib/style.css';
@@ -81,16 +81,15 @@ const AddTaskModal = props => {
 
   // Classification
   const classificationOptions = [
-
-    {value:"Food",label:"Food"},
-    {value:"Energy",label:"Energy"},
-    {value:"Housing",label:"Housing"},
-    {value:"Education",label:"Education"},
-    {value:"Soceity",label:"Soceity"},
-    {value:"Economics",label:"Economics"},
-    {value:"Stewardship",label:"Stewardship"},
-    {value:"Other",label:"Other"}
-  ]
+    { value: 'Food', label: 'Food' },
+    { value: 'Energy', label: 'Energy' },
+    { value: 'Housing', label: 'Housing' },
+    { value: 'Education', label: 'Education' },
+    { value: 'Soceity', label: 'Soceity' },
+    { value: 'Economics', label: 'Economics' },
+    { value: 'Stewardship', label: 'Stewardship' },
+    { value: 'Other', label: 'Other' },
+  ];
   const [classification, setClassification] = useState('Housing');
 
   // Warning
@@ -306,9 +305,27 @@ const AddTaskModal = props => {
     setIntentInfo(props.tasks.copiedTask.intentInfo);
     setEndstateInfo(props.tasks.copiedTask.endstateInfo);
   };
+  //FUNCTION TO UPDATE TASK MOTHER
+  const updateTaskMother = () => {
+    let qty = 0;
+    if (props.taskId) {
+      if (props.childrenQty >= 0) {
+        qty = props.childrenQty + 1;
+      }
+      const updatedTask = {
+        resources: resourceItems,
+        hasChild: true,
+        childrenQty: qty,
+      };
+      props.updateTask(props.taskId, updatedTask, props.hasPermission);
+    } else {
+      return;
+    }
+  };
 
   const addNewTask = () => {
     setIsLoading(true);
+    updateTaskMother();
 
     const newTask = {
       wbsId: props.wbsId,
@@ -337,7 +354,7 @@ const AddTaskModal = props => {
       endstateInfo: endstateInfo,
       classification,
     };
-    
+
     props.addNewTask(newTask, props.wbsId);
 
     setTimeout(() => {
@@ -353,16 +370,14 @@ const AddTaskModal = props => {
     if (props.level >= 1) {
       const classificationMother = props.tasks.taskItems.find(({ _id }) => _id === props.taskId)
         .classification;
-        if(classificationMother){
-          setClassification(classificationMother);
-        }
-    }
-    else {
+      if (classificationMother) {
+        setClassification(classificationMother);
+      }
+    } else {
       const res = props.allProjects.projects.filter(obj => obj._id === props.projectId)[0];
       setClassification(res.category);
     }
   }, [props.level]);
-
 
   getNewNum();
 
@@ -608,9 +623,13 @@ const AddTaskModal = props => {
               <tr>
                 <td scope="col">Classification</td>
                 <td scope="col">
-                  <select value={classification} onChange={e => setClassification(e.target.value)} >
-                    {classificationOptions.map(cla =>{
-                      return <option value={cla.value} key={cla.value}>{cla.label}</option>
+                  <select value={classification} onChange={e => setClassification(e.target.value)}>
+                    {classificationOptions.map(cla => {
+                      return (
+                        <option value={cla.value} key={cla.value}>
+                          {cla.label}
+                        </option>
+                      );
                     })}
                   </select>
                 </td>
@@ -747,4 +766,5 @@ const mapStateToProps = state => {
 export default connect(mapStateToProps, {
   addNewTask,
   fetchAllTasks,
+  updateTask,
 })(AddTaskModal);

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -9,7 +9,13 @@ import { Button, Dropdown, DropdownItem, DropdownToggle, DropdownMenu } from 're
 import { BsFillCaretDownFill, BsFillCaretUpFill } from 'react-icons/bs';
 import AddTaskModal from '../AddTask/AddTaskModal';
 import EditTaskModal from '../EditTask/EditTaskModal';
-import { moveTasks, fetchAllTasks, deleteTask, copyTask } from '../../../../../actions/task.js';
+import {
+  moveTasks,
+  fetchAllTasks,
+  deleteTask,
+  copyTask,
+  deleteChildrenTasks,
+} from '../../../../../actions/task.js';
 import './tagcolor.css';
 import './task.css';
 import { Editor } from '@tinymce/tinymce-react';
@@ -121,6 +127,9 @@ const Task = props => {
   };
 
   const deleteTask = (taskId, mother) => {
+    if (mother !== null) {
+      props.deleteChildrenTasks(mother);
+    }
     props.deleteTask(taskId, mother);
     props.fetchAllTasks(props.wbsId, -1);
     setTimeout(() => {
@@ -142,6 +151,7 @@ const Task = props => {
     props.copyTask(id);
   };
 
+  console.log('PROPS >>>', props);
   return (
     <>
       {props.id ? (
@@ -423,8 +433,10 @@ const Task = props => {
                     parentId2={props.parentId2}
                     parentId3={props.parentId3}
                     mother={props.mother}
+                    childrenQty={props.childrenQty}
                     level={props.level}
                     openChild={e => openChild(props.num, props.id)}
+                    hasPermission={true}
                   />
                 ) : null}
                 <EditTaskModal
@@ -558,4 +570,5 @@ export default connect(mapStateToProps, {
   deleteTask,
   copyTask,
   getPopupById,
+  deleteChildrenTasks,
 })(Task);

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -32,12 +32,12 @@ const WBSTasks = props => {
   const [openAll, setOpenAll] = useState(false);
   const [loadAll, setLoadAll] = useState(false);
 
-  const load = async()=>{
-    const levelList = [0,1,2,3,4];
+  const load = async () => {
+    const levelList = [0, 1, 2, 3, 4];
     await Promise.all(levelList.map(level => props.fetchAllTasks(wbsId, level)));
     AutoOpenAll(false);
     setLoadAll(true);
-  }
+  };
 
   useEffect(() => {
     load().then(setOpenAll(false));
@@ -182,19 +182,17 @@ const WBSTasks = props => {
     }
   };
 
-  const LoadTasks = props.state.tasks.taskItems
-    .slice(0)
-    .sort((a, b) => {
-      var former = a.num.split('.');
-      var latter = b.num.split('.');
-      for(var i = 0; i< 4; i++){
-        var _former = +former[i] || 0;
-        var _latter = +latter[i] || 0;
-        if(_former === _latter) continue;
-        else return _former > _latter ? 1: -1
-      }
-      return 0;
-    });
+  const LoadTasks = props.state.tasks.taskItems.slice(0).sort((a, b) => {
+    var former = a.num.split('.');
+    var latter = b.num.split('.');
+    for (var i = 0; i < 4; i++) {
+      var _former = +former[i] || 0;
+      var _latter = +latter[i] || 0;
+      if (_former === _latter) continue;
+      else return _former > _latter ? 1 : -1;
+    }
+    return 0;
+  });
   const filteredTasks = filterTasks(LoadTasks, filterState);
 
   return (
@@ -236,8 +234,11 @@ const WBSTasks = props => {
           Refresh{' '}
         </Button>
 
-        {loadAll === false? (
-        <Button color="warning" size="sm">  Task Loading......  </Button>
+        {loadAll === false ? (
+          <Button color="warning" size="sm">
+            {' '}
+            Task Loading......{' '}
+          </Button>
         ) : null}
 
         <div className="toggle-all">
@@ -359,6 +360,7 @@ const WBSTasks = props => {
                 whyInfo={task.whyInfo}
                 intentInfo={task.intentInfo}
                 endstateInfo={task.endstateInfo}
+                childrenQty={task.childrenQty}
               />
             ))}
           </tbody>

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -44,6 +44,7 @@ export const ENDPOINTS = {
   TASK_DEL: (taskId, motherId) => `${APIEndpoint}/task/del/${taskId}/${motherId}`,
   GET_TASK: taskId => `${APIEndpoint}/task/${taskId}`,
   TASK_UPDATE: taskId => `${APIEndpoint}/task/update/${taskId}`,
+  DELETE_CHILDREN: taskId => `${APIEndpoint}/task/delete/children/${taskId}`,
   GET_USER_BY_NAME: name => `${APIEndpoint}/userprofile/name/${name}`,
   FIX_TASKS: wbsId => `${APIEndpoint}/tasks/${wbsId}`,
   UPDATE_PARENT_TASKS: wbsId => `${APIEndpoint}/task/updateAllParents/${wbsId}`,


### PR DESCRIPTION
Fixe bug ( PRIORITY MEDIUM) - 5 from PROJECT/TASK/WBS COMPONENT
Description
Creating sub-tasks in a WBS doesn’t create a new folder and makes the tasks uneditable
Logged in as Admin → Other Links → Projects → AAA USE THIS PROJECT → Click WBS Icon → Choose “Jae's WBS - USE THIS” → Choose task not in folder → Edit → Add Task → Should create folder out of parent and including new task

## Related PRS (if any):
This frontend PR is related to the [#283](https://github.com/OneCommunityGlobal/HGNRest/pull/283) backend PR.


Mainly changes explained:
1 - Creating sub-tasks in a WBS create a new folder.
2 - Make subtasks editable and can be deleted.

How to test:
1 - check into current branch
2 - do `npm install` and ... to run this PR locally
3 - log as admin user
4 - Go to dashboard→ Other Links→ Projects→ chose the Project "AAA USE THIS PROJECT"→ click "[ Jae's WBS - USE THIS]"
→ Add a task → Create a subtask for this task
![Captura de Tela (71)](https://user-images.githubusercontent.com/39320057/220209311-b746c0c7-2cc0-4d75-a240-3d8bd61439b7.png)
![Captura de Tela (72)](https://user-images.githubusercontent.com/39320057/220209378-6d65bc32-91f3-4735-a961-c3432c3f6d47.png)
