### PR TITLE
Jianjun - Add bio status to weekly report

### DIFF
--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -451,16 +451,18 @@ class PeopleReport extends Component {
             </h4>
             <p>End Date</p>
           </div>
-          <div>
-            <h4>Bio {this.state.isBioPosted ? 'posted' : 'requested'}</h4>
-            {this.state.authRole == 'Administrator' || this.state.authRole == 'Owner' ? (
-              <ToggleSwitch
-                switchType="bio"
-                state={this.state.isBioPosted ? false : true}
-                handleUserProfile={onChangeBioPosted}
-              />
-            ) : null}
-          </div>
+          {!this.state.isBioPosted ? (
+            <div>
+              <h4>Bio {this.state.isBioPosted ? 'posted' : 'requested'}</h4>{' '}
+              {this.state.authRole == 'Administrator' || this.state.authRole == 'Owner' ? (
+                <ToggleSwitch
+                  switchType="bio"
+                  state={this.state.isBioPosted ? false : true}
+                  handleUserProfile={onChangeBioPosted}
+                />
+              ) : null}
+            </div>
+          ) : null}
         </div>
       </ReportPage.ReportHeader>
     );

--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -454,10 +454,10 @@ class PeopleReport extends Component {
           {!this.state.isBioPosted ? (
             <div>
               <h4>Bio {this.state.isBioPosted ? 'posted' : 'requested'}</h4>{' '}
-              {this.state.authRole == 'Administrator' || this.state.authRole == 'Owner' ? (
+              {this.state.authRole === 'Administrator' || this.state.authRole === 'Owner' ? (
                 <ToggleSwitch
                   switchType="bio"
-                  state={this.state.isBioPosted ? false : true}
+                  state={!this.state.isBioPosted}
                   handleUserProfile={onChangeBioPosted}
                 />
               ) : null}

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -12,7 +12,7 @@ import axios from 'axios';
 import { ENDPOINTS } from '../../utils/URL';
 import { useState } from 'react';
 
-const FormattedReport = ({ summaries, weekIndex, role = null }) => {
+const FormattedReport = ({ summaries, weekIndex }) => {
   const emails = [];
 
   summaries.forEach(summary => {
@@ -153,120 +153,61 @@ const FormattedReport = ({ summaries, weekIndex, role = null }) => {
     }
   };
 
-  const buildSummaryPageHasPermission = summaries => {
-    return alphabetize(summaries).map((summary, index) => {
-      const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
-      const googleDocLink = getGoogleDocLink(summary);
-      const [isBioPosted, setIsBioPosted] = useState(summary.bioPosted);
-      return (
-        <div
-          style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
-          key={'summary-' + index}
-        >
-          <div>
-            <b>Name: </b>
-            <Link to={`/userProfile/${summary._id}`} title="View Profile">
-              {summary.firstName} {summary.lastName}
-            </Link>
-
-            <span onClick={() => handleGoogleDocClick(googleDocLink)}>
-              <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
-            </span>
-          </div>
-          <div>
-            {' '}
-            <b>Media URL:</b> {getMediaUrlLink(summary)}
-          </div>
-          <div>
-            <div className="bio-toggle">
-              <b>Bio announcement:</b>
-            </div>
-            <div className="bio-toggle">
-              <ToggleSwitch
-                switchType="bio"
-                state={isBioPosted ? false : true}
-                handleUserProfile={() => {
-                  handleChangeBioPosted(summary._id, isBioPosted);
-                  setIsBioPosted(!isBioPosted);
-                }}
-              />
-            </div>
-          </div>
-          {getTotalValidWeeklySummaries(summary)}
-          {hoursLogged >= summary.weeklycommittedHours && (
-            <p>
-              <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
-            </p>
-          )}
-          {hoursLogged < summary.weeklycommittedHours && (
-            <p style={{ color: 'red' }}>
-              <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
-            </p>
-          )}
-          {getWeeklySummaryMessage(summary)}
-        </div>
-      );
-    });
-  };
-
-  const buildSummaryPageNoPermission = summaries => {
-    return alphabetize(summaries).map((summary, index) => {
-      const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
-      const googleDocLink = getGoogleDocLink(summary);
-      const [isBioPosted, setIsBioPosted] = useState(summary.bioPosted);
-      return (
-        <div
-          style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
-          key={'summary-' + index}
-        >
-          <div>
-            <b>Name: </b>
-            <Link to={`/userProfile/${summary._id}`} title="View Profile">
-              {summary.firstName} {summary.lastName}
-            </Link>
-
-            <span onClick={() => handleGoogleDocClick(googleDocLink)}>
-              <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
-            </span>
-          </div>
-          <div>
-            {' '}
-            <b>Media URL:</b> {getMediaUrlLink(summary)}
-          </div>
-          <div>
-            <div className="bio-toggle">
-              <b>Bio announcement:</b>
-            </div>
-            <div className="bio-toggle">
-              <ToggleSwitch
-                switchType="bio"
-                state={isBioPosted ? false : true}
-                handleUserProfile={() => {}}
-              />
-            </div>
-          </div>
-          {getTotalValidWeeklySummaries(summary)}
-          {hoursLogged >= summary.weeklycommittedHours && (
-            <p>
-              <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
-            </p>
-          )}
-          {hoursLogged < summary.weeklycommittedHours && (
-            <p style={{ color: 'red' }}>
-              <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
-            </p>
-          )}
-          {getWeeklySummaryMessage(summary)}
-        </div>
-      );
-    });
-  };
-
   return (
     <>
-      {role === 'Administrator' || role === 'Owner'
-        ? buildSummaryPageHasPermission(summaries)
-        : buildSummaryPageNoPermission(summaries)}
+      {alphabetize(summaries).map((summary, index) => {
+        const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
+        const googleDocLink = getGoogleDocLink(summary);
+        const [isBioPosted, setIsBioPosted] = useState(summary.bioPosted);
+        return (
+          <div
+            style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
+            key={'summary-' + index}
+          >
+            <div>
+              <b>Name: </b>
+              <Link to={`/userProfile/${summary._id}`} title="View Profile">
+                {summary.firstName} {summary.lastName}
+              </Link>
+
+              <span onClick={() => handleGoogleDocClick(googleDocLink)}>
+                <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
+              </span>
+            </div>
+            <div>
+              {' '}
+              <b>Media URL:</b> {getMediaUrlLink(summary)}
+            </div>
+            <div>
+              <div className="bio-toggle">
+                <b>Bio announcement:</b>
+              </div>
+              <div className="bio-toggle">
+                <ToggleSwitch
+                  switchType="bio"
+                  state={isBioPosted ? false : true}
+                  handleUserProfile={() => {
+                    handleChangeBioPosted(summary._id, isBioPosted);
+                    setIsBioPosted(!isBioPosted);
+                  }}
+                />
+              </div>
+            </div>
+            {getTotalValidWeeklySummaries(summary)}
+            {hoursLogged >= summary.weeklycommittedHours && (
+              <p>
+                <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
+              </p>
+            )}
+            {hoursLogged < summary.weeklycommittedHours && (
+              <p style={{ color: 'red' }}>
+                <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
+              </p>
+            )}
+            {getWeeklySummaryMessage(summary)}
+          </div>
+        );
+      })}
       <h4>Emails</h4>
       <p>{emailString}</p>
     </>

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -12,7 +12,7 @@ import axios from 'axios';
 import { ENDPOINTS } from '../../utils/URL';
 import { useState } from 'react';
 
-const FormattedReport = ({ summaries, weekIndex }) => {
+const FormattedReport = ({ summaries, weekIndex, role = null }) => {
   const emails = [];
 
   summaries.forEach(summary => {
@@ -153,61 +153,120 @@ const FormattedReport = ({ summaries, weekIndex }) => {
     }
   };
 
+  const buildSummaryPageHasPermission = summaries => {
+    return alphabetize(summaries).map((summary, index) => {
+      const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
+      const googleDocLink = getGoogleDocLink(summary);
+      const [isBioPosted, setIsBioPosted] = useState(summary.bioPosted);
+      return (
+        <div
+          style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
+          key={'summary-' + index}
+        >
+          <div>
+            <b>Name: </b>
+            <Link to={`/userProfile/${summary._id}`} title="View Profile">
+              {summary.firstName} {summary.lastName}
+            </Link>
+
+            <span onClick={() => handleGoogleDocClick(googleDocLink)}>
+              <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
+            </span>
+          </div>
+          <div>
+            {' '}
+            <b>Media URL:</b> {getMediaUrlLink(summary)}
+          </div>
+          <div>
+            <div className="bio-toggle">
+              <b>Bio announcement:</b>
+            </div>
+            <div className="bio-toggle">
+              <ToggleSwitch
+                switchType="bio"
+                state={isBioPosted ? false : true}
+                handleUserProfile={() => {
+                  handleChangeBioPosted(summary._id, isBioPosted);
+                  setIsBioPosted(!isBioPosted);
+                }}
+              />
+            </div>
+          </div>
+          {getTotalValidWeeklySummaries(summary)}
+          {hoursLogged >= summary.weeklycommittedHours && (
+            <p>
+              <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
+            </p>
+          )}
+          {hoursLogged < summary.weeklycommittedHours && (
+            <p style={{ color: 'red' }}>
+              <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
+            </p>
+          )}
+          {getWeeklySummaryMessage(summary)}
+        </div>
+      );
+    });
+  };
+
+  const buildSummaryPageNoPermission = summaries => {
+    return alphabetize(summaries).map((summary, index) => {
+      const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
+      const googleDocLink = getGoogleDocLink(summary);
+      const [isBioPosted, setIsBioPosted] = useState(summary.bioPosted);
+      return (
+        <div
+          style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
+          key={'summary-' + index}
+        >
+          <div>
+            <b>Name: </b>
+            <Link to={`/userProfile/${summary._id}`} title="View Profile">
+              {summary.firstName} {summary.lastName}
+            </Link>
+
+            <span onClick={() => handleGoogleDocClick(googleDocLink)}>
+              <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
+            </span>
+          </div>
+          <div>
+            {' '}
+            <b>Media URL:</b> {getMediaUrlLink(summary)}
+          </div>
+          <div>
+            <div className="bio-toggle">
+              <b>Bio announcement:</b>
+            </div>
+            <div className="bio-toggle">
+              <ToggleSwitch
+                switchType="bio"
+                state={isBioPosted ? false : true}
+                handleUserProfile={() => {}}
+              />
+            </div>
+          </div>
+          {getTotalValidWeeklySummaries(summary)}
+          {hoursLogged >= summary.weeklycommittedHours && (
+            <p>
+              <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
+            </p>
+          )}
+          {hoursLogged < summary.weeklycommittedHours && (
+            <p style={{ color: 'red' }}>
+              <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
+            </p>
+          )}
+          {getWeeklySummaryMessage(summary)}
+        </div>
+      );
+    });
+  };
+
   return (
     <>
-      {alphabetize(summaries).map((summary, index) => {
-        const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
-        const googleDocLink = getGoogleDocLink(summary);
-        const [isBioPosted, setIsBioPosted] = useState(summary.bioPosted);
-        return (
-          <div
-            style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
-            key={'summary-' + index}
-          >
-            <div>
-              <b>Name: </b>
-              <Link to={`/userProfile/${summary._id}`} title="View Profile">
-                {summary.firstName} {summary.lastName}
-              </Link>
-
-              <span onClick={() => handleGoogleDocClick(googleDocLink)}>
-                <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
-              </span>
-            </div>
-            <div>
-              {' '}
-              <b>Media URL:</b> {getMediaUrlLink(summary)}
-            </div>
-            <div>
-              <div className="bio-toggle">
-                <b>Bio announcement:</b>
-              </div>
-              <div className="bio-toggle">
-                <ToggleSwitch
-                  switchType="bio"
-                  state={isBioPosted ? false : true}
-                  handleUserProfile={() => {
-                    handleChangeBioPosted(summary._id, isBioPosted);
-                    setIsBioPosted(!isBioPosted);
-                  }}
-                />
-              </div>
-            </div>
-            {getTotalValidWeeklySummaries(summary)}
-            {hoursLogged >= summary.weeklycommittedHours && (
-              <p>
-                <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
-              </p>
-            )}
-            {hoursLogged < summary.weeklycommittedHours && (
-              <p style={{ color: 'red' }}>
-                <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
-              </p>
-            )}
-            {getWeeklySummaryMessage(summary)}
-          </div>
-        );
-      })}
+      {role === 'Administrator' || role === 'Owner'
+        ? buildSummaryPageHasPermission(summaries)
+        : buildSummaryPageNoPermission(summaries)}
       <h4>Emails</h4>
       <p>{emailString}</p>
     </>

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.css
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.css
@@ -22,3 +22,7 @@
   height: 20px;
   margin-left: 10px;
 }
+
+.bio-toggle {
+  display: inline-block;
+}

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -18,7 +18,6 @@ export class WeeklySummariesReport extends Component {
     loading: true,
     summaries: [],
     activeTab: '1',
-    role: null,
   };
 
   async componentDidMount() {
@@ -27,7 +26,6 @@ export class WeeklySummariesReport extends Component {
       error: this.props.error,
       loading: this.props.loading,
       summaries: this.props.summaries,
-      role: this.props.auth.user.role,
     });
   }
 
@@ -52,7 +50,7 @@ export class WeeklySummariesReport extends Component {
   };
 
   render() {
-    const { error, loading, summaries, activeTab, role } = this.state;
+    const { error, loading, summaries, activeTab } = this.state;
 
     if (error) {
       return (
@@ -140,7 +138,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={0} role={role} />
+                    <FormattedReport summaries={summaries} weekIndex={0} />
                   </Col>
                 </Row>
               </TabPane>
@@ -160,7 +158,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={1} role={role} />
+                    <FormattedReport summaries={summaries} weekIndex={1} />
                   </Col>
                 </Row>
               </TabPane>
@@ -180,7 +178,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={2} role={role} />
+                    <FormattedReport summaries={summaries} weekIndex={2} />
                   </Col>
                 </Row>
               </TabPane>
@@ -200,7 +198,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={3} role={role} />
+                    <FormattedReport summaries={summaries} weekIndex={3} />
                   </Col>
                 </Row>
               </TabPane>
@@ -219,11 +217,10 @@ WeeklySummariesReport.propTypes = {
   summaries: PropTypes.array.isRequired,
 };
 
-const mapStateToProps = state => ({
-  auth: state.auth,
-  error: state.weeklySummariesReport.error,
-  loading: state.weeklySummariesReport.loading,
-  summaries: state.weeklySummariesReport.summaries,
+const mapStateToProps = ({ weeklySummariesReport }) => ({
+  error: weeklySummariesReport.error,
+  loading: weeklySummariesReport.loading,
+  summaries: weeklySummariesReport.summaries,
 });
 
 export default connect(mapStateToProps, { getWeeklySummariesReport })(WeeklySummariesReport);

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -18,6 +18,7 @@ export class WeeklySummariesReport extends Component {
     loading: true,
     summaries: [],
     activeTab: '1',
+    role: null,
   };
 
   async componentDidMount() {
@@ -26,6 +27,7 @@ export class WeeklySummariesReport extends Component {
       error: this.props.error,
       loading: this.props.loading,
       summaries: this.props.summaries,
+      role: this.props.auth.user.role,
     });
   }
 
@@ -50,7 +52,7 @@ export class WeeklySummariesReport extends Component {
   };
 
   render() {
-    const { error, loading, summaries, activeTab } = this.state;
+    const { error, loading, summaries, activeTab, role } = this.state;
 
     if (error) {
       return (
@@ -138,7 +140,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={0} />
+                    <FormattedReport summaries={summaries} weekIndex={0} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -158,7 +160,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={1} />
+                    <FormattedReport summaries={summaries} weekIndex={1} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -178,7 +180,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={2} />
+                    <FormattedReport summaries={summaries} weekIndex={2} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -198,7 +200,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={3} />
+                    <FormattedReport summaries={summaries} weekIndex={3} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -217,10 +219,11 @@ WeeklySummariesReport.propTypes = {
   summaries: PropTypes.array.isRequired,
 };
 
-const mapStateToProps = ({ weeklySummariesReport }) => ({
-  error: weeklySummariesReport.error,
-  loading: weeklySummariesReport.loading,
-  summaries: weeklySummariesReport.summaries,
+const mapStateToProps = state => ({
+  auth: state.auth,
+  error: state.weeklySummariesReport.error,
+  loading: state.weeklySummariesReport.loading,
+  summaries: state.weeklySummariesReport.summaries,
 });
 
 export default connect(mapStateToProps, { getWeeklySummariesReport })(WeeklySummariesReport);


### PR DESCRIPTION
### Description
Add a “Bio Posted/Requested” selection to the Weekly Summary Report page

### Mainly changes explained:
1.A toggle switch that can change the status of bio announcement has been added to this page for every user.
<img width="552" alt="img" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/d104ea1e-9506-437d-a14d-c7ace4a8a28c">
2.The toggle and words about the bio status will disappear on the people report page if the bio has been posted.
If the user has NOT posted it:
<img width="192" alt="1" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/e07fea6b-a6ac-497e-aa48-03de697fd643">
If the user has posted it:
<img width="175" alt="2" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/876ee8c2-4ffb-4be0-a329-1f49eac32b16">


### How to test:
**Important: Please test with the** [PR352](https://github.com/OneCommunityGlobal/HGNRest/pull/352).
Login in:
1.dashboard-->report-->weekly summary report
2.dashboard-->report-->report-->people-->click any user(compare the user that posted bio vs didn't)