### PR TITLE
Yan - PARTIAL PR, CHECK BUT DONT’ MERGE  Summary Management front end first demo without onclick

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -17,6 +17,7 @@ import {
   BADGE_MANAGEMENT,
   PROJECTS,
   TEAMS,
+  SUMMARY_MANAGEMENT,
   WELCOME,
   VIEW_PROFILE,
   UPDATE_PASSWORD,
@@ -211,7 +212,12 @@ export const Header = props => {
                           {TEAMS}
                         </DropdownItem>
                       )}
-                      {hasPermission(user.role, 'seePopupManagement', roles, userPermissions) ? (
+                      {hasPermission(user.role, 'seeTeamsManagement', roles, userPermissions) && (
+                      <DropdownItem tag={Link} to="/summarymanagement">
+                        {SUMMARY_MANAGEMENT}
+                      </DropdownItem>
+                    )}
+                    {hasPermission(user.role, 'seePopupManagement', roles, userPermissions) ? (
                         <>
                           <DropdownItem divider />
                           <DropdownItem tag={Link} to={`/admin/`}>

--- a/src/components/SummaryManagement/SummaryManagement.jsx
+++ b/src/components/SummaryManagement/SummaryManagement.jsx
@@ -1,0 +1,106 @@
+import React, { Component } from 'react';
+import { TEAM_MEMBER, SUMMARY_RECEIVER, SUMMARY_GROUP, ACTIONS, ACTIVE } from 'languages/en/ui';
+import SummaryTablesearchPanel from './SummaryTableSearchPanel';
+import SummarysOverview from './SummarysOverview';
+
+class SummaryManagement extends Component {
+  data = [
+    {
+      summaryGroupId: 1,
+      name: 'Summary Group 1',
+      active: (
+        <div className="isActive">
+          <i className="fa fa-circle" aria-hidden="true" />
+        </div>
+      ),
+      teamMember: (
+        <button type="button" className="btn btn-outline-info">
+          {TEAM_MEMBER}
+        </button>
+      ),
+      summaryReceiver: (
+        <button type="button" className="btn btn-outline-info">
+          {SUMMARY_RECEIVER}
+        </button>
+      ),
+    },
+    {
+      summaryGroupId: 2,
+      name: 'Summary Group 2',
+      active: (
+        <div className="isNotActive">
+          <i className="fa fa-circle-o" aria-hidden="true" />
+        </div>
+      ),
+      teamMember: (
+        <button type="button" className="btn btn-outline-info">
+          {TEAM_MEMBER}
+        </button>
+      ),
+      summaryReceiver: (
+        <button type="button" className="btn btn-outline-info">
+          {SUMMARY_RECEIVER}
+        </button>
+      ),
+    },
+  ];
+
+  render() {
+    return (
+      <React.Fragment>
+        <div className="container">
+          <SummarysOverview />
+          <SummaryTablesearchPanel />
+          <table className="table table-bordered table-responsive-sm">
+            <thead>
+              <tr>
+                <th scope="col" id="summary__order">
+                  {' '}
+                  #
+                </th>
+                <th scope="col" id="summary_name">
+                  {SUMMARY_GROUP}
+                </th>
+                <th scope="col" id="summary__active">
+                  {ACTIVE}
+                </th>
+                <th scope="col" id="summary_team__member">
+                  {TEAM_MEMBER}
+                </th>
+                <th scope="col" id="summary_receiver">
+                  {SUMMARY_RECEIVER}
+                </th>
+                <th scope="col" id="summary_actions">
+                  {ACTIONS}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {this.data.map((row, index) => (
+                <tr key={index}>
+                  <td>{index + 1}</td>
+                  <td>{row.name}</td>
+                  <td>{row.active}</td>
+                  <td>{row.teamMember}</td>
+                  <td>{row.summaryReceiver}</td>
+                  <td>
+                    <div className="btn-group">
+                      <button type="button" className="btn btn-outline-secondary">
+                        <i className="fa fa-pencil" aria-hidden="true" />
+                      </button>
+                      <button type="button" className="btn btn-outline-secondary">
+                        <i className="fa fa-trash" aria-hidden="true" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+
+export default SummaryManagement;

--- a/src/components/SummaryManagement/SummaryTableSearchPanel.jsx
+++ b/src/components/SummaryManagement/SummaryTableSearchPanel.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { SEARCH, CREATE_SUMMARY_GROUP} from '../../languages/en/ui';
+//import hasPermission from 'utils/permissions';
+///*{hasPermission(props.requestorRole, 'createTeam', props.roles, props.userPermissions) &&
+/**
+ * The search panel stateless component for  Teams grid
+ */
+const SummaryTablesearchPanel = props => {
+  return (
+    <div className="input-group" id="new_team">
+        <button
+          type="button"
+          className="btn btn-info"
+          onClick={e => {
+            props.onCreateNewTeamClick();
+          }}
+        >
+          {CREATE_SUMMARY_GROUP}
+        </button>
+      
+      <div className="input-group-prepend" style={{ marginLeft: '10px' }}>
+        <span className="input-group-text">{SEARCH}</span>
+      </div>
+      <input
+        type="text"
+        className="form-control"
+        aria-label="Search"
+        placeholder="Search Text"
+        id="team-profiles-wild-card-search"
+        //onChange={e => {
+          //props.onSearch(e.target.value);
+        //}}
+      />
+    </div>
+  );
+};
+
+
+
+export default SummaryTablesearchPanel;

--- a/src/components/SummaryManagement/SummarysOverview.jsx
+++ b/src/components/SummaryManagement/SummarysOverview.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { TOTAL_SUMMARY, ACTIVE_SUMMARY } from '../../languages/en/ui';
+
+const SummarysOverview = props => {
+  return (
+    <div className="teams__overview--top">
+      <div className="card" id="card_team">
+        <div className="card-body">
+          <h4 className="card-title">{props.numberOfSummaryGroup}</h4>
+          <h6 className="card-subtitle">
+            <i className="fa fa-users" aria-hidden="true"></i> {TOTAL_SUMMARY}
+          </h6>
+        </div>
+      </div>
+
+      <div className="card" id="card_active">
+        <div className="card-body">
+          <h4 className="card-title">{props.numberOfActiveSummaryGroup}</h4>
+          <h6 className="card-subtitle">
+            <div className="isActive">
+              <i className="fa fa-circle" aria-hidden="true"></i> {ACTIVE_SUMMARY}
+            </div>
+          </h6>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SummarysOverview;

--- a/src/languages/en/ui.js
+++ b/src/languages/en/ui.js
@@ -1,3 +1,5 @@
+import { enCA } from "date-fns/locale";
+
 /** *******************************************************************************
  * LANGUAGE - UI - CONST
  * Stores all variables that display texts on the UI
@@ -7,9 +9,11 @@ export const INACTIVE = 'InActive';
 export const ACTIVE_PROJECTS = 'Active Projects';
 export const DASHBOARD = 'Dashboard';
 export const DELETE = 'Delete';
+export const EDIT = 'Edit';
 export const LOGO = 'Time Tracking Tool';
 export const LOGOUT = 'Logout';
 export const MEMBERS = 'Members';
+export const MANAGER = 'Team Manager';
 export const OTHER_LINKS = 'Other Links';
 export const PROJECTS = 'Projects';
 export const PROJECT_NAME = 'Project Name';
@@ -50,3 +54,11 @@ export const POPUP_MANAGEMENT = 'Popup Management';
 export const CANCEL = 'Delete Final Day';
 export const SET_FINAL_DAY = 'Set Final Day';
 export const MANAGE_FINAL_DAY = 'Manage Final Day';
+export const SUMMARY_MANAGEMENT = 'Summary Management';
+export const TEAM_MEMBER = 'Team Member';
+export const SUMMARY_RECEIVER = 'Summary Receiver';
+export const SUMMARY_GROUP = 'Summary Group';
+export const ACTIONS = 'Actions';
+export const CREATE_SUMMARY_GROUP = 'Create Summary Group';
+export const TOTAL_SUMMARY = 'Summary';
+export const ACTIVE_SUMMARY = 'Active Summary';

--- a/src/routes.js
+++ b/src/routes.js
@@ -14,6 +14,7 @@ import UpdatePassword from './components/UpdatePassword';
 import Header from './components/Header';
 import Projects from './components/Projects';
 import Teams from './components/Teams/Teams';
+import SummaryManagement from 'components/SummaryManagement/SummaryManagement';
 import UserManagement from './components/UserManagement';
 import Members from './components/Projects/Members';
 import WBS from './components/Projects/WBS';
@@ -35,6 +36,7 @@ import { TaskEditSuggestions } from 'components/TaskEditSuggestions/TaskEditSugg
 import { RoutePermissions } from 'utils/routePermissions';
 import PermissionsManagement from 'components/PermissionsManagement/PermissionsManagement';
 import UserRoleTab from 'components/PermissionsManagement/UserRoleTab';
+
 
 export default (
   <React.Fragment>
@@ -130,6 +132,12 @@ export default (
         exact
         component={Teams}
         routePermissions={RoutePermissions.teams}
+      />
+      <ProtectedRoute
+        path="/summarymanagement"
+        exact
+        component={SummaryManagement}
+        allowedRoles={[UserRole.Administrator, UserRole.Owner]}
       />
       <ProtectedRoute path="/project/members/:projectId" component={Members} />
 


### PR DESCRIPTION
This file is aim to create a summary management page statically. It is just a front-end demo,  the PR of the CRUD function will b push in the next step.

How to test:

1)go to the admin account
2)click the other links
3) select the summary management page
4) The layout is shown below:
![52711678679296_ pic](https://user-images.githubusercontent.com/108507783/224604663-4a9a3bfa-4f8c-42ea-91db-ddc81174997f.jpg)

Note: current step, there is no permission tag name seeSummaryMangement, therefore, I just use seeTeamsManagement instead, which will be complete in the future.

