### PR TITLE
Nicolle fix team member tasks

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -439,6 +439,7 @@ const TeamMemberTasks = props => {
           setClickedToShowModal={setClickedToShowModal}
         />
       )}
+      <div className='table-container'>
       <Table>
         <thead className="pc-component">
           <tr>
@@ -486,6 +487,8 @@ const TeamMemberTasks = props => {
 
         <tbody>{isLoading ? <Loading /> : renderTeamsList()}</tbody>
       </Table>
+      </div>
+      
     </div>
   );
 };

--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -1,11 +1,15 @@
 .team-member-tasks {
   background-color: white;
-  overflow-x: auto;
+  
 }
 
 .team-member-tasks h1 {
   color: black;
   font-size: 20px;
+}
+
+.table-container{
+  overflow-x: auto;
 }
 
 .team-member-tasks-bell {

--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -1,5 +1,6 @@
 .team-member-tasks {
   background-color: white;
+  overflow-x: auto;
 }
 
 .team-member-tasks h1 {


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/101591708/234392258-aa1d6717-feae-425a-ba73-fbbcf98fa86a.png)


## Mainly changes explained:
A container with an overflow property set to "auto" has been added to enable users to scroll through the Team member task table on smaller screens

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
go to dashboard
Check if the table is being displayed correctly.


## Screenshots or videos of changes:

**Before**


https://user-images.githubusercontent.com/101591708/234395863-2f5ed79c-4f34-44dc-bdcc-9fe2ccad18c3.MP4



.....
**After**

https://user-images.githubusercontent.com/101591708/234395877-34fd3ec0-03d2-45e6-9507-dc0273a4c633.MP4

