### PR TITLE
add bio requested status to report page

### DIFF
--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -1,22 +1,24 @@
-import React, { Component, useState } from 'react'
+import React, { Component, useState } from 'react';
 import '../../Teams/Team.css';
 import './PeopleReport.css';
-import { Button, Dropdown, DropdownButton } from 'react-bootstrap'
-import { connect } from 'react-redux'
+import { Button, Dropdown, DropdownButton } from 'react-bootstrap';
+import { connect } from 'react-redux';
 import { FiUser } from 'react-icons/fi';
-import { getUserProfile, getUserTask } from '../../../actions/userProfile';
-import { getUserProjects } from '../../../actions/userProjects'
-import { getWeeklySummaries, updateWeeklySummaries } from '../../../actions/weeklySummaries'
-import moment from 'moment'
-import "react-input-range/lib/css/index.css"
-import Collapse from 'react-bootstrap/Collapse'
-import { getTimeEntriesForPeriod } from '../../../actions/timeEntries'
-import InfringementsViz from '../InfringementsViz'
-import TimeEntriesViz from '../TimeEntriesViz'
-import PeopleTableDetails from '../PeopleTableDetails'
-import { ReportPage } from "../sharedComponents/ReportPage";
-import { getPeopleReportData } from "./selectors";
+import { updateUserProfile, getUserProfile, getUserTask } from '../../../actions/userProfile';
+import { getUserProjects } from '../../../actions/userProjects';
+import { getWeeklySummaries, updateWeeklySummaries } from '../../../actions/weeklySummaries';
+import moment from 'moment';
+import 'react-input-range/lib/css/index.css';
+import Collapse from 'react-bootstrap/Collapse';
+import { getTimeEntriesForPeriod } from '../../../actions/timeEntries';
+import InfringementsViz from '../InfringementsViz';
+import TimeEntriesViz from '../TimeEntriesViz';
+import PeopleTableDetails from '../PeopleTableDetails';
+import { ReportPage } from '../sharedComponents/ReportPage';
+import { getPeopleReportData } from './selectors';
 import { PeopleTasksPieChart } from './components';
