### PR TITLE
Jinchao fix visibility issues in leaderboard

### DIFF
--- a/src/components/LeaderBoard/LeaderBoard.container.jsx
+++ b/src/components/LeaderBoard/LeaderBoard.container.jsx
@@ -8,37 +8,10 @@ const mapStateToProps = state => {
   let leaderBoardData = get(state, 'leaderBoardData', []);
   let user = get(state, 'userProfile', []);
 
-  //created an auxiliar variable so the filtering do not interfere with the main variable
-  let nonTutorsData = [];
-
-  //filtering users with non zero hours and role different from Mentor
-  if (user.role === 'Administrator' || user.role === 'Owner' || user.role === 'Core Team') {
-    //nothing happens if the user is an administrator, owner or core team, they are able to see all the leaderboard, including members with zero hours and mentor members
-    leaderBoardData = leaderBoardData
-  } else if (
-    //if the user is not an administrator, nor owner, nor mentor, and also not a core team, it will only see the people from the same team, no zero hour members and not mentor members
-    user.role !== 'Administrator' &&
-    user.role !== 'Owner' &&
-    user.role !== 'Mentor' &&
-    user.role !== 'Core Team' &&
-    user.weeklycommittedHours > 0
-  ) {
-    nonTutorsData = leaderBoardData.filter(element => {
-      if (element.weeklycommittedHours > 0 && element.role !== 'Mentor') {
-        return element;
-      }
+  if (user.role !== 'Administrator' && user.role !== 'Owner' && user.role !== 'Core Team') {
+    leaderBoardData = leaderBoardData.filter(element => {
+      return element.weeklycommittedHours > 0 || user._id === element.personId;
     });
-    leaderBoardData = nonTutorsData;
-  } else if (user.role === 'Mentor' || user.weeklycommittedHours === 0) { //if the user is a mentor, or have zero hours, it will be able to see itself and the members from it's team
-    nonTutorsData = leaderBoardData.filter(element => {
-      if (
-        (element.weeklycommittedHours > 0 && element.role !== 'Mentor') ||
-        user._id === element.personId
-      ) {
-        return element;
-      }
-    });
-    leaderBoardData = nonTutorsData;
   }
 
   if (leaderBoardData.length) {


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/94319381/236583429-345b84eb-f042-4e69-b34a-fa2c5ea57a27.png)
This PR fixes all visibility issues about the leaderboard. The current logic for what a user can see in the leaderboard:
![image](https://user-images.githubusercontent.com/94319381/236583905-8e295506-e3a9-4530-b03d-d47a7eaec24d.png)
## Main change
The updated logic removes the mentor conditions and streamlines the if-else statements for readability. 
The new logic checks the user's role and filters the leaderboard data accordingly. Administrators, owners, and core team members can see all the data, including members with zero hours. Other users can only see team members with non-zero hours.
## How to test
Please create a team having all classes of users in it, testing all cases in the above charts to see if the data in the leaderboard is correct.
## Note

- For the visibility function, please refer to #731.

- To improve testing, you can utilize the red/green dot in the leaderboard. Clicking on the dot will redirect you to the dashboard of the respective user, allowing you to quickly check their leaderboard. This will help streamline the testing process and make it more efficient.

![image](https://user-images.githubusercontent.com/94319381/236584463-af1e6977-004b-4a0f-9cae-42927725f4be.png)
