### PR TITLE
Make timelog open in new tab on cmd/ctrl + click

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -241,7 +241,6 @@ function UserProfile(props) {
     }
   };
 
-
   const getTeamMembersWeeklySummary = async () => {
     const userId = props?.match?.params?.userId;
 
@@ -521,7 +520,7 @@ function UserProfile(props) {
       ...userProfile,
       isVisible: !userProfile.isVisible ?? true,
     });
-  }
+  };
 
   if ((showLoading && !props.isAddNewUser) || userProfile === undefined) {
     return (
@@ -540,9 +539,10 @@ function UserProfile(props) {
   const userPermissions = props.auth.user?.permissions?.frontPermissions;
 
   const isUserSelf = targetUserId === requestorId;
-  const canEditProfile = userProfile.role === 'Owner' ? 
-  hasPermission(requestorRole, 'addDeleteEditOwners', roles, userPermissions) :
-  hasPermission(requestorRole, 'editUserProfile', roles, userPermissions);
+  const canEditProfile =
+    userProfile.role === 'Owner'
+      ? hasPermission(requestorRole, 'addDeleteEditOwners', roles, userPermissions)
+      : hasPermission(requestorRole, 'editUserProfile', roles, userPermissions);
   const canEdit = canEditProfile || isUserSelf;
 
   const customStyles = {
@@ -652,7 +652,14 @@ function UserProfile(props) {
                   aria-hidden="true"
                   style={{ fontSize: 24, cursor: 'pointer' }}
                   title="Click to see user's timelog"
-                  onClick={() => props.history.push(`/timelog/${targetUserId}`)}
+                  onClick={e => {
+                    if (e.metaKey || e.ctrlKey) {
+                      window.open(`/timelog/${targetUserId}`, '_blank');
+                    } else {
+                      e.preventDefault();
+                      props.history.push(`/timelog/${targetUserId}`);
+                    }
+                  }}
                 />
               )}
               <Button
@@ -695,7 +702,9 @@ function UserProfile(props) {
               showSelect &&
               showSummary &&
               summarySelected.map((data, i) => {
-                return <TeamWeeklySummaries key={data["_id"]} i={i} name={summaryName} data={data} />;
+                return (
+                  <TeamWeeklySummaries key={data['_id']} i={i} name={summaryName} data={data} />
+                );
               })}
             <Badges
               userProfile={userProfile}


### PR DESCRIPTION
# Description
Make time log icon command(mac)/control(PC) clickable (WIP Tooba)
On the profile page, command + clicking the time log icon (see below) to make the person’s time log open in a new tab is currently not possible 
![timelog-icon](https://user-images.githubusercontent.com/52610124/235079885-73d58fef-30f8-49d6-8d4b-bbe04cde44e5.png)


## Mainly changes explained:
Add conditional statement in UserProfile.jsx to allow open time log in a new tab on cmd/ ctrl + click on time log icon.

## How to test:
check into the current branch
do `npm install` and `...` to run this PR locally
go to View Profile
cmd/ ctrl + click on the time log icon and verify if it opens time log in a new tab

![timelog-icon](https://user-images.githubusercontent.com/52610124/235079607-4eef6ef2-6706-4625-b773-e434be1a1120.png)


## Screenshots or videos of changes:

### Before

https://user-images.githubusercontent.com/52610124/235080898-81e494fa-1648-49f6-854f-5b6b233b0966.mp4

### After

https://user-images.githubusercontent.com/52610124/235080853-ba90f197-0aa4-4a2a-87fd-54aec9eee8de.mp4



