### PR TITLE
Yongian - Fix button to save visibibility edit for manager role

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -1268,7 +1268,7 @@ function UserProfile(props) {
                   </Link>
                 )}
               {canEdit &&
-                (activeTab === '1' ||
+                (activeTab === '1' || activeTab === '3' ||
                   hasPermission(requestorRole, 'editUserProfile', roles, userPermissions)) && (
                   <>
                     <SaveButton
@@ -1282,16 +1282,18 @@ function UserProfile(props) {
                       }
                       userProfile={userProfile}
                     />
-                    <span
-                      onClick={() => {
-                        setUserProfile(originalUserProfile);
-                        setTasks(originalTasks);
-                        setTeams(originalTeams);
-                      }}
-                      className="btn btn-outline-danger mr-1 btn-bottom"
-                    >
-                      Cancel
-                    </span>
+                    {activeTab !== '3' && (
+                      <span
+                        onClick={() => {
+                          setUserProfile(originalUserProfile);
+                          setTasks(originalTasks);
+                          setTeams(originalTeams);
+                        }}
+                        className="btn btn-outline-danger mr-1 btn-bottom"
+                      >
+                        Cancel
+                      </span>
+                    )}
                   </>
                 )}
               <Button outline onClick={() => loadUserProfile()}>


### PR DESCRIPTION
# Description
![Screen Shot 2023-04-20 at 4 35 02 PM](https://user-images.githubusercontent.com/46613683/233508084-7930fdb7-1135-471a-a499-4af1d445aff0.png)

## Mainly changes explained:
Under manager role, created "Save Changes" button to save the changes of visible/invisible toggle button. I merely created a new branch in this PR to solve the same problem and addressed issue (presence of duplicate "Save Changes" button in "Basic Information" tab under user profile page) in related PR: [PR#785](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/785).

## How to test:
1. check into current branch
2. do `npm run start:local` to run this PR locally
3. login as manager role, under "Welcome, XXX" -> View Profile -> Teams, inspect presence of "Save Changes" button and toggle "visible/invisible" and click on "Save Changes" button to verify ability to save the changes.

## Screenshots
![Screen Shot 2023-04-25 at 11 55 39 AM](https://user-images.githubusercontent.com/46613683/234430726-baf7442d-5150-4203-967a-5508b03b9221.png)
![Screen Shot 2023-04-25 at 11 56 21 AM](https://user-images.githubusercontent.com/46613683/234430729-a4e0faa3-98b8-4ce9-8846-7d44809b4a9b.png)

![Screen Shot 2023-04-25 at 11 56 30 AM](https://user-images.githubusercontent.com/46613683/234430733-fe61533d-71cb-4301-bd87-acaeea63ade7.png)
![Screen Shot 2023-04-25 at 11 56 51 AM](https://user-images.githubusercontent.com/46613683/234430734-acb3e2f4-8461-480a-96f5-bc346a31643d.png)
