### PR TITLE
Fix WBS Bug

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -81,9 +81,9 @@ function AddTaskModal(props) {
 
   // category
   const categoryOptions = [
+    { value: 'Housing', label: 'Housing' },
     { value: 'Food', label: 'Food' },
     { value: 'Energy', label: 'Energy' },
-    { value: 'Housing', label: 'Housing' },
     { value: 'Education', label: 'Education' },
     { value: 'Soceity', label: 'Soceity' },
     { value: 'Economics', label: 'Economics' },

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -539,9 +539,9 @@ const EditTaskModal = props => {
                       setCategory(e.target.value);
                     }}
                   >
+                    <option value="Housing">Housing</option>
                     <option value="Food">Food</option>
                     <option value="Energy">Energy</option>
-                    <option value="Housing">Housing</option>
                     <option value="Education">Education</option>
                     <option value="Soceity">Society</option>
                     <option value="Economics">Economics</option>


### PR DESCRIPTION
### Description
This PR fixes up the frontend for WBS bug category not displaying correctly (Backend PR to [PR 330](https://github.com/OneCommunityGlobal/HGNRest/pull/330)). 

In the Edit Task Modal the Category was not displaying correctly.
The default category should be Housing not Food

### Mainly changes explained:
Changed the order for Options so that the default option is Housing not Food.

### How to test:
Check into the current branch for frontend
Check into the `johny_fix_wbs_categories_not_saving_correctly` for backend
Do `npm install` and `... ` to run this PR locally
Log as owner user
Add new task for project with unspecified category, check if the default category allotted is Housing
Add new Task for project with an assigned category (say Education), check if the category is reflected in TaskEditModal.

### Screenshots
Before:
<img width="1440" alt="Screen Shot 2023-05-19 at 1 26 15 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/29037428/9272acf9-fafe-4c80-be41-92e9fbd39a66">
<img width="1440" alt="Screen Shot 2023-05-19 at 1 27 06 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/29037428/d7811c96-6ede-4acc-af64-7b40f0640cf5">


After:
<img width="1440" alt="Screen Shot 2023-05-19 at 1 21 13 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/29037428/dac4cd3c-42da-49fe-80c6-fee171a99468">
<img width="1440" alt="Screen Shot 2023-05-19 at 1 21 36 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/29037428/38c33c02-d8cd-4611-b755-0dea0ae86da7">
