### PR TITLE
refresh after deleting a task

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -120,12 +120,8 @@ const Task = props => {
     props.getPopupById(TASK_DELETE_POPUP_ID);
   };
 
-  const deleteTask = (taskId, mother) => {
-    props.deleteTask(taskId, mother);
-    props.fetchAllTasks(props.wbsId, -1);
-    setTimeout(() => {
-      props.fetchAllTasks(props.wbsId, 0);
-    }, 2000);
+  const deleteOneTask = (taskId, mother) => {
+    props.deleteWBSTask(taskId, mother);
   };
 
   const onMove = (from, to) => {
@@ -537,7 +533,7 @@ const Task = props => {
                   closeModal={() => {
                     setModalDelete(false);
                   }}
-                  confirmModal={() => deleteTask(props.id, props.mother)}
+                  confirmModal={() => deleteOneTask(props.id, props.mother)}
                   modalMessage={props.state.popupEditor.currPopup.popupContent || ''}
                   modalTitle={Message.CONFIRM_DELETION}
                 />

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -31,13 +31,14 @@ const WBSTasks = props => {
   const [filterState, setFilterState] = useState('all');
   const [openAll, setOpenAll] = useState(false);
   const [loadAll, setLoadAll] = useState(false);
+  const [isDeleted, setIsDeleted] = useState(false);
 
-  const load = async()=>{
-    const levelList = [0,1,2,3,4];
+  const load = async () => {
+    const levelList = [0, 1, 2, 3, 4];
     await Promise.all(levelList.map(level => props.fetchAllTasks(wbsId, level)));
     AutoOpenAll(false);
     setLoadAll(true);
-  }
+  };
 
   useEffect(() => {
     load().then(setOpenAll(false));
@@ -58,6 +59,13 @@ const WBSTasks = props => {
   useEffect(() => {
     AutoOpenAll(openAll);
   }, [openAll]);
+
+  useEffect(() => {
+    if (isDeleted) {
+      refresh();
+    }
+    setIsDeleted(false);
+  }, [isDeleted]);
 
   const AutoOpenAll = openflag => {
     if (openflag) {
@@ -139,11 +147,9 @@ const WBSTasks = props => {
     //props.updateNumList(wbsId, list);*/
   };
 
-  const deleteTask = taskId => {
-    props.deleteTask(taskId);
-    setTimeout(() => {
-      props.fetchAllTasks(wbsId);
-    }, 4000);
+  const deleteWBSTask = (taskId, mother) => {
+    props.deleteTask(taskId, mother);
+    setIsDeleted(true);
   };
 
   const filterTasks = (allTaskItems, filter) => {
@@ -182,19 +188,17 @@ const WBSTasks = props => {
     }
   };
 
-  const LoadTasks = props.state.tasks.taskItems
-    .slice(0)
-    .sort((a, b) => {
-      var former = a.num.split('.');
-      var latter = b.num.split('.');
-      for(var i = 0; i< 4; i++){
-        var _former = +former[i] || 0;
-        var _latter = +latter[i] || 0;
-        if(_former === _latter) continue;
-        else return _former > _latter ? 1: -1
-      }
-      return 0;
-    });
+  const LoadTasks = props.state.tasks.taskItems.slice(0).sort((a, b) => {
+    var former = a.num.split('.');
+    var latter = b.num.split('.');
+    for (var i = 0; i < 4; i++) {
+      var _former = +former[i] || 0;
+      var _latter = +latter[i] || 0;
+      if (_former === _latter) continue;
+      else return _former > _latter ? 1 : -1;
+    }
+    return 0;
+  });
   const filteredTasks = filterTasks(LoadTasks, filterState);
 
   return (
@@ -236,8 +240,11 @@ const WBSTasks = props => {
           Refresh{' '}
         </Button>
 
-        {loadAll === false? (
-        <Button color="warning" size="sm">  Task Loading......  </Button>
+        {loadAll === false ? (
+          <Button color="warning" size="sm">
+            {' '}
+            Task Loading......{' '}
+          </Button>
         ) : null}
 
         <div className="toggle-all">
@@ -352,7 +359,7 @@ const WBSTasks = props => {
                 isOpen={openAll}
                 drop={dropTask}
                 drag={dragTask}
-                deleteTask={deleteTask}
+                deleteWBSTask={deleteWBSTask}
                 hasChildren={task.hasChild}
                 siblings={props.state.tasks.taskItems.filter(item => item.mother === task.mother)}
                 taskId={task.taskId}


### PR DESCRIPTION
### Description
Fixes bug priority low 12 of PROJECTS/TASKS/WBS COMPONENT:
Deleting tasks doesn’t refresh the showing tasks correctly
a. When deleting a task, just the “level 0” tasks are being fetched
b. Reloading the page shows the tasks correctly

### Mainly changes explained:
Previous version only clean the page and reload level 0 tasks after deleting a task. Now it will refresh and reload all tasks.
Also, it had multiple functions with the same name `deleteTask` (the same as the one from action) and one of them was not used at all. They have been renamed to make the code easier to read.

PS: some line changes are due to the prettier code formatting and didn't cause actual change.

### How to test:
check into current branch
do npm install and ... to run this PR locally
Logged in  → Other Links → Projects → WBS → Delete any task → Open a task folder