### PR TITLE
Jinchao add icon to invisible users on leaderboard

### DIFF
--- a/src/components/LeaderBoard/LeaderBoard.container.jsx
+++ b/src/components/LeaderBoard/LeaderBoard.container.jsx
@@ -32,6 +32,7 @@ const mapStateToProps = state => {
       element.barcolor = getcolor(element.totaltangibletime_hrs);
       element.barprogress = getProgressValue(element.totaltangibletime_hrs, 40);
       element.totaltime = round(element.totaltime_hrs, 2);
+      element.isVisible = element.role === 'Volunteer' || element.isVisible;
 
       return element;
     });

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -33,6 +33,7 @@ const LeaderBoard = ({
   asUser,
 }) => {
   const userId = asUser ? asUser : loggedInUser.userId;
+  const isAdmin = ['Owner', 'Administrator', 'Core Team'].includes(loggedInUser.role);
 
   useDeepEffect(() => {
     getLeaderboardData(userId);
@@ -279,6 +280,8 @@ const LeaderBoard = ({
                   <Link to={`/userprofile/${item.personId}`} title="View Profile">
                     {item.name}
                   </Link>
+                  &nbsp;&nbsp;&nbsp;
+                  {isAdmin && !item.isVisible && <i className="fa fa-eye-slash" title="User is invisible"></i>}
                 </th>
                 <td className="align-middle" id={`id${item.personId}`}>
                   <span title="Tangible time">{item.tangibletime}</span>


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/f8452127-6d13-4df5-8151-d551cbc7d19f)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/b099de49-2bca-45c1-a1ca-d1ce90fe200e)
This PR added an [icon](https://fontawesome.com/v4/icon/eye-slash) to invisible users on leaderboard for admin users
Please test with BE PR: [365](https://github.com/OneCommunityGlobal/HGNRest/pull/365)
## Main changes explained:
Added `isVisible` field to `leaderBoardData` in leaderboard container.
Added `isAdmin` to only allow Owner/Admin/CT to see the icon.
## How to test

- Checkout the branch at both FE and BE, make sure to rebuild and restart the BE.

- Log in as Owner/Admin/CT users to check if there are icons after invisible users in leaderboard

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/f06cb0ec-042a-4ee8-b18f-f9c31ba10d7b)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/dd4510f4-2887-4590-b71d-0a84e1bc4e66)

- Log in as Manager/Mentor/Volunteer to make sure there is no icon. (Manager and mentor will be able to see themselves when they set their visibility to invisible while there should be no icon after their name)

## Note
If you are not familiar with the 'Visibility' feature, please refer to #804 and #731 