### PR TITLE
Yiyun add one more tab for weekly summaries

### DIFF
--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -40,6 +40,7 @@ export class WeeklySummary extends Component {
       summary: '',
       summaryLastWeek: '',
       summaryBeforeLast: '',
+      summaryThreeWeeksAgo: '',
       mediaUrl: '',
       weeklySummariesCount: 0,
       mediaConfirm: false,
@@ -58,6 +59,11 @@ export class WeeklySummary extends Component {
       .endOf('week')
       .subtract(2, 'week')
       .toISOString(),
+    dueDateThreeWeeksAgo: moment()
+      .tz('America/Los_Angeles')
+      .endOf('week')
+      .subtract(3, 'week')
+      .toISOString(),
     activeTab: '1',
     errors: {},
     fetchError: null,
@@ -72,6 +78,8 @@ export class WeeklySummary extends Component {
       (weeklySummaries && weeklySummaries[1] && weeklySummaries[1].summary) || '';
     const summaryBeforeLast =
       (weeklySummaries && weeklySummaries[2] && weeklySummaries[2].summary) || '';
+    const summaryThreeWeeksAgo =
+      (weeklySummaries && weeklySummaries[3] && weeklySummaries[3].summary) || '';
 
     const dueDateThisWeek = weeklySummaries && weeklySummaries[0] && weeklySummaries[0].dueDate;
     // Make sure server dueDate is not before the localtime dueDate.
@@ -84,12 +92,16 @@ export class WeeklySummary extends Component {
     const dueDateBeforeLast =
       (weeklySummaries && weeklySummaries[2] && weeklySummaries[2].dueDate) ||
       this.state.dueDateBeforeLast;
+    const dueDateThreeWeeksAgo =
+      (weeklySummaries && weeklySummaries[3] && weeklySummaries[3].dueDate) ||
+      this.state.dueDateThreeWeeksAgo;
 
     this.setState({
       formElements: {
         summary,
         summaryLastWeek,
         summaryBeforeLast,
+        summaryThreeWeeksAgo,
         mediaUrl: mediaUrl || '',
         weeklySummariesCount: weeklySummariesCount || 0,
         mediaConfirm: false,
@@ -97,6 +109,7 @@ export class WeeklySummary extends Component {
       dueDate,
       dueDateLastWeek,
       dueDateBeforeLast,
+      dueDateThreeWeeksAgo,
       activeTab: '1',
       fetchError: this.props.fetchError,
       loading: this.props.loading,
@@ -141,6 +154,10 @@ export class WeeklySummary extends Component {
       .regex(this.regexPattern)
       .label('Minimum 50 words'),
     summaryBeforeLast: Joi.string()
+      .allow('')
+      .regex(this.regexPattern)
+      .label('Minimum 50 words'),
+    summaryThreeWeeksAgo: Joi.string()
       .allow('')
       .regex(this.regexPattern)
       .label('Minimum 50 words'),
@@ -233,6 +250,10 @@ export class WeeklySummary extends Component {
           summary: this.state.formElements.summaryBeforeLast,
           dueDate: this.state.dueDateBeforeLast,
         },
+        {
+          summary: this.state.formElements.summaryThreeWeeksAgo,
+          dueDate: this.state.dueDateThreeWeeksAgo,
+        },
       ],
       weeklySummariesCount: this.state.formElements.weeklySummariesCount,
     };
@@ -274,6 +295,7 @@ export class WeeklySummary extends Component {
       fetchError,
       dueDateLastWeek,
       dueDateBeforeLast,
+      dueDateThreeWeeksAgo,
     } = this.state;
     const summariesLabels = {
       summary: 'This Week',
@@ -283,6 +305,9 @@ export class WeeklySummary extends Component {
       summaryBeforeLast: this.doesDateBelongToWeek(dueDateBeforeLast, 2)
         ? 'Week Before Last'
         : moment(dueDateBeforeLast).format('YYYY-MMM-DD'),
+      summaryThreeWeeksAgo: this.doesDateBelongToWeek(dueDateThreeWeeksAgo, 3)
+        ? 'Three Weeks Ago'
+        : moment(dueDateThreeWeeksAgo).format('YYYY-MMM-DD'),
     };
 
     if (fetchError) {
@@ -367,7 +392,7 @@ export class WeeklySummary extends Component {
                           onEditorChange={this.handleEditorChange}
                         />
                       </FormGroup>
-                      {(errors.summary || errors.summaryLastWeek || errors.summaryBeforeLast) && (
+                      {(errors.summary || errors.summaryLastWeek || errors.summaryBeforeLast || errors.summaryThreeWeeksAgo) && (
                         <Alert color="danger">
                           The summary must contain a minimum of 50 words.
                         </Alert>

--- a/src/components/WeeklySummary/WeeklySummary.test.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.test.jsx
@@ -53,7 +53,7 @@ describe('WeeklySummary page', () => {
       render(<WeeklySummary {...props} />);
     });
 
-    it('should display 3 tabs even when the user summaries related fields have not been initialized in the database', () => {
+    it('should display 4 tabs even when the user summaries related fields have not been initialized in the database', () => {
       props = {
         currentUser: { userid: '1' },
         getWeeklySummaries: jest.fn(),
@@ -65,12 +65,12 @@ describe('WeeklySummary page', () => {
       render(<WeeklySummary {...props} />);
 
       const li = screen.getAllByRole('listitem');
-      expect(li.length).toEqual(3);
+      expect(li.length).toEqual(4);
     });
 
-    it('should have 3 tab', () => {
+    it('should have 4 tab', () => {
       const li = screen.getAllByRole('listitem');
-      expect(li.length).toEqual(3);
+      expect(li.length).toEqual(4);
     });
 
     it('should have first tab set to "active" by default', () => {
@@ -91,6 +91,11 @@ describe('WeeklySummary page', () => {
       // Third tab click.
       userEvent.click(screen.getByTestId('tab-3'));
       expect(screen.getByTestId('tab-3').classList.contains('active')).toBe(true);
+    });
+    it('should make 4th tab active when clicked', () => {
+      // Fourth tab click.
+      userEvent.click(screen.getByTestId('tab-4'));
+      expect(screen.getByTestId('tab-4').classList.contains('active')).toBe(true);
     });
   });
 


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/5071040/224442594-3509c621-ad20-43ac-bbc2-d710e8b869e9.png)
This PR is for URGENT bug #1 
This PR is **ONLY** for adding one more tab on weekly summaries dashboard, to show the weekly summary of "three weeks ago".
**This PR doesn't have any contribution on fixing the "total submitted".** 

## Related PRS (if any):
#622 Alan worked on this before but didn't get it completed. I'm going to close it since I'll raise new ones.

## Mainly changes explained:
`src/components/WeeklySummary/WeeklySummary.jsx`: update the UI and properties to make the weekly summaries dashboard show 4 tabs instead of 3, add `dueDateThreeWeeksAgo`, `summaryThreeWeeksAgo`, etc.
`src/components/WeeklySummary/WeeklySummary.test.jsx`: update test suites to pass the `run npm test` command.

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
log as any role user or a new created user
go to dashboard→ weekly summaries
verify adding summaries on the 4 tabs can work

## Screenshots or videos of changes:
![image](https://user-images.githubusercontent.com/5071040/224447306-5f57f363-d5ac-4b05-925b-2db6357068dd.png)

## Note:
1. I made some changes on the Dev database for testing this PR
Before my change, weeklySummaries in Dev database somehow showed the three dates identical, both of them are the current week's due date. This [link](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/622#issuecomment-1383054737) shows how the identical due dates problem found.
I used below commands to update the due dates to be correct. **Since the due dates in our Beta database are correct, I didn't make any changes there.**
![image](https://user-images.githubusercontent.com/5071040/224447875-1b9a7131-c6de-4422-a3a2-62aa99c73629.png)

2. From the below discussion, we decide to improve the current logic of counting "total submitted", I'll try to fix this part next week, in my next PR.
![image](https://user-images.githubusercontent.com/5071040/224443105-19dbd796-326e-4676-86b5-587b0d780f66.png)
