### PR TITLE
add change bio announcement to permission management

### DIFF
--- a/src/__tests__/mockAdminState.js
+++ b/src/__tests__/mockAdminState.js
@@ -1631,6 +1631,7 @@ export default {
             "dataIsTangibleTimelog",
             "toggleSubmitForm",
             "seePermissionsManagement",
+            "changeBioAnnouncement",
           ],
           permissionsBackEnd: [
             "seeBadges",
@@ -1815,6 +1816,7 @@ export default {
             "addDeleteEditOwners",
             "toggleSubmitForm",
             "seePermissionsManagement",
+            "changeBioAnnouncement",
           ],
           permissionsBackEnd: [
             "seeBadges",

--- a/src/__tests__/mockStates.js
+++ b/src/__tests__/mockStates.js
@@ -1050,6 +1050,7 @@ export const rolesMock = {
           "dataIsTangibleTimelog",
           "toggleSubmitForm",
           "seePermissionsManagement",
+          "changeBioAnnouncement",
         ],
         permissionsBackEnd: [
           "seeBadges",

--- a/src/components/PermissionsManagement/UserRoleTab.jsx
+++ b/src/components/PermissionsManagement/UserRoleTab.jsx
@@ -48,6 +48,7 @@ export const permissionLabel = {
   assignOnlyBlueSquares: 'Only Assign Blue Squares',
   seePermissionsManagement: 'See Permissions Management Tab',
   submitWeeklySummaryForOthers: 'Submit Weekly Summary For Others',
+  changeBioAnnouncement: 'Change the Bio Announcement Status',
 };
 
 const UserRoleTab = props => {

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -13,9 +13,9 @@ import { ENDPOINTS } from '../../utils/URL';
 import { useState } from 'react';
 import { assignStarDotColors, showStar } from 'utils/leaderboardPermissions';
 
-const FormattedReport = ({ summaries, weekIndex, role }) => {
+const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
   const emails = [];
-  const bioCanEdit = role === 'Owner' || role === 'Administrator';
+  //const bioCanEdit = role === 'Owner' || role === 'Administrator';
 
   summaries.forEach(summary => {
     if (summary.email !== undefined && summary.email !== null) {
@@ -192,7 +192,7 @@ const FormattedReport = ({ summaries, weekIndex, role }) => {
       {alphabetize(summaries).map((summary, index) => {
         const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
         const googleDocLink = getGoogleDocLink(summary);
-        
+
         return (
           <div
             style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
@@ -230,7 +230,7 @@ const FormattedReport = ({ summaries, weekIndex, role }) => {
                       fontSize: '10px',
                     }}
                   >
-                    +{Math.round((hoursLogged / summary.weeklycommittedHours - 1) * 100)}% 
+                    +{Math.round((hoursLogged / summary.weeklycommittedHours - 1) * 100)}%
                   </span>
                 </i>
               )}

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -11,6 +11,7 @@ import Loading from '../common/Loading';
 import { getWeeklySummariesReport } from '../../actions/weeklySummariesReport';
 import FormattedReport from './FormattedReport';
 import GeneratePdfReport from './GeneratePdfReport';
+import hasPermission from '../../utils/permissions';
 
 export class WeeklySummariesReport extends Component {
   state = {
@@ -51,7 +52,10 @@ export class WeeklySummariesReport extends Component {
 
   render() {
     const { error, loading, summaries, activeTab } = this.state;
-    const role = this.props.authRole;
+    const role = this.props.authUser.role;
+    const userPermissions = this.props.authUser?.permissions?.frontPermissions;
+    const roles = this.props.roles;
+    const bioEditPermission = hasPermission(role, 'changeBioAnnouncement', roles, userPermissions);
 
     if (error) {
       return (
@@ -139,7 +143,11 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={0} role={role} />
+                    <FormattedReport
+                      summaries={summaries}
+                      weekIndex={0}
+                      bioCanEdit={bioEditPermission}
+                    />
                   </Col>
                 </Row>
               </TabPane>
@@ -159,7 +167,11 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={1} role={role} />
+                    <FormattedReport
+                      summaries={summaries}
+                      weekIndex={1}
+                      bioCanEdit={bioEditPermission}
+                    />
                   </Col>
                 </Row>
               </TabPane>
@@ -179,7 +191,11 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={2} role={role} />
+                    <FormattedReport
+                      summaries={summaries}
+                      weekIndex={2}
+                      bioCanEdit={bioEditPermission}
+                    />
                   </Col>
                 </Row>
               </TabPane>
@@ -199,7 +215,11 @@ export class WeeklySummariesReport extends Component {
                 </Row>
                 <Row>
                   <Col>
-                    <FormattedReport summaries={summaries} weekIndex={3} role={role} />
+                    <FormattedReport
+                      summaries={summaries}
+                      weekIndex={3}
+                      bioCanEdit={bioEditPermission}
+                    />
                   </Col>
                 </Row>
               </TabPane>
@@ -216,11 +236,11 @@ WeeklySummariesReport.propTypes = {
   getWeeklySummariesReport: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
   summaries: PropTypes.array.isRequired,
-  authRole: PropTypes.string.isRequired,
 };
 
 const mapStateToProps = state => ({
-  authRole: state.auth.user.role,
+  authUser: state.auth.user,
+  roles: state.role.roles,
   error: state.weeklySummariesReport.error,
   loading: state.weeklySummariesReport.loading,
   summaries: state.weeklySummariesReport.summaries,

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -52,7 +52,7 @@ export class WeeklySummariesReport extends Component {
 
   render() {
     const { error, loading, summaries, activeTab } = this.state;
-    const role = this.props.authUser.role;
+    const role = this.props.authUser?.role;
     const userPermissions = this.props.authUser?.permissions?.frontPermissions;
     const roles = this.props.roles;
     const bioEditPermission = hasPermission(role, 'changeBioAnnouncement', roles, userPermissions);

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.test.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.test.jsx
@@ -11,6 +11,8 @@ describe('WeeklySummariesReport page', () => {
         error: { message: 'SOME ERROR CONNECTING!!!' },
         loading: false,
         summaries: [],
+        authUser: {role:''},
+        roles: [],
       };
       render(<WeeklySummariesReport {...props} />);
 
@@ -24,6 +26,8 @@ describe('WeeklySummariesReport page', () => {
         getWeeklySummariesReport: jest.fn(),
         loading: true,
         summaries: [],
+        authUser: {role:''},
+        roles: [],
       };
       render(<WeeklySummariesReport {...props} />);
       expect(screen.getByTestId('loading')).toBeInTheDocument();
@@ -35,6 +39,8 @@ describe('WeeklySummariesReport page', () => {
       getWeeklySummariesReport: jest.fn(),
       loading: false,
       summaries: [],
+      authUser: {role:''},
+      roles: [],
     };
     beforeEach(() => {
       render(<WeeklySummariesReport {...props} />);

--- a/src/components/WeeklySummary/WeeklySummary.test.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.test.jsx
@@ -17,6 +17,8 @@ describe('WeeklySummary page', () => {
         updateWeeklySummaries: jest.fn(),
         loading: true,
         summaries: weeklySummaryMockData1,
+        authUser: {role:''},
+        roles: [],
       };
 
       render(<WeeklySummary {...props} />);
@@ -31,6 +33,8 @@ describe('WeeklySummary page', () => {
         fetchError: { message: 'SOME ERROR CONNECTING!!!' },
         loading: false,
         summaries: weeklySummaryMockData1,
+        authUser: {role:''},
+        roles: [],
       };
       render(<WeeklySummary {...props} />);
 
@@ -47,6 +51,8 @@ describe('WeeklySummary page', () => {
       updateWeeklySummaries: jest.fn(),
       loading: false,
       summaries: weeklySummaryMockData1,
+      authUser: {role:''},
+      roles: [],
     };
 
     beforeEach(() => {
@@ -60,6 +66,8 @@ describe('WeeklySummary page', () => {
         updateWeeklySummaries: jest.fn(),
         loading: false,
         summaries: {},
+        authUser: {role:''},
+        roles: [],
       };
 
       render(<WeeklySummary {...props} />);
@@ -122,6 +130,8 @@ describe('WeeklySummary page', () => {
       updateWeeklySummaries: jest.fn(),
       loading: false,
       summaries: weeklySummaryMockData1,
+      authUser: {role:''},
+      roles: [],
     };
 
     beforeEach(() => {
@@ -156,6 +166,8 @@ describe('WeeklySummary page', () => {
       updateWeeklySummaries: jest.fn(),
       loading: false,
       summaries: {},
+      authUser: {role:''},
+      roles: [],
     };
 
     beforeEach(() => {


### PR DESCRIPTION
# Description
While many roles have the permission to view the weekly summaries report page, we expect only admin/owner can change/edit the bio announcement status with a toggle switch, and other roles just see the label. But outside of Owner/Admin, there will be people who will be granted editing ability. The users or classes can be granted special editing ability via the Other Links --> Permissions Management option.

## Related PRS (if any):
This frontend PR is related to the [backend PR382](https://github.com/OneCommunityGlobal/HGNRest/pull/382)  (So that by default the owner/admin has the editing ability).

## Main changes explained:
- add `changeBioAnnouncement` as an entry of the permission.
- use `hasPermission` to check the editing ability in the weekly summaries report page and then pass the result to the `formattedReport` component.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as roles who can only view the report (for example, manager) --> go to Reports→ weekly summary report--> can see the label of the bio announcement.
![4](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/c6e66602-054b-45f7-a751-d93479dd52e3)

5. log as admin/owner --> go to Reports→ weekly summary report--> can edit the toggle switch of the bio announcement.
![5](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/746cbe23-8e88-4c39-a4da-6e2d53b909a9)

7. log as owner --> go to Other Links --> Permissions Management 
--> 1)click a role to change the permission of bio status --> the editing ability of any user from that class/role will change. 
![3](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/5e75449a-c05e-4d32-8d4b-1e069837d1fe)

-->2)click the blue button 'Manage User Permissions' --> search and select a user to change their permission of bio status -->the editing ability of that exact user will change.
![2](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/d6cf04be-88b3-4f27-94e6-739826a3d739)


## Screenshots or videos of changes:
Owner can change the permission for a role:
<img width="728" alt="1" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/0dbceb22-ec57-4424-a29b-ffc2f3966dae">
Owner can change the permission for a specific user:
<img width="667" alt="2" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/a056c947-73b5-41f2-8182-2edb24e9469f">


## Note:
The changes made to the `mockAdminState.js, mockStates.js, WeeklySummary.test.jsx and WeeklySummariesReport.test.jsx` are just to make the test file consistent with the update, they should not make any differences to the running app.