### PR TITLE
Jinchao update weeklysummaryrequired

### DIFF
--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -55,7 +55,7 @@ const EndDate = props => {
 
 const WeeklySummaryOptions = props => {
   if (!props.canEdit) {
-    return <p>{props.userProfile.WeeklySummaryOption}</p>
+    return <p>{props.userProfile.weeklySummaryOption??(props.userProfile.weeklySummaryNotReq?'Not Required':'Required')}</p>
   }
   return (
     <FormGroup>

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Row, Label, Input, Col } from 'reactstrap';
+import { Row, Label, Input, Col, FormGroup } from 'reactstrap';
 import moment from 'moment-timezone';
 import { capitalize } from 'lodash';
 import style from '../UserProfileEdit/ToggleSwitch/ToggleSwitch.module.scss';
@@ -53,30 +53,29 @@ const EndDate = props => {
   );
 };
 
-const WeeklySummaryReqd = props => {
+const WeeklySummaryOptions = props => {
   if (!props.canEdit) {
-    return <p>{props.userProfile.weeklySummaryNotReq ? 'Not Required' : 'Required'}</p>;
+    return <p>{props.userProfile.WeeklySummaryOption}</p>
   }
   return (
-    <div className={style.switchContainer} style={{ justifyContent: 'left', marginBottom: '10px' }}>
-      Required
-      <input
-        id="weeklySummaryNotReqd"
-        data-testid="weeklySummary-switch"
-        type="checkbox"
-        className={style.toggle}
+    <FormGroup>
+      <select
+        name="WeeklySummaryOptions"
+        id="weeklySummaryOptions"
+        className="form-control"
+        disabled={!props.canEdit}
+        value={props.userProfile.weeklySummaryOption??(props.userProfile.weeklySummaryNotReq?'Not Required':'Required')}
         onChange={e => {
-          props.setUserProfile({
-            ...props.userProfile,
-            weeklySummaryNotReq: !props.userProfile.weeklySummaryNotReq,
-          });
+          props.setUserProfile({ ...props.userProfile, weeklySummaryOption: e.target.value });
         }}
-        checked={props.userProfile.weeklySummaryNotReq}
-      />
-      Not Required
-    </div>
-  );
-};
+      >
+        <option value="Required">Required</option>
+        <option value="Not Required">Not Required</option>
+        <option value="Team">Team</option>
+      </select>
+    </FormGroup>
+  )
+}
 
 const WeeklyCommittedHours = props => {
   if (!props.canEdit) {
@@ -252,10 +251,10 @@ const ViewTab = props => {
 
       <Row className="volunteering-time-row">
         <Col md="6">
-          <Label className="hours-label">Weekly Summary Required </Label>
+          <Label className="hours-label">Weekly Summary Options </Label>
         </Col>
         <Col md="6">
-          <WeeklySummaryReqd
+          <WeeklySummaryOptions
             role={role}
             userProfile={userProfile}
             setUserProfile={setUserProfile}

--- a/src/components/UserProfile/VolunteeringTimeTab/timeTab.css
+++ b/src/components/UserProfile/VolunteeringTimeTab/timeTab.css
@@ -7,6 +7,10 @@
   padding: 8px 0;
 }
 
+.volunteering-time-row .col-md-6 .form-group {
+  margin-bottom: 0;
+}
+
 .col-md-6 .hours-label {
   margin-bottom: 0;
 }

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -39,14 +39,43 @@ const FormattedReport = ({ summaries, weekIndex }) => {
   };
 
   const getWeeklySummaryMessage = summary => {
-    if (!summary)
+    if (!summary) {
       return (
         <p>
           <b>Weekly Summary:</b> Not provided!
         </p>
       );
-
+    }
+    
     const summaryText = summary?.weeklySummaries[weekIndex]?.summary;
+    
+    const summaryContent = (() => {
+      if (summaryText) {
+        const style = {};
+        switch (summary?.weeklySummaryOption) {
+          case 'Team':
+            style.color = 'magenta';
+            break;
+          case 'Not Required':
+            style.color = 'green';
+            break;
+          case 'Required':
+            break;
+          default:
+            if (summary.weeklySummaryNotReq) {
+              style.color = 'green';
+            }
+            break;
+        }
+        return <div style={style}>{ReactHtmlParser(summaryText)}</div>;
+      }else{
+        if (summary?.weeklySummaryOption === 'Not Required' || (!summary?.weeklySummaryOption && summary.weeklySummaryNotReq)) {
+          return <p style={{ color: 'green' }}>Not required for this user</p>;
+        }else {
+          return <span style={{ color: 'red' }}>Not provided!</span>;
+        }
+      }
+    })();
 
     return (
       <>
@@ -57,18 +86,7 @@ const FormattedReport = ({ summaries, weekIndex }) => {
             .format('YYYY-MMM-DD')}
           ):
         </p>
-
-        {summaryText && (
-          summary?.weeklySummaryOption === 'Team' ? 
-            <div style={{ color: 'magenta' }}>{ReactHtmlParser(summaryText)}</div> :
-            ReactHtmlParser(summaryText)
-        )}
-
-        {!summaryText && (
-          summary?.weeklySummaryOption === 'Not Required' || summary.weeklySummaryNotReq ?
-            <p style={{ color: 'magenta' }}>Not required for this user</p> :
-            <span style={{ color: 'red' }}>Not provided!</span>
-        )}
+        {summaryContent}
       </>
     );
   };

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -58,14 +58,16 @@ const FormattedReport = ({ summaries, weekIndex }) => {
           ):
         </p>
 
-        {summaryText && ReactHtmlParser(summaryText)}
-
-        {summary.weeklySummaryNotReq === true && !summaryText && (
-          <p style={{ color: 'magenta' }}>Not required for this user</p>
+        {summaryText && (
+          summary?.weeklySummaryOption === 'Team' ? 
+            <div style={{ color: 'magenta' }}>{ReactHtmlParser(summaryText)}</div> :
+            ReactHtmlParser(summaryText)
         )}
 
-        {!summaryText && !summary.weeklySummaryNotReq && (
-          <span style={{ color: 'red' }}>Not provided!</span>
+        {!summaryText && (
+          summary?.weeklySummaryOption === 'Not Required' || summary.weeklySummaryNotReq ?
+            <p style={{ color: 'magenta' }}>Not required for this user</p> :
+            <span style={{ color: 'red' }}>Not provided!</span>
         )}
       </>
     );

--- a/src/components/WeeklySummariesReport/GeneratePdfReport.jsx
+++ b/src/components/WeeklySummariesReport/GeneratePdfReport.jsx
@@ -20,7 +20,7 @@ const GeneratePdfReport = ({ summaries, weekIndex, weekDates }) => {
     const weeklySummaryNotProvidedMessage =
       '<div><b>Weekly Summary:</b> <span style="color: red;">Not provided!</span></div>';
     const weeklySummaryNotRequiredMessage =
-      '<div><b>Weekly Summary:</b> <span style="color: magenta;">Not required for this user</span></div>';
+      '<div><b>Weekly Summary:</b> <span style="color: green;">Not required for this user</span></div>';
 
     summaries.sort((a, b) =>
       `${a.firstName} ${a.lastName}`.localeCompare(`${b.firstName} ${b.lastname}`),
@@ -49,7 +49,18 @@ const GeneratePdfReport = ({ summaries, weekIndex, weekDates }) => {
         : '<span style="color: red;">Not provided!</span>';
 
       const totalValidWeeklySummaries = weeklySummariesCount || 'No valid submissions yet!';
-
+      const colorStyle = (() => {
+        switch (weeklySummaryOption) {
+          case 'Team':
+            return 'style="color: magenta;"';
+          case 'Not Required':
+            return 'style="color: green"';
+          case 'Required':
+            return '';
+          default:
+            return eachSummary.weeklySummaryNotReq ? 'style="color: green"' : '';
+        }
+      })();
       let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
       if (Array.isArray(weeklySummaries) && weeklySummaries[weekIndex]) {
         const { dueDate, summary } = weeklySummaries[weekIndex];
@@ -59,10 +70,10 @@ const GeneratePdfReport = ({ summaries, weekIndex, weekDates }) => {
           )
             .tz('America/Los_Angeles')
             .format('YYYY-MMM-DD')}</b>):</div>
-                                  <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}" ${weeklySummaryOption === 'Team' ? 'style="color: magenta;"' : ''}>${summary
+                                  <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}" ${colorStyle}>${summary
                                     .replace(styleRegex, '')
                                     .replace(styleInlineRegex, '')}</div>`;
-        } else if (weeklySummaryOption === 'Not Required' || eachSummary.weeklySummaryNotReq === true) {
+        } else if (weeklySummaryOption === 'Not Required' || (!weeklySummaryOption && eachSummary.weeklySummaryNotReq)) {
           weeklySummaryMessage = weeklySummaryNotRequiredMessage;
         }
       }

--- a/src/components/WeeklySummariesReport/GeneratePdfReport.jsx
+++ b/src/components/WeeklySummariesReport/GeneratePdfReport.jsx
@@ -35,6 +35,7 @@ const GeneratePdfReport = ({ summaries, weekIndex, weekDates }) => {
         weeklySummariesCount,
         weeklycommittedHours,
         totalSeconds,
+        weeklySummaryOption,
       } = eachSummary;
 
       const hoursLogged = (totalSeconds[weekIndex] || 0) / 3600;
@@ -58,10 +59,10 @@ const GeneratePdfReport = ({ summaries, weekIndex, weekDates }) => {
           )
             .tz('America/Los_Angeles')
             .format('YYYY-MMM-DD')}</b>):</div>
-                                  <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}">${summary
+                                  <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}" ${weeklySummaryOption === 'Team' ? 'style="color: magenta;"' : ''}>${summary
                                     .replace(styleRegex, '')
                                     .replace(styleInlineRegex, '')}</div>`;
-        } else if (eachSummary.weeklySummaryNotReq === true) {
+        } else if (weeklySummaryOption === 'Not Required' || eachSummary.weeklySummaryNotReq === true) {
           weeklySummaryMessage = weeklySummaryNotRequiredMessage;
         }
       }


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/94319381/231906373-9bd0d506-05db-49d7-a092-11a148c3602e.png)
Frontend update for [#316](https://github.com/OneCommunityGlobal/HGNRest/pull/316).
## Mainly changes explained:
Replace Weekly Summary Required switch on volunteerTimeTab with Weekly Summary Options selection input. Update the showing logic of weekly summaries in Weekly Summaries Reports page and generated PDF.
## How to test:
Please test this PR with the backend [#316](https://github.com/OneCommunityGlobal/HGNRest/pull/316) update.
Please open both the dev host https://hgnapplication_react_dev.surge.sh/ branch and your localhost since this PR will replace the previous 'Weekly Summary Required' with the new 'Weekly Summary Option', without directly modifying the database. The database will only be updated when a user clicks the save changes button.

1. Log in to both dev host and localhost as an admin user, go to other links -> user management -> open any user's profile page -> volunteering times tab. Check if the **weekly summary options** in localhost synchronize with **Weekly Summary Required** in dev (Avoid using any accounts that have a name like jinchaoxxx, I made my own test on these accounts lol)
![image](https://user-images.githubusercontent.com/94319381/231939474-6ead71e9-c8b7-41fe-bb77-e76c7971e50b.png)
![image](https://user-images.githubusercontent.com/94319381/231939532-bbee0bb9-cd9f-4877-a5f2-1a5632a1c3ad.png)
2. Change the **Weekly Summary Required** in dev. Restart the local HGNRest and go to userProfile page, check if the **weekly summary options** changed as well (This ensures that if an account doesn't have a weekly summary option set in the database, the system will use the old information. Currently, there is a bug preventing changing from "Not Required" to "Required", so just check by changing from "Required" to "Not Required")
3. Log in as a non-admin user and check the synchronization in read-only view:
![image](https://user-images.githubusercontent.com/94319381/231941019-144e06fa-eee1-42c2-8fe2-e4d37d4a82f5.png)
![image](https://user-images.githubusercontent.com/94319381/231941045-ef9df7de-da87-4034-816d-ed4b3de7a6e1.png)

4. Change the **weekly summary options** in localhost to 'Team' and save changes. Check if the save changes button work as intended.
5. Go to Reports->weekly summary reports to check if the color for different options(required, team, not required) is correct
![image](https://user-images.githubusercontent.com/94319381/231943273-54beed7a-4e8f-40fa-9b55-71ee125e94f5.png)
6. Click Open PDF at the top of the weekly summary reports page to check if the pdf report is correct.
![image](https://user-images.githubusercontent.com/94319381/231943478-60b67bf7-6b7f-4851-ad82-56d7b07aff43.png)
7. Repeat step 5 and 6 with the different weekly summary options, and check if the reports are correct based on color pattern table in Note.
## Note:
Color pattern: 
![image](https://user-images.githubusercontent.com/94319381/231946726-c758c8fd-4f78-4b4b-a75f-f870dafe3d09.png)
