### PR TITLE
Abdel make reports buttons obvious when clicked

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -80,18 +80,15 @@ body,
 }
 
 .bg-bright-red {
-  background-color: #FF3300 !important;
+  background-color: #ff3300 !important;
   /*  bright-red */
 }
 
 .bg-almost-red {
-  background-color: #CC3366 !important;
+  background-color: #cc3366 !important;
   /*  90%to100%-red */
 }
 
 nav ul.navbar-nav li:last-child > div {
-   transform: translate3d(-26px, 40px, 0px) !important;
+  transform: translate3d(-26px, 40px, 0px) !important;
 }
-
-
-

--- a/src/components/Reports/PeopleTable.js
+++ b/src/components/Reports/PeopleTable.js
@@ -7,61 +7,60 @@ import moment from 'moment';
 const PeopleTable = props => {
   let PeopleList = [];
   if (props.userProfiles.length > 0) {
-    PeopleList = props.userProfiles.sort((a, b) =>
-    a.firstName.localeCompare(b.firstName) ).map((person, index) => (
-      <tr className="teams__tr" id={`tr_${person._id}`} key={person._id}>
-        <th className="teams__order--input" scope="row">
-          <div>{index + 1}</div>
-        </th>
-        <td>
-          <Link to={`/peoplereport/${person._id}`} personId={person._id}>
-            {person.firstName} {person.lastName}
-          </Link>
-        </td>
-        <td
-          className="teams__active--input"
-          onClick={e => {
-            person.onStatusClick(person.firstName, person._id, person.isActive);
-          }}
-        >
-          {person.isActive ? (
-            <div className="isActive">
-              <i className="fa fa-circle" aria-hidden="true" />
-            </div>
-          ) : (
-            <div className="isNotActive">
-              <i className="fa fa-circle-o" aria-hidden="true" />
-            </div>
-          )}
-        </td>
-        <td>{moment(person.createdDate).format('MM/DD/YYYY')}</td>
-        <td>{moment(person.endDate).format('MM/DD/YYYY') || 'N/A'}</td>
-        {/* <td>
+    PeopleList = props.userProfiles
+      .sort((a, b) => a.firstName.localeCompare(b.firstName))
+      .map((person, index) => (
+        <tr className="teams__tr" id={`tr_${person._id}`} key={person._id}>
+          <th className="teams__order--input" scope="row">
+            <div>{index + 1}</div>
+          </th>
+          <td>
+            <Link to={`/peoplereport/${person._id}`} personId={person._id}>
+              {person.firstName} {person.lastName}
+            </Link>
+          </td>
+          <td
+            className="teams__active--input"
+            onClick={e => {
+              person.onStatusClick(person.firstName, person._id, person.isActive);
+            }}
+          >
+            {person.isActive ? (
+              <div className="isActive">
+                <i className="fa fa-circle" aria-hidden="true" />
+              </div>
+            ) : (
+              <div className="isNotActive">
+                <i className="fa fa-circle-o" aria-hidden="true" />
+              </div>
+            )}
+          </td>
+          <td>{moment(person.createdDate).format('MM/DD/YYYY')}</td>
+          <td>{moment(person.endDate).format('MM/DD/YYYY') || 'N/A'}</td>
+          {/* <td>
           {person.blueSquares||"N/A"}
         </td> */}
-      </tr>
-    ));
+        </tr>
+      ));
   }
 
   return (
-    <table className="center">
-      <table className="table table-bordered table-responsive-sm">
-        <thead>
-          <tr>
-            <th scope="col" id="projects__order">
-              #
-            </th>
-            <th scope="col">Person Name</th>
-            <th scope="col" id="projects__active">
-              Active
-            </th>
-            <th scope="col">Start Date</th>
-            <th scope="col">End Date</th>
-            {/* <th scope="col">Blue Squares</th> */}
-          </tr>
-        </thead>
-        <tbody>{PeopleList}</tbody>
-      </table>
+    <table className="table table-bordered table-responsive-sm">
+      <thead>
+        <tr>
+          <th scope="col" id="projects__order">
+            #
+          </th>
+          <th scope="col">Person Name</th>
+          <th scope="col" id="projects__active">
+            Active
+          </th>
+          <th scope="col">Start Date</th>
+          <th scope="col">End Date</th>
+          {/* <th scope="col">Blue Squares</th> */}
+        </tr>
+      </thead>
+      <tbody>{PeopleList}</tbody>
     </table>
   );
 };

