### PR TITLE
vitor redesign permissions page and user permission component

### DIFF
--- a/src/components/PermissionsManagement/PermissionsManagement.css
+++ b/src/components/PermissionsManagement/PermissionsManagement.css
@@ -3,19 +3,22 @@
   width: 40%;
   min-width: 400px;
   margin: 1.5rem auto;
-  border: 1px solid lightgrey;
-  box-shadow: 6px 6px 18px 2px rgb(158, 158, 158);
+  box-shadow: 1px 1px 8px rgb(158, 158, 158);
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  border-radius: 8px;
 }
 
 .permissions-management__header {
   display: flex;
-  flex-direction: column;
-  row-gap: 1rem;
   align-items: center;
+  gap: 30px;
 }
 
 .permissions-management__title {
   font-size: 1.8rem;
+  margin-bottom: ;
 }
 
 .createRole__alert {
@@ -50,38 +53,66 @@
   font-size: 1.2rem;
 }
 
+.user-role-tab__permission {
+  display: flex;
+  align-items: center;
+  border-bottom: solid 1px #ced4da;
+}
+.user-role-tab__permission:hover {
+  background-color: #ced4da;
+}
+
 .permissions-management--flex {
   display: flex;
   justify-content: space-between;
   flex-direction: row-reverse;
 }
 
