### PR TITLE
Jinchao apply missed hours to Core Team member

### DIFF
--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -171,7 +171,7 @@ const SummaryBar = props => {
   };
 
   if (userProfile !== undefined && leaderData !== undefined) {
-    const weeklyCommittedHours = userProfile.weeklycommittedHours;
+    const weeklyCommittedHours = userProfile.weeklycommittedHours + (userProfile.missedHours ?? 0);
     const weeklySummary = getWeeklySummary(userProfile);
     return (
       <Container fluid className={matchUser ? 'px-lg-0 bg--bar' : 'px-lg-0 bg--bar disabled-bar'}>

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -327,7 +327,7 @@ const ViewTab = props => {
           <Label className="hours-label">Total Tangible Hours </Label>
         </Col>
         <Col md="6">
-          <p className='hours-totalTangible'>{totalTangibleHours}</p>
+          <p className="hours-totalTangible">{totalTangibleHours}</p>
         </Col>
 
         {props?.userProfile?.hoursByCategory

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -327,7 +327,7 @@ const ViewTab = props => {
           <Label className="hours-label">Total Tangible Hours </Label>
         </Col>
         <Col md="6">
-          <p>{totalTangibleHours}</p>
+          <p className='hours-totalTangible'>{totalTangibleHours}</p>
         </Col>
 
         {props?.userProfile?.hoursByCategory

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -100,6 +100,28 @@ const WeeklyCommittedHours = props => {
   );
 };
 
+const MissedHours = props => {
+  if (!props.canEdit) {
+    return <p>{props.userProfile.missedHours ?? 0}</p>;
+  }
+  return (
+    <Input
+      type="number"
+      name="missedHours"
+      id="missedHours"
+      data-testid="missedHours"
+      value={props.userProfile.missedHours ?? 0}
+      onChange={e => {
+        props.setUserProfile({
+          ...props.userProfile,
+          missedHours: Number(e.target.value),
+        });
+      }}
+      placeholder="Additional Make-up Hours This Week"
+    />
+  );
+};
+
 const TotalTangibleHours = props => {
   //isUserAdmin is currently a value of Undefined. Therefore, !props.isUserAdmin is set to true all the time.
   //Therefore, I have chosen to comment out the other return statement section as it is not being rendered.
@@ -270,6 +292,21 @@ const ViewTab = props => {
             />
           </Col>
         </Row>
+        {userProfile.role === 'Core Team' && (
+          <Row>
+            <Col md="6">
+              <Label>Additional Make-up Hours This Week </Label>
+            </Col>
+            <Col md="6">
+              <MissedHours
+                role={role}
+                userProfile={userProfile}
+                setUserProfile={setUserProfile}
+                canEdit={canEdit}
+              />
+            </Col>
+          </Row>
+        )}
         <Row>
           <Col md="6">
             <Label>Total Intangible Hours </Label>
@@ -391,6 +428,20 @@ const ViewTab = props => {
             />
           </Col>
         </Col>
+        {userProfile.role === 'Core Team' && (
+          <Col>
+            <Col md="6">
+              <Label>Additional Make-up Hours This Week </Label>
+            </Col>
+            <Col md="6">
+            <MissedHours
+              userProfile={userProfile}
+              setUserProfile={setUserProfile}
+              canEdit={canEdit}
+            />
+            </Col>
+          </Col>
+        )}
         <Col>
           <Col md="6">
             <Label>Total Intangible Hours </Label>


### PR DESCRIPTION
# Description
Front end update for: a&b
![image](https://user-images.githubusercontent.com/94319381/230246489-e3d848b2-bf84-459d-88ba-b70a714342e6.png)

## Mainly changes explained:
Add new attribution for Core Team members under the volunteering time tab: Additional Make-up Hours This Week. 

Weekly committed time for Core Team members in the summary bar, leaderboard, and tasks board is now the sum of weekly committed hours and their last week's missed hours(Additional Make-up Hours This Week).

## How to test:
Please test with back-end [PR313](https://github.com/OneCommunityGlobal/HGNRest/pull/313)

Frontend functionality:
1. Log in as an admin user and see userProfile pages of users in different roles 
(Other links->user management->click on user's name -> volunteer). 
Make sure that **ONLY THE CORE TEAM** members have the 'Additional Make-up Hours This Week' in their volunteering times tab. 
![image](https://user-images.githubusercontent.com/94319381/230263655-3d0a8c74-9eea-4043-bd3e-ceffdd187f1a.png)


2. Try if the new field can be edited and saved like other number value fields.
3. Log in as other non-admin roles and check if the field is read-only
![image](https://user-images.githubusercontent.com/94319381/230263821-6e1547da-a4d5-4439-a3a8-ce0ae91af82d.png)

4. Log in as a core team member, and check if the weekly committed time in the dashboard is now the sum of weekly committed hours and additional make-up hours. (Summary Bar, Leaderboard, team member tasks)
![image](https://user-images.githubusercontent.com/94319381/230264133-9678ca1f-87ed-4565-8934-2575fce3fce4.png)
![image](https://user-images.githubusercontent.com/94319381/230264515-3bf76191-4253-458e-a441-300f57477624.png)
![image](https://user-images.githubusercontent.com/94319381/230264683-03541423-118c-4e4b-ba6e-72ae45fac0fe.png)

5. Log some time logs and see if the progress bar in the summary bar and the red/green dot in the leaderboard work as indeed. You can first log 1 min of tangible time using the clock and edit the time length of it at the current week timelog tab. The red dot should turn to green when the user has met the required hours. In my example, the weekly committed hour for the user is 30 hours while it has 12 hours of make-up time.
![image](https://user-images.githubusercontent.com/94319381/230266548-b5e98061-5578-42d5-9877-65faae250005.png)

6. Create a new user of the Core Team role or set a user's role to Core Team. Check if the make-up time is set to 0 as default.
## Note:
**Please also read the test instructions in the backend [PR313](https://github.com/OneCommunityGlobal/HGNRest/pull/313): This function needs to be thoroughly tested at both the frontend and backend.**
