### PR TITLE
Jinchao add notice at top of leaderboard to invisible user

### DIFF
--- a/src/components/LeaderBoard/LeaderBoard.container.jsx
+++ b/src/components/LeaderBoard/LeaderBoard.container.jsx
@@ -84,6 +84,7 @@ const mapStateToProps = state => {
     loggedInUser: get(state, 'auth.user', {}),
     organizationData: orgData,
     timeEntries: get(state, 'timeEntries', {}),
+    isVisible: user.role === 'Volunteer' || user.isVisible,
   };
 };
 export default connect(mapStateToProps, { getLeaderboardData, getOrgData })(Leaderboard);

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -3,6 +3,7 @@ import './Leaderboard.css';
 import { isEqual } from 'lodash';
 import { Link } from 'react-router-dom';
 import { Table, Progress, Modal, ModalBody, ModalFooter, ModalHeader, Button } from 'reactstrap';
+import Alert from 'reactstrap/lib/Alert';
 
 function useDeepEffect(effectFunc, deps) {
   const isFirst = useRef(true);
@@ -28,6 +29,7 @@ const LeaderBoard = ({
   loggedInUser,
   organizationData,
   timeEntries,
+  isVisible,
   asUser,
   setLeaderData,
 }) => {
@@ -56,9 +58,68 @@ const LeaderBoard = ({
   }, [leaderBoardData]);
 
   const [isOpen, setOpen] = useState(false);
+  const [modalContent, setContent] = useState(null);
 
   const toggle = () => setOpen(isOpen => !isOpen);
-
+ 
+  const modalInfos = [
+    <>
+      <p>
+        This is the One Community Leaderboard! It is used to show how much tangible and total
+        time you’ve contributed, whether or not you’ve achieved your total committed hours for
+        the week, and (in the case of teams) where your completed hours for the week rank you
+        compared to other team members. It can also be used to access key areas of this
+        application.
+      </p>
+      <ul>
+        <li>
+          The HGN Totals at the top shows how many volunteers are currently active in the
+          system, how many volunteer hours they are collectively committed to, and how many
+          tangible and total hours they have completed.
+          {/*The color and length of that bar
+          changes based on what percentage of the total committed hours for the week have been
+          completed: 0-20%: Red, 20-40%: Orange, 40-60% hrs: Green, 60-80%: Blue, 80-100%:Indigo, 
+          and Equal or More than 100%: Purple.*/}
+        </li>
+        <li>
+          The red/green dot shows whether or not a person has completed their “tangible” hours
+          commitment for the week. Green = yes (Great job!), Red = no. Clicking this dot will
+          take you to a person’s tasks section on their/your dashboard.{' '}
+        </li>
+        <li>
+          The time bar shows how much tangible and total (tangible + intangible) time you’ve
+          completed so far this week. In the case of teams, it also shows you where your
+          completed hours for the week rank you compared to other people on your team.
+          Clicking a person’s time bar will take you to the time log section on their/your
+          dashboard. This bar also changes color based on how many tangible hours you have
+          completed: 0-5 hrs: Red, 5-10 hrs: Orange, 10-20 hrs: Green, 20-30 hrs: Blue, 30-40
+          hrs: Indigo, 40-50 hrs: Violet, and 50+ hrs: Purple
+        </li>
+        <li>Clicking a person’s name will lead to their/your profile page.</li>
+      </ul>
+      <p>Hovering over any of these areas will tell you how they function too. </p>
+    </>,
+    <>
+      <p>
+        An Admin has made it so you can see your team but they can't see you. We recommend you keep this setting as it is. 
+      </p>
+      <p>
+        If you want to change this setting so your team/everyone can see and access your time log though, you can do so by going to&nbsp; 
+        <Link to={`/userprofile/${userId}`} title="View Profile">
+          Your Profile&nbsp;
+        </Link>
+        --&gt; Teams Tab --&gt; toggle the “Visibility” switch to “Visible”.
+      </p>
+      <p>
+        Note: Admins and Core Team can always see all team members. This cannot be changed.
+      </p>
+    </>
+  ]
+  
+  const handleModalOpen = idx => {
+    setContent(modalInfos[idx]);
+    setOpen(true);
+  }
   // add state hook for the popup the personal's dashboard from leaderboard
   const [isDashboardOpen, setIsDashboardOpen] = useState(false);
   const dashboardToggle = item => setIsDashboardOpen(item.personId);
@@ -96,47 +157,32 @@ const LeaderBoard = ({
           style={{ fontSize: 24, cursor: 'pointer' }}
           aria-hidden="true"
           className="fa fa-info-circle"
-          onClick={toggle}
+          onClick={() => {
+            handleModalOpen(0);
+          }}
         />
       </h3>
+      {!isVisible && (
+        <Alert color="warning">
+          Note: You are currently invisible to the team(s) you are on.&nbsp;&nbsp; 
+          <i
+          data-toggle="tooltip"
+          data-placement="right"
+          title="Click for more information"
+          style={{ fontSize: 20, cursor: 'pointer' }}
+          aria-hidden="true"
+          className="fa fa-info-circle"
+          onClick={() => {
+            handleModalOpen(1);
+          }}
+        />
+        </Alert>)
+      }
       <span className="leaderboard">
         <Modal isOpen={isOpen} toggle={toggle}>
           <ModalHeader toggle={toggle}>Leaderboard Info</ModalHeader>
           <ModalBody>
-            <p>
-              This is the One Community Leaderboard! It is used to show how much tangible and total
-              time you’ve contributed, whether or not you’ve achieved your total committed hours for
-              the week, and (in the case of teams) where your completed hours for the week rank you
-              compared to other team members. It can also be used to access key areas of this
-              application.
-            </p>
-            <ul>
-              <li>
-                The HGN Totals at the top shows how many volunteers are currently active in the
-                system, how many volunteer hours they are collectively committed to, and how many
-                tangible and total hours they have completed.
-                {/*The color and length of that bar
-                changes based on what percentage of the total committed hours for the week have been
-                completed: 0-20%: Red, 20-40%: Orange, 40-60% hrs: Green, 60-80%: Blue, 80-100%:Indigo, 
-                and Equal or More than 100%: Purple.*/}
-              </li>
-              <li>
-                The red/green dot shows whether or not a person has completed their “tangible” hours
-                commitment for the week. Green = yes (Great job!), Red = no. Clicking this dot will
-                take you to a person’s tasks section on their/your dashboard.{' '}
-              </li>
-              <li>
-                The time bar shows how much tangible and total (tangible + intangible) time you’ve
-                completed so far this week. In the case of teams, it also shows you where your
-                completed hours for the week rank you compared to other people on your team.
-                Clicking a person’s time bar will take you to the time log section on their/your
-                dashboard. This bar also changes color based on how many tangible hours you have
-                completed: 0-5 hrs: Red, 5-10 hrs: Orange, 10-20 hrs: Green, 20-30 hrs: Blue, 30-40
-                hrs: Indigo, 40-50 hrs: Violet, and 50+ hrs: Purple
-              </li>
-              <li>Clicking a person’s name will lead to their/your profile page.</li>
-            </ul>
-            <p>Hovering over any of these areas will tell you how they function too. </p>
+            {modalContent}
           </ModalBody>
           <ModalFooter>
             <Button onClick={toggle} color="secondary" className="float-left">


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/94319381/235326274-158b0466-4743-4af3-b3a6-e29e512d8721.png)
![image](https://user-images.githubusercontent.com/94319381/235326371-079f085b-4ed6-42eb-9a82-f5b204c7def7.png)

## Main change made
Update `LeadeBoard.container.jsx` to pass the visibility of the user to the `LeaderBoard` component.
Update `LeaderBoard.jsx` to add a dynamic modal to show the info from leaderboard header and visibility alert info. (Go to check at UserProfile->Teams->Visibility)
## How to test

- Log in as any role (except volunteer), and check if there is an alert when the user visibility is set to invisible.

![image](https://user-images.githubusercontent.com/94319381/235326474-acbfed66-5e7d-43c4-b5a9-244571af8eb7.png)

- Click the 'i' in the alert and see if the modal content is correct.

![image](https://user-images.githubusercontent.com/94319381/235326486-006bb94c-5e7b-4454-8e01-e97161116f1b.png)

- Click the 'Your Profile' link and check if it jumps to the correct user profile page.

- Change the visibility to visible and check if the alert disappears correctly.

## Note
For the non-admin users (mentor, manager, core team) to change the visibility, there isn't a 'save change' button in the Teams tab (Yongian fixed in #792 ), please use the 'save change' button in basic information tabs to save the change.
