### PR TITLE
Fix Other override for WBS Task

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -546,6 +546,7 @@ const EditTaskModal = props => {
                     <option value="Soceity">Society</option>
                     <option value="Economics">Economics</option>
                     <option value="Stewardship">Stewardship</option>
+                    <option value="Other">Other</option>
                     <option value="Not Assigned">Not Assigned</option>
                   </select>
                 </td>


### PR DESCRIPTION
### Description
This PR fixes up the frontend for WBS bug category not displaying correctly for task.

In the Edit Task Modal the Category was not displaying correctly for projects with category Other.

### Mainly changes explained:
Added the option Other for the EditModal for the task.

### How to test:
Check into the current branch for frontend
Do `npm install` and `... ` to run this PR locally
Log as owner user
Add new task for project with Other category, check if the Edit Modal displays correct category

### Screenshots
Before:
<img width="1440" alt="Screen Shot 2023-05-26 at 3 36 47 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/29037428/709680df-9bbe-4a42-bfc3-cdc34747be0b">

After:
<img width="1440" alt="Screen Shot 2023-05-26 at 3 36 33 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/29037428/8bafa591-094c-4c20-9199-8a5cde4f367f">
