### PR TITLE
Jianjun - Two bug fix

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -65,7 +65,7 @@ const Badge = props => {
   const permissionsUser = props.userProfile?.permissions?.frontPermissions;
   return (
     <>
-      <Container>
+      <Container className="right-padding-temp-fix">
         <Row>
           <Col md={12}>
             <Card style={{ backgroundColor: '#fafafa', borderRadius: 0 }} id="badgesearned">

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -51,7 +51,7 @@ export const Dashboard = props => {
         leaderData={leaderData}
       />
 
-      <Row >
+      <Row>
         <Col lg={{ size: 7 }}>&nbsp;</Col>
         <Col lg={{ size: 5 }}>
           <div className="row justify-content-center">
@@ -62,7 +62,12 @@ export const Dashboard = props => {
               onKeyDown={toggle}
               tabIndex="0"
             >
-              <WeeklySummary isPopup asUser={userId} setSubmittedSummary={setSubmittedSummary} />
+              <WeeklySummary
+                isDashboard={true}
+                isPopup={popup}
+                asUser={userId}
+                setSubmittedSummary={setSubmittedSummary}
+              />
             </div>
           </div>
         </Col>

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -361,8 +361,8 @@ class Timelog extends Component {
                 </div>
               </div>
             ) : null}
-            <Row className="right-padding-temp-fix">
-              <Col className="right-padding-temp-fix" md={12}>
+            <Row>
+              <Col md={12}>
                 <Card>
                   <CardHeader>
                     <Row>
@@ -673,7 +673,6 @@ class Timelog extends Component {
                   </CardBody>
                 </Card>
               </Col>
-              <Col md={4} />
             </Row>
           </Container>
         )}

--- a/src/components/WeeklySummary/DueDateTime.jsx
+++ b/src/components/WeeklySummary/DueDateTime.jsx
@@ -5,14 +5,18 @@ import { faCalendarCheck } from '@fortawesome/free-regular-svg-icons';
 import moment from 'moment';
 import { CountdownTimer } from './CountdownTimer';
 
-function DueDateTime({ dueDate }) {
+function DueDateTime({ dueDate, isShow }) {
   // The display time should add 1 sec so it displays Sunday at 00:00 and not Saturday at 23:59:59.
   const displayTime = moment(dueDate)
     .tz('America/Los_Angeles')
     .add(1, 'second');
   return (
     <div className="my-4 my-md-1">
-      <div className="mb-1">Weekly Summary Due Date (click to add)</div>
+      {isShow ? (
+        <div className="mb-1">Weekly Summary Due Date (click to close)</div>
+      ) : (
+        <div className="mb-1">Weekly Summary Due Date (click to add)</div>
+      )}
       <div className="mx-auto due-section">
         <div className="text-white due-section__date">
           <FontAwesomeIcon icon={faCalendarCheck} className="mr-1" />{' '}

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -103,12 +103,21 @@ export class WeeklySummary extends Component {
     const dueDate = moment(dueDateThisWeek).isBefore(this.state.dueDate)
       ? this.state.dueDate
       : dueDateThisWeek;
-    
+
     // Calculate due dates for the last three weeks by subtracting 1, 2, and 3 weeks from the current due date
     // and then setting the due date to the end of the ISO week (Saturday) for each respective week
-    const dueDateLastWeek = moment(dueDate).subtract(1, 'weeks').startOf('isoWeek').add(5, 'days');
-    const dueDateBeforeLast = moment(dueDate).subtract(2, 'weeks').startOf('isoWeek').add(5, 'days');
-    const dueDateThreeWeeksAgo = moment(dueDate).subtract(3, 'weeks').startOf('isoWeek').add(5, 'days');
+    const dueDateLastWeek = moment(dueDate)
+      .subtract(1, 'weeks')
+      .startOf('isoWeek')
+      .add(5, 'days');
+    const dueDateBeforeLast = moment(dueDate)
+      .subtract(2, 'weeks')
+      .startOf('isoWeek')
+      .add(5, 'days');
+    const dueDateThreeWeeksAgo = moment(dueDate)
+      .subtract(3, 'weeks')
+      .startOf('isoWeek')
+      .add(5, 'days');
 
     this.setState({
       formElements: {
@@ -271,9 +280,9 @@ export class WeeklySummary extends Component {
       currentSubmittedCount += 1;
     }
     // Check whether has newly filled summary
-    const diffInSubmittedCount = currentSubmittedCount-this.state.submittedCountInFourWeeks
+    const diffInSubmittedCount = currentSubmittedCount - this.state.submittedCountInFourWeeks;
     if (diffInSubmittedCount !== 0) {
-      this.setState({summariesCountShowing: this.state.formElements.weeklySummariesCount + 1});
+      this.setState({ summariesCountShowing: this.state.formElements.weeklySummariesCount + 1 });
     }
 
     const modifiedWeeklySummaries = {
@@ -290,7 +299,7 @@ export class WeeklySummary extends Component {
           dueDate: this.state.dueDateThreeWeeksAgo,
         },
       ],
-      weeklySummariesCount: this.state.formElements.weeklySummariesCount+diffInSubmittedCount,
+      weeklySummariesCount: this.state.formElements.weeklySummariesCount + diffInSubmittedCount,
     };
 
     const updateWeeklySummaries = this.props.updateWeeklySummaries(
@@ -372,15 +381,18 @@ export class WeeklySummary extends Component {
       );
     }
 
-    if (this.props.isModal || this.props.isPopup) {
-      return <DueDateTime dueDate={moment(dueDate)} />;
+    if (this.props.isDashboard) {
+      return <DueDateTime isShow={this.props.isPopup} dueDate={moment(dueDate)} />;
     }
 
     return (
       <Container fluid={this.props.isModal ? true : false} className="bg--white-smoke py-3 mb-5">
         <h3>Weekly Summaries</h3>
         {/* Before clicking Save button, summariesCountShowing is 0 */}
-        <div>Total submitted: {this.state.summariesCountShowing || this.state.formElements.weeklySummariesCount}</div>
+        <div>
+          Total submitted:{' '}
+          {this.state.summariesCountShowing || this.state.formElements.weeklySummariesCount}
+        </div>
 
         <Form className="mt-4">
           <Nav tabs>
@@ -433,7 +445,10 @@ export class WeeklySummary extends Component {
                           onEditorChange={this.handleEditorChange}
                         />
                       </FormGroup>
-                      {(errors.summary || errors.summaryLastWeek || errors.summaryBeforeLast || errors.summaryThreeWeeksAgo) && (
+                      {(errors.summary ||
+                        errors.summaryLastWeek ||
+                        errors.summaryBeforeLast ||
+                        errors.summaryThreeWeeksAgo) && (
                         <Alert color="danger">
                           The summary must contain a minimum of 50 words.
                         </Alert>


### PR DESCRIPTION
### Description
**1.PRIORITY LOW of WEEKLY SUMMARIES COMPONENT**
Have words above countdown clock change
If you click the words below on the Dashboard, it’ll open the Summary submission page. When that page is open, please have the text below change to “(click to close)” so people know how to close it
<img width="698" alt="1" src="https://user-images.githubusercontent.com/9314962/232264868-0ea5c318-e98f-4688-bca9-d8974d2f1e72.png">

**2.PRIORITY LOW of TIMELOG COMPONENT**
The time log component and badge component do not align
<img width="782" alt="bug" src="https://user-images.githubusercontent.com/9314962/232264619-0bc2b422-9fc8-4a75-950b-7d8e0f11b1e0.png">

### Mainly changes explained:
1.The prop` isPopup `of the `DueDateTime` was not used properly. Now is used to change the reminder text (click to add/close) as below
<img width="348" alt="image" src="https://user-images.githubusercontent.com/9314962/232264552-a8bf63ad-97e1-4530-8799-87bee0b7fbf6.png">
2.A class attribute `right-padding-temp-fix` was introduced by previous developer's work to apply to the timelog component. It should also be applied to the badge component to make them aligned.
<img width="723" alt="2" src="https://user-images.githubusercontent.com/9314962/232264936-798c54c7-ccfb-4cf1-9396-09712847afd1.png">


### How to test:
check into current branch
do npm install and ... to run this PR locally
Click the countdown to open/close the weeklysummary component.