### PR TITLE
Papia fix header height

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,5 +1,5 @@
 .header-wrapper {
-  height: fit-content;
+  height: 82px;
   width: clamp(100vw, .1rem + 1vw ,100%);
   margin-bottom: 1rem;
 }
@@ -64,6 +64,10 @@
   }
 }
 
-
+@media(max-width: 1200px) {
+  .header-wrapper {
+    height: 56px;
+  }
+}
 
 

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,5 +1,5 @@
 .header-wrapper {
-  height: 82px;
+  height: fit-content;
   width: clamp(100vw, .1rem + 1vw ,100%);
   margin-bottom: 1rem;
 }
@@ -64,10 +64,6 @@
   }
 }
 
-@media(max-width: 1200px) {
-  .header-wrapper {
-    height: 56px;
-  }
-}
+
 
 


### PR DESCRIPTION
Hello everyone, please review my PR #809 , thank you
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/809

**(PRIORITY low): Header height fixed**
![headerheight](https://user-images.githubusercontent.com/86232710/236884544-ed61f341-0eee-4256-b154-faee27a5b550.jpg)


made the header height responsive. so that it there is a gap between header component and component below it.
![headerheightnew](https://user-images.githubusercontent.com/86232710/236884602-a9cdfb77-41a6-49aa-a6b0-904d8fec26df.jpg)

**How to Test:**
1. Check out this branch and run the application locally.
2. run "npm run start:local"
3. Log in to any user account.
4. change the screen size to see there is a gap between header and component below it