### PR TITLE
Badge preview fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15943,6 +15943,12 @@
         "topo": "3.x.x"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
+      "integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ==",
+      "peer": true
+    },
     "node_modules/js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -25138,6 +25144,19 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -39674,6 +39693,12 @@
         "topo": "3.x.x"
       }
     },
+    "jquery": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
+      "integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ==",
+      "peer": true
+    },
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -47001,6 +47026,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -135,3 +135,10 @@
 .badgeTooltip .tooltip-inner {
   background-color: #666;
 }
+
+.popover img {
+  width: 100%;
+  height: 100%;
+  max-width: 120px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
# Description
Fix badge previews… they are looking squished on the Profile Page and the dashboard badges section 

Before 
![Before](https://user-images.githubusercontent.com/82662768/232276629-966b14c4-874d-4a67-ae75-d10e9abb9c66.jpg)


## Mainly changes explained:
When you hover on the badge the preview image is squished/stretched. I have added CSS to fix this.

```
.popover img {
  width: 100%;
  height: 100%;
  max-width: 120px;
  margin: 0 auto;
}
```
…

## How to test:
check into current branch
do `npm install` and `npm run start:local` to run this PR locally
log as admin user
go to dashboard→  welcome -> view profile → hover on badge

## Screenshots or videos of changes:
After 
![Screenshot 2023-04-16 113837](https://user-images.githubusercontent.com/82662768/232276653-26412793-cf3b-4b3f-b3f7-1730f01e76a4.jpg)

