### PR TITLE
Bada - add reducer action to empty task items. call it when WBSTasks unmounts

### DIFF
--- a/src/actions/task.js
+++ b/src/actions/task.js
@@ -29,13 +29,13 @@ export const fetchTeamMembersTask = (currentUserId, authenticatedUserId) => asyn
   try {
     const state = getState();
     //The userId will be equal the currentUserId if provided, if not, it'll call the selectFetchTeamMembersTaskData, that will return the current user id that's on the store
-    
+
     const userId = currentUserId ? currentUserId : selectFetchTeamMembersTaskData(state);
     const authUserId = authenticatedUserId ? authenticatedUserId : null
     console.log(authUserId)
-    
+
     dispatch(fetchTeamMembersTaskBegin());
-    
+
     const response = await axios.get(ENDPOINTS.TEAM_MEMBER_TASKS(userId));
 
 
@@ -184,6 +184,12 @@ export const fetchAllTasks = (wbsId, level = 0, mother = null) => {
   };
 };
 
+export const emptyAllTaskItems = () => {
+  return async dispatch => {
+    dispatch(emptyTaskItems());
+  }
+}
+
 export const deleteTask = (taskId, mother) => {
   const url = ENDPOINTS.TASK_DEL(taskId, mother);
   return async dispatch => {
@@ -223,6 +229,12 @@ export const setTasks = (taskItems, level, mother) => {
     taskItems,
     level,
     mother,
+  };
+};
+
+export const emptyTaskItems = () => {
+  return {
+    type: types.EMPTY_TASK_ITEMS,
   };
 };
 

--- a/src/actions/task.js
+++ b/src/actions/task.js
@@ -32,7 +32,6 @@ export const fetchTeamMembersTask = (currentUserId, authenticatedUserId) => asyn
 
     const userId = currentUserId ? currentUserId : selectFetchTeamMembersTaskData(state);
     const authUserId = authenticatedUserId ? authenticatedUserId : null
-    console.log(authUserId)
 
     dispatch(fetchTeamMembersTaskBegin());
 

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router-dom';
 import { NavItem, Button } from 'reactstrap';
 import ReactTooltip from 'react-tooltip';
 import hasPermission from 'utils/permissions';
-import { fetchAllTasks, updateNumList, deleteTask } from '../../../../actions/task';
+import { fetchAllTasks, emptyAllTaskItems, updateNumList, deleteTask } from '../../../../actions/task';
 import { fetchAllMembers } from '../../../../actions/projectMembers.js';
 import Task from './Task';
 import AddTaskModal from './AddTask/AddTaskModal';
@@ -39,6 +39,12 @@ function WBSTasks(props) {
     AutoOpenAll(false);
     setLoadAll(true);
   };
+
+  useEffect(() => {
+    return () => {
+      props.emptyAllTaskItems();
+    };
+  }, [])
 
   useEffect(() => {
     load().then(setOpenAll(false));
@@ -268,10 +274,10 @@ function WBSTasks(props) {
           >
             Unassigned
           </Button>
-          <Button 
-            color="info" 
-            size="sm" 
-            onClick={() => setFilterState('active')} 
+          <Button
+            color="info"
+            size="sm"
+            onClick={() => setFilterState('active')}
             className="ml-2"
           >
             Active
@@ -349,7 +355,7 @@ function WBSTasks(props) {
               <td colSpan={14} />
             </tr>
 
-            {filteredTasks.map((task, i) => (
+            {props.state.tasks.fetched && filteredTasks.map((task, i) => (
               <Task
                 key={`${task._id}${i}`}
                 id={task._id}
@@ -401,6 +407,7 @@ const mapStateToProps = state => ({ state });
 
 export default connect(mapStateToProps, {
   fetchAllTasks,
+  emptyAllTaskItems,
   updateNumList,
   deleteTask,
   fetchAllMembers,

--- a/src/constants/task.js
+++ b/src/constants/task.js
@@ -26,3 +26,6 @@ export const UPDATE_NUMS = 'UPDATE_NUMS';
 
 // COPY TASK
 export const COPY_TASK = 'COPY_TASK';
+
+// EMPTY TASK ITEMS
+export const EMPTY_TASK_ITEMS = 'EMPTY_TASK_ITEMS';

--- a/src/reducers/allTasksReducer.js
+++ b/src/reducers/allTasksReducer.js
@@ -120,6 +120,11 @@ export const taskReducer = (allTasks = allTasksInital, action) => {
         fetching: false,
         error: 'none',
       };
+    case types.EMPTY_TASK_ITEMS:
+      return {
+        ...allTasks,
+        taskItems: []
+      };
     case types.UPDATE_TASK:
       let updIndexStart = allTasks.taskItems.findIndex(task => task._id === action.taskId);
       let updIndexEnd = updIndexStart;


### PR DESCRIPTION
The task items table shows the data from the last viewed task items while the current ones are fetching.
Empty the task items when the component that render the table unmounts.

This may also have an effect on [the WBS task items bug](https://highest-good.slack.com/archives/CSCN20FA5/p1683690232066899).

[BEFORE](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/7866f744-64a7-462f-83ca-977a32040ebd) - [AFTER](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/90e84f70-06f6-4ab0-abcb-cab1727b9dd5)

1. Adds a reducer action `EMPTY_TASK_ITEMS` to set the `taskItems` to an empty array.
2. Dispatches the action when the `WBSTasks` component unmounts.
3. This clears the table and prevents the task items from a previous WBS from showing briefly before the proper ones are fetched.