--- a/src/components/Reports/ProjectTable.jsx
+++ b/src/components/Reports/ProjectTable.jsx
@@ -32,21 +32,19 @@ const ProjectTable = props => {
   }
 
   return (
-    <table class="center">
-      <table className="table table-bordered table-responsive-sm">
-        <thead>
-          <tr>
-            <th scope="col" id="projects__order">
-              #
-            </th>
-            <th scope="col">Project Name</th>
-            <th scope="col" id="projects__active">
-              Active
-            </th>
-          </tr>
-        </thead>
-        <tbody>{ProjectsList}</tbody>
-      </table>
+    <table className="table table-bordered table-responsive-sm">
+      <thead>
+        <tr>
+          <th scope="col" id="projects__order">
+            #
+          </th>
+          <th scope="col">Project Name</th>
+          <th scope="col" id="projects__active">
+            Active
+          </th>
+        </tr>
+      </thead>
+      <tbody>{ProjectsList}</tbody>
     </table>
   );
 };

--- a/src/components/Reports/Reports.jsx
+++ b/src/components/Reports/Reports.jsx
@@ -92,24 +92,24 @@ class ReportsPage extends Component {
   /**
    * callback for search
    */
-  onWildCardSearch = (searchText) => {
+  onWildCardSearch = searchText => {
     this.setState({
       wildCardSearchText: searchText,
     });
   };
 
-  filteredProjectList = (projects) => {
-    const filteredList = projects.filter((project) => {
+  filteredProjectList = projects => {
+    const filteredList = projects.filter(project => {
       // Applying the search filters before creating each team table data element
       if (
-        (project.projectName
-          && project.projectName.toLowerCase().indexOf(this.state.teamNameSearchText.toLowerCase())
-            > -1
-          && this.state.wildCardSearchText === '')
+        (project.projectName &&
+          project.projectName.toLowerCase().indexOf(this.state.teamNameSearchText.toLowerCase()) >
+            -1 &&
+          this.state.wildCardSearchText === '') ||
         // the wild card search, the search text can be match with any item
-        || (this.state.wildCardSearchText !== ''
-          && project.projectName.toLowerCase().indexOf(this.state.wildCardSearchText.toLowerCase())
-            > -1)
+        (this.state.wildCardSearchText !== '' &&
+          project.projectName.toLowerCase().indexOf(this.state.wildCardSearchText.toLowerCase()) >
+            -1)
       ) {
         return project;
       }
@@ -119,16 +119,16 @@ class ReportsPage extends Component {
     return filteredList;
   };
 
-  filteredTeamList = (allTeams) => {
-    const filteredList = allTeams?.filter((team) => {
+  filteredTeamList = allTeams => {
+    const filteredList = allTeams?.filter(team => {
       // Applying the search filters before creating each team table data element
       if (
-        (team.teamName
-          && team.teamName.toLowerCase().indexOf(this.state.teamNameSearchText.toLowerCase()) > -1
-          && this.state.wildCardSearchText === '')
+        (team.teamName &&
+          team.teamName.toLowerCase().indexOf(this.state.teamNameSearchText.toLowerCase()) > -1 &&
+          this.state.wildCardSearchText === '') ||
         // the wild card search, the search text can be match with any item
-        || (this.state.wildCardSearchText !== ''
-          && team.teamName.toLowerCase().indexOf(this.state.wildCardSearchText.toLowerCase()) > -1)
+        (this.state.wildCardSearchText !== '' &&
+          team.teamName.toLowerCase().indexOf(this.state.wildCardSearchText.toLowerCase()) > -1)
       ) {
         return team;
       }
@@ -138,28 +138,27 @@ class ReportsPage extends Component {
     return filteredList;
   };
 
-  filteredPeopleList = (userProfiles) => {
-    const filteredList = userProfiles.filter((userProfile) => {
+  filteredPeopleList = userProfiles => {
+    const filteredList = userProfiles.filter(userProfile => {
       // Applying the search filters before creating each team table data element
       if (
-        (userProfile.firstName
-          && userProfile.firstName.toLowerCase().indexOf(this.state.teamNameSearchText.toLowerCase())
-            > -1
-          && this.state.wildCardSearchText === '')
+        (userProfile.firstName &&
+          userProfile.firstName.toLowerCase().indexOf(this.state.teamNameSearchText.toLowerCase()) >
+            -1 &&
+          this.state.wildCardSearchText === '') ||
         // the wild card search, the search text can be match with any item
-        || (this.state.wildCardSearchText !== ''
-          && (userProfile.firstName.toLowerCase().indexOf(this.state.wildCardSearchText.toLowerCase()) > -1
-          )
-        )
-        || (this.state.wildCardSearchText !== ''
-        && userProfile.lastName
-        && (userProfile.lastName.toLowerCase().indexOf(this.state.wildCardSearchText.toLowerCase()) > -1
-        )
-        )
-
+        (this.state.wildCardSearchText !== '' &&
+          userProfile.firstName.toLowerCase().indexOf(this.state.wildCardSearchText.toLowerCase()) >
+            -1) ||
+        (this.state.wildCardSearchText !== '' &&
+          userProfile.lastName &&
+          userProfile.lastName.toLowerCase().indexOf(this.state.wildCardSearchText.toLowerCase()) >
+            -1)
       ) {
-        return (new Date(Date.parse(userProfile.createdDate)) >= this.state.startDate)
-                && (this.state.startDate <= new Date(Date.parse(userProfile?.endDate)) <= (this.state.endDate));
+        return (
+          new Date(Date.parse(userProfile.createdDate)) >= this.state.startDate &&
+          this.state.startDate <= new Date(Date.parse(userProfile?.endDate)) <= this.state.endDate
+        );
       }
       return false;
     });
@@ -168,13 +167,13 @@ class ReportsPage extends Component {
   };
 
   setActive() {
-    this.setState((state) => ({
+    this.setState(state => ({
       checkActive: 'true',
     }));
   }
 
   setAll() {
-    this.setState((state) => ({
+    this.setState(state => ({
       checkActive: '',
     }));
   }
@@ -186,7 +185,7 @@ class ReportsPage extends Component {
   }
 
   showProjectTable() {
-    this.setState((prevState) => ({
+    this.setState(prevState => ({
       showProjects: !prevState.showProjects,
       showPeople: false,
       showTeams: false,
@@ -194,7 +193,7 @@ class ReportsPage extends Component {
   }
 
   showTeamsTable() {
-    this.setState((prevState) => ({
+    this.setState(prevState => ({
       showProjects: false,
       showPeople: false,
       showTeams: !prevState.showTeams,
@@ -202,7 +201,7 @@ class ReportsPage extends Component {
   }
 
   showPeopleTable() {
-    this.setState((prevState) => ({
+    this.setState(prevState => ({
       showProjects: false,
       showPeople: !prevState.showPeople,
       showTeams: false,
@@ -210,7 +209,7 @@ class ReportsPage extends Component {
   }
 
   showTasksTable() {
-    this.setState((prevState) => ({
+    this.setState(prevState => ({
       showProjects: false,
       showPeople: false,
       showTeams: false,
@@ -225,16 +224,16 @@ class ReportsPage extends Component {
     this.state.peopleSearchData = this.filteredPeopleList(userProfiles);
     this.state.projectSearchData = this.filteredProjectList(projects);
     if (this.state.checkActive === 'true') {
-      this.state.teamSearchData = allTeams.filter((team) => team.isActive === true);
-      this.state.projectSearchData = projects.filter((project) => project.isActive === true);
-      this.state.peopleSearchData = userProfiles.filter((user) => user.isActive === true);
+      this.state.teamSearchData = allTeams.filter(team => team.isActive === true);
+      this.state.projectSearchData = projects.filter(project => project.isActive === true);
+      this.state.peopleSearchData = userProfiles.filter(user => user.isActive === true);
       this.state.teamSearchData = this.filteredTeamList(this.state.teamSearchData);
       this.state.peopleSearchData = this.filteredPeopleList(this.state.peopleSearchData);
       this.state.projectSearchData = this.filteredProjectList(this.state.projectSearchData);
     } else if (this.state.checkActive === 'false') {
-      this.state.teamSearchData = allTeams.filter((team) => team.isActive === false);
-      this.state.projectSearchData = projects.filter((project) => project.isActive === false);
-      this.state.peopleSearchData = userProfiles.filter((user) => user.isActive === false);
+      this.state.teamSearchData = allTeams.filter(team => team.isActive === false);
+      this.state.projectSearchData = projects.filter(project => project.isActive === false);
+      this.state.peopleSearchData = userProfiles.filter(user => user.isActive === false);
       this.state.teamSearchData = this.filteredTeamList(this.state.teamSearchData);
       this.state.peopleSearchData = this.filteredPeopleList(this.state.peopleSearchData);
       this.state.projectSearchData = this.filteredProjectList(this.state.projectSearchData);
@@ -243,7 +242,6 @@ class ReportsPage extends Component {
       this.state.peopleSearchData = this.filteredPeopleList(this.state.peopleSearchData);
     }
     return (
-
       <Container fluid className="mb-5 container-component-wrapper">
         <div className="container-component-category">
           <h2 className="mt-3 mb-5">Reports Page</h2>
@@ -251,37 +249,28 @@ class ReportsPage extends Component {
             <p>Select a Category</p>
           </div>
           <div className="category-container">
-            <button className="card-category-item" onClick={this.showProjectTable}>
-              <h3 className="card-category-item-title">
-                {' '}
-                Projects
-              </h3>
-              <h3 className="card-category-item-number">
-                {this.state.projectSearchData.length}
-                {' '}
-              </h3>
+            <button
+              className={`card-category-item ${this.state.showProjects ? 'selected' : ''}`}
+              onClick={this.showProjectTable}
+            >
+              <h3 className="card-category-item-title"> Projects</h3>
+              <h3 className="card-category-item-number">{this.state.projectSearchData.length} </h3>
               <img src={projectsImage} alt="Image that representes the projects" />
             </button>
-            <button className="card-category-item" onClick={this.showPeopleTable}>
-              <h3 className="card-category-item-title">
-                {' '}
-                People
-                {' '}
-              </h3>
-              <h3 className="card-category-item-number">
-                {this.state.peopleSearchData.length}
-              </h3>
+            <button
+              className={`card-category-item ${this.state.showPeople ? 'selected' : ''}`}
+              onClick={this.showPeopleTable}
+            >
+              <h3 className="card-category-item-title"> People </h3>
+              <h3 className="card-category-item-number">{this.state.peopleSearchData.length}</h3>
               <img src={peopleImage} alt="Image that representes the people" />
             </button>
-            <button className="card-category-item" onClick={this.showTeamsTable}>
-              <h3 className="card-category-item-title">
-                {' '}
-                Teams
-                {' '}
-              </h3>
-              <h3 className="card-category-item-number">
-                {this.state.teamSearchData?.length}
-              </h3>
+            <button
+              className={`card-category-item ${this.state.showTeams ? 'selected' : ''}`}
+              onClick={this.showTeamsTable}
+            >
+              <h3 className="card-category-item-title"> Teams </h3>
+              <h3 className="card-category-item-number">{this.state.teamSearchData?.length}</h3>
               <img src={teamsImage} alt="Image that representes the teams" />
             </button>
             {/* <button style={{ margin: '5px' }} exact className="btn btn-info btn-bg mt-3" onClick={this.showProjectTable}>
@@ -345,12 +334,30 @@ class ReportsPage extends Component {
             </div>
             <div className="date-picker-container">
               <td id="task_startDate" className="date-picker-item">
-                <label for="task_startDate" className="date-picker-label"> Start Date</label>
-                <DatePicker selected={this.state.startDate} minDate={new Date('01/01/2010')} maxDate={new Date()} onChange={(date) => this.setState({ startDate: date })} className="form-control" />
+                <label for="task_startDate" className="date-picker-label">
+                  {' '}
+                  Start Date
+                </label>
+                <DatePicker
+                  selected={this.state.startDate}
+                  minDate={new Date('01/01/2010')}
+                  maxDate={new Date()}
+                  onChange={date => this.setState({ startDate: date })}
+                  className="form-control"
+                />
               </td>
               <td id="task_EndDate" className="date-picker-item">
-                <label for="task_EndDate" className="date-picker-label"> End Date</label>
-                <DatePicker selected={this.state.endDate} maxDate={new Date()} minDate={new Date('01/01/2010')} onChange={(date) => this.setState({ endDate: date })} className="form-control" />
+                <label for="task_EndDate" className="date-picker-label">
+                  {' '}
+                  End Date
+                </label>
+                <DatePicker
+                  selected={this.state.endDate}
+                  maxDate={new Date()}
+                  minDate={new Date('01/01/2010')}
+                  onChange={date => this.setState({ endDate: date })}
+                  className="form-control"
+                />
               </td>
             </div>
           </div>
@@ -365,7 +372,7 @@ class ReportsPage extends Component {
   }
 }
 
-const mapStateToProps = (state) => ({ state });
+const mapStateToProps = state => ({ state });
 
 export default connect(mapStateToProps, {
   fetchAllProjects,

--- a/src/components/Reports/TeamTable.jsx
+++ b/src/components/Reports/TeamTable.jsx
@@ -31,19 +31,19 @@ function TeamTable(props) {
     ));
   }
   return (
-    <table className="center">
-      <table className="table table-bordered table-responsive-sm">
-        <thead>
-          <tr>
-            <th scope="col" id="projects__order">#</th>
-            <th scope="col">Team Name</th>
-            <th scope="col" id="projects__active">Active</th>
-          </tr>
-        </thead>
-        <tbody>
-          {TeamsList}
-        </tbody>
-      </table>
+    <table className="table table-bordered table-responsive-sm">
+      <thead>
+        <tr>
+          <th scope="col" id="projects__order">
+            #
+          </th>
+          <th scope="col">Team Name</th>
+          <th scope="col" id="projects__active">
+            Active
+          </th>
+        </tr>
+      </thead>
+      <tbody>{TeamsList}</tbody>
     </table>
   );
 }

--- a/src/components/Reports/reportsPage.css
+++ b/src/components/Reports/reportsPage.css
@@ -4,6 +4,11 @@
   padding: 0;
 }
 
+.category-container > .card-category-item.selected {
+  background-color: #d7cdda;
+  box-shadow: 0px 8px 16px rgba(78, 32, 125, 0.2);
+  transform: scale(1.05);
+}
 .center {
   margin-left: auto;
   margin-right: auto;
@@ -21,7 +26,7 @@
   flex-direction: row;
   justify-content: flex-start;
   align-items: flex-start;
-  background-color: #FAF7FC;
+  background-color: #faf7fc;
 }
 
 .container-component-category {
@@ -40,13 +45,13 @@
   width: 200px;
   padding: 24px;
   border: 0;
-  background-color: #F1EBF7;
+  background-color: #f1ebf7;
   border-radius: 8px;
   cursor: pointer;
 }
 
 .card-category-item:hover {
-  background-color: #F1EBF7;
+  background-color: #f1ebf7;
   box-shadow: 0px 8px 16px rgba(78, 32, 125, 0.2);
   transform: scale(1.05);
 }
@@ -95,36 +100,36 @@
 
 @media screen and (max-width: 1100px) {
   .container-component-wrapper {
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-start;
-      align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
   }
 }
 
 @media screen and (max-width: 700px) {
   .container-component-wrapper {
-      padding: 16px;
+    padding: 16px;
   }
   .container-component-category {
-      width: 100%;
-      display: flex;
-      flex-direction: column;
-      border-radius: 0 0 16px 16px;
-      padding: 16px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    border-radius: 0 0 16px 16px;
+    padding: 16px;
   }
   .card-category-item {
-      width: 180px;
-      padding: 16px;
-      margin: 4px;
+    width: 180px;
+    padding: 16px;
+    margin: 4px;
   }
   .card-category-item img {
-      width: 72px;
-      height: 72px;
+    width: 72px;
+    height: 72px;
   }
   .card-category-item-number {
-      font-size: 24px;
-      font-weight: 700;
-      margin: 8px 0;
+    font-size: 24px;
+    font-weight: 700;
+    margin: 8px 0;
   }
 }

--- a/src/components/Reports/reportsPage.css
+++ b/src/components/Reports/reportsPage.css
@@ -13,6 +13,13 @@
   margin-left: auto;
   margin-right: auto;
 }
+.table-data-container {
+  flex: 1;
+  overflow-x: scroll;
+}
+.table-data-container::-webkit-scrollbar {
+  display: none; /* Hide the scrollbar for WebKit browsers */
+}
 
 .category-container {
   display: flex;
@@ -54,6 +61,10 @@
   background-color: #f1ebf7;
   box-shadow: 0px 8px 16px rgba(78, 32, 125, 0.2);
   transform: scale(1.05);
+}
+
+.card-category-item:focus-visible {
+  outline: none;
 }
 
 .card-category-item img {

--- a/src/components/Reports/reportsPage.css
+++ b/src/components/Reports/reportsPage.css
@@ -4,36 +4,15 @@
   padding: 0;
 }
 
-.category-container > .card-category-item.selected {
-  background-color: #d7cdda;
-  box-shadow: 0px 8px 16px rgba(78, 32, 125, 0.2);
-  transform: scale(1.05);
-}
-.center {
-  margin-left: auto;
-  margin-right: auto;
-}
-.table-data-container {
-  flex: 1;
-  overflow-x: scroll;
-}
-.table-data-container::-webkit-scrollbar {
-  display: none; /* Hide the scrollbar for WebKit browsers */
-}
-
-.category-container {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-}
-
 .container-component-wrapper {
   min-height: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: flex-start;
+  width: 100vw;
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  justify-content: center;
+  align-content: start;
   background-color: #faf7fc;
+  margin: 0px;
 }
 
 .container-component-category {
@@ -42,6 +21,22 @@
   flex-direction: column;
   border-radius: 0 0 16px 16px;
   padding: 32px;
+}
+
+.category-container > .card-category-item.selected {
+  background-color: #d7cdda;
+  box-shadow: 0px 8px 16px rgba(78, 32, 125, 0.2);
+  transform: scale(1.05);
+}
+
+.table-data-container {
+  width: 600px;
+}
+
+.category-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 }
 
 .card-category-item {
@@ -109,12 +104,48 @@
   margin: 8px 0;
 }
 
+@media screen and (max-width: 1350px) {
+  .container-component-wrapper {
+    padding: 16px;
+  }
+
+  .container-component-category {
+    width: 500px;
+    padding: 16px;
+  }
+
+  .card-category-item {
+    width: calc(100% / 3 - 16px);
+    padding: 16px;
+    margin: 4px;
+  }
+  .card-category-item img {
+    width: 72px;
+    height: 72px;
+  }
+  .card-category-item-number {
+    font-size: 24px;
+    font-weight: 700;
+    margin: 8px 0;
+  }
+}
+
 @media screen and (max-width: 1100px) {
   .container-component-wrapper {
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
     align-items: center;
+  }
+  .table-data-container {
+    width: 100%;
+    max-width: 600px;
+  }
+  .table-data-container {
+    overflow-x: scroll;
+  }
+  .table-data-container::-webkit-scrollbar {
+    display: none;
   }
 }
 
@@ -130,7 +161,7 @@
     padding: 16px;
   }
   .card-category-item {
-    width: 180px;
+    width: calc(100% / 3 - 8px);
     padding: 16px;
     margin: 4px;
   }


### PR DESCRIPTION
# Description

 (PRIORITY LOW) Yiyun/Jae: Make reports buttons obvious they are "click to show/click to hide"
    1. When you click on “Projects”, “People” or “Teams”, the right table will disappear after an even number of clicks. We need an outline or shadow or other clear indicator which button is clicked so that it’s also clear that clicking it again will hide the related content.


## Mainly changes explained:
    1. dynamically adding the “selected” class to the report buttons when they’re clicked.
    2. Adjusted the size of the table container to prevent the report buttons from overlapping or stacking on top of each other. 
## How to test:
    1. check into current branch
    2. do `npm run start:local` to run this PR locally
    3. go to Reports > Reports
    4. Click on the report buttons (Projects/People/Teams) to see the style changes.

## Videos of changes:
### Before:


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/49083865/efe02938-43d5-4e66-9dcc-212a2fbad1c4


### After:


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/49083865/43457ed0-8e76-40ee-b549-02998be0e064

