### PR TITLE
Jinchao make user invisible to the teams they are on

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
@@ -4,7 +4,7 @@ import AddTeamPopup from './AddTeamPopup';
 import UserTeamsTable from './UserTeamsTable';
 
 const TeamsTab = props => {
-  const { teamsData, userTeams, onDeleteteam, onAssignTeam, edit, role, onUserVisibilitySwitch, isVisible, isUserSelf } = props;
+  const { teamsData, userTeams, onDeleteteam, onAssignTeam, edit, role, onUserVisibilitySwitch, isVisible, canEditVisibility } = props;
   const [addTeamPopupOpen, setaddTeamPopupOpen] = useState(false);
   const [renderedOn, setRenderedOn] = useState(0);
 
@@ -38,7 +38,7 @@ const TeamsTab = props => {
         onButtonClick={onAddTeamPopupShow}
         onDeleteClick={onSelectDeleteTeam}
         onUserVisibilitySwitch={onUserVisibilitySwitch}
-        isUserSelf={isUserSelf}
+        canEditVisibility = {canEditVisibility}
         isVisible={isVisible}
         renderedOn={renderedOn}
         edit={edit}

--- a/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
@@ -4,7 +4,7 @@ import AddTeamPopup from './AddTeamPopup';
 import UserTeamsTable from './UserTeamsTable';
 
 const TeamsTab = props => {
-  const { teamsData, userTeams, onDeleteteam, onAssignTeam, edit, role } = props;
+  const { teamsData, userTeams, onDeleteteam, onAssignTeam, edit, role, onUserVisibilitySwitch, isVisible, isUserSelf } = props;
   const [addTeamPopupOpen, setaddTeamPopupOpen] = useState(false);
   const [renderedOn, setRenderedOn] = useState(0);
 
@@ -37,6 +37,9 @@ const TeamsTab = props => {
         userTeamsById={userTeams}
         onButtonClick={onAddTeamPopupShow}
         onDeleteClick={onSelectDeleteTeam}
+        onUserVisibilitySwitch={onUserVisibilitySwitch}
+        isUserSelf={isUserSelf}
+        isVisible={isVisible}
         renderedOn={renderedOn}
         edit={edit}
         role={role}

--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
@@ -9,12 +9,11 @@ import styles from './UserTeamsTable.css';
 const UserTeamsTable = props => {
   const { roles } = useSelector(state => state.role);
   const userPermissions = useSelector(state => state.auth.user?.permissions?.frontPermissions);
-  const canEditVisibility = props.role && props.role !== 'Volunteer' && (props.isUserSelf || props.edit);
   return (
     <div>
       <div className="teamtable-container desktop">
         <div className="container">
-          {canEditVisibility && (
+          {props.canEditVisibility && (
             <div className="row">
               <Col md='7'>
               <span className="teams-span">Visibility</span>
@@ -103,7 +102,7 @@ const UserTeamsTable = props => {
       </div>
       <div className="teamtable-container tablet">
           <div style={{ display: 'flex', flexDirection: 'column' }}>
-          {canEditVisibility && (
+          {props.canEditVisibility && (
             <>
               <Col 
                 md='12' 

--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button, Col } from 'reactstrap';
 import './TeamsAndProjects.css';
+import ToggleSwitch from '../UserProfileEdit/ToggleSwitch';
 import hasPermission from '../../../utils/permissions';
 import { useSelector } from 'react-redux';
 import styles from './UserTeamsTable.css';
@@ -8,10 +9,25 @@ import styles from './UserTeamsTable.css';
 const UserTeamsTable = props => {
   const { roles } = useSelector(state => state.role);
   const userPermissions = useSelector(state => state.auth.user?.permissions?.frontPermissions);
+  const canEditVisibility = props.role && props.role !== 'Volunteer' && (props.isUserSelf || props.edit);
   return (
     <div>
       <div className="teamtable-container desktop">
         <div className="container">
+          {canEditVisibility && (
+            <div className="row">
+              <Col md='7'>
+              <span className="teams-span">Visibility</span>
+              </Col>
+              <Col md='5'>
+              <ToggleSwitch
+                  switchType="visible"
+                  state={props.isVisible}
+                  handleUserProfile={props.onUserVisibilitySwitch}
+                />
+              </Col>
+            </div>
+          )}
           <div className="row">
             <Col
               md={props.edit ? '7' : '12'}
@@ -87,8 +103,29 @@ const UserTeamsTable = props => {
       </div>
       <div className="teamtable-container tablet">
           <div style={{ display: 'flex', flexDirection: 'column' }}>
+          {canEditVisibility && (
+            <>
+              <Col 
+                md='12' 
+                style={{
+                  backgroundColor: ' #e9ecef',
+                  border: '1px solid #ced4da',
+                  marginBottom: '10px',
+                }}
+              >
+              <span className="teams-span">Visibility</span>
+              </Col>
+              <Col md='12' style={{ display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
+                <ToggleSwitch
+                  switchType="visible"
+                  state={props.isVisible}
+                  handleUserProfile={props.onUserVisibilitySwitch}
+                />
+              </Col>
+            </>
+          )}
             <Col
-              md={props.edit ? '7' : '12'}
+              md='12'
               style={{
                 backgroundColor: ' #e9ecef',
                 border: '1px solid #ced4da',
@@ -98,7 +135,7 @@ const UserTeamsTable = props => {
               <span className="teams-span">Teams</span>
             </Col>
             {props.edit && props.role && (
-              <Col md="5" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
+              <Col md='12' style={{ display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
                 {hasPermission(props.role, 'assignTeamToUser', roles, userPermissions) ? (
                   <Button
                     className="btn-addteam"

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -917,7 +917,7 @@ const UserProfile = props => {
                     edit={hasPermission(requestorRole, 'editUserProfile', roles, userPermissions)}
                     role={requestorRole}
                     roles={roles}
-                    handleUserProfile={handleUserProfile}
+                    onUserVisibilitySwitch={onUserVisibilitySwitch}
                     isVisible={userProfile.isVisible}
                     canEditVisibility={canEdit && userProfile.role != 'Volunteer'}
                   />

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -719,7 +719,7 @@ const UserProfile = props => {
                   roles={roles}
                   onUserVisibilitySwitch={onUserVisibilitySwitch}
                   isVisible={userProfile.isVisible}
-                  isUserSelf={isUserSelf}
+                  canEditVisibility={canEdit && userProfile.role != 'Volunteer'}
                 />
               </TabPane>
               <TabPane tabId="4">
@@ -919,7 +919,7 @@ const UserProfile = props => {
                     roles={roles}
                     handleUserProfile={handleUserProfile}
                     isVisible={userProfile.isVisible}
-                    isUserSelf={isUserSelf}
+                    canEditVisibility={canEdit && userProfile.role != 'Volunteer'}
                   />
                 </ModalBody>
                 <ModalFooter>

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -450,6 +450,13 @@ const UserProfile = props => {
     }
   };
 
+  const onUserVisibilitySwitch = () => {
+    setUserProfile({
+      ...userProfile,
+      isVisible: !userProfile.isVisible ?? true,
+    });
+  }
+
   if ((showLoading && !props.isAddNewUser) || userProfile === undefined) {
     return (
       <Container fluid>
@@ -710,6 +717,9 @@ const UserProfile = props => {
                   edit={hasPermission(requestorRole, 'editUserProfile', roles, userPermissions)}
                   role={requestorRole}
                   roles={roles}
+                  onUserVisibilitySwitch={onUserVisibilitySwitch}
+                  isVisible={userProfile.isVisible}
+                  isUserSelf={isUserSelf}
                 />
               </TabPane>
               <TabPane tabId="4">
@@ -907,6 +917,9 @@ const UserProfile = props => {
                     edit={hasPermission(requestorRole, 'editUserProfile', roles, userPermissions)}
                     role={requestorRole}
                     roles={roles}
+                    handleUserProfile={handleUserProfile}
+                    isVisible={userProfile.isVisible}
+                    isUserSelf={isUserSelf}
                   />
                 </ModalBody>
                 <ModalFooter>

--- a/src/components/UserProfile/UserProfileEdit/ToggleSwitch/ToggleSwitch.jsx
+++ b/src/components/UserProfile/UserProfileEdit/ToggleSwitch/ToggleSwitch.jsx
@@ -133,6 +133,44 @@ const ToggleSwitch = ({ switchType, state, handleUserProfile }) => {
           </div>
         </div>
       );
+    case 'visible':
+      if (state) {
+        return (
+          <div className='blueSqare'>
+            <div className={style.switchSection}>
+              <div className={style.switchContainer}>
+                visible
+                <input
+                  data-testid="visibility-switch"
+                  id="leaderboardVisibility"
+                  type="checkbox"
+                  className={style.toggle}
+                  onChange={handleUserProfile}
+                />
+                invisible
+              </div>
+            </div>
+          </div>
+        )
+      }
+      return (
+        <div className='blueSqare'>
+          <div className={style.switchSection}>
+            <div className={style.switchContainer}>
+              visible
+              <input
+                data-testid="visibility-switch"
+                id="leaderboardVisibility"
+                type="checkbox"
+                className={style.toggle}
+                onChange={handleUserProfile}
+                defaultChecked
+              />
+              invisible
+            </div>
+          </div>
+        </div>
+      );
     default:
       break;
   }


### PR DESCRIPTION
# Description
Front end for: 
![image](https://user-images.githubusercontent.com/94319381/227058071-22f0dff8-206e-46af-8d3f-f69811791bf0.png)

## Mainly changes explained:
Add a switch at the teams tab on userProfile page. All roles except 'Volunteer' are now invisible to their teammates on the leaderboard by default. 'Owner', 'Administrator', and 'Core Team' can still see them on the leaderboard.

## How to test:
Please test with backend change: [PR300](https://github.com/OneCommunityGlobal/HGNRest/pull/300)
1. Log in as admin and create a team having all classes of users('Volunteer', 'Mentor', 'Manager', 'Core Team', 'Administrator', 'Owner'): 
![image](https://user-images.githubusercontent.com/94319381/227059075-f77093d1-a3f1-431f-8301-1b3c74906967.png)
2. Log in to each team member's dashboard and check their leaderboard. Volunteer/mentor/manager should only see volunteer teammates and Core Team/Administrator/Owner will see all teammates.
![image](https://user-images.githubusercontent.com/94319381/227064077-e45a8f7f-f35b-410b-9a6f-e20c8babcf9b.png)

3. Go to Userprofile->Teams, and check if there is a visibility switch for all roles except 'Volunteer'.  Change the status to visible and check if the user can be viewed by all other team members on their leaderboard
![image](https://user-images.githubusercontent.com/94319381/227064284-c3955d96-b518-40f6-a8f0-229721f46089.png)

4. Log in Administrator/Owner to check if they can change the visibility of other users (except 'Volunteer') through userProfile page.
