### PR TITLE
Edwin - Finished stars for additional hour eidts and slight changes for the s…

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -4,6 +4,7 @@ import { isEqual } from 'lodash';
 import { Link } from 'react-router-dom';
 import { Table, Progress, Modal, ModalBody, ModalFooter, ModalHeader, Button } from 'reactstrap';
 import Alert from 'reactstrap/lib/Alert';
+import hasLeaderboardPermissions from 'utils/leaderboardPermissions';
 
 function useDeepEffect(effectFunc, deps) {
   const isFirst = useRef(true);
@@ -220,7 +221,7 @@ const LeaderBoard = ({
                       borderRadius: 7.5,
                       margin: 'auto',
                     }}
-                  />
+                  />  
                 </Link>
               </td>
               <th scope="row">{organizationData.name}</th>
@@ -261,18 +262,42 @@ const LeaderBoard = ({
                   </div>
 
                   {/* <Link to={`/dashboard/${item.personId}`}> */}
-                  <div
-                    title={`Weekly Committed: ${item.weeklycommittedHours} hours`}
-                    style={{
-                      backgroundColor:
-                        item.tangibletime >= item.weeklycommittedHours ? 'green' : 'red',
-                      width: 15,
-                      height: 15,
-                      borderRadius: 7.5,
-                      margin: 'auto',
-                      verticalAlign: 'middle',
-                    }}
-                  />
+                  {
+                    hasLeaderboardPermissions(loggedInUser.role) && 
+                    item.tangibletime >= item.weeklycommittedHours * 1.25 ? (
+                        <i
+                        className="fa fa-star"
+                        title={`Weekly Committed: ${item.weeklycommittedHours} hours`}
+                        style={{
+                          color:
+                          item.tangibletime >= item.weeklycommittedHours * 1.75
+                              ? 'purple'
+                              : item.tangibletime >= item.weeklycommittedHours * 1.5 &&
+                              item.tangibletime < item.weeklycommittedHours * 1.75
+                              ? 'fuchsia'
+                              : item.tangibletime >= item.weeklycommittedHours * 1.25 &&
+                              item.tangibletime < item.weeklycommittedHours * 1.5
+                              ? 'darkgreen'
+                              : null,
+                          fontSize: '20px',
+                          marginLeft: '16px',
+                          verticalAlign: 'middle',
+                        }}
+                      />) : (
+                        <div
+                          title={`Weekly Committed: ${item.weeklycommittedHours} hours`}
+                          style={{
+                            backgroundColor:
+                              item.tangibletime >= item.weeklycommittedHours ? 'green' : 'red',
+                            width: 15,
+                            height: 15,
+                            borderRadius: 7.5,
+                            margin: 'auto',
+                            verticalAlign: 'middle',
+                          }}
+                        />
+                      )
+                  }
                   {/* </Link> */}
                 </td>
                 <th scope="row">

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -264,7 +264,7 @@ const LeaderBoard = ({
                   {/* <Link to={`/dashboard/${item.personId}`}> */}
                   {
                     hasLeaderboardPermissions(loggedInUser.role) && 
-                    item.weeklycommittedHours > 0 && item.tangibletime >= item.weeklycommittedHours * 1.25 ? (
+                    item.weeklycommittedHours !== 0 && item.tangibletime >= item.weeklycommittedHours * 1.25 ? (
                         <i
                         className="fa fa-star"
                         title={`Weekly Committed: ${item.weeklycommittedHours} hours`}

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -288,7 +288,7 @@ const LeaderBoard = ({
                           title={`Weekly Committed: ${item.weeklycommittedHours} hours`}
                           style={{
                             backgroundColor:
-                              item.tangibletime >= item.weeklycommittedHours ? 'green' : 'red',
+                              item.tangibletime >= item.weeklycommittedHours ? '#32CD32' : 'red',
                             width: 15,
                             height: 15,
                             borderRadius: 7.5,

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -4,7 +4,7 @@ import { isEqual } from 'lodash';
 import { Link } from 'react-router-dom';
 import { Table, Progress, Modal, ModalBody, ModalFooter, ModalHeader, Button } from 'reactstrap';
 import Alert from 'reactstrap/lib/Alert';
-import hasLeaderboardPermissions from 'utils/leaderboardPermissions';
+import { hasLeaderboardPermissions, assignStarDotColors, showStar } from 'utils/leaderboardPermissions';
 
 function useDeepEffect(effectFunc, deps) {
   const isFirst = useRef(true);
@@ -264,24 +264,16 @@ const LeaderBoard = ({
                   {/* <Link to={`/dashboard/${item.personId}`}> */}
                   {
                     hasLeaderboardPermissions(loggedInUser.role) && 
-                    item.weeklycommittedHours !== 0 && item.tangibletime >= item.weeklycommittedHours * 1.25 ? (
+                    showStar(item.tangibletime, item.weeklycommittedHours) ? (
                         <i
                         className="fa fa-star"
                         title={`Weekly Committed: ${item.weeklycommittedHours} hours`}
                         style={{
-                          color:
-                          item.tangibletime >= item.weeklycommittedHours * 1.75
-                              ? 'purple'
-                              : item.tangibletime >= item.weeklycommittedHours * 1.5 &&
-                              item.tangibletime < item.weeklycommittedHours * 1.75
-                              ? 'fuchsia'
-                              : item.tangibletime >= item.weeklycommittedHours * 1.25 &&
-                              item.tangibletime < item.weeklycommittedHours * 1.5
-                              ? 'darkgreen'
-                              : null,
+                          color: assignStarDotColors(item.tangibletime, item.weeklycommittedHours),
                           fontSize: '20px',
-                          marginLeft: '16px',
-                          verticalAlign: 'middle',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
                         }}
                       />) : (
                         <div

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -264,7 +264,7 @@ const LeaderBoard = ({
                   {/* <Link to={`/dashboard/${item.personId}`}> */}
                   {
                     hasLeaderboardPermissions(loggedInUser.role) && 
-                    item.tangibletime >= item.weeklycommittedHours * 1.25 ? (
+                    item.weeklycommittedHours > 0 && item.tangibletime >= item.weeklycommittedHours * 1.25 ? (
                         <i
                         className="fa fa-star"
                         title={`Weekly Committed: ${item.weeklycommittedHours} hours`}

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -173,7 +173,7 @@ const FormattedReport = ({ summaries, weekIndex }) => {
               <span onClick={() => handleGoogleDocClick(googleDocLink)}>
                 <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
               </span>
-              {hoursLogged >= summary.weeklycommittedHours * 1.25 && (
+              {summary.weeklycommitedHours > 0 && hoursLogged >= summary.weeklycommittedHours * 1.25 && (
                 <i
                   className="fa fa-star"
                   title={`Weekly Committed: ${summary.weeklycommittedHours} hours`}

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -11,6 +11,7 @@ import ToggleSwitch from '../UserProfile/UserProfileEdit/ToggleSwitch';
 import axios from 'axios';
 import { ENDPOINTS } from '../../utils/URL';
 import { useState } from 'react';
+import { assignStarDotColors, showStar } from 'utils/leaderboardPermissions';
 
 const FormattedReport = ({ summaries, weekIndex }) => {
   const emails = [];
@@ -173,21 +174,12 @@ const FormattedReport = ({ summaries, weekIndex }) => {
               <span onClick={() => handleGoogleDocClick(googleDocLink)}>
                 <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
               </span>
-              {summary.weeklycommittedHours !== 0 && hoursLogged >= summary.weeklycommittedHours * 1.25 && (
+              {showStar(hoursLogged, summary.weeklycommittedHours) && (
                 <i
                   className="fa fa-star"
                   title={`Weekly Committed: ${summary.weeklycommittedHours} hours`}
                   style={{
-                    color:
-                      hoursLogged >= summary.weeklycommittedHours * 1.75
-                        ? 'purple'
-                        : hoursLogged >= summary.weeklycommittedHours * 1.5 &&
-                          hoursLogged < summary.weeklycommittedHours * 1.75
-                        ? 'fuchsia'
-                        : hoursLogged >= summary.weeklycommittedHours * 1.25 &&
-                          hoursLogged < summary.weeklycommittedHours * 1.5
-                        ? 'darkgreen'
-                        : 'green',
+                    color: assignStarDotColors(hoursLogged, summary.weeklycommittedHours),
                     fontSize: '55px',
                     marginLeft: '10px',
                     verticalAlign: 'middle',

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -173,6 +173,42 @@ const FormattedReport = ({ summaries, weekIndex }) => {
               <span onClick={() => handleGoogleDocClick(googleDocLink)}>
                 <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
               </span>
+              {hoursLogged >= summary.weeklycommittedHours * 1.25 && (
+                <i
+                  className="fa fa-star"
+                  title={`Weekly Committed: ${summary.weeklycommittedHours} hours`}
+                  style={{
+                    color:
+                      hoursLogged >= summary.weeklycommittedHours * 1.75
+                        ? 'purple'
+                        : hoursLogged >= summary.weeklycommittedHours * 1.5 &&
+                          hoursLogged < summary.weeklycommittedHours * 1.75
+                        ? 'fuchsia'
+                        : hoursLogged >= summary.weeklycommittedHours * 1.25 &&
+                          hoursLogged < summary.weeklycommittedHours * 1.5
+                        ? 'darkgreen'
+                        : 'green',
+                    fontSize: '55px',
+                    marginLeft: '10px',
+                    verticalAlign: 'middle',
+                    position: 'relative',
+                  }}
+                >
+                  <span
+                    style={{
+                      position: 'absolute',
+                      top: '50%',
+                      left: '50%',
+                      transform: 'translate(-50%, -50%)',
+                      color: 'white',
+                      fontWeight: 'bold',
+                      fontSize: '10px',
+                    }}
+                  >
+                    +{Math.round((hoursLogged / summary.weeklycommittedHours - 1) * 100)}% 
+                  </span>
+                </i>
+              )}
             </div>
             <div>
               {' '}

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -173,7 +173,7 @@ const FormattedReport = ({ summaries, weekIndex }) => {
               <span onClick={() => handleGoogleDocClick(googleDocLink)}>
                 <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
               </span>
-              {summary.weeklycommitedHours > 0 && hoursLogged >= summary.weeklycommittedHours * 1.25 && (
+              {summary.weeklycommittedHours !== 0 && hoursLogged >= summary.weeklycommittedHours * 1.25 && (
                 <i
                   className="fa fa-star"
                   title={`Weekly Committed: ${summary.weeklycommittedHours} hours`}

--- a/src/utils/leaderboardPermissions.js
+++ b/src/utils/leaderboardPermissions.js
@@ -1,0 +1,11 @@
+const hasLeaderboardPermissions = (authRole) => {
+    return (
+        authRole === "Owner" || 
+        authRole === "Administrator" || 
+        authRole === "Manager" ||
+        authRole === "Mentor" || 
+        authRole === "Core Team"
+    )
+}
+
+export default hasLeaderboardPermissions;

--- a/src/utils/leaderboardPermissions.js
+++ b/src/utils/leaderboardPermissions.js
@@ -1,4 +1,9 @@
-const hasLeaderboardPermissions = (authRole) => {
+const PURPLE_TIER= 1.75;
+const FUCHSIA_TIER = 1.5;
+const DARKGREEN_TIER = 1.25;
+
+
+export const hasLeaderboardPermissions = (authRole) => {
     return (
         authRole === "Owner" || 
         authRole === "Administrator" || 
@@ -8,4 +13,19 @@ const hasLeaderboardPermissions = (authRole) => {
     )
 }
 
-export default hasLeaderboardPermissions;
+export const assignStarDotColors = (hoursLogged, weeklyCommittedHours) => {
+   return (hoursLogged >= weeklyCommittedHours * PURPLE_TIER) 
+   ? 'purple'
+   : hoursLogged >= weeklyCommittedHours * FUCHSIA_TIER &&
+     hoursLogged < weeklyCommittedHours * PURPLE_TIER
+   ? 'fuchsia'
+   : hoursLogged >= weeklyCommittedHours * DARKGREEN_TIER &&
+     hoursLogged < weeklyCommittedHours * FUCHSIA_TIER
+   ? 'darkgreen'
+   : 'green'
+}
+
+export const showStar = (hoursLogged, weeklyCommittedHours) => {
+    return (weeklyCommittedHours !== 0 && 
+        hoursLogged >= weeklyCommittedHours * DARKGREEN_TIER)
+}


### PR DESCRIPTION
# Description

<img width="719" alt="Screen Shot 2023-05-27 at 5 55 10 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/eb39b629-1428-40ed-af92-a458d4fa9555">

## Mainly changes explained:
    1. Created a function to check leaderboard permissions (whether the user is Owner, Admin, Manager, Mentor or Core Team)
    2. Added a conditional to check for the leaderboard permissions and render stars or dots based on their user account role
 
## How to test:
    1. check into current branch
    2. do `npm run start:local` to run this PR locally
    4. Log in an admin account
    5. go to Dashboard and the leaderboard status should now include stars, green or red dots based on the criteria
    6. go to Reports -> Weekly Summaries Report
    7. No stars should be shown when time logged is less than 25% over their weekly commitment. Light green star was changed to dark green and "+" sign has been added inside all the stars for the percentages
    9. Log in a volunteer acount
    10. go to Dashboard and the leaderboard status should only have green or red dots based on the criteria

## Videos of changes:
### Before:

Admin Account: 

<img width="664" alt="Screen Shot 2023-05-27 at 6 03 22 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/c5b85b42-6736-46a3-9f56-dac9dfdeb5f5">

### After:

Admin Account:

<img width="700" alt="Screen Shot 2023-05-27 at 5 49 46 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/663626b5-a35a-41a8-9e6a-cae2687e5829">

<img width="1348" alt="Screen Shot 2023-05-27 at 5 51 33 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/b865d871-1e82-439e-b155-35045b4a721b">
