### PR TITLE
Bada - filter members for only active

### DIFF
--- a/src/components/Projects/Members/Members.jsx
+++ b/src/components/Projects/Members/Members.jsx
@@ -35,6 +35,8 @@ const Members = props => {
     });
   };
 
+  const activeMembers = props.state.projectMembers.members.filter(member => member.isActive === true);
+
   return (
     <React.Fragment>
       <div className="container">
@@ -129,7 +131,7 @@ const Members = props => {
             </tr>
           </thead>
           <tbody>
-            {props.state.projectMembers.members.map((member, i) => (
+            {activeMembers.map((member, i) => (
               <Member
                 index={i}
                 key={member._id}

--- a/src/components/Projects/Members/Members.jsx
+++ b/src/components/Projects/Members/Members.jsx
@@ -35,7 +35,42 @@ const Members = props => {
     });
   };
 
-  const activeMembers = props.state.projectMembers.members.filter(member => member.isActive === true);
+  const activeMembers = [];
+  const inactiveMembers = [];
+  props.state.projectMembers.members.forEach((member) => {
+    if (member.isActive) {
+      activeMembers.push(member);
+    } else {
+      inactiveMembers.push(member);
+    }
+  })
+
+  const renderMembersTable = (tableTitle, members) => (
+    <table className="table table-bordered table-responsive-sm">
+      <thead>
+        <tr>
+          <th scope="col" id="members__order">
+            #
+          </th>
+          <th scope="col" id="members__name">{tableTitle}</th>
+          {hasPermission(role, 'unassignUserInProject', roles, userPermissions) ? (
+            <th scope="col" id="members__name"></th>
+          ) : null}
+        </tr>
+      </thead>
+      <tbody>
+        {members.map((member, i) => (
+          <Member
+            index={i}
+            key={member._id}
+            projectId={projectId}
+            uid={member._id}
+            fullName={member.firstName + ' ' + member.lastName}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
 
   return (
     <React.Fragment>
@@ -117,31 +152,8 @@ const Members = props => {
             </tbody>
           </table>
         )}
-
-        <table className="table table-bordered table-responsive-sm">
-          <thead>
-            <tr>
-              <th scope="col" id="members__order">
-                #
-              </th>
-              <th scope="col" id="members__name"></th>
-              {hasPermission(role, 'unassignUserInProject', roles, userPermissions) ? (
-                <th scope="col" id="members__name"></th>
-              ) : null}
-            </tr>
-          </thead>
-          <tbody>
-            {activeMembers.map((member, i) => (
-              <Member
-                index={i}
-                key={member._id}
-                projectId={projectId}
-                uid={member._id}
-                fullName={member.firstName + ' ' + member.lastName}
-              />
-            ))}
-          </tbody>
-        </table>
+        {activeMembers.length > 0 ? renderMembersTable('Active Members', activeMembers) : null}
+        {inactiveMembers.length > 0 ? renderMembersTable('Inactive Members', inactiveMembers) : null}
       </div>
     </React.Fragment>
   );

--- a/src/components/Projects/Members/Members.jsx
+++ b/src/components/Projects/Members/Members.jsx
@@ -35,16 +35,6 @@ const Members = props => {
     });
   };
 
-  const activeMembers = [];
-  const inactiveMembers = [];
-  props.state.projectMembers.members.forEach((member) => {
-    if (member.isActive) {
-      activeMembers.push(member);
-    } else {
-      inactiveMembers.push(member);
-    }
-  })
-
   const renderMembersTable = (tableTitle, members) => (
     <table className="table table-bordered table-responsive-sm">
       <thead>
@@ -71,6 +61,18 @@ const Members = props => {
       </tbody>
     </table>
   );
+
+  const activeMembers = [];
+  const inactiveMembers = [];
+  props.state.projectMembers.members.forEach((member) => {
+    if (member.isActive) {
+      activeMembers.push(member);
+    } else {
+      inactiveMembers.push(member);
+    }
+  })
+  const activeMembersTable = activeMembers.length > 0 ? renderMembersTable('Active Members', activeMembers) : null;
+  const inactiveMembersTable = inactiveMembers.length > 0 ? renderMembersTable('Inactive Members', inactiveMembers) : null;
 
   return (
     <React.Fragment>
@@ -152,8 +154,8 @@ const Members = props => {
             </tbody>
           </table>
         )}
-        {activeMembers.length > 0 ? renderMembersTable('Active Members', activeMembers) : null}
-        {inactiveMembers.length > 0 ? renderMembersTable('Inactive Members', inactiveMembers) : null}
+        {activeMembersTable}
+        {inactiveMembersTable}
       </div>
     </React.Fragment>
   );

--- a/src/components/Projects/Members/Members.jsx
+++ b/src/components/Projects/Members/Members.jsx
@@ -24,6 +24,8 @@ const Members = props => {
   const projectId = props.match.params.projectId;
   const { roles } = props.state.role;
 
+  const projectName = props.state?.allProjects?.projects?.filter((project) => project?._id === projectId)?.[0]?.projectName ?? `Project #${projectId}`;
+
   useEffect(() => {
     props.fetchAllMembers(projectId);
   }, [projectId]);
@@ -88,6 +90,7 @@ const Members = props => {
             <div id="member_project__name">PROJECTS {props.projectId}</div>
           </ol>
         </nav>
+        <h3>{projectName}</h3>
         {hasPermission(role, 'findUserInProject', roles, userPermissions) ? (
           <div className="input-group" id="new_project">
             <div className="input-group-prepend">


### PR DESCRIPTION
Needs the [BE PR #363](https://github.com/OneCommunityGlobal/HGNRest/pull/363).


1) Display the active and inactive members separately on the project members page.
2) Display the project name.


To test,`/project/members/614f683cbef0d303a9a75e07` for example has 12 members total and with one inactive.


| | |
| -- | -- |
| 1. Go to Other Links -> Projects | ![Screenshot 2023-05-26 at 19 51 55](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/e2be5e96-cbe4-4b35-afff-19e05dccfe2c) |
| 2. Find project 8 "Badge Testing Energy" and click the members icon. | ![Screenshot 2023-05-26 at 19 52 18](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/4f7c4eac-b669-4888-9225-a1e5ee3f4ec0) |
| 3. Check with the development branch and verify 12 members. | ![Screenshot 2023-05-26 at 19 54 17](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/cf0cb5eb-0a26-495f-ad86-84077d8eb57c) |
| 4. Check with both the FE and [BE](https://github.com/OneCommunityGlobal/HGNRest/pull/363) features branches and verify 11 active members and 1 inactive member (LucileTest Admin) | ![Screenshot 2023-05-28 at 20 22 12](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/b237cfad-babf-4290-a677-3bf7ee9b9816) |
| 5. A project with only active members (for example project 1 ".wbs bug") does not show the inactive members table | ![Screenshot 2023-05-28 at 20 24 09](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/6d396c93-0691-4e16-bb22-a9cf8423b432) ![Screenshot 2023-05-28 at 20 21 41](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/cbf79901-0d27-4b75-abe4-743535b57ec1) |
| 6. Verify the the project name shows: | ![Screenshot 2023-05-30 at 17 13 24](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/1325c735-f7f4-4d1f-bfd1-efb4b8fd0eaf) |