### PR TITLE
make the total submitted of weekly summaries update on time

### DIFF
--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -64,6 +64,7 @@ export class WeeklySummary extends Component {
       .endOf('week')
       .subtract(3, 'week')
       .toISOString(),
+    submittedCountInFourWeeks: 0,
     activeTab: '1',
     errors: {},
     fetchError: null,
@@ -80,6 +81,19 @@ export class WeeklySummary extends Component {
       (weeklySummaries && weeklySummaries[2] && weeklySummaries[2].summary) || '';
     const summaryThreeWeeksAgo =
       (weeklySummaries && weeklySummaries[3] && weeklySummaries[3].summary) || '';
+    let submittedCountInFourWeeks = 0;
+    if (summary !== '') {
+      submittedCountInFourWeeks += 1;
+    }
+    if (summaryLastWeek !== '') {
+      submittedCountInFourWeeks += 1;
+    }
+    if (summaryBeforeLast !== '') {
+      submittedCountInFourWeeks += 1;
+    }
+    if (summaryThreeWeeksAgo !== '') {
+      submittedCountInFourWeeks += 1;
+    }
 
     const dueDateThisWeek = weeklySummaries && weeklySummaries[0] && weeklySummaries[0].dueDate;
     // Make sure server dueDate is not before the localtime dueDate.
@@ -110,6 +124,7 @@ export class WeeklySummary extends Component {
       dueDateLastWeek,
       dueDateBeforeLast,
       dueDateThreeWeeksAgo,
+      submittedCountInFourWeeks,
       activeTab: '1',
       fetchError: this.props.fetchError,
       loading: this.props.loading,
@@ -241,6 +256,21 @@ export class WeeklySummary extends Component {
     this.setState({ errors: errors || {} });
     if (errors) return;
 
+    let currentSubmittedCount = 0;
+    if (this.state.formElements.summary !== '') {
+      currentSubmittedCount += 1;
+    }
+    if (this.state.formElements.summaryLastWeek !== '') {
+      currentSubmittedCount += 1;
+    }
+    if (this.state.formElements.summaryBeforeLast !== '') {
+      currentSubmittedCount += 1;
+    }
+    if (this.state.formElements.summaryThreeWeeksAgo !== '') {
+      currentSubmittedCount += 1;
+    }
+    const diffInSubmittedCount = currentSubmittedCount-this.state.submittedCountInFourWeeks
+
     const modifiedWeeklySummaries = {
       mediaUrl: this.state.formElements.mediaUrl.trim(),
       weeklySummaries: [
@@ -255,7 +285,7 @@ export class WeeklySummary extends Component {
           dueDate: this.state.dueDateThreeWeeksAgo,
         },
       ],
-      weeklySummariesCount: this.state.formElements.weeklySummariesCount,
+      weeklySummariesCount: this.state.formElements.weeklySummariesCount+diffInSubmittedCount,
     };
 
     const updateWeeklySummaries = this.props.updateWeeklySummaries(
@@ -275,7 +305,6 @@ export class WeeklySummary extends Component {
       });
       this.props.getUserProfile(this.props.currentUser.userid);
       this.props.getWeeklySummaries(this.props.asUser || this.props.currentUser.userid);
-      this.props.setSubmittedSummary(true);
     } else {
       toast.error('✘ The data could not be saved!', {
         toastId: toastIdOnSave,

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -36,6 +36,7 @@ import { getUserProfile } from 'actions/userProfile';
 // Need this export here in order for automated testing to work.
 export class WeeklySummary extends Component {
   state = {
+    summariesCountShowing: 0,
     formElements: {
       summary: '',
       summaryLastWeek: '',
@@ -81,6 +82,8 @@ export class WeeklySummary extends Component {
       (weeklySummaries && weeklySummaries[2] && weeklySummaries[2].summary) || '';
     const summaryThreeWeeksAgo =
       (weeklySummaries && weeklySummaries[3] && weeklySummaries[3].summary) || '';
+
+    // Before submitting summaries, count current submits in four weeks
     let submittedCountInFourWeeks = 0;
     if (summary !== '') {
       submittedCountInFourWeeks += 1;
@@ -256,6 +259,7 @@ export class WeeklySummary extends Component {
     this.setState({ errors: errors || {} });
     if (errors) return;
 
+    // After submitting summaries, count current submits in four week
     let currentSubmittedCount = 0;
     if (this.state.formElements.summary !== '') {
       currentSubmittedCount += 1;
@@ -269,7 +273,11 @@ export class WeeklySummary extends Component {
     if (this.state.formElements.summaryThreeWeeksAgo !== '') {
       currentSubmittedCount += 1;
     }
+    // Check whether has newly filled summary
     const diffInSubmittedCount = currentSubmittedCount-this.state.submittedCountInFourWeeks
+    if (diffInSubmittedCount !== 0) {
+      this.setState({summariesCountShowing: this.state.formElements.weeklySummariesCount + 1});
+    }
 
     const modifiedWeeklySummaries = {
       mediaUrl: this.state.formElements.mediaUrl.trim(),
@@ -368,7 +376,8 @@ export class WeeklySummary extends Component {
     return (
       <Container fluid={this.props.isModal ? true : false} className="bg--white-smoke py-3 mb-5">
         <h3>Weekly Summaries</h3>
-        <div>Total submitted: {formElements.weeklySummariesCount}</div>
+        {/* Before clicking Save button, summariesCountShowing is 0 */}
+        <div>Total submitted: {this.state.summariesCountShowing || this.state.formElements.weeklySummariesCount}</div>
 
         <Form className="mt-4">
           <Nav tabs>


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/5071040/224442594-3509c621-ad20-43ac-bbc2-d710e8b869e9.png)
This PR is for URGENT bug #1 
This PR is **ONLY** for fixing the "total submitted" number of weekly summaries

## Related PRS (if any):
First part of URGENT bug #1, add one more tab for weekly summaries part, has been addressed by the following PRs:
frontend: #707 
backend: [#305](https://github.com/OneCommunityGlobal/HGNRest/pull/305)

And I will raise another backend PR to clean up the previous `weeklySummariesCount` implementation. 

## Mainly changes explained:
Check and update the "total submitted" by each time submitting a weeklySummary.
Introduce a new variable called `submittedCountInFourWeeks`, for counting whether we need to increment the `weeklySummariesCount` by one.

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
log as any role user or a new created user
go to dashboard→ weekly summaries
verify adding summaries on the 4 tabs to see if the "total number" has changed after re-rendering.

## Screenshots or videos of changes:
[PR demo video](https://www.dropbox.com/s/1e96vqry2fn6r71/PR%20demo%20showing.mp4?dl=0)

## Note:
1. Somehow the dev database will update the dueDate of each weeklySummary by the current week's dueDate, but the Beta database works well. I manually fix the dueDate problem in dev database for testing purposes to match the Beta database.