### PR TITLE
yihan hide select featured button from all but self and Owner/Admin classes

### DIFF
--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -43,26 +43,30 @@ const Badges = props => {
               Featured Badges <i className="fa fa-info-circle" id="FeaturedBadgeInfo" />
             </span>
             <div>
-              <Button className="btn--dark-sea-green" onClick={toggle}>
-                Select Featured
-              </Button>
-              <Modal size="lg" isOpen={isOpen} toggle={toggle}>
-                <ModalHeader toggle={toggle}>Full View of Badge History</ModalHeader>
-                <ModalBody>
-                  <BadgeReport
-                    badges={props.userProfile.badgeCollection}
-                    userId={props.userProfile._id}
-                    role={props.role}
-                    firstName={props.userProfile.firstName}
-                    lastName={props.userProfile.lastName}
-                    close={toggle}
-                    setUserProfile={props.setUserProfile}
-                    setOriginalUserProfile={props.setOriginalUserProfile}
-                    handleSubmit={props.handleSubmit}
-                    permissionsUser={permissionsUser}
-                  />
-                </ModalBody>
-              </Modal>
+              {(props.canEdit || props.role == 'Owner' || props.role == 'Administrator') && (
+                <>
+                  <Button className="btn--dark-sea-green" onClick={toggle}>
+                    Select Featured
+                  </Button>
+                  <Modal size="lg" isOpen={isOpen} toggle={toggle}>
+                    <ModalHeader toggle={toggle}>Full View of Badge History</ModalHeader>
+                    <ModalBody>
+                      <BadgeReport
+                        badges={props.userProfile.badgeCollection}
+                        userId={props.userProfile._id}
+                        role={props.role}
+                        firstName={props.userProfile.firstName}
+                        lastName={props.userProfile.lastName}
+                        close={toggle}
+                        setUserProfile={props.setUserProfile}
+                        setOriginalUserProfile={props.setOriginalUserProfile}
+                        handleSubmit={props.handleSubmit}
+                        permissionsUser={permissionsUser}
+                      />
+                    </ModalBody>
+                  </Modal>
+                </>
+              )}
               {((props.canEdit && (props.role == 'Owner' || props.role == 'Administrator')) ||
                 props.userPermissions.includes('assignBadgeOthers')) && (
                 <>


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/64bf3f99-d6f4-4909-8a6c-59be304bc0cb)
[PR#771](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/771)

## Mainly changes explained:
Add conditional rendering on select featured button. So, the button only shows up when the users are on themselves profile pages or of Owner/Admin class.

## How to test:
check into current branch
do `npm run start:local` to run this PR locally
log as different type of user
go to profile page→ Select Featured
check if (1) users can see this button for themselves, (2) Owner/Admin users can see this button for everyone.

## Screenshots or videos of changes:
Owner/Admin users can see this button for self:
![owner-self](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/69137a0a-9b2c-4795-b543-a1951ce4adf9)

Owner/Admin users can see this button for others:
![Owner-others](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/f42fc3dc-3b44-4766-aca5-a76864a34832)

other users can see this button for self:
![mgr-self](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/93d7ae9d-6d53-413b-a0ad-249be79a5df3)

other users cannot see this button for others:
![mgr-Admin](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/4a1dca47-befa-43a5-b8d5-faac61e9f10f)
