### PR TITLE
Alex- Add Copy Email Icon to User Management Table 

### DIFF
--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -6,6 +6,9 @@ import { useHistory } from 'react-router-dom';
 import ActiveCell from './ActiveCell';
 import hasPermission from 'utils/permissions';
 import Table from 'react-bootstrap/Table';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCopy } from '@fortawesome/free-solid-svg-icons';
+import { toast } from 'react-toastify';
 
 /**
  * The body row of the user table
@@ -38,7 +41,17 @@ const UserTableData = React.memo(props => {
         <a href={`/userprofile/${props.user._id}`}>{props.user.lastName}</a>
       </td>
       <td>{props.user.role}</td>
-      <td>{props.user.email}</td>
+      <td>
+        {props.user.email}
+        <FontAwesomeIcon
+          className="copy_icon"
+          icon={faCopy}
+          onClick={() => {
+            navigator.clipboard.writeText(props.user.email)
+            toast.success('Email Copied!');
+          }}
+        />
+      </td>
       <td>{props.user.weeklycommittedHours}</td>
       <td>
         <button

--- a/src/components/UserManagement/usermanagement.css
+++ b/src/components/UserManagement/usermanagement.css
@@ -47,6 +47,12 @@ thead {
   color: white;
 }
 
+
+.copy_icon {
+  float: right;
+  cursor: pointer;
+ }
+
 .usermanagement__order--input div {
   margin-top: 7px;
 }


### PR DESCRIPTION
# Description
- Having to drag across a user's email to select and then copy it is inefficient
- With the proposed changes, an admin can use the Copy Icon to the right of the email to quickly copy a user's email address. 
- After a successful copy, the admin will be notified via a pop up.

![tast_copy_email](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59572783/3a835f0d-99e0-4d97-b6ba-732f20a6b27f)


## Main changes explained:

1. Added Copy Icon next to each email
2. Clicking the Copy Icon will copy the users email to your clipboard
3. A success message will display after copying email

## How to test:

1. check into current branch 
2. run `npm run start:local` 
3. log as admin user
4. Navigate to user management (Other links -> User Management)
5. Click on the copy icon next to the email you would like to copy
6. Paste the email to make sure it was properly copied
7. You should receive an success window pop up



## Screenshots or videos of changes:

BEFORE SCREENSHOT
![COPY_BTN_USER_MANAGEMENT](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59572783/fef4ada1-10d6-4b5b-b936-8540ee2ebd20)

AFTER SCREENSHOT
![COPT_BTN_USER_MAN COMPLETE](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59572783/8a87b3e2-b3d2-4830-af90-5ca14a082199)

AFTER VIDEO
[COPY_EMAIL_COMPLETE.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59572783/505ab46e-5338-49dc-a675-c64eac8354b5)
