### PR TITLE
only admin can edit bio in weekly summaries report

### DIFF
--- a/src/components/PermissionsManagement/UserRoleTab.jsx
+++ b/src/components/PermissionsManagement/UserRoleTab.jsx
@@ -48,6 +48,7 @@ export const permissionLabel = {
   assignOnlyBlueSquares: 'Only Assign Blue Squares',
   seePermissionsManagement: 'See Permissions Management Tab',
   submitWeeklySummaryForOthers: 'Submit Weekly Summary For Others',
+  editBioAnnoucementStatus: 'Edit Bio Annoucement Status: Posted or Requested',
 };
 
 const UserRoleTab = props => {

--- a/src/components/PermissionsManagement/UserRoleTab.jsx
+++ b/src/components/PermissionsManagement/UserRoleTab.jsx
@@ -48,7 +48,6 @@ export const permissionLabel = {
   assignOnlyBlueSquares: 'Only Assign Blue Squares',
   seePermissionsManagement: 'See Permissions Management Tab',
   submitWeeklySummaryForOthers: 'Submit Weekly Summary For Others',
-  editBioAnnoucementStatus: 'Edit Bio Annoucement Status: Posted or Requested',
 };
 
 const UserRoleTab = props => {

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -154,68 +154,39 @@ const FormattedReport = ({ summaries, weekIndex, role }) => {
     }
   };
 
-  //These two similar but different(toggle switch onclick action) functions below are to wrap 
-  //up the actions that makes the content for each user's summary. Depending on whether the user
-  //has the permission, one of the two will be called in the map function.
-  //Checking the role once should be better than checking inside the map loop.
-  const summaryCardCanChange = (summary, index) => {
-    const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
-    const googleDocLink = getGoogleDocLink(summary);
-    const [isBioPosted, setIsBioPosted] = useState(summary.bioPosted);
+  const bioSwitch = (userId, bioPosted) => {
+    const [isBioPosted, setIsBioPosted] = useState(bioPosted);
     return (
-      <div
-        style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
-        key={'summary-' + index}
-      >
-        <div>
-          <b>Name: </b>
-          <Link to={`/userProfile/${summary._id}`} title="View Profile">
-            {summary.firstName} {summary.lastName}
-          </Link>
-
-          <span onClick={() => handleGoogleDocClick(googleDocLink)}>
-            <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
-          </span>
+      <div>
+        <div className="bio-toggle">
+          <b>Bio announcement:</b>
         </div>
-        <div>
-          {' '}
-          <b>Media URL:</b> {getMediaUrlLink(summary)}
+        <div className="bio-toggle">
+          <ToggleSwitch
+            switchType="bio"
+            state={isBioPosted ? false : true}
+            handleUserProfile={() => {
+              handleChangeBioPosted(userId, isBioPosted);
+              setIsBioPosted(!isBioPosted);
+            }}
+          />
         </div>
-        <div>
-          <div className="bio-toggle">
-            <b>Bio announcement:</b>
-          </div>
-          <div className="bio-toggle">
-            <ToggleSwitch
-              switchType="bio"
-              state={isBioPosted ? false : true}
-              handleUserProfile={() => {
-                handleChangeBioPosted(summary._id, isBioPosted);
-                setIsBioPosted(!isBioPosted);
-              }}
-            />
-          </div>
-        </div>
-        {getTotalValidWeeklySummaries(summary)}
-        {hoursLogged >= summary.weeklycommittedHours && (
-          <p>
-            <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
-          </p>
-        )}
-        {hoursLogged < summary.weeklycommittedHours && (
-          <p style={{ color: 'red' }}>
-            <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
-          </p>
-        )}
-        {getWeeklySummaryMessage(summary)}
       </div>
     );
   };
 
-  const summaryCardNoChange = (summary, index) => {
+  const bioLabel = (userId, bioPosted) => {
+    return (
+      <div>
+        <b>Bio announcement:</b>
+        {bioPosted ? ' Posted' : ' Requested'}
+      </div>
+    );
+  };
+
+  const summaryCard = (summary, index, bioFunction) => {
     const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
     const googleDocLink = getGoogleDocLink(summary);
-    const [isBioPosted, setIsBioPosted] = useState(summary.bioPosted);
     return (
       <div
         style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
@@ -235,20 +206,7 @@ const FormattedReport = ({ summaries, weekIndex, role }) => {
           {' '}
           <b>Media URL:</b> {getMediaUrlLink(summary)}
         </div>
-        <div>
-          <div className="bio-toggle">
-            <b>Bio announcement:</b>
-          </div>
-          <div className="bio-toggle">
-            <ToggleSwitch
-              switchType="bio"
-              state={isBioPosted ? false : true}
-              handleUserProfile={() => {
-                toast.error('You have not be authethrized to change the bio annoucement status.');
-              }}
-            />
-          </div>
-        </div>
+        {bioFunction(summary._id, summary.bioPosted)}
         {getTotalValidWeeklySummaries(summary)}
         {hoursLogged >= summary.weeklycommittedHours && (
           <p>
@@ -269,10 +227,10 @@ const FormattedReport = ({ summaries, weekIndex, role }) => {
     <>
       {bioCanEdit
         ? alphabetize(summaries).map((summary, index) => {
-            return summaryCardCanChange(summary, index);
+            return summaryCard(summary, index, bioSwitch);
           })
         : alphabetize(summaries).map((summary, index) => {
-            return summaryCardNoChange(summary, index);
+            return summaryCard(summary, index, bioLabel);
           })}
       <h4>Emails</h4>
       <p>{emailString}</p>

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -12,8 +12,9 @@ import axios from 'axios';
 import { ENDPOINTS } from '../../utils/URL';
 import { useState } from 'react';
 
-const FormattedReport = ({ summaries, weekIndex, editPermission }) => {
+const FormattedReport = ({ summaries, weekIndex, role }) => {
   const emails = [];
+  const bioCanEdit = role === 'Owner' || role === 'Administrator';
 
   summaries.forEach(summary => {
     if (summary.email !== undefined && summary.email !== null) {
@@ -224,7 +225,7 @@ const FormattedReport = ({ summaries, weekIndex, editPermission }) => {
 
   return (
     <>
-      {editPermission
+      {bioCanEdit
         ? alphabetize(summaries).map((summary, index) => {
             return summaryCard(summary, index, bioSwitch);
           })

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -12,9 +12,8 @@ import axios from 'axios';
 import { ENDPOINTS } from '../../utils/URL';
 import { useState } from 'react';
 
-const FormattedReport = ({ summaries, weekIndex, role }) => {
+const FormattedReport = ({ summaries, weekIndex, editPermission }) => {
   const emails = [];
-  const bioCanEdit = role === 'Owner' || role === 'Administrator';
 
   summaries.forEach(summary => {
     if (summary.email !== undefined && summary.email !== null) {
@@ -225,7 +224,7 @@ const FormattedReport = ({ summaries, weekIndex, role }) => {
 
   return (
     <>
-      {bioCanEdit
+      {editPermission
         ? alphabetize(summaries).map((summary, index) => {
             return summaryCard(summary, index, bioSwitch);
           })

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -184,7 +184,7 @@ const FormattedReport = ({ summaries, weekIndex, role }) => {
     );
   };
 
-  const summaryCard = (summary, index, bioFunction) => {
+  const summaryCard = (summary, index) => {
     const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
     const googleDocLink = getGoogleDocLink(summary);
     return (
@@ -223,15 +223,13 @@ const FormattedReport = ({ summaries, weekIndex, role }) => {
     );
   };
 
+  const bioFunction = bioCanEdit ? bioSwitch : bioLabel;
+
   return (
     <>
-      {bioCanEdit
-        ? alphabetize(summaries).map((summary, index) => {
-            return summaryCard(summary, index, bioSwitch);
-          })
-        : alphabetize(summaries).map((summary, index) => {
-            return summaryCard(summary, index, bioLabel);
-          })}
+      {alphabetize(summaries).map((summary, index) => {
+        return summaryCard(summary, index);
+      })}
       <h4>Emails</h4>
       <p>{emailString}</p>
     </>

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -18,7 +18,6 @@ export class WeeklySummariesReport extends Component {
     loading: true,
     summaries: [],
     activeTab: '1',
-    role: null,
   };
 
   async componentDidMount() {
@@ -27,7 +26,6 @@ export class WeeklySummariesReport extends Component {
       error: this.props.error,
       loading: this.props.loading,
       summaries: this.props.summaries,
-      role: this.props.authRole,
     });
   }
 
@@ -52,7 +50,8 @@ export class WeeklySummariesReport extends Component {
   };
 
   render() {
-    const { error, loading, summaries, activeTab, role } = this.state;
+    const { error, loading, summaries, activeTab } = this.state;
+    const role = this.props.authRole;
 
     if (error) {
       return (

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -239,6 +239,8 @@ WeeklySummariesReport.propTypes = {
   getWeeklySummariesReport: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
   summaries: PropTypes.array.isRequired,
+  auth: PropTypes.object.isRequired,
+  roles: PropTypes.array.isRequired,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -11,6 +11,7 @@ import Loading from '../common/Loading';
 import { getWeeklySummariesReport } from '../../actions/weeklySummariesReport';
 import FormattedReport from './FormattedReport';
 import GeneratePdfReport from './GeneratePdfReport';
+import hasPermission from '../../utils/permissions';
 
 export class WeeklySummariesReport extends Component {
   state = {
@@ -18,7 +19,8 @@ export class WeeklySummariesReport extends Component {
     loading: true,
     summaries: [],
     activeTab: '1',
-    role: null,
+    auth: [],
+    roles: [],
   };
 
   async componentDidMount() {
@@ -27,7 +29,8 @@ export class WeeklySummariesReport extends Component {
       error: this.props.error,
       loading: this.props.loading,
       summaries: this.props.summaries,
-      role: this.props.authRole,
+      auth: this.props.auth,
+      roles: this.props.roles,
     });
   }
 
@@ -52,7 +55,10 @@ export class WeeklySummariesReport extends Component {
   };
 
   render() {
-    const { error, loading, summaries, activeTab, role } = this.state;
+    const { error, loading, summaries, activeTab, auth, roles } = this.state;
+    const authRole = auth.user ? auth.user.role : '';
+    const authPermissions = auth.user ? auth.user.permissions?.frontPermissions : [];
+    const bioCanEdit = hasPermission(authRole, 'editBioAnnoucementStatus', roles, authPermissions);
 
     if (error) {
       return (
@@ -140,7 +146,11 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={0} role={role} />
+                    <FormattedReport
+                      summaries={summaries}
+                      weekIndex={0}
+                      editPermission={bioCanEdit}
+                    />
                   </Col>
                 </Row>
               </TabPane>
@@ -160,7 +170,11 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={1} role={role} />
+                    <FormattedReport
+                      summaries={summaries}
+                      weekIndex={1}
+                      editPermission={bioCanEdit}
+                    />
                   </Col>
                 </Row>
               </TabPane>
@@ -180,7 +194,11 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={2} role={role} />
+                    <FormattedReport
+                      summaries={summaries}
+                      weekIndex={2}
+                      editPermission={bioCanEdit}
+                    />
                   </Col>
                 </Row>
               </TabPane>
@@ -200,7 +218,11 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={3} role={role} />
+                    <FormattedReport
+                      summaries={summaries}
+                      weekIndex={3}
+                      editPermission={bioCanEdit}
+                    />
                   </Col>
                 </Row>
               </TabPane>
@@ -217,11 +239,13 @@ WeeklySummariesReport.propTypes = {
   getWeeklySummariesReport: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
   summaries: PropTypes.array.isRequired,
-  authRole: PropTypes.string.isRequired,
+  auth: PropTypes.object.isRequired,
+  roles: PropTypes.array.isRequired,
 };
 
 const mapStateToProps = state => ({
-  authRole: state.auth.user.role,
+  auth: state.auth,
+  roles: state.role.roles,
   error: state.weeklySummariesReport.error,
   loading: state.weeklySummariesReport.loading,
   summaries: state.weeklySummariesReport.summaries,

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -11,7 +11,6 @@ import Loading from '../common/Loading';
 import { getWeeklySummariesReport } from '../../actions/weeklySummariesReport';
 import FormattedReport from './FormattedReport';
 import GeneratePdfReport from './GeneratePdfReport';
-import hasPermission from '../../utils/permissions';
 
 export class WeeklySummariesReport extends Component {
   state = {
@@ -19,8 +18,7 @@ export class WeeklySummariesReport extends Component {
     loading: true,
     summaries: [],
     activeTab: '1',
-    auth: [],
-    roles: [],
+    role: null,
   };
 
   async componentDidMount() {
@@ -29,8 +27,7 @@ export class WeeklySummariesReport extends Component {
       error: this.props.error,
       loading: this.props.loading,
       summaries: this.props.summaries,
-      auth: this.props.auth,
-      roles: this.props.roles,
+      role: this.props.authRole,
     });
   }
 
@@ -55,10 +52,7 @@ export class WeeklySummariesReport extends Component {
   };
 
   render() {
-    const { error, loading, summaries, activeTab, auth, roles } = this.state;
-    const authRole = auth.user ? auth.user.role : '';
-    const authPermissions = auth.user ? auth.user.permissions?.frontPermissions : [];
-    const bioCanEdit = hasPermission(authRole, 'editBioAnnoucementStatus', roles, authPermissions);
+    const { error, loading, summaries, activeTab, role } = this.state;
 
     if (error) {
       return (
@@ -146,11 +140,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport
-                      summaries={summaries}
-                      weekIndex={0}
-                      editPermission={bioCanEdit}
-                    />
+                    <FormattedReport summaries={summaries} weekIndex={0} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -170,11 +160,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport
-                      summaries={summaries}
-                      weekIndex={1}
-                      editPermission={bioCanEdit}
-                    />
+                    <FormattedReport summaries={summaries} weekIndex={1} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -194,11 +180,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport
-                      summaries={summaries}
-                      weekIndex={2}
-                      editPermission={bioCanEdit}
-                    />
+                    <FormattedReport summaries={summaries} weekIndex={2} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -218,11 +200,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport
-                      summaries={summaries}
-                      weekIndex={3}
-                      editPermission={bioCanEdit}
-                    />
+                    <FormattedReport summaries={summaries} weekIndex={3} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -239,13 +217,11 @@ WeeklySummariesReport.propTypes = {
   getWeeklySummariesReport: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
   summaries: PropTypes.array.isRequired,
-  auth: PropTypes.object.isRequired,
-  roles: PropTypes.array.isRequired,
+  authRole: PropTypes.string.isRequired,
 };
 
 const mapStateToProps = state => ({
-  auth: state.auth,
-  roles: state.role.roles,
+  authRole: state.auth.user.role,
   error: state.weeklySummariesReport.error,
   loading: state.weeklySummariesReport.loading,
   summaries: state.weeklySummariesReport.summaries,

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -239,8 +239,6 @@ WeeklySummariesReport.propTypes = {
   getWeeklySummariesReport: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
   summaries: PropTypes.array.isRequired,
-  auth: PropTypes.object.isRequired,
-  roles: PropTypes.array.isRequired,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -18,6 +18,7 @@ export class WeeklySummariesReport extends Component {
     loading: true,
     summaries: [],
     activeTab: '1',
+    role: null,
   };
 
   async componentDidMount() {
@@ -26,6 +27,7 @@ export class WeeklySummariesReport extends Component {
       error: this.props.error,
       loading: this.props.loading,
       summaries: this.props.summaries,
+      role: this.props.authRole,
     });
   }
 
@@ -50,7 +52,7 @@ export class WeeklySummariesReport extends Component {
   };
 
   render() {
-    const { error, loading, summaries, activeTab } = this.state;
+    const { error, loading, summaries, activeTab, role } = this.state;
 
     if (error) {
       return (
@@ -138,7 +140,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={0} />
+                    <FormattedReport summaries={summaries} weekIndex={0} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -158,7 +160,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={1} />
+                    <FormattedReport summaries={summaries} weekIndex={1} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -178,7 +180,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={2} />
+                    <FormattedReport summaries={summaries} weekIndex={2} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -198,7 +200,7 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={3} />
+                    <FormattedReport summaries={summaries} weekIndex={3} role={role} />
                   </Col>
                 </Row>
               </TabPane>
@@ -217,10 +219,11 @@ WeeklySummariesReport.propTypes = {
   summaries: PropTypes.array.isRequired,
 };
 
-const mapStateToProps = ({ weeklySummariesReport }) => ({
-  error: weeklySummariesReport.error,
-  loading: weeklySummariesReport.loading,
-  summaries: weeklySummariesReport.summaries,
+const mapStateToProps = state => ({
+  authRole: state.auth.user.role,
+  error: state.weeklySummariesReport.error,
+  loading: state.weeklySummariesReport.loading,
+  summaries: state.weeklySummariesReport.summaries,
 });
 
 export default connect(mapStateToProps, { getWeeklySummariesReport })(WeeklySummariesReport);

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -217,6 +217,7 @@ WeeklySummariesReport.propTypes = {
   getWeeklySummariesReport: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
   summaries: PropTypes.array.isRequired,
+  authRole: PropTypes.string.isRequired,
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
### Description
We expect only the admin/owner can edit the bio announcement posted status in the weekly summary report page. Other roles who can go to this page can see the status but cannot change it (now anyone who can see the summary report page can change it). 

### Mainly changes explained:
1.Pass the authorized role as the props to the component `FormattdReport` from `weeklySummariesReport`.
2.Check the role once and render different content (can edit the bio announcement or not. The screenshot below shows if a user can view but not edit it.)
<img width="1060" alt="img" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/9c46efb5-9016-4822-aa5e-102de747ef5b">


### How to test:
Log in as admin/owner-->weekly summary report page-->click the toggle switch of any user to change their bio status
Log in as other roles with access to weekly summary report page (for example, manager)-->only show the label but no switch.