### PR TITLE
in TimeLog userId for the clicked user is working fine

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -101,7 +101,7 @@ class Timelog extends Component {
   state = this.initialState;
 
   async componentDidMount() {
-    const userId = this.props.asUser; //Including fix for "undefined"
+    const userId = this.props.asUser || this.props.match.params.userId; //Including fix for "undefined"
     const isOwner = this.props.auth.user.userid === this.props.asUser;
     if (!isOwner || this.props.userProfile) {
       await this.props.getUserProfile(userId);
@@ -141,7 +141,6 @@ class Timelog extends Component {
     if (!isDashboard) {
       this.setState({ activeTab: 1 });
     }
-
   }
 
   async componentDidUpdate(prevProps) {

--- a/src/components/Timelog/WeeklySummaries.jsx
+++ b/src/components/Timelog/WeeklySummaries.jsx
@@ -2,39 +2,35 @@ import React from 'react';
 import parse from 'html-react-parser';
 
 const WeeklySummaries = ({ userProfile }) => {
+  if (!userProfile.weeklySummaries || userProfile.weeklySummaries.length < 3) {
+    return <div>No weekly summaries available</div>;
+  }
+
+  const renderSummary = (title, summary) => {
+    if (summary) {
+      return (
+        <div>
+          <h3>{title}</h3>
+          <p>{parse(summary)}</p>
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          <h3>{title}</h3>
+          <p>
+            {userProfile.firstName} {userProfile.lastName} did not submit a summary.
+          </p>
+        </div>
+      );
+    }
+  };
+
   return (
     <div>
-      {userProfile.weeklySummaries[0].summary ? (
-        <div>
-          <h4>This week's summary</h4>
-          <h4>{parse(userProfile.weeklySummaries[0].summary)}</h4>
-        </div>
-      ) : (
-        <h4>
-          {userProfile.firstName} {userProfile.lastName} did not submit a summary for this week.
-        </h4>
-      )}
-      {userProfile.weeklySummaries[1].summary ? (
-        <div>
-          <h4>Last week's summary</h4>
-          <h4>{parse(userProfile.weeklySummaries[1].summary)}</h4>
-        </div>
-      ) : (
-        <h4>
-          {userProfile.firstName} {userProfile.lastName} did not submit a summary last week.
-        </h4>
-      )}
-      {userProfile.weeklySummaries[2].summary ? (
-        <div>
-          <h4>The week before last's summary</h4>
-          <h4>{parse(userProfile.weeklySummaries[2].summary)}</h4>
-        </div>
-      ) : (
-        <h4>
-          {userProfile.firstName} {userProfile.lastName} did not submit a summary for the week
-          before last.
-        </h4>
-      )}
+      {renderSummary("This week's summary", userProfile.weeklySummaries[0]?.summary)}
+      {renderSummary("Last week's summary", userProfile.weeklySummaries[1]?.summary)}
+      {renderSummary("The week before last's summary", userProfile.weeklySummaries[2]?.summary)}
     </div>
   );
 };


### PR DESCRIPTION
# Description

Fixes: Anyone else having problems viewing other people’s time logs after the latest merges? Dashboard --> Leaderboard Section --> Click time bar for another person.

…

## Mainly changes explained:
1 - added the right logic to get the clikced user id at TimeLog.jsx, because was getting undefined.
2 -  Inside the page TimeLog for the user the weekly summaries was not working properly, so I rebuild the component with a best logic.
…

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
log as admin user
go to   Dashboard→  Leaderboard Section → Click time bar for another person.

 (feel free to include screenshot here)

## Screenshots or videos of changes:
![Captura de Tela (329)](https://user-images.githubusercontent.com/39320057/231896942-d9c90487-d65a-4a29-985b-0b59da4a4857.png)


