### PR TITLE
yihan hide assign badges button from all but owner/admin class

### DIFF
--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -62,15 +62,12 @@ const Badges = props => {
                   />
                 </ModalBody>
               </Modal>
-              {props.canEdit && (
+              {((props.canEdit && (props.role == "Owner" || props.role == "Administrator")) || 
+              props.userPermissions.includes("assignBadgeOthers"))&& (
                 <>
-                {(props.role == "Owner" || 
-                  props.role == "Administrator" || 
-                  props.userPermissions.includes("assignBadgeOthers")) && (
-                    <Button className="btn--dark-sea-green mr-2" onClick={assignToggle}>
-                      Assign Badges
-                    </Button>
-                )}
+                  <Button className="btn--dark-sea-green mr-2" onClick={assignToggle}>
+                    Assign Badges
+                  </Button>
                   <Modal size="lg" isOpen={isAssignOpen} toggle={assignToggle}>
                     <ModalHeader toggle={assignToggle}>Assign Badges</ModalHeader>
                     <ModalBody>

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -64,9 +64,13 @@ const Badges = props => {
               </Modal>
               {props.canEdit && (
                 <>
-                  <Button className="btn--dark-sea-green mr-2" onClick={assignToggle}>
-                    Assign Badges
-                  </Button>
+                {(props.role == "Owner" || 
+                  props.role == "Administrator" || 
+                  props.userPermissions.includes("assignBadgeOthers")) && (
+                    <Button className="btn--dark-sea-green mr-2" onClick={assignToggle}>
+                      Assign Badges
+                    </Button>
+                )}
                   <Modal size="lg" isOpen={isAssignOpen} toggle={assignToggle}>
                     <ModalHeader toggle={assignToggle}>Assign Badges</ModalHeader>
                     <ModalBody>


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/94303659/232168216-baa18360-eda7-4c62-bedf-954ffd1e1f31.png)

## Mainly changes explained:
Add conditional rendering on assign badges button. So, the button only shows up when the users is of Owner/Admin class or has assign badges permission.

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
log as different type of user
go to profile page→ Assign badges→ Choose→ Save
check if only owner, administrator and users who has the permission can see the button and assign badges.

## Screenshots or videos of changes:
owner, administrator or other users who have assign badges permission:
![hide-button-has-permission](https://user-images.githubusercontent.com/94303659/232168856-62c77f30-1c50-4f1d-984e-cdcf55b9363a.png)

users don't have assign badges permission:
![hide-button-no-permission](https://user-images.githubusercontent.com/94303659/232168909-9b9165ba-4133-45d9-9291-75ed5a6c8c41.png)
