### PR TITLE
change timer and button container classes to use flex display

### DIFF
--- a/src/components/SummaryBar/SummaryBar.css
+++ b/src/components/SummaryBar/SummaryBar.css
@@ -168,6 +168,10 @@
   filter: alpha(opacity=40); /* msie */
 }
 
+.dashboard-fullname{
+  white-space: nowrap; 
+  font-size: 2vw;}
+
 /* XLarge devices (landscape phones, 544px and down) */
 @media (max-width: 1200px) {
   .med_text_summary {

--- a/src/components/SummaryBar/SummaryBar.css
+++ b/src/components/SummaryBar/SummaryBar.css
@@ -168,10 +168,6 @@
   filter: alpha(opacity=40); /* msie */
 }
 
-.dashboard-fullname{
-  white-space: nowrap; 
-  font-size: 2vw;}
-
 /* XLarge devices (landscape phones, 544px and down) */
 @media (max-width: 1200px) {
   .med_text_summary {

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -195,7 +195,7 @@ const SummaryBar = props => {
               </CardTitle>
             </div>
           </Col>
-          <Col className="col-lg-3 col-12 no-gutters">
+          <Col className="d-flex col-lg-3 col-12 no-gutters">
             <Row className="no-gutters">
               {totalEffort < weeklyCommittedHours && (
                 <div className="border-red col-4 bg--white-smoke" align="center">
@@ -238,7 +238,7 @@ const SummaryBar = props => {
             </Row>
           </Col>
 
-          <Col className="col-lg-3 col-12 no-gutters">
+          <Col className="d-flex col-lg-3 col-12 no-gutters">
             <Row className="no-gutters">
               {!weeklySummary ? (
                 <div className="border-red col-4 bg--white-smoke no-gutters" align="center">

--- a/src/components/Timer/Timer.css
+++ b/src/components/Timer/Timer.css
@@ -1,5 +1,6 @@
 .timer {
   margin: auto;
+  display:flex;
 }
 
 .timer button {
@@ -13,7 +14,7 @@
 }
 
 .button-container {
-  display: inline-block;
+  display: flex;
 }
 
 @media (min-width: 1550px) {


### PR DESCRIPTION
### **(PRIORITY MEDIUM) Jae: Fix appearance of Dashboard at all widths** 

1. Here you can see a width it is very broken
2. Don’t worry about the timer, that will be fixed with the new timer. Please fix the section below it though. 

![Screenshot 2023-03-11 at 1 49 19 PM](https://user-images.githubusercontent.com/97488347/224512963-cd35cf4f-a5b2-4141-a7ca-b5edbe7d1ea1.png)

### **Main Changes Explained:**
I added a flex display inside of the .timer  and .button-container classes so that the buttons remain side by side regardless of the window size. 

### **How to Test:**

1. check out this branch and run the application locally. 
2. resize the window and make sure the width of the dashboard navigation bar does not change.  
3. refer to the before and after videos below. 

**Before:** 

https://user-images.githubusercontent.com/97488347/224513169-73ddcaaf-77ae-45dc-bb27-16d58e6e72d2.mov

**After:**

https://user-images.githubusercontent.com/97488347/224513177-b16e6115-a874-4124-85f7-3712a8ae2bf9.mov