### PR TITLE
Edwin - Removed option for Admins to reset password for Owners

### DIFF
--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -77,7 +77,10 @@ class UserManagement extends React.PureComponent {
             <div className="table-responsive">
               <Table className="table table-bordered noWrap">
                 <thead>
-                  <UserTableHeader />
+                  <UserTableHeader 
+                  authRole={this.props.state.auth.user.role} 
+                  roleSearchText={this.state.roleSearchText}
+                  />
                   <UserTableSearchHeader
                     onFirstNameSearch={this.onFirstNameSearch}
                     onLastNameSearch={this.onLastNameSearch}
@@ -85,6 +88,8 @@ class UserManagement extends React.PureComponent {
                     onEmailSearch={this.onEmailSearch}
                     onWeeklyHrsSearch={this.onWeeklyHrsSearch}
                     roles={roles}
+                    authRole={this.props.state.auth.user.role} 
+                    roleSearchText={this.state.roleSearchText}
                   />
                 </thead>
                 <tbody>{userTable}</tbody>

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -29,7 +29,7 @@ const UserTableData = React.memo(props => {
       props.role,
       'addDeleteEditOwners',
       props.roles,
-      props.userPermissions) ? true : false
+      props.userPermissions)
     )}
      
   return (
@@ -96,6 +96,7 @@ const UserTableData = React.memo(props => {
           : ''}
       </td>
       <td>{props.user.endDate ? props.user.endDate.toLocaleString().split('T')[0] : 'N/A'}</td>
+      {checkPermissionsOnOwner() ? null : (
       <td>
         <span className="usermanagement-actions-cell">
           {checkPermissionsOnOwner() ? null : (
@@ -111,11 +112,10 @@ const UserTableData = React.memo(props => {
           )}
         </span>
         <span className="usermanagement-actions-cell">
-        {checkPermissionsOnOwner() ? null : (
-          <ResetPasswordButton user={props.user} isSmallButton />)
-          } 
+          <ResetPasswordButton user={props.user} isSmallButton />
         </span>
       </td>
+      )}
     </tr>
   );
 });

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -99,7 +99,6 @@ const UserTableData = React.memo(props => {
       {checkPermissionsOnOwner() ? null : (
       <td>
         <span className="usermanagement-actions-cell">
-          {checkPermissionsOnOwner() ? null : (
             <button
               type="button"
               className="btn btn-outline-danger btn-sm"
@@ -109,7 +108,6 @@ const UserTableData = React.memo(props => {
             >
               {DELETE}
             </button>
-          )}
         </span>
         <span className="usermanagement-actions-cell">
           <ResetPasswordButton user={props.user} isSmallButton />

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -24,6 +24,21 @@ const UserTableData = React.memo(props => {
     onReset(false);
   }, [props.isActive, props.resetLoading]);
 
+  const checkPermissionsOnOwner = () => {
+    return (props.user.role === 'Owner' && !hasPermission(
+      props.role,
+      'addDeleteEditOwners',
+      props.roles,
+      props.userPermissions) ? true : false
+    )}
+    
+    props.user.role === 'Owner' &&
+          !hasPermission(
+            props.role,
+            'addDeleteEditOwners',
+            props.roles,
+            props.userPermissions,
+          )
   return (
     <tr className="usermanagement__tr" id={`tr_user_${props.index}`}>
       <td className="usermanagement__active--input">
@@ -90,13 +105,7 @@ const UserTableData = React.memo(props => {
       <td>{props.user.endDate ? props.user.endDate.toLocaleString().split('T')[0] : 'N/A'}</td>
       <td>
         <span className="usermanagement-actions-cell">
-          {props.user.role === 'Owner' &&
-          !hasPermission(
-            props.role,
-            'addDeleteEditOwners',
-            props.roles,
-            props.userPermissions,
-          ) ? null : (
+          {checkPermissionsOnOwner() ? null : (
             <button
               type="button"
               className="btn btn-outline-danger btn-sm"
@@ -109,7 +118,9 @@ const UserTableData = React.memo(props => {
           )}
         </span>
         <span className="usermanagement-actions-cell">
-          <ResetPasswordButton user={props.user} isSmallButton />
+        {checkPermissionsOnOwner() ? null : (
+          <ResetPasswordButton user={props.user} isSmallButton />)
+          } 
         </span>
       </td>
     </tr>

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -31,14 +31,7 @@ const UserTableData = React.memo(props => {
       props.roles,
       props.userPermissions) ? true : false
     )}
-    
-    props.user.role === 'Owner' &&
-          !hasPermission(
-            props.role,
-            'addDeleteEditOwners',
-            props.roles,
-            props.userPermissions,
-          )
+     
   return (
     <tr className="usermanagement__tr" id={`tr_user_${props.index}`}>
       <td className="usermanagement__active--input">

--- a/src/components/UserManagement/UserTableHeader.jsx
+++ b/src/components/UserManagement/UserTableHeader.jsx
@@ -10,6 +10,7 @@ import {
   USER_RESUME_DATE,
   MANAGE_FINAL_DAY,
 } from '../../languages/en/ui';
+import userTableDataPermissions from 'utils/userTableDataPermissions';
 
 /**
  * The header row of the user table.
@@ -47,10 +48,7 @@ const UserTableHeader = React.memo(props => {
       <th scope="col" id="usermanagement_resume_date">
         End Date
       </th>
-      {((
-        props.authRole !=="Owner" && 
-        props.roleSearchText !=="Owner") || 
-        props.authRole =="Owner") && (
+      {userTableDataPermissions(props.authRole, props.roleSearchText) && (
         <th scope="col" id="usermanagement_delete"></th>
       )}
     </tr>

--- a/src/components/UserManagement/UserTableHeader.jsx
+++ b/src/components/UserManagement/UserTableHeader.jsx
@@ -47,7 +47,9 @@ const UserTableHeader = React.memo(props => {
       <th scope="col" id="usermanagement_resume_date">
         End Date
       </th>
-      <th scope="col" id="usermanagement_delete"></th>
+      {props.authRole !=="Owner" && props.roleSearchText !=="Owner" && (
+        <th scope="col" id="usermanagement_delete"></th>
+      )}
     </tr>
   );
 });

--- a/src/components/UserManagement/UserTableHeader.jsx
+++ b/src/components/UserManagement/UserTableHeader.jsx
@@ -47,7 +47,10 @@ const UserTableHeader = React.memo(props => {
       <th scope="col" id="usermanagement_resume_date">
         End Date
       </th>
-      {props.authRole !=="Owner" && props.roleSearchText !=="Owner" && (
+      {((
+        props.authRole !=="Owner" && 
+        props.roleSearchText !=="Owner") || 
+        props.authRole =="Owner") && (
         <th scope="col" id="usermanagement_delete"></th>
       )}
     </tr>

--- a/src/components/UserManagement/UserTableSearchHeader.jsx
+++ b/src/components/UserManagement/UserTableSearchHeader.jsx
@@ -52,9 +52,12 @@ const UserTableSearchHeader = React.memo(props => {
       <td id="user_finalDay"></td>
       <td id="user_resume_date"></td>
       <td id="user_end_date"></td>
-      {props.authRole !=="Owner" && props.roleSearchText !=="Owner" && (
+      {((
+        props.authRole !=="Owner" && 
+        props.roleSearchText !=="Owner") || 
+        props.authRole =="Owner") && (
         <td id="user__delete"></td>
-      )}
+      )}  
     </tr>
   );
 });

--- a/src/components/UserManagement/UserTableSearchHeader.jsx
+++ b/src/components/UserManagement/UserTableSearchHeader.jsx
@@ -52,7 +52,9 @@ const UserTableSearchHeader = React.memo(props => {
       <td id="user_finalDay"></td>
       <td id="user_resume_date"></td>
       <td id="user_end_date"></td>
-      <td id="user__delete"></td>
+      {props.authRole !=="Owner" && props.roleSearchText !=="Owner" && (
+        <td id="user__delete"></td>
+      )}
     </tr>
   );
 });

--- a/src/components/UserManagement/UserTableSearchHeader.jsx
+++ b/src/components/UserManagement/UserTableSearchHeader.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import TextSearchBox from './TextSearchBox';
 import DropDownSearchBox from './DropDownSearchBox';
+import userTableDataPermissions from 'utils/userTableDataPermissions';
 
 /**
  * The header row of the user table.
@@ -52,10 +53,7 @@ const UserTableSearchHeader = React.memo(props => {
       <td id="user_finalDay"></td>
       <td id="user_resume_date"></td>
       <td id="user_end_date"></td>
-      {((
-        props.authRole !=="Owner" && 
-        props.roleSearchText !=="Owner") || 
-        props.authRole =="Owner") && (
+      {userTableDataPermissions(props.authRole, props.roleSearchText) && (
         <td id="user__delete"></td>
       )}  
     </tr>

--- a/src/utils/userTableDataPermissions.js
+++ b/src/utils/userTableDataPermissions.js
@@ -1,7 +1,9 @@
 const userTableDataPermissions = (authRole, roleSearchText) => {
-   return ((authRole !== "Owner" && 
+   return ((
+    authRole !== "Owner" && 
     roleSearchText !== "Owner") || 
-    authRole === "Owner")
+    authRole === "Owner"
+    )
 }
 
 export default userTableDataPermissions;

--- a/src/utils/userTableDataPermissions.js
+++ b/src/utils/userTableDataPermissions.js
@@ -1,0 +1,7 @@
+const userTableDataPermissions = (authRole, roleSearchText) => {
+   return ((authRole !== "Owner" && 
+    roleSearchText !== "Owner") || 
+    authRole === "Owner")
+}
+
+export default userTableDataPermissions;


### PR DESCRIPTION
# Description

<img width="559" alt="Screen Shot 2023-05-22 at 7 42 14 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/d708fd40-afba-44a9-a406-e2fc08bd8ef7">

## Mainly changes explained:
    1. Created a function to check permissions on owner user accounts to avoid duplicate code. 
    2. Added a conditional to check if the current user role has the correct permissions on owner user accounts. If it does, render the "reset password" button, if not don't. 
 
## How to test:
    1. check into current branch
    2. do `npm run start:local` to run this PR locally
    4. Login an admin account
    5. go to Other Links -> User Management
    6. Check that there is no "reset password" button for all owner accounts. 

## Videos of changes:
### Before:

Admin Account: 
<img width="1671" alt="Screen Shot 2023-05-22 at 7 49 12 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/1b940065-9568-4c79-b6b7-ec9992da5d73">

### After:

Admin Account:
<img width="1669" alt="Screen Shot 2023-05-22 at 7 47 40 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/82a85065-bd2e-4942-95f9-4eeb1559c772">

Owner Account: 
<img width="1675" alt="Screen Shot 2023-05-23 at 10 49 28 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/36419d98-51fa-4e17-a786-83f01b9ff236">