### PR TITLE
Jinchao add weekly summary indicator on leaderboard for admin users

### DIFF
--- a/src/components/LeaderBoard/LeaderBoard.container.jsx
+++ b/src/components/LeaderBoard/LeaderBoard.container.jsx
@@ -32,7 +32,8 @@ const mapStateToProps = state => {
       element.barcolor = getcolor(element.totaltangibletime_hrs);
       element.barprogress = getProgressValue(element.totaltangibletime_hrs, 40);
       element.totaltime = round(element.totaltime_hrs, 2);
-
+      element.isVisible = element.role === 'Volunteer' || element.isVisible;
+      
       return element;
     });
   }

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -244,7 +244,7 @@ const LeaderBoard = ({
             </tr>
             {leaderBoardData.map((item, key) => (
               <tr key={key}>
-                <td className="align-middle" onClick={() => dashboardToggle(item)}>
+                <td className="align-middle">
                   <div>
                     <Modal isOpen={isDashboardOpen === item.personId} toggle={dashboardToggle}>
                       <ModalHeader toggle={dashboardToggle}>Jump to personal Dashboard</ModalHeader>
@@ -261,10 +261,12 @@ const LeaderBoard = ({
                       </ModalFooter>
                     </Modal>
                   </div>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: isAdmin ? 'space-between' : 'center' }}>
 
                   {/* <Link to={`/dashboard/${item.personId}`}> */}
-                  {
-                    hasLeaderboardPermissions(loggedInUser.role) && 
+                  <div onClick={() => dashboardToggle(item)}>
+                    {
+                      hasLeaderboardPermissions(loggedInUser.role) && 
                     showStar(item.tangibletime, item.weeklycommittedHours) ? (
                         <i
                         className="fa fa-star"
@@ -290,7 +292,21 @@ const LeaderBoard = ({
                           }}
                         />
                       )
+                    }
+                  </div>
+                  {
+                    isAdmin && item.hasSummary && 
+                    <div
+                      title={`Weekly Summary Submitted`}
+                      style={{
+                        color: '#32a518',
+                        cursor: 'default',
+                      }}
+                    >
+                      <strong>✓</strong>
+                    </div>
                   }
+                  </div>
                   {/* </Link> */}
                 </td>
                 <th scope="row">

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -34,6 +34,7 @@ const LeaderBoard = ({
   asUser,
 }) => {
   const userId = asUser ? asUser : loggedInUser.userId;
+  const isAdmin = ['Owner', 'Administrator', 'Core Team'].includes(loggedInUser.role);
 
   useDeepEffect(() => {
     getLeaderboardData(userId);
@@ -207,23 +208,7 @@ const LeaderBoard = ({
           </thead>
           <tbody className="my-custome-scrollbar">
             <tr>
-              <td className="align-middle">
-                <Link to={`/dashboard/`}>
-                  <div
-                    title={`Weekly Committed: ${organizationData.weeklycommittedHours} hours`}
-                    style={{
-                      backgroundColor:
-                        organizationData.tangibletime >= organizationData.weeklycommittedHours
-                          ? 'green'
-                          : 'red',
-                      width: 15,
-                      height: 15,
-                      borderRadius: 7.5,
-                      margin: 'auto',
-                    }}
-                  />  
-                </Link>
-              </td>
+              <td/>
               <th scope="row">{organizationData.name}</th>
               <td className="align-middle">
                 <span title="Tangible time">{organizationData.tangibletime}</span>
@@ -312,6 +297,8 @@ const LeaderBoard = ({
                   <Link to={`/userprofile/${item.personId}`} title="View Profile">
                     {item.name}
                   </Link>
+                  &nbsp;&nbsp;&nbsp;
+                  {isAdmin && !item.isVisible && <i className="fa fa-eye-slash" title="User is invisible"></i>}
                 </th>
                 <td className="align-middle" id={`id${item.personId}`}>
                   <span title="Tangible time">{item.tangibletime}</span>


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/94319381/d6622996-7e86-473a-918b-b7dd2f6d1be2)

This PR adds a green √ next to the green/red dot/star on leaderboard for users who have submitted their weekly summaries of this week.

## Related PRS (if any):
Invisibility update PR: #859 
This frontend PR is related to the [#383](https://github.com/OneCommunityGlobal/HGNRest/pull/383) backend PR, please test these two PRs together.

## Main changes explained:
- Moved `onClick={() => dashboardToggle(item)}` from outside `<td>` to inside `<div>` that wrapped the dot/star.
- Added a flex div to hold the weekly summary indicator and the state dot/star, which will keep the dot/star on left for admin user and in center for non-admin user.
- Added the green check mark.

## How to test:
1. check into current branch on both HGNRest and HGNApp
2. do `npm run build` and `npm start` on HGNRest
3. log as Owner/Admin/Core Team user and check if there are green marks for users that have submitted their weekly summary:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/22f120e9-b64e-4171-80f7-21fcdb98ad90)
4. log as non-admin user, check if there is no green check marks and the position of dot is in the center.
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/14dcd2f9-46ce-46bd-ba92-b2847ebb2349)
5. submit the weekly summary, log as Owner/Admin/Core Team user to check if the indicator works as expected.

