### PR TITLE
fix view other users dashboard task bug

### DIFF
--- a/src/actions/task.js
+++ b/src/actions/task.js
@@ -14,6 +14,7 @@ import { createOrUpdateTaskNotificationHTTP } from './taskNotification';
 import { createTaskEditSuggestionHTTP } from 'components/TaskEditSuggestions/service';
 
 const selectFetchTeamMembersTaskData = state => state.auth.user.userid;
+const selectViewTeamMembersTaskData = state => state.userProfile._id;
 const selectUserId = state => state.auth.user.userid;
 const selectUpdateTaskData = (state, taskId) =>
   state.tasks.taskItems.find(({ _id }) => _id === taskId);
@@ -21,10 +22,16 @@ const selectUpdateTaskData = (state, taskId) =>
 export const fetchTeamMembersTask = () => async (dispatch, getState) => {
   try {
     const state = getState();
-    const userId = selectFetchTeamMembersTaskData(state);
+    const authUserId = selectFetchTeamMembersTaskData(state);
+    const viewUserId = selectViewTeamMembersTaskData(state);
     dispatch(fetchTeamMembersTaskBegin());
-    const response = await axios.get(ENDPOINTS.TEAM_MEMBER_TASKS(userId));
-    dispatch(fetchTeamMembersTaskSuccess(response.data));
+    if (viewUserId) {
+      const response = await axios.get(ENDPOINTS.TEAM_MEMBER_TASKS(viewUserId));
+      dispatch(fetchTeamMembersTaskSuccess(response.data));
+    } else {
+      const response = await axios.get(ENDPOINTS.TEAM_MEMBER_TASKS(authUserId));
+      dispatch(fetchTeamMembersTaskSuccess(response.data));
+    }
   } catch (error) {
     dispatch(fetchTeamMembersTaskError());
   }


### PR DESCRIPTION
### Description
(PRIORITY MEDIUM) LEADERBOARD COMPONENT bug fix
Jae: Dashboard → Click dot by person’s name in the Leaderboard
This correctly shows another person’s dashboard but the “Tasks” tab is still showing the Tasks of the person viewing versus the person being viewed

### Mainly changes explained:
The `fetchTeamMembersTask` always fetch data of the user authorized (`state.auth.user`), even when we click the dot on the leaderboard to view others. The solution is to change the function so that when the authorized user is different with the user being viewed, fetch the data of the latter instead of the former one.

### How to test:
check into current branch
Run this PR locally
Login in as userA, click the dot of userB on the leaderboard to view their dashboard, check the task tab of the popup page to see if it is different. (The task tab of these two users should have different data to test the result)
<img width="529" alt="img" src="https://user-images.githubusercontent.com/9314962/233818224-fa05a712-d767-4721-804f-9ffb5716ca53.png">
