### PR TITLE
yihan add missing tab to the Weekly Summaries Reports

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -111,6 +111,15 @@ export class WeeklySummariesReport extends Component {
                   Week Before Last
                 </NavLink>
               </NavItem>
+              <NavItem>
+                <NavLink
+                  className={classnames({ active: activeTab === '4' })}
+                  data-testid="tab-4"
+                  onClick={() => this.toggleTab('4')}
+                >
+                  Three Weeks Ago
+                </NavLink>
+              </NavItem>
             </Nav>
             <TabContent activeTab={activeTab} className="p-4">
               <TabPane tabId="1">
@@ -170,6 +179,26 @@ export class WeeklySummariesReport extends Component {
                 <Row>
                   <Col>
                     <FormattedReport summaries={summaries} weekIndex={2} />
+                  </Col>
+                </Row>
+              </TabPane>
+              <TabPane tabId="4">
+                <Row>
+                  <Col sm="12" md="8" className="mb-2">
+                    From <b>{this.getWeekDates(3).fromDate}</b> to{' '}
+                    <b>{this.getWeekDates(3).toDate}</b>
+                  </Col>
+                  <Col sm="12" md="4">
+                    <GeneratePdfReport
+                      summaries={summaries}
+                      weekIndex={3}
+                      weekDates={this.getWeekDates(3)}
+                    />
+                  </Col>
+                </Row>
+                <Row>
+                  <Col>
+                    <FormattedReport summaries={summaries} weekIndex={3} />
                   </Col>
                 </Row>
               </TabPane>

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.test.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.test.jsx
@@ -40,9 +40,9 @@ describe('WeeklySummariesReport page', () => {
       render(<WeeklySummariesReport {...props} />);
     });
 
-    it('should have 3 tab', () => {
+    it('should have 4 tab', () => {
       const li = screen.getAllByRole('listitem');
-      expect(li.length).toEqual(3);
+      expect(li.length).toEqual(4);
     });
 
     it('should have first tab set to "active" by default', () => {
@@ -63,6 +63,11 @@ describe('WeeklySummariesReport page', () => {
       // Third tab click.
       fireEvent.click(screen.getByTestId('tab-3'));
       expect(screen.getByTestId('tab-3').classList.contains('active')).toBe(true);
+    });
+    it('should make 4th tab active when clicked', () => {
+      // Fourth tab click.
+      fireEvent.click(screen.getByTestId('tab-4'));
+      expect(screen.getByTestId('tab-4').classList.contains('active')).toBe(true);
     });
   });
 });

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.test.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.test.jsx
@@ -40,9 +40,8 @@ describe('WeeklySummariesReport page', () => {
       render(<WeeklySummariesReport {...props} />);
     });
 
-    it('should have 4 tab', () => {
-      const li = screen.getAllByRole('listitem');
-      expect(li.length).toEqual(4);
+    afterEach(() => {
+      jest.clearAllMocks();
     });
 
     it('should have first tab set to "active" by default', () => {


### PR DESCRIPTION
# Description
![add-summaries-report-tab-bug](https://user-images.githubusercontent.com/94303659/232927516-92f634d9-295c-4919-af53-22adf2f948ee.png)

## Mainly changes explained:
1. Add "Three Weeks Ago" tab and tab panel to the WeeklySummariesReport.jsx.
2. Update the unit test of WeeklySummariesReport.

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
log as any user first, and submit weekly summaries of three weeks ago.
Then log as admin/owner user
go to Reports→ Weekly Summaries Report, check if the "Three Weeks Ago" tab exist and can show the correct summaries after it is clicked. 

## Screenshots or videos of changes:
"Three Weeks Ago" tab:
![add-summaries-report-tab2](https://user-images.githubusercontent.com/94303659/232928821-43792032-fe7b-47ed-828a-d81e0e295bfa.png)

The weekly summaries under this tab:
![add-summaries-report-tab](https://user-images.githubusercontent.com/94303659/232928892-0ee91f49-8ef2-400c-9249-428674c35a31.png)

