### PR TITLE
yihan fix saved changes popup disappear

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -429,7 +429,6 @@ function UserProfile(props) {
       alert('An error occurred while attempting to save this profile.');
     }
     setShouldRefresh(true);
-    window.location.reload();
   };
 
   const toggle = modalName => setMenuModalTabletScreen(modalName);


### PR DESCRIPTION
# Description
9. **(PRIORITY MEDIUM) Jae:** **Fix saved changes popup disappearing before “close” button is clicked.**
a.	When you save changes on the Profile Page, there is a rotating selection of popups that show. They have a “close” button but they have been closing on their own. They should only close after that button is clicked. 

## Mainly changes explained:
In file UserProfile.jsx, a reload function was added at the end of handleSubmit function, which cause page automatic refresh. I delete this function so that the saved changes popup wont disappear until we click the close button in it.

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
go to Leaderboard→yourself or anyone's profile page that you can make change on
try to make a change on any part that cause a popup after we click on the "save changes" button, the popup won't disapearing before "close button" is clicked.

## Screenshots or videos of changes:
Before:

https://user-images.githubusercontent.com/94303659/230514318-621ed5a5-7705-42b7-bb4e-cce07a0e96cf.mp4

After:

https://user-images.githubusercontent.com/94303659/230514329-c939adc7-5fc1-42df-ace4-01e664fa636f.mp4


