### PR TITLE
yihan fix save changes warning

### DIFF
--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -283,6 +283,9 @@ const BadgeReport = props => {
     props.setUserProfile(prevProfile => {
       return { ...prevProfile, badgeCollection: sortBadges };
     });
+    props.setOriginalUserProfile(prevProfile => {
+      return { ...prevProfile, badgeCollection: sortBadges };
+    });
     props.handleSubmit();
     //close the modal
     props.close();

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -57,13 +57,14 @@ const Badges = props => {
                     lastName={props.userProfile.lastName}
                     close={toggle}
                     setUserProfile={props.setUserProfile}
+                    setOriginalUserProfile={props.setOriginalUserProfile}
                     handleSubmit={props.handleSubmit}
                     permissionsUser={permissionsUser}
                   />
                 </ModalBody>
               </Modal>
-              {((props.canEdit && (props.role == "Owner" || props.role == "Administrator")) || 
-              props.userPermissions.includes("assignBadgeOthers"))&& (
+              {((props.canEdit && (props.role == 'Owner' || props.role == 'Administrator')) ||
+                props.userPermissions.includes('assignBadgeOthers')) && (
                 <>
                   <Button className="btn--dark-sea-green mr-2" onClick={assignToggle}>
                     Assign Badges

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -706,6 +706,7 @@ function UserProfile(props) {
             <Badges
               userProfile={userProfile}
               setUserProfile={setUserProfile}
+              setOriginalUserProfile={setOriginalUserProfile}
               role={requestorRole}
               canEdit={canEdit}
               handleSubmit={handleSubmit}


### PR DESCRIPTION
# Description
12. PRIORITY (MEDIUM) Jae: Fix reminder to save popup happening after confirmed save (WIP Yihan)
Please see this video:


https://user-images.githubusercontent.com/94303659/236592478-764efa9b-cc27-4f87-9055-90c980e427a8.mp4


## Mainly changes explained:
Transfer setOriginalUserProfile() to BadgeReport component, then set userProfile and originalUserProfile at the same time. Now, there's no save warning flash when we modify badges.

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
go to dashboard, then go to user profile, click 'select featured' button
make some change of badges and click 'save changes', see if there's save changes warning flash above.

