### PR TITLE
Nida - AddTaskModal & EditTaskModal - Table overflowing Modal css updates for the bug fix

### DIFF
--- a/src/components/OwnerMessage/OwnerMessage.css
+++ b/src/components/OwnerMessage/OwnerMessage.css
@@ -28,7 +28,7 @@ img {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: .25rem;
+  padding: 0.25rem;
   border-radius: 4px;
   margin-left: 1rem;
 }
@@ -53,7 +53,7 @@ button > img:hover {
   flex-direction: column;
 }
 
-@media(max-width: 1400px) {
+@media (max-width: 1400px) {
   .message-container {
     align-items: center;
     justify-content: center;
@@ -63,5 +63,4 @@ button > img:hover {
   .message {
     color: black;
   }
-
 }

--- a/src/components/OwnerMessage/OwnerMessage.css
+++ b/src/components/OwnerMessage/OwnerMessage.css
@@ -38,12 +38,12 @@ button {
   background: none;
 }
 
-button > img {
+button>img {
   width: 18px;
   height: 18px;
 }
 
-button > img:hover {
+button>img:hover {
   cursor: pointer;
   opacity: 0.6;
 }
@@ -63,5 +63,5 @@ button > img:hover {
   .message {
     color: black;
   }
-  
+
 }

--- a/src/components/OwnerMessage/OwnerMessage.css
+++ b/src/components/OwnerMessage/OwnerMessage.css
@@ -38,12 +38,12 @@ button {
   background: none;
 }
 
-button>img {
+button > img {
   width: 18px;
   height: 18px;
 }
 
-button>img:hover {
+button > img:hover {
   cursor: pointer;
   opacity: 0.6;
 }

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -24,7 +24,7 @@ function AddTaskModal(props) {
   const setToggle = () => {
     try {
       props.openChild();
-    } catch {}
+    } catch { }
     toggle();
   };
 
@@ -387,7 +387,7 @@ function AddTaskModal(props) {
         <ModalBody>
           <ReactTooltip />
 
-          <table className="table table-bordered">
+          <table className="table table-bordered responsive">
             <tbody>
               <tr>
                 <td scope="col" data-tip="WBS ID">
@@ -518,8 +518,8 @@ function AddTaskModal(props) {
                     />
                     <div className="warning">
                       {
-                        hoursWarning ? 
-                        'Hours - Best-case < Hours - Most-case < Hours - Most-case' : ''
+                        hoursWarning ?
+                          'Hours - Best-case < Hours - Most-case < Hours - Most-case' : ''
                       }
                     </div>
                   </div>

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -518,8 +518,8 @@ function AddTaskModal(props) {
                     />
                     <div className="warning">
                       {
-                        hoursWarning ?
-                         'Hours - Best-case < Hours - Most-case < Hours - Most-case' : ''
+                        hoursWarning ? 
+                        'Hours - Best-case < Hours - Most-case < Hours - Most-case' : ''
                       }
                     </div>
                   </div>

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -348,8 +348,7 @@ function AddTaskModal(props) {
 
   useEffect(() => {
     if (props.level >= 1) {
-      const categoryMother = props.tasks.taskItems.find(({ _id }) => _id === props.taskId)
-        .category;
+      const categoryMother = props.tasks.taskItems.find(({ _id }) => _id === props.taskId).category;
       if (categoryMother) {
         setCategory(categoryMother);
       }
@@ -517,10 +516,9 @@ function AddTaskModal(props) {
                       className="w-25"
                     />
                     <div className="warning">
-                      {
-                        hoursWarning ? 
-                        'Hours - Best-case < Hours - Most-case < Hours - Most-case' : ''
-                      }
+                      {hoursWarning
+                        ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
+                        : ''}
                     </div>
                   </div>
                   <div className="py-2 flex-responsive">

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -24,7 +24,7 @@ function AddTaskModal(props) {
   const setToggle = () => {
     try {
       props.openChild();
-    } catch { }
+    } catch {}
     toggle();
   };
 
@@ -519,7 +519,7 @@ function AddTaskModal(props) {
                     <div className="warning">
                       {
                         hoursWarning ?
-                          'Hours - Best-case < Hours - Most-case < Hours - Most-case' : ''
+                         'Hours - Best-case < Hours - Most-case < Hours - Most-case' : ''
                       }
                     </div>
                   </div>

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -502,7 +502,7 @@ function AddTaskModal(props) {
                   Hours
                 </td>
                 <td scope="col" data-tip="Hours - Best-case" className="w-100">
-                  <div className="d-inline py-2">
+                  <div className="py-2 flex-responsive">
                     <label htmlFor="bestCase" className="text-nowrap mr-2 w-25 mr-4">
                       Best-case
                     </label>
@@ -523,7 +523,7 @@ function AddTaskModal(props) {
                       }
                     </div>
                   </div>
-                  <div className="d-inline py-2">
+                  <div className="py-2 flex-responsive">
                     <label htmlFor="worstCase" className="text-nowrap mr-2  w-25 mr-4">
                       Worst-case
                     </label>
@@ -542,7 +542,7 @@ function AddTaskModal(props) {
                         : ''}
                     </div>
                   </div>
-                  <div className="d-inline py-2">
+                  <div className="py-2 flex-responsive">
                     <label htmlFor="mostCase" className="text-nowrap mr-2 w-25 mr-4">
                       Most-case
                     </label>
@@ -561,7 +561,7 @@ function AddTaskModal(props) {
                         : ''}
                     </div>
                   </div>
-                  <div className="d-inline py-2">
+                  <div className="py-2 flex-responsive">
                     <label htmlFor="Estimated" className="text-nowrap mr-2  w-25 mr-4">
                       Estimated
                     </label>

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -284,19 +284,18 @@ const EditTaskModal = props => {
           {hasPermission(role, 'editTask', roles, userPermissions)
             ? 'Edit'
             : hasPermission(role, 'suggestTask', roles, userPermissions)
-            ? 'Suggest'
-            : 'View'}
+              ? 'Suggest'
+              : 'View'}
         </ModalHeader>
         <ModalBody>
           <ReactTooltip />
           <table
-            className={`table table-bordered 
-            ${
-              hasPermission(role, 'editTask', roles, userPermissions) ||
-              hasPermission(role, 'suggestTask', roles, userPermissions)
+            className={`table table-bordered responsive
+            ${hasPermission(role, 'editTask', roles, userPermissions) ||
+                hasPermission(role, 'suggestTask', roles, userPermissions)
                 ? null
                 : 'disable-div'
-            }`}
+              }`}
           >
             <tbody>
               <tr>
@@ -385,29 +384,29 @@ const EditTaskModal = props => {
                 <td scope="col">
                   <div className="flex-row  d-inline align-items-center">
                     <div className="form-check form-check-inline">
-                    <input
-                      className="form-check-input"
-                      type="radio"
-                      id="started"
-                      name="started"
-                      value="true"
-                      onChange={(e) => handleStatus('true')}
-                      checked={status === 'true' ? true : false}
-                    />
+                      <input
+                        className="form-check-input"
+                        type="radio"
+                        id="started"
+                        name="started"
+                        value="true"
+                        onChange={(e) => handleStatus('true')}
+                        checked={status === 'true' ? true : false}
+                      />
                       <label className="form-check-label" htmlFor="started">
                         Started
                       </label>
                     </div>
                     <div className="form-check form-check-inline">
-                    <input
-                      className="form-check-input"
-                      type="radio"
-                      id="notStarted"
-                      name="started"
-                      value="false"
-                      onChange={(e) => handleStatus('false')}
-                      checked={status === 'false' ? true : false}
-                    />
+                      <input
+                        className="form-check-input"
+                        type="radio"
+                        id="notStarted"
+                        name="started"
+                        value="false"
+                        onChange={(e) => handleStatus('false')}
+                        checked={status === 'false' ? true : false}
+                      />
                       <label className="form-check-label" htmlFor="notStarted">
                         Not Started
                       </label>
@@ -657,7 +656,7 @@ const EditTaskModal = props => {
           </table>
         </ModalBody>
         {hasPermission(role, 'editTask', roles, userPermissions) ||
-        hasPermission(role, 'suggestTask', roles, userPermissions) ? (
+          hasPermission(role, 'suggestTask', roles, userPermissions) ? (
           <ModalFooter>
             {taskName !== '' && startedDate !== '' && dueDate !== '' ? (
               <Button color="primary" onClick={updateTask}>
@@ -674,8 +673,8 @@ const EditTaskModal = props => {
         {hasPermission(role, 'editTask', roles, userPermissions)
           ? 'Edit'
           : hasPermission(role, 'suggestTask', roles, userPermissions)
-          ? 'Suggest'
-          : 'View'}
+            ? 'Suggest'
+            : 'View'}
       </Button>
     </div>
   );

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -57,7 +57,6 @@ const EditTaskModal = props => {
   // assigned
   const [assigned, setAssigned] = useState(false);
 
-
   // status
   const [status, setStatus] = useState('false');
 
@@ -117,7 +116,6 @@ const EditTaskModal = props => {
   const findMembers = () => {
     const memberList = members.members ? props.projectMembers.members : members;
     for (let i = 0; i < memberList.length; i++) {
-
       if (
         `${memberList[i].firstName} ${memberList[i].lastName}`
           .toLowerCase()
@@ -269,11 +267,11 @@ const EditTaskModal = props => {
     }
   };
 
-  const handleAssign = (value) => {
+  const handleAssign = value => {
     setAssigned(value);
   };
 
-  const handleStatus = (value) => {
+  const handleStatus = value => {
     setStatus(value);
   };
 
@@ -284,18 +282,19 @@ const EditTaskModal = props => {
           {hasPermission(role, 'editTask', roles, userPermissions)
             ? 'Edit'
             : hasPermission(role, 'suggestTask', roles, userPermissions)
-              ? 'Suggest'
-              : 'View'}
+            ? 'Suggest'
+            : 'View'}
         </ModalHeader>
         <ModalBody>
           <ReactTooltip />
           <table
             className={`table table-bordered responsive
-            ${hasPermission(role, 'editTask', roles, userPermissions) ||
-                hasPermission(role, 'suggestTask', roles, userPermissions)
+            ${
+              hasPermission(role, 'editTask', roles, userPermissions) ||
+              hasPermission(role, 'suggestTask', roles, userPermissions)
                 ? null
                 : 'disable-div'
-              }`}
+            }`}
           >
             <tbody>
               <tr>
@@ -355,7 +354,7 @@ const EditTaskModal = props => {
                         id="true"
                         name="Assigned"
                         value="true"
-                        onChange={(e) => handleAssign(true)}
+                        onChange={e => handleAssign(true)}
                         checked={assigned}
                       />
                       <label className="form-check-label" htmlFor="true">
@@ -369,7 +368,7 @@ const EditTaskModal = props => {
                         id="false"
                         name="Assigned"
                         value="false"
-                        onChange={(e) => handleAssign(false)}
+                        onChange={e => handleAssign(false)}
                         checked={!assigned}
                       />
                       <label className="form-check-label" htmlFor="false">
@@ -390,7 +389,7 @@ const EditTaskModal = props => {
                         id="started"
                         name="started"
                         value="true"
-                        onChange={(e) => handleStatus('true')}
+                        onChange={e => handleStatus('true')}
                         checked={status === 'true' ? true : false}
                       />
                       <label className="form-check-label" htmlFor="started">
@@ -404,7 +403,7 @@ const EditTaskModal = props => {
                         id="notStarted"
                         name="started"
                         value="false"
-                        onChange={(e) => handleStatus('false')}
+                        onChange={e => handleStatus('false')}
                         checked={status === 'false' ? true : false}
                       />
                       <label className="form-check-label" htmlFor="notStarted">
@@ -656,7 +655,7 @@ const EditTaskModal = props => {
           </table>
         </ModalBody>
         {hasPermission(role, 'editTask', roles, userPermissions) ||
-          hasPermission(role, 'suggestTask', roles, userPermissions) ? (
+        hasPermission(role, 'suggestTask', roles, userPermissions) ? (
           <ModalFooter>
             {taskName !== '' && startedDate !== '' && dueDate !== '' ? (
               <Button color="primary" onClick={updateTask}>
@@ -673,8 +672,8 @@ const EditTaskModal = props => {
         {hasPermission(role, 'editTask', roles, userPermissions)
           ? 'Edit'
           : hasPermission(role, 'suggestTask', roles, userPermissions)
-            ? 'Suggest'
-            : 'View'}
+          ? 'Suggest'
+          : 'View'}
       </Button>
     </div>
   );

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -419,7 +419,7 @@ const EditTaskModal = props => {
                   Hours
                 </td>
                 <td scope="col" data-tip="Hours - Best-case" className="w-100">
-                  <div className="d-inline py-2">
+                  <div className="py-2 flex-responsive">
                     <label htmlFor="bestCase" className="text-nowrap mr-2 w-25 mr-4">
                       Best-case
                     </label>
@@ -439,7 +439,7 @@ const EditTaskModal = props => {
                         : ''}
                     </div>
                   </div>
-                  <div className="d-inline py-2">
+                  <div className="py-2 flex-responsive">
                     <label htmlFor="worstCase" className="text-nowrap mr-2  w-25 mr-4">
                       Worst-case
                     </label>
@@ -458,7 +458,7 @@ const EditTaskModal = props => {
                         : ''}
                     </div>
                   </div>
-                  <div className="d-inline py-2">
+                  <div className="py-2 flex-responsive">
                     <label htmlFor="mostCase" className="text-nowrap mr-2 w-25 mr-4">
                       Most-case
                     </label>
@@ -477,7 +477,7 @@ const EditTaskModal = props => {
                         : ''}
                     </div>
                   </div>
-                  <div className="d-inline py-2">
+                  <div className="py-2 flex-responsive">
                     <label htmlFor="Estimated" className="text-nowrap mr-2  w-25 mr-4">
                       Estimated
                     </label>

--- a/src/components/Projects/WBS/WBSDetail/wbs.css
+++ b/src/components/Projects/WBS/WBSDetail/wbs.css
@@ -36,7 +36,6 @@
   position: relative;
   z-index: -50;
   opacity: 0.1;
-
 }
 .load {
   position: relative;
@@ -168,17 +167,17 @@
 
 @media only screen and (max-width: 600px) {
   .desktop-view {
-      display: none;
+    display: none;
   }
 
   .table td {
-      padding: 5px !important;
+    padding: 5px !important;
   }
 }
 
-@media (min-width:200px) and (max-width: 1496px) {
+@media (min-width: 200px) and (max-width: 1496px) {
   table.responsive {
-    table-layout: fixed
+    table-layout: fixed;
   }
 
   .flex-responsive {

--- a/src/components/Projects/WBS/WBSDetail/wbs.css
+++ b/src/components/Projects/WBS/WBSDetail/wbs.css
@@ -38,7 +38,6 @@
   opacity: 0.1;
 
 }
-
 .load {
   position: relative;
 }
@@ -169,11 +168,11 @@
 
 @media only screen and (max-width: 600px) {
   .desktop-view {
-    display: none;
+      display: none;
   }
 
   .table td {
-    padding: 5px !important;
+      padding: 5px !important;
   }
 }
 

--- a/src/components/Projects/WBS/WBSDetail/wbs.css
+++ b/src/components/Projects/WBS/WBSDetail/wbs.css
@@ -38,6 +38,7 @@
   opacity: 0.1;
 
 }
+
 .load {
   position: relative;
 }
@@ -168,9 +169,16 @@
 
 @media only screen and (max-width: 600px) {
   .desktop-view {
-      display: none;
+    display: none;
   }
+
   .table td {
-      padding: 5px !important;
+    padding: 5px !important;
+  }
+}
+
+@media (min-width:200px) and (max-width: 1496px) {
+  table.responsive {
+    table-layout: fixed
   }
 }

--- a/src/components/Projects/WBS/WBSDetail/wbs.css
+++ b/src/components/Projects/WBS/WBSDetail/wbs.css
@@ -181,4 +181,10 @@
   table.responsive {
     table-layout: fixed
   }
+
+  .flex-responsive {
+    display: flex;
+    flex-direction: row;
+    column-gap: 2vw;
+  }
 }

--- a/src/components/Reports/TableFilter/TableFilter.css
+++ b/src/components/Reports/TableFilter/TableFilter.css
@@ -1,4 +1,4 @@
-td > input,
+td>input,
 select {
   width: 100%;
 }

--- a/src/components/Reports/TableFilter/TableFilter.css
+++ b/src/components/Reports/TableFilter/TableFilter.css
@@ -1,4 +1,4 @@
-td>input,
+td > input,
 select {
   width: 100%;
 }


### PR DESCRIPTION
# Description
The AddTaskModal and EditTaskModal have their input fields overflow the size of the modal when the page is opened/refreshed with developer tools open
Fixes # (bug list priority low)
Added media query on `wbs.css` which should enforce a fixed table layout when the window size changes on a responsive layout triggered by developer tools. 

## Main changes explained:
- Added media query on `wbs.css` between 200px and 1496px that applies the css rule `table-layout: fixed`

## How to test:
1. check into current branch
2. log as admin user
3. Open Developer Tools
4. Refresh the page
5.  Other Links > Projects > WBS > select an item > Add Task/Edit Task (any of them)
6. Please Verify that the fields inside the modal DO NOT overflow the width of the modal.

## Screenshots or videos of changes:
### Before:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/32549172/7b7785eb-a2f8-4ac6-b36f-e6133c8dfa8f)

### After
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/32549172/7f99acbf-39e8-4631-afef-c95231b10af0)


