### PR TITLE
Fixed unassigned hours issue

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -309,7 +309,7 @@ const TimeEntryForm = props => {
       //Get category
       const category = foundProject
         ? foundProject.category.toLowerCase()
-        : foundTask.classification.toLowerCase();
+        : foundTask.category.toLowerCase();
 
       //update hours
       const isFindCategory = Object.keys(hoursByCategory).find(key => key === category && key !== 'unassigned');
@@ -367,7 +367,7 @@ const TimeEntryForm = props => {
 
     category = foundProject
       ? foundProject.category.toLowerCase()
-      : foundTask?.classification.toLowerCase();
+      : foundTask?.category.toLowerCase();
     const isFindCategory = Object.keys(hoursByCategory).find(key => key === category && key !== 'unassigned');
 
     //if change timeEntry from intangible to tangible, we need add hours on categories

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -312,7 +312,7 @@ const TimeEntryForm = props => {
         : foundTask.classification.toLowerCase();
 
       //update hours
-      const isFindCategory = Object.keys(hoursByCategory).find(key => key === category);
+      const isFindCategory = Object.keys(hoursByCategory).find(key => key === category && key !== 'unassigned');
       if (isFindCategory) {
         hoursByCategory[category] += volunteerTime;
       } else {
@@ -368,7 +368,7 @@ const TimeEntryForm = props => {
     category = foundProject
       ? foundProject.category.toLowerCase()
       : foundTask?.classification.toLowerCase();
-    const isFindCategory = Object.keys(hoursByCategory).find(key => key === category);
+    const isFindCategory = Object.keys(hoursByCategory).find(key => key === category && key !== 'unassigned');
 
     //if change timeEntry from intangible to tangible, we need add hours on categories
     if (oldIsTangible === 'false' && currIsTangible === 'true') {


### PR DESCRIPTION
# Description
Currently, the time logged in the Other category tasks/project would not get reflected in the unassigned hours category in the user profile page, volunteering times tab

Fixes # (bug list priority high/medium/low x.y.z)
time logged in the Other category tasks/project gets reflected in the unassigned hours category in the user profile page, volunteering times tab

## Main changes explained:
Modified the updateHoursByCategory and editHoursByCategory function in the TimeEntryForm so that the userProfile categoryByHours gets updated correctly.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log in as owner user 
4. Create a project with category unspecified/Other
5. Create a task with category Other and assign it to a volunteer
6. Log in as the volunteer with assigned task and log time entry
7. Check if the time gets reflected in the 

## Screenshots or videos of changes:
Before
<img width="1440" alt="Screen Shot 2023-06-01 at 3 14 45 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/29037428/b71ca36a-34ca-44c1-8012-9ae275d9cb1b">
After 
<img width="1440" alt="Screen Shot 2023-06-01 at 3 15 01 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/29037428/5051d40b-f82c-47a8-971b-6366876fb827">
