### PR TITLE
Akshay Fix Timelog Views

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -133,6 +133,13 @@ class Timelog extends Component {
     if (UserHaveTask) {
       this.setState({ activeTab: 0 });
     }
+
+    const isDashboard = this.props.hasOwnProperty('isDashboard');
+
+    if (!isDashboard) {
+      this.setState({ activeTab: 1 });
+    }
+
   }
 
   async componentDidUpdate(prevProps) {

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -134,8 +134,10 @@ class Timelog extends Component {
       this.setState({ activeTab: 0 });
     }
 
+    // Checks if there is a property named "isDashboard" in props
     const isDashboard = this.props.hasOwnProperty('isDashboard');
 
+    // Sets active tab to "Current Week Timelog" when the Progress bar in Leaderboard is clicked
     if (!isDashboard) {
       this.setState({ activeTab: 1 });
     }


### PR DESCRIPTION
# Description
This PR fixes the "Fix Timelog Views" issue.

## Mainly changes explained:
1. Dashboard → Click a person’s time bar in the Leaderboard to see their time log
2. When doing this a person should see the time log tab, not their tasks tab
3. The Timelog should be the person they are looking at, not their own
4. Admins/Owners: When doing this, the “Add Time Entry for <person’s name>” label should show the person’s name they are looking at not the user’s (option should only exist for qualified classes)

Note: 3 and 4 were fixed by a different developer as part of another fix. Only test for 2.

## How to test:
1. Check into the current branch
2. Do `npm install` and `...` to run this PR locally
3. Go to Dashboard→ Click a person’s Progress bar in the Leaderboard to see their time log
4. Time log should be of the person they are looking at, not their own
6. The “Add Time Entry for <person’s name>” label should show the person’s name they are looking at not the user’s 

## Screenshots:
<img width="1116" alt="Fix Timelog Bug Default Tab" src="https://user-images.githubusercontent.com/94432002/226070759-f9f6f2d8-aeae-4bc5-9e9a-f34089efb9ac.png">