### PR TITLE
833 Follow up - Style Email Table Cell and Copy Icon

### DIFF
--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -41,7 +41,7 @@ const UserTableData = React.memo(props => {
         <a href={`/userprofile/${props.user._id}`}>{props.user.lastName}</a>
       </td>
       <td>{props.user.role}</td>
-      <td>
+      <td className="email_cell">
         {props.user.email}
         <FontAwesomeIcon
           className="copy_icon"

--- a/src/components/UserManagement/usermanagement.css
+++ b/src/components/UserManagement/usermanagement.css
@@ -47,11 +47,17 @@ thead {
   color: white;
 }
 
-
+.email_cell {
+  position: relative;
+}
+ 
 .copy_icon {
-  float: right;
-  cursor: pointer;
- }
+   cursor: pointer;
+   position: absolute; 
+   top: 0; 
+   right: 0; 
+   margin: 2px 2px;
+  }
 
 .usermanagement__order--input div {
   margin-top: 7px;


### PR DESCRIPTION
# Description
- This is a follow up from the recently merged PR [833](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/833)
  - (833 added a Copy Icon to the email table cell in order to make copying email addresses easier)
- This PR updates the styling of the email table cell-- specifically aligns the Copy Icon to the top right of the cell

## How to test:
1. Follow same testing instructions from [833](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/833) (steps 1-7).
2. Change the size of the browser window and note any changes to the Icons positioning. 
3. There should not be any! 

## Screenshots of changes:
### BEFORE
![833_style_suggesstion](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59572783/ede9b104-558b-4391-9bbb-2d96518f6d23)
<br>
### AFTER
![833_style_updated](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59572783/510709ec-eb82-420e-9c3c-cf4c83e5f07d)

@stevenpaalz please check out these changes and let me know your thoughts! 

