### PR TITLE
Make cancel button visible on smaller screens

### DIFF
--- a/src/components/Login/ForgotPassword.jsx
+++ b/src/components/Login/ForgotPassword.jsx
@@ -169,7 +169,7 @@ const ForgotPassword = React.memo(() => {
           </Button>
           <Link to="login">
             {' '}
-            <Button style={{ marginLeft: '350px' }}>Cancel</Button>
+            <Button style={{ float: 'right' }}>Cancel</Button>
           </Link>
         </div>
       </form>


### PR DESCRIPTION
# Description
(PRIORITY LOW) Jae: Make “cancel” button visible on small screens
There is no cancel button visible when using the “forgot password” option on a phone 

## Mainly changes explained:
Replace { marginLeft: '350px' } with { float: 'right' } on the cancel button inline styles.

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
verify if the cancel button is visible on smaller screens when using the "forgot password" option

## Screenshots or videos of changes:
### Before


https://user-images.githubusercontent.com/52610124/232740745-62dec2a0-f907-4fa0-ac66-45bc156abd3c.mp4


### After



https://user-images.githubusercontent.com/52610124/232740788-030e0a39-42b3-4521-adea-a6961beb98f2.mp4



