### PR TITLE
vitor warning not being displayed correctly

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -629,12 +629,12 @@ function UserProfile(props) {
             </div>
           </Col>
           <Col md="8">
+            {!isProfileEqual || !isTasksEqual || !isTeamsEqual || !isProjectsEqual ? (
+              <Alert color="warning">
+                Please click on "Save changes" to save the changes you have made.{' '}
+              </Alert>
+            ) : null}
             <div className="profile-head">
-              {!isProfileEqual || !isTasksEqual || !isTeamsEqual || !isProjectsEqual ? (
-                <Alert color="warning">
-                  Please click on "Save changes" to save the changes you have made.{' '}
-                </Alert>
-              ) : null}
               <h5>{`${firstName} ${lastName}`}</h5>
               <i
                 data-toggle="tooltip"
@@ -850,13 +850,20 @@ function UserProfile(props) {
                 />
               </TabPane>
               <TabPane tabId="2">
-                { <VolunteeringTimeTab
-                  userProfile={userProfile}
-                  setUserProfile={setUserProfile}
-                  isUserSelf={isUserSelf}
-                  role={requestorRole}
-                  canEdit={hasPermission(requestorRole, 'editUserProfile', roles, userPermissions)}
-                /> }
+                {
+                  <VolunteeringTimeTab
+                    userProfile={userProfile}
+                    setUserProfile={setUserProfile}
+                    isUserSelf={isUserSelf}
+                    role={requestorRole}
+                    canEdit={hasPermission(
+                      requestorRole,
+                      'editUserProfile',
+                      roles,
+                      userPermissions,
+                    )}
+                  />
+                }
               </TabPane>
               <TabPane tabId="3">
                 <TeamsTab


### PR DESCRIPTION
Just a hot fix to the warning that was being displayed incorrectly on user profile page.
This PR is completely safe and should be merged as soon as possible. The change on another component is just automatic indentation.

Before: 
![image](https://user-images.githubusercontent.com/17365161/229861240-8c242069-1f54-4a1e-b286-def4660896cb.png)

After: 
![image](https://user-images.githubusercontent.com/17365161/229861405-acc40d56-2cc6-413e-bde1-50a85e1e8c7b.png)
