### PR TITLE
Sav - Set tasks tab default unless user has completed all tasks

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -49,7 +49,6 @@ import hasPermission from '../../utils/permissions';
 
 const doesUserHaveTaskWithWBS = tasks => {
   let check = false;
-  console.log(tasks);
   for (let task of tasks) {
     if (task.wbsId && task.status !== 'Complete') {
       check = true;

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -49,8 +49,9 @@ import hasPermission from '../../utils/permissions';
 
 const doesUserHaveTaskWithWBS = tasks => {
   let check = false;
+  console.log(tasks);
   for (let task of tasks) {
-    if (task.wbsId) {
+    if (task.wbsId && task.status !== 'Complete') {
       check = true;
       break;
     }


### PR DESCRIPTION
# Description
While working on the task stay default tab bug I found a small bug where the tasks tab would still be shown even if a user had completed all of their tasks. I added a small conditional to check the status of the tasks when the dashboard loads. Just a small adjustment to handle an edge case.  This fix should only apply to volunteer accounts as admin accounts will always default to the tasks tab on the dashboard.
Fixes #6  (Reports Component  priority low)

## Related PRS (if any):
This frontend PR is related to the #686 frontend PR.

## Mainly changes explained:
Added secondary conditional to check the status of tasks in userTasks array.

## How to test:
Check into the current branch
Do `npm install` and `...` to run this PR locally
Log in as an admin user
Go to Projects -> WBS -> make three tasks for a volunteer. 
Set each one of the tasks to ‘not started’, ‘started’, and ‘complete’
Log in to volunteer acct.
Take note of dashboard load behavior. Is the task tab showing as default with the user-assigned tasks?
If you delete tasks or make them all complete it should show the current week time log tab by default on the dashboard.

## Screenshots or videos of changes:
![complete status](https://user-images.githubusercontent.com/98275089/227540301-aa004125-f930-4e14-adec-681e23b3de54.png)

## Note:
I was able to quickly test this by opening a second terminal for the front end and running it on port 3001 to have two windows. One for the admin and one for the volunteer.