+import { toast } from 'react-toastify';
+import ToggleSwitch from '../../UserProfile/UserProfileEdit/ToggleSwitch';
 
 class PeopleReport extends Component {
   constructor(props) {
@@ -27,84 +29,86 @@ class PeopleReport extends Component {
       userProjects: {},
       userId: '',
       isLoading: true,
+      isBioPosted: '',
+      authRole: '',
       infringements: {},
-      isAssigned: "",
-      isActive: "",
+      isAssigned: '',
+      isActive: '',
       priority: '',
       status: '',
       hasFilter: true,
       allClassification: [],
       classification: '',
-      users: "",
+      users: '',
       classificationList: [],
       priorityList: [],
       statusList: [],
-      fromDate: "2016-01-01",
+      fromDate: '2016-01-01',
       toDate: this.endOfWeek(0),
       timeEntries: {},
       startDate: '',
       endDate: '',
       fetched: false,
-    }
-    this.setStatus = this.setStatus.bind(this)
-    this.setPriority = this.setPriority.bind(this)
-    this.setActive = this.setActive.bind(this)
-    this.setAssign = this.setAssign.bind(this)
-    this.setFilter = this.setFilter.bind(this)
-    this.setClassfication = this.setClassfication.bind(this)
-    this.setUsers = this.setUsers.bind(this)
-    this.setDate = this.setDate.bind(this)
-    this.setStartDate = this.setStartDate.bind(this)
-    this.setEndDate = this.setEndDate.bind(this)
+    };
+    this.setStatus = this.setStatus.bind(this);
+    this.setPriority = this.setPriority.bind(this);
+    this.setActive = this.setActive.bind(this);
+    this.setAssign = this.setAssign.bind(this);
+    this.setFilter = this.setFilter.bind(this);
+    this.setClassfication = this.setClassfication.bind(this);
+    this.setUsers = this.setUsers.bind(this);
+    this.setDate = this.setDate.bind(this);
+    this.setStartDate = this.setStartDate.bind(this);
+    this.setEndDate = this.setEndDate.bind(this);
   }
 
   async componentDidMount() {
     if (this.props.match) {
       const userId = this.props.match.params.userId;
-      await this.props.getUserProfile(userId)
-      await this.props.getUserTask(userId)
-      await this.props.getUserProjects(userId)
+      await this.props.getUserProfile(userId);
+      await this.props.getUserTask(userId);
+      await this.props.getUserProjects(userId);
       await this.props.getWeeklySummaries(userId);
-      await this.props.getTimeEntriesForPeriod(userId, this.state.fromDate, this.state.toDate)
+      await this.props.getTimeEntriesForPeriod(userId, this.state.fromDate, this.state.toDate);
       this.setState({
         userId,
         isLoading: false,
+        isBioPosted: this.props.userProfile.bioPosted,
+        authRole: this.props.auth.user.role,
         userProfile: {
           ...this.props.userProfile,
         },
-        userTask: [
-          ...this.props.userTask
-        ],
+        userTask: [...this.props.userTask],
         userProjects: {
-          ...this.props.userProjects
+          ...this.props.userProjects,
         },
-        allClassification:
-          [...Array.from(new Set(this.props.userTask.map((item) => item.classification)))],
+        allClassification: [
+          ...Array.from(new Set(this.props.userTask.map(item => item.classification))),
+        ],
         infringements: this.props.userProfile.infringements,
         timeEntries: {
           ...this.props.timeEntries,
         },
-      }
-      )
+      });
     }
   }
   setStartDate(date) {
-    this.setState((state) => {
+    this.setState(state => {
       return {
-        startDate: date
-      }
+        startDate: date,
+      };
     });
   }
   setEndDate(date) {
-    this.setState((state) => {
+    this.setState(state => {
       return {
-        endDate: date
-      }
+        endDate: date,
+      };
     });
   }
 
   setDate(e) {
-    this.setState({ [e.target.name]: e.target.value })
+    this.setState({ [e.target.name]: e.target.value });
   }
 
   startOfWeek(offset) {
@@ -112,7 +116,7 @@ class PeopleReport extends Component {
       .tz('America/Los_Angeles')
       .startOf('week')
       .subtract(offset, 'weeks')
-      .format('YYYY-MM-DD')
+      .format('YYYY-MM-DD');
   }
 
   endOfWeek(offset) {
@@ -120,66 +124,60 @@ class PeopleReport extends Component {
       .tz('America/Los_Angeles')
       .endOf('week')
       .subtract(offset, 'weeks')
-      .format('YYYY-MM-DD')
+      .format('YYYY-MM-DD');
   }
 
   setActive(activeValue) {
-    this.setState((state) => {
+    this.setState(state => {
       return {
-        isActive: activeValue
-      }
+        isActive: activeValue,
+      };
     });
   }
   setPriority(priorityValue) {
     if (priorityValue != 'Filter Off') {
-      this.setState((state) => {
+      this.setState(state => {
         return {
           priority: priorityValue,
-          priorityList: this.state.priorityList.concat(priorityValue)
-
-        }
+          priorityList: this.state.priorityList.concat(priorityValue),
+        };
       });
-    }
-    else {
-      this.setState((state) => {
+    } else {
+      this.setState(state => {
         return {
           priority: priorityValue,
-          priorityList: []
-        }
+          priorityList: [],
+        };
       });
-
     }
   }
   setStatus(statusValue) {
     if (statusValue != 'Filter Off') {
-      this.setState((state) => {
+      this.setState(state => {
         return {
           status: statusValue,
-          statusList: this.state.statusList.concat(statusValue)
-
-        }
+          statusList: this.state.statusList.concat(statusValue),
+        };
       });
-    }
-    else {
-      this.setState((state) => {
+    } else {
+      this.setState(state => {
         return {
           status: statusValue,
-          statusList: []
-        }
+          statusList: [],
+        };
       });
-
     }
   }
   setAssign(assignValue) {
-    this.setState((state) => {
+    this.setState(state => {
       return {
-        isAssigned: assignValue
-      }
+        isAssigned: assignValue,
+      };
     });
   }
 
   setFilter(filterValue) {
-    this.setState((state) => {
+    this.setState(state => {
       return {
         isAssigned: false,
         isActive: false,
@@ -189,41 +187,38 @@ class PeopleReport extends Component {
         statusList: [],
         classificationList: [],
         classification: '',
-        users: "",
-        fromDate: "2016-01-01",
+        users: '',
+        fromDate: '2016-01-01',
         toDate: this.endOfWeek(0),
         startDate: '',
-        endDate: ''
-      }
+        endDate: '',
+      };
     });
   }
 
   setClassfication(classificationValue) {
     if (classificationValue != 'Filter Off') {
-      this.setState((state) => {
+      this.setState(state => {
         return {
           classification: classificationValue,
-          classificationList: this.state.classificationList.concat(classificationValue)
-
-        }
+          classificationList: this.state.classificationList.concat(classificationValue),
+        };
       });
-    }
-    else {
-      this.setState((state) => {
+    } else {
+      this.setState(state => {
         return {
           classification: classificationValue,
-          classificationList: []
-        }
+          classificationList: [],
+        };
       });
-
     }
   }
 
   setUsers(userValue) {
-    this.setState((state) => {
+    this.setState(state => {
       return {
-        users: userValue
-      }
+        users: userValue,
+      };
     });
   }
 
@@ -240,60 +235,58 @@ class PeopleReport extends Component {
     } = this.state;
     const { firstName, lastName, weeklycommittedHours, totalTangibleHrs } = userProfile;
 
-    var totalTangibleHrsRound = 0
+    var totalTangibleHrsRound = 0;
     if (totalTangibleHrs) {
       totalTangibleHrsRound = totalTangibleHrs.toFixed(2);
     }
 
     const UserProject = props => {
-      let userProjectList = []
-      return (
-        <div>
-          {userProjectList}
-        </div>
-      )
-    }
+      let userProjectList = [];
+      return <div>{userProjectList}</div>;
+    };
 
     const ClassificationOptions = props => {
       return (
-        <DropdownButton style={{ margin: '3px' }} exact id="dropdown-basic-button" title="Classification">
+        <DropdownButton
+          style={{ margin: '3px' }}
+          exact
+          id="dropdown-basic-button"
+          title="Classification"
+        >
           {props.allClassification.map((c, index) => (
             <Dropdown.Item onClick={() => this.setClassfication(c)}>{c}</Dropdown.Item>
           ))}
-
         </DropdownButton>
-      )
+      );
     };
 
     const StatusOptions = props => {
-      var allStatus = [...Array.from(new Set(props.get_tasks.map((item) => item.status))).sort()]
-      allStatus.unshift("Filter Off")
+      var allStatus = [...Array.from(new Set(props.get_tasks.map(item => item.status))).sort()];
+      allStatus.unshift('Filter Off');
       return (
         <DropdownButton style={{ margin: '3px' }} exact id="dropdown-basic-button" title="Status">
           {allStatus.map((c, index) => (
             <Dropdown.Item onClick={() => this.setStatus(c)}>{c}</Dropdown.Item>
           ))}
         </DropdownButton>
-      )
+      );
     };
 
     const UserOptions = props => {
-      let users = []
-      props.userTask.map((task, index) => (
-        task.resources.map(resource => (
-          users.push(resource.name)
-        ))
-      ))
+      let users = [];
+      props.userTask.map((task, index) =>
+        task.resources.map(resource => users.push(resource.name)),
+      );
 
-      users = Array.from(new Set(users)).sort()
-      users.unshift("Filter Off")
+      users = Array.from(new Set(users)).sort();
+      users.unshift('Filter Off');
       return (
         <DropdownButton style={{ margin: '3px' }} exact id="dropdown-basic-button" title="Users">
           {users.map((c, index) => (
             <Dropdown.Item onClick={() => this.setUsers(c)}>{c}</Dropdown.Item>
           ))}
         </DropdownButton>
-      )
+      );
     };
     const ShowInfringementsCollapse = props => {
       const [open, setOpen] = useState(false);
@@ -304,112 +297,102 @@ class PeopleReport extends Component {
               <thead>
                 <tr>
                   <th scope="col" id="projects__order">
-                    <Button variant="light"
-                      onClick={() => setOpen(!open)}
-                      aria-expanded={open}>
+                    <Button variant="light" onClick={() => setOpen(!open)} aria-expanded={open}>
                       ⬇
                     </Button>
                   </th>
 
-                  <th scope="col" id="projects__order">Date</th>
+                  <th scope="col" id="projects__order">
+                    Date
+                  </th>
                   <th scope="col">Description</th>
                 </tr>
               </thead>
               <Collapse in={open}>
-                <tbody>
-                  {props.BlueSquare}
-                </tbody>
+                <tbody>{props.BlueSquare}</tbody>
               </Collapse>
             </table>
           </table>
-
         </div>
-
-      )
-    }
+      );
+    };
 
     const Infringements = props => {
-      let BlueSquare = []
-      let dict = {}
+      let BlueSquare = [];
+      let dict = {};
 
       //aggregate infringements
       for (let i = 0; i < props.infringements.length; i++) {
         if (props.infringements[i].date in dict) {
-          dict[props.infringements[i].date].count += 1
-          dict[props.infringements[i].date].des.push(props.infringements[i].description)
+          dict[props.infringements[i].date].count += 1;
+          dict[props.infringements[i].date].des.push(props.infringements[i].description);
         } else {
-          dict[props.infringements[i].date] = { count: 1, des: [props.infringements[i].description] }
+          dict[props.infringements[i].date] = {
+            count: 1,
+            des: [props.infringements[i].description],
+          };
         }
       }
 
-      const startdate = Object.keys(dict)[0]
-      var startdateStr = ""
+      const startdate = Object.keys(dict)[0];
+      var startdateStr = '';
       if (startdate) {
-        startdateStr = startdate.toString()
-
+        startdateStr = startdate.toString();
       }
       if (props.infringements.length > 0) {
         BlueSquare = props.infringements.map((current, index) => (
           <tr className="teams__tr">
-            <td>{index + 1}
-            </td>
-            <td>
-              {current.date}
-            </td>
-            <td>
-              {current.description}
-            </td>
+            <td>{index + 1}</td>
+            <td>{current.date}</td>
+            <td>{current.description}</td>
           </tr>
-        ))
+        ));
       }
       return (
         <div>
-
-          <div>
-          </div>
+          <div></div>
         </div>
-      )
-    }
+      );
+    };
 
     const PeopleDataTable = props => {
       let peopleData = {
-        "alertVisible": false,
-        "taskData": [
-        ],
-        "color": null,
-        "message": ""
-      }
+        alertVisible: false,
+        taskData: [],
+        color: null,
+        message: '',
+      };
 
       for (let i = 0; i < userTask.length; i++) {
         let task = {
-          "taskName": "",
-          "priority": "",
-          "status": "",
-          "resources": [],
-          "active": "",
-          "assign": "",
-          "estimatedHours": "",
-          "_id": "",
-          "startDate": "",
-          "endDate": "",
-          "hoursBest": "",
-          "hoursMost": "",
-          "hoursWorst": "",
-          "whyInfo": "",
-          "endstateInfo": "",
-          "intentInfo": "",
-        }
-        let resourcesName = []
+          taskName: '',
+          priority: '',
+          status: '',
+          resources: [],
+          active: '',
+          assign: '',
+          estimatedHours: '',
+          _id: '',
+          startDate: '',
+          endDate: '',
+          hoursBest: '',
+          hoursMost: '',
+          hoursWorst: '',
+          whyInfo: '',
+          endstateInfo: '',
+          intentInfo: '',
+        };
+        let resourcesName = [];
 
         if (userTask[i].isActive) {
-          task.active = "Yes";
+          task.active = 'Yes';
         } else {
-          task.active = "No";
+          task.active = 'No';
         }
         if (userTask[i].isAssigned) {
-          task.assign = "Yes";
+          task.assign = 'Yes';
         } else {
-          task.assign = "No";
+          task.assign = 'No';
         }
         task.taskName = userTask[i].taskName;
         task.priority = userTask[i].priority;
@@ -418,26 +401,25 @@ class PeopleReport extends Component {
         task.estimatedHours = n.toFixed(2);
         for (let j = 0; j < userTask[i].resources.length; j++) {
           let tempResource = {
-            "name": "",
-            "profilePic": ""
-          }
+            name: '',
+            profilePic: '',
+          };
           if (userTask[i].resources[j].profilePic) {
             tempResource.name = userTask[i].resources[j].name;
             tempResource.profilePic = userTask[i].resources[j].profilePic;
-          }
-          else {
+          } else {
             tempResource.name = userTask[i].resources[j].name;
-            tempResource.profilePic = "/pfp-default.png";
+            tempResource.profilePic = '/pfp-default.png';
           }
           resourcesName.push(tempResource);
         }
         task._id = userTask[i]._id;
         task.resources.push(resourcesName);
         if (userTask[i].startedDatetime == null) {
-          task.startDate = "null";
+          task.startDate = 'null';
         }
         if (userTask[i].endedDatime == null) {
-          task.endDate = "null";
+          task.endDate = 'null';
         }
         task.hoursBest = userTask[i].hoursBest;
         task.hoursMost = userTask[i].hoursMost;
@@ -448,10 +430,8 @@ class PeopleReport extends Component {
         peopleData.taskData.push(task);
       }
 
-      return (
-        <PeopleTableDetails taskData={peopleData.taskData} />
-      )
-    }
+      return <PeopleTableDetails taskData={peopleData.taskData} />;
+    };
 
     const renderProfileInfo = () => (
       <ReportPage.ReportHeader
@@ -460,24 +440,53 @@ class PeopleReport extends Component {
         isActive={isActive}
         name={`${firstName} ${lastName}`}
       >
-
         <div className="stats">
           <div>
             <h4>{moment(userProfile.createdDate).format('YYYY-MM-DD')}</h4>
             <p>Start Date</p>
           </div>
           <div>
-            <h4>{userProfile.endDate ? userProfile.endDate.toLocaleString().split('T')[0] : 'N/A'}</h4>
+            <h4>
+              {userProfile.endDate ? userProfile.endDate.toLocaleString().split('T')[0] : 'N/A'}
+            </h4>
             <p>End Date</p>
+          </div>
+          <div>
+            <h4>Bio {this.state.isBioPosted ? 'posted' : 'requested'}</h4>
+            {this.state.authRole == 'Administrator' || this.state.authRole == 'Owner' ? (
+              <ToggleSwitch
+                switchType="bio"
+                state={this.state.isBioPosted ? false : true}
+                handleUserProfile={onChangeBioPosted}
+              />
+            ) : null}
           </div>
         </div>
       </ReportPage.ReportHeader>
-    )
+    );
+
+    const onChangeBioPosted = async () => {
+      const userId = this.state.userId || this.props.match?.params?.userId;
+      const bioStatus = this.state.isBioPosted;
+      this.setState(state => {
+        return {
+          isBioPosted: !bioStatus,
+        };
+      });
+      try {
+        await this.props.updateUserProfile(userId, {
+          ...this.state.userProfile,
+          bioPosted: !bioStatus,
+        });
+        toast.success('You have changed the bio announcement status of this user.');
+      } catch (err) {
+        alert('An error occurred while attempting to save the bioPosted change to the profile.');
+      }
+    };
 
     return (
       <ReportPage renderProfile={renderProfileInfo}>
-
-        <div className='people-report-time-logs-wrapper'>
+        <div className="people-report-time-logs-wrapper">
           <ReportPage.ReportBlock
             firstColor="#ff5e82"
             secondColor="#e25cb2"
@@ -486,15 +495,27 @@ class PeopleReport extends Component {
             <h3>{weeklycommittedHours}</h3>
             <p>Weekly Committed Hours</p>
           </ReportPage.ReportBlock>
-          <ReportPage.ReportBlock firstColor='#b368d2' secondColor='#831ec4' className='people-report-time-log-block'>
+          <ReportPage.ReportBlock
+            firstColor="#b368d2"
+            secondColor="#831ec4"
+            className="people-report-time-log-block"
+          >
             <h3>{this.props.tangibleHoursReportedThisWeek}</h3>
             <p>Hours Logged This Week</p>
           </ReportPage.ReportBlock>
-          <ReportPage.ReportBlock firstColor='#64b7ff' secondColor='#928aef' className='people-report-time-log-block'>
+          <ReportPage.ReportBlock
+            firstColor="#64b7ff"
+            secondColor="#928aef"
+            className="people-report-time-log-block"
+          >
             <h3>{infringements.length}</h3>
             <p>Blue squares</p>
           </ReportPage.ReportBlock>
-          <ReportPage.ReportBlock firstColor='#ffdb56' secondColor='#ff9145' className='people-report-time-log-block'>
+          <ReportPage.ReportBlock
+            firstColor="#ffdb56"
+            secondColor="#ff9145"
+            className="people-report-time-log-block"
+          >
             <h3>{totalTangibleHrsRound}</h3>
             <p>Total Hours Logged</p>
           </ReportPage.ReportBlock>
@@ -509,23 +530,30 @@ class PeopleReport extends Component {
 
           <PeopleDataTable />
 
-          <div className='container'>
-
+          <div className="container">
             <table>
               <UserProject userProjects={userProjects} />
-              <Infringements infringements={infringements} fromDate={fromDate} toDate={toDate} timeEntries={timeEntries} />
-              <div className='visualizationDiv'>
-                <InfringementsViz infringements={infringements} fromDate={fromDate} toDate={toDate} />
+              <Infringements
+                infringements={infringements}
+                fromDate={fromDate}
+                toDate={toDate}
+                timeEntries={timeEntries}
+              />
+              <div className="visualizationDiv">
+                <InfringementsViz
+                  infringements={infringements}
+                  fromDate={fromDate}
+                  toDate={toDate}
+                />
               </div>
-              <div className='visualizationDiv'>
+              <div className="visualizationDiv">
                 <TimeEntriesViz timeEntries={timeEntries} fromDate={fromDate} toDate={toDate} />
               </div>
             </table>
-
           </div>
         </ReportPage.ReportBlock>
       </ReportPage>
-    )
+    );
   }
 }
 
@@ -535,5 +563,6 @@ export default connect(getPeopleReportData, {
   updateWeeklySummaries,
   getUserTask,
   getUserProjects,
-  getTimeEntriesForPeriod
+  updateUserProfile,
+  getTimeEntriesForPeriod,
 })(PeopleReport);

--- a/src/components/UserProfile/UserProfileEdit/ToggleSwitch/ToggleSwitch.jsx
+++ b/src/components/UserProfile/UserProfileEdit/ToggleSwitch/ToggleSwitch.jsx
@@ -43,7 +43,6 @@ const ToggleSwitch = ({ switchType, state, handleUserProfile }) => {
           </div>
         </div>
       );
-
     case 'email':
       if (state) {
         return (
@@ -136,7 +135,7 @@ const ToggleSwitch = ({ switchType, state, handleUserProfile }) => {
     case 'visible':
       if (state) {
         return (
-          <div className='blueSqare'>
+          <div className="blueSqare">
             <div className={style.switchSection}>
               <div className={style.switchContainer}>
                 visible
@@ -151,10 +150,10 @@ const ToggleSwitch = ({ switchType, state, handleUserProfile }) => {
               </div>
             </div>
           </div>
-        )
+        );
       }
       return (
-        <div className='blueSqare'>
+        <div className="blueSqare">
           <div className={style.switchSection}>
             <div className={style.switchContainer}>
               visible
@@ -167,6 +166,25 @@ const ToggleSwitch = ({ switchType, state, handleUserProfile }) => {
                 defaultChecked
               />
               invisible
+            </div>
+          </div>
+        </div>
+      );
+    case 'bio':
+      return (
+        <div className="blueSqare">
+          <div className={style.switchSection}>
+            <div className={style.switchContainer}>
+              posted
+              <input
+                data-testid="bio-switch"
+                id="bioPosted"
+                type="checkbox"
+                className={style.toggle}
+                onChange={handleUserProfile}
+                checked={state}
+              />
+              requested
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Description
Add a “Bio Posted/Requested” selection to the Reports page
This is so anyone looking at the reports page knows if a person’s bio announcement is in the process of being created or already created.  
Changing this should auto-save (show saving notification like saving an intangible time log) but not refresh the page 
It should be editable by Owner/Admin class only

### Mainly changes explained:
Add a switch toggle which can only view and edited by Admin/Owner in the people report page. Add a line of text showing the current bio status that can be viewed by anyone.
PS: many lines of changes are just brought by formatting.

### How to test:
**Please test with the [back end PR](https://github.com/OneCommunityGlobal/HGNRest/pull/346).**
Login in as a Owner/Admin: dashboard-->report-->people-->click any user
<img width="220" alt="1" src="https://user-images.githubusercontent.com/9314962/236655207-2adafbf8-83ac-4c42-9280-12189acf686c.png">
Login in as a other role: dashboard-->report-->people-->click any user
<img width="206" alt="2" src="https://user-images.githubusercontent.com/9314962/236655214-bacef9f6-da2f-4988-ab4a-983c582d6312.png">