### PR TITLE
yihan eliminate extra space in People Report

### DIFF
--- a/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
+++ b/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
@@ -9,7 +9,8 @@
 }
 
 .report-page-content {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   grid-row-start: 1;
   row-gap: 32px;
   padding-bottom: 24px;

--- a/src/components/Reports/sharedComponents/ReportPage/ReportPage.jsx
+++ b/src/components/Reports/sharedComponents/ReportPage/ReportPage.jsx
@@ -4,8 +4,8 @@ import './ReportPage.css';
 
 export const ReportPage = ({ children, renderProfile, contentClassName }) => (
   <section className="report-page-wrapper">
-    <div className="report-page-profile">{renderProfile()}</div>
     <div className={`report-page-content ${contentClassName}`}>{children}</div>
+    <div className="report-page-profile">{renderProfile()}</div>
   </section>
 );
 


### PR DESCRIPTION
# Description
**(PRIORITY LOW) Jae:When no charts showing on a People Report, eliminate empty space**
a.	Reports → Reports → People → Choose “Jae Sabol”
b.	See extra space I’d like to have collapsed when there aren’t any charts. For example WITH CHARTS, see JL Test. I’d like to eliminate the extra space above the charts there too please. 
![image](https://user-images.githubusercontent.com/94303659/230690127-edd64b53-680b-4d7d-abef-93ee6b07214c.png)

## Mainly changes explained:
In ReportPage.css, I changed the display property of report-page-content class from grid to flex, and set the flex-direction to row.

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
go to Reports → Reports → People → Choose “Jae Sabol”(or anyone that has no chart), check if there's no empty space. Then, go back to People and choose JL Test(or anyone that has chart), see if there's no extra space above the chart.

## Screenshots or videos of changes:
![image](https://user-images.githubusercontent.com/94303659/230690514-f2836bd9-4af1-4a58-afcd-2a245a879eb0.png)
![image](https://user-images.githubusercontent.com/94303659/230690541-037f8368-8557-4e35-8147-b0a1dbff1c2e.png)

