### PR TITLE
Jinchao add weeklySummaryOption to new user creation modal

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -68,6 +68,7 @@ class AddUserProfile extends Component {
         timeZone: '',
         location: '',
         showphone: true,
+        weeklySummaryOption: 'Required',
       },
       formValid: {},
       formErrors: {
@@ -257,6 +258,26 @@ class AddUserProfile extends Component {
                           this.props.role.roles,
                           this.props.auth.user?.permissions?.frontPermissions,
                         ) && <option value="Owner">Owner</option>}
+                      </Input>
+                    </FormGroup>
+                  </Col>
+                </Row>
+                <Row>
+                  <Col md={{ size: 4 }} className="text-md-right my-2">
+                    <Label className="weeklySummaryOptionsLabel" >Weekly Summary Options</Label>
+                  </Col>
+                  <Col md="6">
+                    <FormGroup>
+                      <Input
+                        type="select"
+                        name="weeklySummaryOption"
+                        id="weeklySummaryOption"
+                        defaultValue="Required"
+                        onChange={this.handleUserProfile}
+                      >
+                        <option value="Required">Required</option>
+                        <option value="Not Required">Not Required</option>
+                        <option value="Team">Team</option>
                       </Input>
                     </FormGroup>
                   </Col>
@@ -536,6 +557,7 @@ class AddUserProfile extends Component {
       jobTitle,
       timeZone,
       location,
+      weeklySummaryOption,
     } = that.state.userProfile;
 
     const userData = {
@@ -547,6 +569,7 @@ class AddUserProfile extends Component {
       phoneNumber: phoneNumber,
       bio: '',
       weeklycommittedHours: that.state.userProfile.weeklyCommittedHours,
+      weeklySummaryOption: weeklySummaryOption,
       personalLinks: [],
       adminLinks: [],
       teams: this.state.teams,
@@ -819,6 +842,18 @@ class AddUserProfile extends Component {
           formErrors: {
             ...formErrors,
             weeklyCommittedHours: !!event.target.value ? '' : 'Committed hours can not be empty',
+          },
+        });
+        break;
+      case 'weeklySummaryOption':
+        this.setState({
+          userProfile: {
+            ...userProfile,
+            [event.target.id]: event.target.value.trim(),
+          },
+          formValid: {
+            ...formValid,
+            [event.target.id]: !!event.target.value,
           },
         });
         break;

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.scss
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.scss
@@ -111,3 +111,7 @@ form-control {
   padding-top: 0.3rem;
   font-size: 0.8rem;
 }
+
+.weeklySummaryOptionsLabel {
+  margin-left: 7px;
+}


### PR DESCRIPTION
# Description:
The fourth function of the "Weekly Summary Option". Previous PR: #764 
![image](https://user-images.githubusercontent.com/94319381/233769588-0a1641e1-c1c0-4960-a91c-f1ff92f87e36.png)

## How to test:
Log in as admin
other links-> user management->create new user
Check if there is a 'Weekly Summary Options' selection under the role selection and if the default value is required.
![image](https://user-images.githubusercontent.com/94319381/233769549-1481953f-b3c9-4573-bf58-895d71a52218.png)
Create new users in different "Weekly Summary Options", then go into their userProfile->Volunteering Times Tab to check if their 'Weekly Summary Option' is correct. 
![image](https://user-images.githubusercontent.com/94319381/233769944-cf080a57-6fe3-4f9a-aeb8-f9d859a8ef41.png)

## Note:
In the current branch, the new user won't show up immediately in the user management table due to a bug. This backend [PR](https://github.com/OneCommunityGlobal/HGNRest/pull/331) fixed the bug and I would recommend you test these two PRs together
