### PR TITLE
show resource full name as data-tip

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -29,6 +29,7 @@ import * as Message from './../../../../../languages/en/messages';
 import { getPopupById } from './../../../../../actions/popupEditorAction';
 import { TASK_DELETE_POPUP_ID } from './../../../../../constants/popupId';
 import hasPermission from 'utils/permissions';
+import ReactTooltip from 'react-tooltip';
 
 function Task(props) {
   const [role] = useState(props.state ? props.state.auth.user.role : null);
@@ -155,6 +156,7 @@ function Task(props) {
     <>
       {props.id ? (
         <>
+          <ReactTooltip/>
           <tr
             ref={tableRowRef}
             key={props.key}


### PR DESCRIPTION
# Description
Fixes **PROJECTS/TASKS/WBS COMPONENT 3(PRIORITY LOW)** Make resource/people icons show full name with mouseover: 
Admin Login → Other Links → Projects → Choose Project → Click WBS Icon → Choose WBS → Resources column (see pic below)
<img width="491" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/792b6bef-db31-47bd-bf4e-45ccc5d06bd4">

## Main changes explained:
- add react-tooltip to show the full name as data-tip.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. Other Links → Projects → Choose Project → Click WBS Icon → Choose WBS → Resources column -->hover the mouse over icon

## Screenshots or videos of changes:
<img width="947" alt="img" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/3e0f7888-6a07-4ee1-a274-c16f61a770e3">