-.permissions-management__button {
-  width: 100%;
+.buttons-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .role-name-container {
-  width: 100%;
+  display: flex;
+  flex-direction: column;
+  border: solid 1px lightgrey;
+  border-radius: 8px;
+  min-width: 300px;
+  height: 270.5px;
+  overflow: auto;
+}
+
+.role-name-container::-webkit-scrollbar {
+  width: 5px;
+}
+
+.role-name-container::-webkit-scrollbar-track {
+  background: rgb(0, 0, 0, 0);
+}
+
+.role-name-container::-webkit-scrollbar-thumb {
+  background: rgb(206, 212, 218);
+  border-radius: 8px;
 }
 
 .role-name {
   text-align: center;
-  border-bottom: 1px solid lightgrey;
+  cursor: pointer;
   margin-bottom: 0;
   padding: 0.5rem 0;
   font-size: 1.2rem;
   font-weight: 500;
+  text-align: center;
 }
 
-.role-name-link {
-  color: black;
-  transition: all 0.2s ease-in-out;
-  transform: scale(1);
+.role-name:hover {
+  background-color: lightgrey;
 }
 
-.role-name-link:hover {
-  display: inline-block;
-  text-decoration: none;
-  transform: scale(1.1);
-  transition: all 0.2 ease-in-out;
+@media only screen and (max-width: 1199px) {
+  .permissions-management__header {
+    flex-direction: column;
+  }
 }

--- a/src/components/PermissionsManagement/PermissionsManagement.css
+++ b/src/components/PermissionsManagement/PermissionsManagement.css
@@ -18,7 +18,6 @@
 
 .permissions-management__title {
   font-size: 1.8rem;
-  margin-bottom: ;
 }
 
 .createRole__alert {

--- a/src/components/PermissionsManagement/PermissionsManagement.css
+++ b/src/components/PermissionsManagement/PermissionsManagement.css
@@ -55,10 +55,8 @@
 .user-role-tab__permission {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   border-bottom: solid 1px #ced4da;
-}
-.user-role-tab__permission:hover {
-  background-color: #ced4da;
 }
 
 .permissions-management--flex {
@@ -79,7 +77,8 @@
   border: solid 1px lightgrey;
   border-radius: 8px;
   min-width: 300px;
-  height: 270.5px;
+  height: 450px;
+  max-height: 480px;
   overflow: auto;
 }
 

--- a/src/components/PermissionsManagement/PermissionsManagement.jsx
+++ b/src/components/PermissionsManagement/PermissionsManagement.jsx
@@ -42,13 +42,13 @@ const PermissionsManagement = ({ getAllRoles, roles, auth, getUserRole, userProf
           {roleNames?.map(roleName => {
             let roleNameLC = roleName.toLowerCase().replace(' ', '-');
             return (
-              <div
+              <button
                 onClick={() => history.push(`/permissionsmanagement/${roleNameLC}`)}
                 key={roleName}
                 className="role-name"
               >
                 {roleName}
-              </div>
+              </button>
             );
           })}
         </div>

--- a/src/components/PermissionsManagement/PermissionsManagement.jsx
+++ b/src/components/PermissionsManagement/PermissionsManagement.jsx
@@ -8,10 +8,12 @@ import { getAllRoles } from '../../actions/role';
 import { updateUserProfile, getUserProfile } from 'actions/userProfile';
 import { getAllUserProfile } from 'actions/userManagement';
 import UserPermissionsPopUp from './UserPermissionsPopUp';
+import { useHistory } from 'react-router-dom';
 
 const PermissionsManagement = ({ getAllRoles, roles, auth, getUserRole, userProfile }) => {
   const [isNewRolePopUpOpen, setIsNewRolePopUpOpen] = useState(false);
   const [isUserPermissionsOpen, setIsUserPermissionsOpen] = useState(false);
+  let history = useHistory();
 
   const togglePopUpNewRole = () => {
     setIsNewRolePopUpOpen(previousState => !previousState);
@@ -34,22 +36,24 @@ const PermissionsManagement = ({ getAllRoles, roles, auth, getUserRole, userProf
 
   return (
     <div className="permissions-management">
+      <h1 className="permissions-management__title">User Roles</h1>
       <div className="permissions-management__header">
-        <h1 className="permissions-management__title">User Roles</h1>
         <div className="role-name-container">
           {roleNames?.map(roleName => {
             let roleNameLC = roleName.toLowerCase().replace(' ', '-');
             return (
-              <p key={roleName} className="role-name">
-                <a href={`/permissionsmanagement/${roleNameLC}`} className="role-name-link">
-                  {roleName}
-                </a>
-              </p>
+              <button
+                onClick={() => history.push(`/permissionsmanagement/${roleNameLC}`)}
+                key={roleName}
+                className="role-name"
+              >
+                {roleName}
+              </button>
             );
           })}
         </div>
         {userProfile?.role === 'Owner' && (
-          <>
+          <div className="buttons-container">
             <Button
               className="permissions-management__button"
               type="button"
@@ -68,7 +72,7 @@ const PermissionsManagement = ({ getAllRoles, roles, auth, getUserRole, userProf
             >
               Manage User Permissions
             </Button>
-          </>
+          </div>
         )}
       </div>
       <div className="permissions-management--flex">
@@ -83,7 +87,6 @@ const PermissionsManagement = ({ getAllRoles, roles, auth, getUserRole, userProf
             <CreateNewRolePopup toggle={togglePopUpNewRole} />
           </ModalBody>
         </Modal>
-
         <Modal
           isOpen={isUserPermissionsOpen}
           toggle={togglePopUpUserPermissions}

--- a/src/components/PermissionsManagement/PermissionsManagement.jsx
+++ b/src/components/PermissionsManagement/PermissionsManagement.jsx
@@ -42,13 +42,13 @@ const PermissionsManagement = ({ getAllRoles, roles, auth, getUserRole, userProf
           {roleNames?.map(roleName => {
             let roleNameLC = roleName.toLowerCase().replace(' ', '-');
             return (
-              <button
+              <div
                 onClick={() => history.push(`/permissionsmanagement/${roleNameLC}`)}
                 key={roleName}
                 className="role-name"
               >
                 {roleName}
-              </button>
+              </div>
             );
           })}
         </div>

--- a/src/components/PermissionsManagement/PermissionsManagement.test.js
+++ b/src/components/PermissionsManagement/PermissionsManagement.test.js
@@ -35,24 +35,24 @@ describe('permissions management page structure', () => {
 
   describe('Add New Role button', () => {
     test('add new role button should be present', () => {
-      if (screen.queryByRole('button')) {
-        expect(screen.queryByRole('button', { name: /add new role/i })).toBeInTheDocument();
+      if (screen.queryByRole('Button')) {
+        expect(screen.queryByRole('Button', { name: /add new role/i })).toBeInTheDocument();
       } else {
-        expect(screen.queryByRole('button', { name: /add new role/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('Button', { name: /add new role/i })).not.toBeInTheDocument();
       }
     });
   });
 
   describe('permissions management behavior', () => {
     it('should fire newRole modal with a form to create a new Role', () => {
-      if (screen.queryByRole('button')) {
+      if (screen.queryByRole('Button')) {
         userEvent.click(screen.getByText(/add new role/i));
         expect(screen.getByRole('dialog')).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+        expect(screen.getByRole('Button', { name: 'Close' })).toBeInTheDocument();
         expect(screen.getByRole('textbox')).toBeInTheDocument();
       } else {
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-        expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('Button', { name: 'Close' })).not.toBeInTheDocument();
         expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
       }
     });

--- a/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
+++ b/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
@@ -164,7 +164,9 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers }) => {
           {Object.entries(permissionLabel).map(([key, value]) => {
             return (
               <li key={key} className="user-role-tab__permission">
-                <p style={{ color: isPermissionChecked(key) ? 'green' : 'red' }}>{value}</p>
+                <div style={{ color: isPermissionChecked(key) ? 'green' : 'red', padding: '14px' }}>
+                  {value}
+                </div>
                 {isPermissionChecked(key) ? (
                   <Button
                     type="button"
@@ -172,7 +174,7 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers }) => {
                     onClick={e => onChangeCheck(key)}
                     disabled={actualUserProfile ? false : true}
                   >
-                    Delete
+                    Remove
                   </Button>
                 ) : (
                   <Button

--- a/src/components/PermissionsManagement/UserRoleTab.jsx
+++ b/src/components/PermissionsManagement/UserRoleTab.jsx
@@ -3,24 +3,17 @@ import RolePermissions from './RolePermissions';
 import { connect } from 'react-redux';
 import './UserRoleTab.css';
 import { getUserProfile } from 'actions/userProfile';
+import { useHistory } from 'react-router-dom';
 
 export const permissionLabel = {
   seeWeeklySummaryReports: 'See Weekly Summary Reports Tab',
   seeUserManagement: 'See User Management Tab (delete and update users)',
   seeBadgeManagement: 'See Badge Management Tab (create badges)',
-  seePopupManagement: 'See Popup Management Tab (create and update popups)',
-  seeProjectManagement: 'See Project Management Tab',
-  seeTeamsManagement: 'See Teams Management Tab',
   deleteOwnBadge: 'Delete Badge',
   modifyOwnBadgeAmount: 'Modify Badge Amount',
   assignBadgeOthers: 'Assign Badges',
-  editTimelogInfo: 'Edit Timelog Information',
-  addTimeEntryOthers: 'Add Time Entry (Others)',
-  deleteTimeEntryOthers: 'Delete Time Entry (Others)',
-  toggleTangibleTime: 'Toggle Tangible Time',
-  changeIntangibleTimeEntryDate: 'Change Date on Intangible Time Entry',
-  editTimeEntry: 'Edit Time Entry',
-  deleteTimeEntry: 'Delete Time Entry',
+  seePopupManagement: 'See Popup Management Tab (create and update popups)',
+  seeProjectManagement: 'See Project Management Tab',
   deleteWbs: 'Delete WBS',
   addTask: 'Add Task',
   deleteTask: 'Delete Task',
@@ -33,17 +26,25 @@ export const permissionLabel = {
   findUserInProject: 'Find User in Project',
   assignUserInProject: 'Assign User in Project',
   unassignUserInProject: 'Unassign User in Project',
+  seeTeamsManagement: 'See Teams Management Tab',
+  editDeleteTeam: 'Edit/Delete Team',
+  createTeam: 'Create Team',
+  assignTeamToUser: 'Assign Team to User',
+  editTimelogInfo: 'Edit Timelog Information',
+  addTimeEntryOthers: 'Add Time Entry (Others)',
+  deleteTimeEntryOthers: 'Delete Time Entry (Others)',
+  toggleTangibleTime: 'Toggle Tangible Time',
+  changeIntangibleTimeEntryDate: 'Change Date on Intangible Time Entry',
+  editTimeEntry: 'Edit Time Entry',
+  deleteTimeEntry: 'Delete Time Entry',
   changeUserStatus: 'Change User Status',
   adminLinks: 'Manage Admin Links in User Profile',
   editUserProfile: 'Edit User Profile',
-  assignTeamToUser: 'Assign Team to User',
   seeUserProfileInProjects: 'See User Profiles in Projects',
-  createTeam: 'Create Team',
-  editDeleteTeam: 'Edit/Delete Team',
-  handleBlueSquare: 'Handle Blue Squares',
   resetPasswordOthers: 'Reset Password (Others)',
   dataIsTangibleTimelog: 'Timelog Data is Tangible',
   toggleSubmitForm: 'Toggle Summary Submit Form (Others)',
+  handleBlueSquare: 'Handle Blue Squares',
   assignOnlyBlueSquares: 'Only Assign Blue Squares',
   seePermissionsManagement: 'See Permissions Management Tab',
 };
@@ -52,6 +53,7 @@ const UserRoleTab = props => {
   useEffect(() => {
     props.getUserRole(props.auth?.user.userid);
   }, []);
+  const history = useHistory();
 
   const roleNames = props.roles.map(role => role.roleName);
   const userRoleParamsURL = props.match.params.userRole;
@@ -81,9 +83,12 @@ const UserRoleTab = props => {
   }
   return (
     <div className="userRoleTab__container">
-      <a href="/permissionsmanagement" className="userRoleTab__backBtn">
+      <button
+        onClick={() => history.push('/permissionsmanagement')}
+        className="userRoleTab__backBtn"
+      >
         Back
-      </a>
+      </button>
       <RolePermissions
         userRole={props.userProfile.role}
         role={roleName}


### PR DESCRIPTION
Decided to redesign the "Manage User Permissions" component and redesigned the permissions management page.

## Main changes
1. Better UX and UI for the Permissions Management page and to the "Manage User Permissions" component.
2. Now, there's a scrollbar if the length of roles is greater than the length of the base roles.

## Description
- The major of the changes is just about css and html. The only change on logic is on the addition of the useHistory hook the substitute the old <a>(Anchor) component.
- **You will need an Owner account the test this PR**
If you don't have one you can use this one: 
email: `email@owner.com`
password: `Vitor.01`

## How to test
1 - Check into current branch
2 - Do `npm install` and `npm run start:local` to run this PR locally
3 - Log as Owner user
4 - Go to dashboard → Other Links → Permissions Management.
5 - Test all the functionalities and see if everything works.

## New design
![image](https://user-images.githubusercontent.com/17365161/234958736-922180e3-f88c-4d74-b994-951427d0a140.png)

![image](https://user-images.githubusercontent.com/17365161/234958845-59e6198a-7e3c-4da0-8d69-2eaafbf322ef.png)





