### PR TITLE
add util to ensure task items have num value

### DIFF
--- a/src/__tests__/ensureTaskItemNum.test.js
+++ b/src/__tests__/ensureTaskItemNum.test.js
@@ -1,0 +1,43 @@
+import ensureTasksHaveNum, { isObject } from "utils/ensureTaskItemNum";
+
+describe('isObject', () => {
+    test('should return true for plain objects', () => {
+        const input = { key: 'value' };
+        const result = isObject(input);
+        expect(result).toBe(true);
+    });
+
+    test('should return false for arrays', () => {
+        const input = [1, 2, 3];
+        const result = isObject(input);
+        expect(result).toBe(false);
+    });
+
+    test('should return false for null', () => {
+        const input = null;
+        const result = isObject(input);
+        expect(result).toBe(false);
+    });
+});
+
+describe('ensureTasksHaveNum', () => {
+    test('should return the original input if not an array of objects', () => {
+        const input = 'not an array';
+        const result = ensureTasksHaveNum(input);
+        expect(result).toEqual(input);
+    });
+
+    test('should add a num property with value "0" to objects without a num property', () => {
+        const input = [{ title: 'Task 1' }, { title: 'Task 2', num: '1' }];
+        const expectedResult = [{ title: 'Task 1', num: '0' }, { title: 'Task 2', num: '1' }];
+        const result = ensureTasksHaveNum(input);
+        expect(result).toEqual(expectedResult);
+    });
+
+    test('should not modify objects with a num property', () => {
+        const input = [{ title: 'Task 1', num: '5' }];
+        const expectedResult = [{ title: 'Task 1', num: '5' }];
+        const result = ensureTasksHaveNum(input);
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/src/actions/task.js
+++ b/src/actions/task.js
@@ -10,6 +10,7 @@ import {
 } from 'components/TeamMemberTasks/actions';
 import * as types from '../constants/task';
 import { ENDPOINTS } from '../utils/URL';
+import ensureTasksHaveNum from '../utils/ensureTaskItemNum';
 import { createOrUpdateTaskNotificationHTTP } from './taskNotification';
 import { createTaskEditSuggestionHTTP } from 'components/TaskEditSuggestions/service';
 
@@ -29,13 +30,13 @@ export const fetchTeamMembersTask = (currentUserId, authenticatedUserId) => asyn
   try {
     const state = getState();
     //The userId will be equal the currentUserId if provided, if not, it'll call the selectFetchTeamMembersTaskData, that will return the current user id that's on the store
-    
+
     const userId = currentUserId ? currentUserId : selectFetchTeamMembersTaskData(state);
     const authUserId = authenticatedUserId ? authenticatedUserId : null
     console.log(authUserId)
-    
+
     dispatch(fetchTeamMembersTaskBegin());
-    
+
     const response = await axios.get(ENDPOINTS.TEAM_MEMBER_TASKS(userId));
 
 
@@ -177,7 +178,7 @@ export const fetchAllTasks = (wbsId, level = 0, mother = null) => {
     await dispatch(setTasksStart());
     try {
       const request = await axios.get(ENDPOINTS.TASKS(wbsId, level === -1 ? 1 : level + 1, mother));
-      dispatch(setTasks(request.data, level, mother));
+      dispatch(setTasks(ensureTasksHaveNum(request.data), level, mother));
     } catch (err) {
       dispatch(setTasksError(err));
     }

--- a/src/utils/ensureTaskItemNum.js
+++ b/src/utils/ensureTaskItemNum.js
@@ -1,0 +1,17 @@
+export const isObject = (x) => typeof x === 'object'
+    && !Array.isArray(x)
+    && x !== null;
+
+const ensureTasksHaveNum = (tasks) => {
+    if (!Array.isArray(tasks) || !tasks.every(isObject)) return tasks;
+
+    return tasks.map((task) => {
+        if (!task.num) {
+            task.num = "0";
+        };
+
+        return task;
+    })
+}
+
+export default ensureTasksHaveNum;


### PR DESCRIPTION
This PR is to fix [a bug reported by Jae](https://highest-good.slack.com/archives/CSCN20FA5/p1683690232066899), where some task items do not have the `num` string property and cause a crash when `split` is called on it.

A new helper function `ensureTasksHaveNum` is used on the fetched task items in `fetchAllTasks` before they're passed to `setTasks`.

Many places in the code expect the string `num` property to exist on the task items, so rather than tracking them all down, this PR adds the missing `num` to task items once they're fetched.