### PR TITLE
fix usermanagement not getting update

### DIFF
--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -53,7 +53,7 @@ class UserManagement extends React.PureComponent {
 
   componentDidMount() {
     // Initiating the user profile fetch action.
-    getAllUserProfile();
+    this.props.getAllUserProfile();
   }
 
   render() {


### PR DESCRIPTION
# Description
Fix bug:
(PRIORITY MEDIUM) Vitor/Jae: When updating a role of a user on the “Profile Page”, the “User Management” page doesn’t get updated, and the changed role of the user remains the same as before.

## Mainly changes explained:
One line change, fix the bug caused by commit [Set final day button admin front-end](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/commit/68ca7d79e4ce9823dae22bf06125c694a728471b)
This bug causes user management page can't trigger the user profile fetch action. In current app, after update a user's role, the user management page can be updated by opening reports and teams management pages since these pages will trigger the action correctly:
![Screenshot 2023-03-07 223032](https://user-images.githubusercontent.com/94319381/223636620-4e944268-b205-4f2d-9887-00772a6c8dfe.png)
![Screenshot 2023-03-07 223111](https://user-images.githubusercontent.com/94319381/223636621-14c4a67c-6336-4a55-9d4e-77cb4f741c00.png)


## How to test:

1. Dashboard -> User management
2. Choose a user and update its role
3. Go back to user management page to see the change.
