### PR TITLE
Fix NaN Display Issue in Leaderboard

### DIFF
--- a/src/components/LeaderBoard/LeaderBoard.container.jsx
+++ b/src/components/LeaderBoard/LeaderBoard.container.jsx
@@ -36,7 +36,7 @@ const mapStateToProps = state => {
   orgData.tangibletime = _.round(orgData.totaltangibletime_hrs, 2);
   orgData.totaltime = _.round(orgData.totaltime_hrs, 2);
   orgData.intangibletime = _.round(orgData.totalintangibletime_hrs, 2);
-  orgData.weeklycommittedHours = _.round(orgData.totalWeeklycommittedHours, 2);
+  orgData.weeklycommittedHours = _.round(orgData.totalweeklycommittedHours, 2);
 
   const tenPTotalOrgTime = orgData.weeklycommittedHours * 0.1;
   const orgTangibleColorTime = orgData.totaltime < tenPTotalOrgTime * 2 ? 0 : 5;


### PR DESCRIPTION
Fixed issue in Leaderboard where NaN was being displayed instead of the total weekly hours.

Before:
<img width="577" alt="LeaderboardBug-1" src="https://user-images.githubusercontent.com/94432002/222318409-444c0586-7e77-4b53-99d8-be19779f5f02.png">

After:
<img width="584" alt="LeaderboardBug-2" src="https://user-images.githubusercontent.com/94432002/222318494-68b7879d-c1fe-440c-9cb4-a164ba372de2.png">

### How To Test:
- Check into the current branch.
- Do npm install and ... to run this PR locally.
- Log into the HGN application.
- Check Leaderboard on the Dashboard and make sure NaN is not displayed under Total Time.