### PR TITLE
Require node version 14

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "hgnreactapp",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=14.0.0 <15"
+  },
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.27",


### PR DESCRIPTION
This PR is to resolve the issue of non-intel Mac machines running into the [node-sass error](https://docs.google.com/document/d/1d-ZzDnb_OOXXUN49V-wExHpAgOFMYpe2se1SaziA7Xw/edit?disco=AAAAws8sLdU).

Running `npm run start:local` in the FE app with an Apple arm chip machine gets this error:
```
Node Sass does not yet support your current environment: OS X Unsupported architecture (arm64) with Node.js 16.x
For more information on which environments are supported please see:
[https://github.com/sass/node-sass/releases/tag/v8.0.0](https://www.google.com/url?q=https://github.com/sass/node-sass/releases/tag/v8.0.0&sa=D&source=docs&ust=1683787278291180&usg=AOvVaw0bXv4W5v14vqwBxKvssKK7)
```

Switching the node version to v14 resolves the issue.

I'd added measures to require node v14. Please let me know if this goes against existing rules or practices.
This should prevent developers from running `npm` commands unless they're using node v14.