### PR TITLE
vitor better aspect ratio and align profile head

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -633,9 +633,7 @@ function UserProfile(props) {
                   Please click on "Save changes" to save the changes you have made.{' '}
                 </Alert>
               ) : null}
-              <h5 style={{ display: 'inline-block', marginRight: 10 }}>
-                {`${firstName} ${lastName}`}
-              </h5>
+              <h5>{`${firstName} ${lastName}`}</h5>
               <i
                 data-toggle="tooltip"
                 data-placement="right"
@@ -654,7 +652,6 @@ function UserProfile(props) {
                       setActiveInactivePopupOpen(true);
                     }}
                   />
-                  &nbsp;
                 </>
               )}
               {canEdit && (
@@ -678,16 +675,16 @@ function UserProfile(props) {
               >
                 Team Weekly Summaries
               </Button>
-              <h6>{jobTitle}</h6>
-              <p className="proile-rating">
-                From : <span>{moment(userProfile.createdDate).format('YYYY-MM-DD')}</span>
-                {'   '}
-                To:{' '}
-                <span>
-                  {userProfile.endDate ? userProfile.endDate.toLocaleString().split('T')[0] : 'N/A'}
-                </span>
-              </p>
             </div>
+            <h6 className="job-title">{jobTitle}</h6>
+            <p className="proile-rating">
+              From : <span>{moment(userProfile.createdDate).format('YYYY-MM-DD')}</span>
+              {'   '}
+              To:{' '}
+              <span>
+                {userProfile.endDate ? userProfile.endDate.toLocaleString().split('T')[0] : 'N/A'}
+              </span>
+            </p>
             {showSelect && summaries === undefined ? <div>Loading</div> : <div />}
             {showSelect && summaries !== undefined ? (
               <div>

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -62,9 +62,15 @@
 }
 .profile-head h5 {
   color: #333;
+  margin: 0;
 }
-.profile-head h6 {
+.job-title {
   color: #0062cc;
+}
+.profile-head {
+  display: flex;
+  align-items: center;
+  gap: 4px
 }
 .profile-edit-btn {
   border: none;


### PR DESCRIPTION
This PR intend to align the head of the user's profile page, and doing so made the page have a better aspect ratio as well.

## Main changes
1. Now, the team weekly summary button is aligned with the neighbors components.

## How to test
1 - Check into current branch
2 - Do `npm install` and `npm run start:local` to run this PR locally
3 - Go to dashboard → User Profile 
4 - All the profile head's components should be aligned.
5- Try comparing this branch with development branch.

## Before

![image](https://user-images.githubusercontent.com/17365161/228953749-5974d44c-0601-467c-8d4c-764aaca4e573.png)

## After

![image](https://user-images.githubusercontent.com/17365161/228953796-9e4d5d9e-a5a0-4695-bd6a-ff6489fac43f.png)



