### PR TITLE
Bada - Bk/reports page datepicker bug fix

### DIFF
--- a/src/components/Reports/Reports.jsx
+++ b/src/components/Reports/Reports.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Image } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
 import { Container } from 'reactstrap';
@@ -11,9 +11,6 @@ import ProjectTable from './ProjectTable';
 import { getAllUserProfile } from '../../actions/userManagement';
 import { fetchAllTasks } from '../../actions/task';
 import ReportTableSearchPanel from './ReportTableSearchPanel';
-import { getUserProfile, getUserTask } from '../../actions/userProfile';
-import httpService from '../../services/httpService';
-import { ENDPOINTS } from '../../utils/URL';
 import 'react-datepicker/dist/react-datepicker.css';
 import './reportsPage.css';
 import projectsImage from './images/Projects.svg';

--- a/src/components/Reports/Reports.jsx
+++ b/src/components/Reports/Reports.jsx
@@ -20,6 +20,8 @@ import projectsImage from './images/Projects.svg';
 import peopleImage from './images/People.svg';
 import teamsImage from './images/Teams.svg';
 
+const DATE_PICKER_MIN_DATE = '01/01/2010';
+
 class ReportsPage extends Component {
   constructor(props) {
     super(props);
@@ -66,7 +68,7 @@ class ReportsPage extends Component {
       peopleSearchData: [],
       projectSearchData: {},
       users: {},
-      startDate: new Date('01-01-2010'),
+      startDate: new Date(DATE_PICKER_MIN_DATE),
       endDate: new Date(),
     };
     this.showProjectTable = this.showProjectTable.bind(this);
@@ -340,7 +342,7 @@ class ReportsPage extends Component {
                 </label>
                 <DatePicker
                   selected={this.state.startDate}
-                  minDate={new Date('01/01/2010')}
+                  minDate={new Date(DATE_PICKER_MIN_DATE)}
                   maxDate={new Date()}
                   onChange={date => this.setState({ startDate: date })}
                   className="form-control"
@@ -354,7 +356,7 @@ class ReportsPage extends Component {
                 <DatePicker
                   selected={this.state.endDate}
                   maxDate={new Date()}
-                  minDate={new Date('01/01/2010')}
+                  minDate={new Date(DATE_PICKER_MIN_DATE)}
                   onChange={date => this.setState({ endDate: date })}
                   className="form-control"
                 />


### PR DESCRIPTION
Visiting the Reports page using Safari and Firefox crashes, but is ok using Chrome.

In Safari and Firefox, passing `'01-01-2010'` to `Date` like `new Date('01-01-2010')` outputs the string `'Invalid Date'`.
The invalid date string was being passed to the `DatePicker` component, crashing the page.

In Chrome, that outputs 2010 January 1st.
Passing `'01/01/2010'` works for all three browsers.

This PR also removes a few unused imports.