### PR TITLE
Angelina - return to dashboard after entering weekly summaries 

### DIFF
--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -80,7 +80,7 @@ export const Dashboard = props => {
           {popup ? (
             <div className="my-2">
               <div id="weeklySum">
-                <WeeklySummary asUser={userId} />
+                <WeeklySummary asUser={userId} setPopup={setPopup} />
               </div>
             </div>
           ) : null}

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -319,6 +319,7 @@ export class WeeklySummary extends Component {
       });
       this.props.getUserProfile(this.props.currentUser.userid);
       this.props.getWeeklySummaries(this.props.asUser || this.props.currentUser.userid);
+      this.props.setPopup(false);
     } else {
       toast.error('✘ The data could not be saved!', {
         toastId: toastIdOnSave,


### PR DESCRIPTION
###  **(PRIORITY MEDIUM) Yongjian/Jae: Return to Dashboard after entering weekly summaries** 

After entering your weekly summaries, link to your media files, and check that “I have provided a minimum of 4 screenshots…” and after clicking on the “Save” button, the dashboard page should display back the “Tasks and Timelogs” instead of still showing your weekly summaries on the page until a user clicks on the “Dashboard” on the navigation bar to refresh the page.

After clicking on the “Save” button after entering your weekly summaries, links, check “I have provided”…

The page should display the following…

<img width="1250" alt="desired display" src="https://user-images.githubusercontent.com/97488347/236657310-9c6e8214-8e3c-48bb-bc93-727bb93dbef4.png">


Instead of still showing the “Weekly Summaries”...
<img width="1250" alt="submit form" src="https://user-images.githubusercontent.com/97488347/236657315-67d0bbfd-8d0d-4e0e-a84e-4a6bd562083d.png">



### **Main Changes Explained:**
I passed down the state function to the WeeklySummary.jsx.  I called the set state function in the submit handler which will close the weekly summary form after submission. 

### **How to Test:**

1. Check out this branch and run the application locally.
2. Log in to any user account.
3. On the Dashboard above select the "!" SUMMARY.
4. Complete the weekly summary and submit the "save" button. (the weekly summary form should close)



