### PR TITLE
Yongjian - Create back to top button on index page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,5 +46,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <a class="top" href="#">Back to Top ↑</a>
   </body>
 </html>

--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,7 @@
 html {
   overflow-x: hidden;
 }
-body,
+body
 #root {
   height: 100%;
 }
@@ -93,5 +93,16 @@ nav ul.navbar-nav li:last-child > div {
    transform: translate3d(-26px, 40px, 0px) !important;
 }
 
-
-
+.top {
+  text-decoration: none;
+  padding: 10px;
+  margin: 10px;
+  font-family: sans-serif;
+  color: #fff;
+  background: #000;
+  border-radius: 100px;
+  place-self: end;
+  position: absolute;
+  right: -30px;
+  bottom: 0;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,10 @@
 html {
   overflow-x: hidden;
 }
-body
+body {
+  display: grid;
+  grid-template-columns: auto 0px;
+}
 #root {
   height: 100%;
 }
@@ -97,12 +100,15 @@ nav ul.navbar-nav li:last-child > div {
   text-decoration: none;
   padding: 10px;
   margin: 10px;
+  --offset: 100px; 
+  margin-top: calc(100vh + var(--offset));
   font-family: sans-serif;
   color: #fff;
   background: #000;
   border-radius: 100px;
   place-self: end;
-  position: absolute;
+  position: sticky;
   right: -30px;
-  bottom: 0;
+  bottom: 10px;
+  white-space: nowrap
 }

--- a/src/components/LeaderBoard/Leaderboard.css
+++ b/src/components/LeaderBoard/Leaderboard.css
@@ -24,3 +24,4 @@
     border-top-color: rgb(222, 226, 230);
   }
 }
+

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -304,7 +304,6 @@ const LeaderBoard = ({
           </tbody>
         </Table>
       </div>
-      <a class="top" href="#">Back to Top ↑</a>
     </div>
   );
 };

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -304,6 +304,7 @@ const LeaderBoard = ({
           </tbody>
         </Table>
       </div>
+      <a class="top" href="#">Back to Top ↑</a>
     </div>
   );
 };


### PR DESCRIPTION
# Description
![Screen Shot 2023-05-04 at 11 23 45 PM](https://user-images.githubusercontent.com/46613683/236389614-3106f345-4e28-4e57-afb7-6f3c52e1a07a.png)

## Mainly changes explained:
Added a link styled as a button that appears as an user starts to scroll down the index (dashboard) page and navigate the user to the top of the dashboard page upon clicking.

## How to test:
1. check into current branch
2. do `npm run start:local`
4. login as any role to the dashboard page and as an user starts to scroll to the bottom of the page, the "Back to Top!" button on the right hand side will appear and upon clicking, the user should be navigated to the top of the dashboard page.

## Screenshots

![Screen Shot 2023-05-06 at 1 55 29 PM](https://user-images.githubusercontent.com/46613683/236646316-a3f3df9a-8ff3-4bf0-870a-848a48dd547f.png)

![Screen Shot 2023-05-06 at 1 55 53 PM](https://user-images.githubusercontent.com/46613683/236646320-39e4a6f8-b116-461a-ba37-f8a82e605805.png)

![Screen Shot 2023-05-06 at 1 56 00 PM](https://user-images.githubusercontent.com/46613683/236646323-4ddb46f2-d2e5-4a3e-8058-a22513c163e2.png)

![Screen Shot 2023-05-06 at 1 56 32 PM](https://user-images.githubusercontent.com/46613683/236646328-0da79613-5a63-4e03-b72f-f2274f6dbcd9.png)



