### PR TITLE
Yongjian - Fix user modal overflow and horizontal scrollbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -89,6 +89,6 @@ body,
   /*  90%to100%-red */
 }
 .dropdown-menu.show {
-  transform: translate3d(-16px, 40px, 0px) !important;
+  transform: translate3d(-24px, 40px, 0px) !important;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -89,6 +89,6 @@ body,
   /*  90%to100%-red */
 }
 .dropdown-menu.show {
-  transform: translate3d(-24px, 40px, 0px) !important;
+  transform: translate3d(-26px, 40px, 0px) !important;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,6 @@
-html,
+html {
+  overflow-x: hidden;
+}
 body,
 #root {
   height: 100%;
@@ -86,3 +88,7 @@ body,
   background-color: #CC3366 !important;
   /*  90%to100%-red */
 }
+.dropdown-menu.show {
+  transform: translate3d(-16px, 40px, 0px) !important;
+}
+

--- a/src/App.css
+++ b/src/App.css
@@ -88,7 +88,10 @@ body,
   background-color: #CC3366 !important;
   /*  90%to100%-red */
 }
-.dropdown-menu.show {
-  transform: translate3d(-26px, 40px, 0px) !important;
+
+nav ul.navbar-nav li:last-child > div {
+   transform: translate3d(-26px, 40px, 0px) !important;
 }
+
+
 


### PR DESCRIPTION
# Description
(PRIORITY LOW) Kaixiang:  Remove the horizontal scroll bar on Dev and Main 
Confirmed by at least 2 people but Jae can’t see it on either site using his computer. 
![Screen Shot 2023-04-17 at 10 29 41 PM](https://user-images.githubusercontent.com/46613683/232680499-c56b5735-7920-40be-9242-d24320e45edb.png)

## Mainly changes explained:
Hid horizontal scrollbar and reduced user modal (dropdown menu under "Welcome, XXX") overflow on dev and main. Related PR: [https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/778](url)

## How to test:
1. check into current branch
2. do `npm run start:local` to run this PR locally
3. inspect dashboard and other pages in the application to verify that the horizontal scroll bar has been removed and user modal dropdown menu is no longer overflowing.

## Screenshots

![Screen Shot 2023-04-20 at 2 42 55 PM](https://user-images.githubusercontent.com/46613683/233495384-e1987936-fec5-4198-9fb3-2cd3648444b4.png)
![Screen Shot 2023-04-20 at 2 43 58 PM](https://user-images.githubusercontent.com/46613683/233495396-6e3e0865-0042-49fa-aee0-b32c38bcdf78.png)
![Screen Shot 2023-04-20 at 2 46 04 PM](https://user-images.githubusercontent.com/46613683/233495413-c7661acb-f499-476f-a932-4f919921d4e8.png)

![Screen Shot 2023-05-02 at 9 31 05 AM](https://user-images.githubusercontent.com/46613683/235728136-8761ce1d-eae3-4c71-8729-2f354f47c48a.png)
![Screen Shot 2023-05-02 at 9 31 12 AM](https://user-images.githubusercontent.com/46613683/235728158-59fc5fb9-a459-42d2-b276-ff61615f5fe1.png)
![Screen Shot 2023-05-02 at 9 31 15 AM](https://user-images.githubusercontent.com/46613683/235728180-c0e22ebc-8db7-4129-9bb7-b42972f21282.png)

