### PR TITLE
Lucas timelog page not loading

### DIFF
--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -11,6 +11,7 @@ import { ENDPOINTS } from '../utils/URL';
 
 export const getUserProfile = userId => {
   const url = ENDPOINTS.USER_PROFILE(userId);
+  console.log(url)
   return async dispatch => {
     let loggedOut = false;
     const res = await axios.get(url).catch(error => {

--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -11,7 +11,6 @@ import { ENDPOINTS } from '../utils/URL';
 
 export const getUserProfile = userId => {
   const url = ENDPOINTS.USER_PROFILE(userId);
-  console.log(url)
   return async dispatch => {
     let loggedOut = false;
     const res = await axios.get(url).catch(error => {

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -100,7 +100,8 @@ class Timelog extends Component {
   state = this.initialState;
 
   async componentDidMount() {
-    const userId = this.props.asUser;
+    console.log(this.props, "esse foi o print que eu fiz")
+    const userId = this.props.auth.user.userid;
     await this.props.getUserProfile(userId);
     this.userProfile = this.props.userProfile;
     await this.props.getUserTask(userId);

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -100,8 +100,7 @@ class Timelog extends Component {
   state = this.initialState;
 
   async componentDidMount() {
-    console.log(this.props, "esse foi o print que eu fiz")
-    const userId = this.props.auth.user.userid;
+    const userId = this.props.auth.user.userid; //It was refering to a undefined userid, so i got the id from the store to the state of the component.
     await this.props.getUserProfile(userId);
     this.userProfile = this.props.userProfile;
     await this.props.getUserTask(userId);


### PR DESCRIPTION
### **DESCRIPTION**
<hr>
I've seen that the timelog page was not loading on the development branch, so i searched the reason and the userId state on the page was getting an undefined state.

### **Main Changes**
<hr>
Inside the Timelog.jsx file, changed userId from this.props.asUser to this.props.auth.user.userid

### **How to test**

- Checkout to current branch
- npm install and npm run start:local
- Log in as various users and roles
- See if timelog page is loading and showind the right data

*note: If you guys know anything about the asUser object, let me know. I've seen that this error happening in other branches too.

![beforeSolvingProblem](https://user-images.githubusercontent.com/92558269/222799986-93cfd478-38f4-4eb5-a856-a6d7db4efaff.png)
![afterSolvingProblem](https://user-images.githubusercontent.com/92558269/222799989-16d504ff-e7f8-491d-ac1f-fd77cab2cdd3.png)
