### PR TITLE
Jinchao block the alert when changing user status at userProfile page

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -398,14 +398,15 @@ const UserProfile = props => {
     });
   };
 
-  const setActiveInactive = isActive => {
+  const setActiveInactive = async (isActive) => {
     setActiveInactivePopupOpen(false);
-    setUserProfile({
+    const newUserProfile = {
       ...userProfile,
       isActive: !userProfile.isActive,
       endDate: userProfile.isActive ? moment(new Date()).format('YYYY-MM-DD') : undefined,
-    });
-    updateUserStatus(userProfile, isActive ? UserStatus.Active : UserStatus.InActive, undefined);
+    };
+    await updateUserStatus(newUserProfile, isActive ? UserStatus.Active : UserStatus.InActive, undefined);
+    setShouldRefresh(true);
   };
 
   const activeInactivePopupClose = () => {

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -398,15 +398,16 @@ const UserProfile = props => {
     });
   };
 
-  const setActiveInactive = async (isActive) => {
+  const setActiveInactive = (isActive) => {
     setActiveInactivePopupOpen(false);
     const newUserProfile = {
       ...userProfile,
       isActive: !userProfile.isActive,
       endDate: userProfile.isActive ? moment(new Date()).format('YYYY-MM-DD') : undefined,
     };
-    await updateUserStatus(newUserProfile, isActive ? UserStatus.Active : UserStatus.InActive, undefined);
-    setShouldRefresh(true);
+    updateUserStatus(newUserProfile, isActive ? UserStatus.Active : UserStatus.InActive, undefined);
+    setUserProfile(newUserProfile);
+    setOriginalUserProfile(newUserProfile);
   };
 
   const activeInactivePopupClose = () => {


### PR DESCRIPTION
# Description
Fix bug: When clicking the green/grey dot on the userProfile page to change the user status, the saving change alert will incorrectly show up.

## Mainly changes explained:
Update setActiveInactive function.
Rather than first setting userprofile and then calling `updateUserStatus`, the new function directly calls the `updateUserStatus` function with new user data, and then sets `shouldRefresh` to true. In this case, the `userProfile` and `originalUserProfile` will both get updated after updating the database, which will block the alert.

## How to test:

1. Log in as an admin user
2. Go to a user's profile and click the green/grey dot to active and inactive the user
![image](https://user-images.githubusercontent.com/94319381/226809618-8279d604-47ac-4e22-a7e5-44b3d635be98.png)

3. Check if the saving change alert is blocked.

## Note:
When clicking the dot very fast, the status may not be changed after clicking the OK button. Click the dot again will change the status correctly. I tried to reduce the bug occurrence by `await updateUserStatus` but I'm not sure about it. Please give me some suggestions, thanks!