### PR TITLE
fix text standard message

### DIFF
--- a/src/components/OwnerMessage/OwnerMessage.jsx
+++ b/src/components/OwnerMessage/OwnerMessage.jsx
@@ -41,9 +41,8 @@ function OwnerMessage({
   const { user } = auth;
 
   const [disableTextInput, setDisableTextInput] = useState(false);
-  const [disableStandardMessageInput, setStandardMessageInput] = useState(true);
+  const [disableButtons, setDisableButtons] = useState(true);
   const [standardMessage, setStandardMessage] = useState('');
-  const [newStandardMessage, setNewStandardMessage] = useState('');
   const [message, setMessage] = useState('');
   const [newMessage, setNewMessage] = useState('');
   const [modal, setModal] = useState(false);
@@ -74,10 +73,12 @@ function OwnerMessage({
     }
     getOwnerStandardMessage();
     if (ownerStandardMessage) {
-      console.log(ownerStandardMessage)
       setStandardMessage(ownerStandardMessage);
     }
-  }, []);
+    newMessage 
+    ? setDisableButtons(false)
+    : setDisableButtons(true)
+  }, [newMessage]);
 
   async function handleImageUpload(event) {
     if (event) event.preventDefault();
@@ -127,44 +128,21 @@ function OwnerMessage({
     setMessage('');
   }
 
-  async function handleStandardImageUpload(event) {
-    if (event) event.preventDefault();
-    const file = event.target.files[0];
-    if (typeof file != 'undefined') {
-      const imageType = /jpg|jpeg|png/g;
-      const validFormats = imageType.test(file.name);
-
-      //Input validation: file type
-      if (!validFormats) {
-        toggle();
-        toggleWrongPictureFormatWarning();
-        return;
-      }
-
-      const fileReader = new FileReader();
-      fileReader.readAsDataURL(file);
-      fileReader.onloadend = () => {
-        setNewStandardMessage(fileReader.result);
-      };
-      setStandardMessageInput(false);
-    }
-  }
-
   async function handleStandardMessage() {
     const ownerStandardMessage = {
-      newStandardMessage: newStandardMessage,
+      newStandardMessage: newMessage,
     };
 
     if (standardMessage) {
       updateOwnerStandardMessage(ownerStandardMessageId, ownerStandardMessage);
       toggle();
       toast.success('Standard Message updated!');
-      setStandardMessage(newStandardMessage);
+      setStandardMessage(newMessage);
     } else {
       createOwnerStandardMessage(ownerStandardMessage);
       toggle();
       toast.success('Standard Message created!');
-      setStandardMessage(newStandardMessage);
+      setStandardMessage(newMessage);
     }
   }
 
@@ -175,7 +153,10 @@ function OwnerMessage({
             ? <img src={message} alt="" />
             : <span className="message">{message}</span>
           )
-        : <img src={standardMessage} alt="" />
+        : (isImage.test(standardMessage) 
+            ? <img src={standardMessage} alt="" />
+            : <span className="message">{standardMessage}</span>
+          )
       }
 
       {user.role == 'Owner' && (
@@ -215,29 +196,12 @@ function OwnerMessage({
             onChange={handleImageUpload}
             className="inputs"
           />
-          <div className="dropdown-divider" style={{marginTop: '1rem', marginBottom: '1rem'}}></div>
-          <div className="standard-message-wrapper">
-            
-          </div>
-          <strong>Set a standard image message:</strong>
-          <span style={{marginBottom: '1rem', fontSize: '.8rem'}}>(max size 1000 x 400 pixels and 100 KB)</span>
-          <Input
-            id="image"
-            name="file"
-            type="file"
-            label="Choose Image"
-            onChange={handleStandardImageUpload}
-            className="inputs"
-          />
         </ModalBody>
         <ModalFooter style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <Button color="secondary" onClick={toggle}>
-            Cancel
+          <Button color="info" onClick={handleStandardMessage} disabled={disableButtons}>
+            {standardMessage ? <span style={{color: 'white'}}>Update as Standard Message</span> : <span style={{color: 'white'}}>Create as Standard Message</span>}
           </Button>
-          <Button color="info" onClick={handleStandardMessage} disabled={disableStandardMessageInput}>
-            {standardMessage ? <span style={{color: 'white'}}>Update as Standard Message</span> : <span>Create as Standard Message</span>}
-          </Button>
-          <Button color="primary" onClick={handleMessage}>
+          <Button color="primary" onClick={handleMessage} disabled={disableButtons}>
             {message ? 'Update' : 'Create'}
           </Button>
         </ModalFooter>


### PR DESCRIPTION
# Description
(DASHBOARD COMPONENT - PRIORITY LOW) - New Requests

> (PRIORITY LOW) Jae: Add to top of app a section that the “Owner” class (only) can edit to post a message to all users of the app like, “Happy Holidays”. (WIP - Raul)
> I’d like the UI for posting the message to have the ability for me to set an expiration date so it’ll automatically return to the logo on that date
> **New Requests:** 
> I. Change “or add a picture” to “Or add a picture (max size ## x ## pixels and XX KB).
> II. Please add a “Clear All” button that will remove whatever has been saved there and return it to blank. (A big red X)

## Mainly changes explained:
Now we have just two inputs for creating both standard and common messages. The button you click will decide which type of message it is. You can create text standard messages as well.

## How to test:
1. git checkout raul_improve_owner_message_2
2. npm install
3. npm run start:local
4. log in as **OWNER**
5. A pen should be displayed for you:
![image](https://user-images.githubusercontent.com/29555732/227401999-b94239e9-e77b-493b-847c-989b67b4ec88.png)

6. click and try to update the standard message. Also, create common messages to test. For image messages, try using these - the resolutions were made for this resource:
![image](https://user-images.githubusercontent.com/29555732/227402343-d04713fe-7f6d-437d-a6ec-c8e9996180f9.png)
![Logo](https://user-images.githubusercontent.com/29555732/227402344-99f8af5e-fe39-43a7-ad56-ffd9eb2806f1.png)

7. The pen should only be displayed for owner accounts. The messages have to be displayed for everyone.
8. This resource is made only for computers (width higher than 1400px).