### PR TITLE
Nida - WeeklySummaryReportPage- Refreshing the Weekly Summaries page stay on the same summary tab 

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -17,24 +17,28 @@ export class WeeklySummariesReport extends Component {
     error: null,
     loading: true,
     summaries: [],
-    activeTab: '2'
+    activeTab: '2',
   };
 
   async componentDidMount() {
     await this.props.getWeeklySummariesReport();
-    window.addEventListener("popstate", () => {
-      localStorage.removeItem('tabSelection')
+    window.addEventListener('popstate', () => {
+      localStorage.removeItem('tabSelection');
     });
     this.setState({
       error: this.props.error,
       loading: this.props.loading,
       summaries: this.props.summaries,
-      activeTab: localStorage.getItem('tabSelection') === null ? '2' : localStorage.getItem('tabSelection'),
+      activeTab:
+        localStorage.getItem('tabSelection') === null ? '2' : localStorage.getItem('tabSelection'),
     });
   }
 
   componentWillUnmount() {
     localStorage.removeItem('tabSelection');
+    window.removeEventListener('popstate', () => {
+      localStorage.removeItem('tabSelection');
+    });
   }
 
   getWeekDates = weekIndex => ({

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -17,16 +17,25 @@ export class WeeklySummariesReport extends Component {
     error: null,
     loading: true,
     summaries: [],
-    activeTab: '1',
+    activeTab: '2'
   };
 
   async componentDidMount() {
     await this.props.getWeeklySummariesReport();
+    window.addEventListener("popstate", () => {
+      localStorage.removeItem('tabSelection')
+    });
     this.setState({
       error: this.props.error,
       loading: this.props.loading,
       summaries: this.props.summaries,
+      activeTab: localStorage.getItem('tabSelection') === null ? '2' : localStorage.getItem('tabSelection'),
     });
+  }
+
+  componentWillUnmount() {
+    localStorage.removeItem('tabSelection');
+    window.removeEventListener("popstate");
   }
 
   getWeekDates = weekIndex => ({
@@ -46,6 +55,7 @@ export class WeeklySummariesReport extends Component {
     const activeTab = this.state.activeTab;
     if (activeTab !== tab) {
       this.setState({ activeTab: tab });
+      localStorage.setItem('tabSelection', tab);
     }
   };
 

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -22,7 +22,6 @@ export class WeeklySummariesReport extends Component {
 
   async componentDidMount() {
     await this.props.getWeeklySummariesReport();
-    window.addEventListener('popstate', removeLocalStorageItem);
     this.setState({
       error: this.props.error,
       loading: this.props.loading,
@@ -34,7 +33,6 @@ export class WeeklySummariesReport extends Component {
 
   componentWillUnmount() {
     localStorage.removeItem('tabSelection');
-    window.removeEventListener('popstate', removeLocalStorageItem);
   }
 
   getWeekDates = weekIndex => ({
@@ -219,10 +217,6 @@ export class WeeklySummariesReport extends Component {
     );
   }
 }
-
-const removeLocalStorageItem = () => {
-  localStorage.removeItem('tabSelection');
-};
 
 WeeklySummariesReport.propTypes = {
   error: PropTypes.any,

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -27,12 +27,14 @@ export class WeeklySummariesReport extends Component {
       loading: this.props.loading,
       summaries: this.props.summaries,
       activeTab:
-        localStorage.getItem('tabSelection') === null ? '2' : localStorage.getItem('tabSelection'),
+        sessionStorage.getItem('tabSelection') === null
+          ? '2'
+          : sessionStorage.getItem('tabSelection'),
     });
   }
 
   componentWillUnmount() {
-    localStorage.removeItem('tabSelection');
+    sessionStorage.removeItem('tabSelection');
   }
 
   getWeekDates = weekIndex => ({
@@ -52,7 +54,7 @@ export class WeeklySummariesReport extends Component {
     const activeTab = this.state.activeTab;
     if (activeTab !== tab) {
       this.setState({ activeTab: tab });
-      localStorage.setItem('tabSelection', tab);
+      sessionStorage.setItem('tabSelection', tab);
     }
   };
 

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -35,7 +35,6 @@ export class WeeklySummariesReport extends Component {
 
   componentWillUnmount() {
     localStorage.removeItem('tabSelection');
-    window.removeEventListener("popstate");
   }
 
   getWeekDates = weekIndex => ({

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -22,9 +22,7 @@ export class WeeklySummariesReport extends Component {
 
   async componentDidMount() {
     await this.props.getWeeklySummariesReport();
-    window.addEventListener('popstate', () => {
-      localStorage.removeItem('tabSelection');
-    });
+    window.addEventListener('popstate', removeLocalStorageItem);
     this.setState({
       error: this.props.error,
       loading: this.props.loading,
@@ -36,9 +34,7 @@ export class WeeklySummariesReport extends Component {
 
   componentWillUnmount() {
     localStorage.removeItem('tabSelection');
-    window.removeEventListener('popstate', () => {
-      localStorage.removeItem('tabSelection');
-    });
+    window.removeEventListener('popstate', removeLocalStorageItem);
   }
 
   getWeekDates = weekIndex => ({
@@ -223,6 +219,10 @@ export class WeeklySummariesReport extends Component {
     );
   }
 }
+
+const removeLocalStorageItem = () => {
+  localStorage.removeItem('tabSelection');
+};
 
 WeeklySummariesReport.propTypes = {
   error: PropTypes.any,

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.test.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.test.jsx
@@ -44,8 +44,8 @@ describe('WeeklySummariesReport page', () => {
       jest.clearAllMocks();
     });
 
-    it('should have first tab set to "active" by default', () => {
-      expect(screen.getByTestId('tab-1').classList.contains('active')).toBe(true);
+    it('should have second tab set to "active" by default', () => {
+      expect(screen.getByTestId('tab-2').classList.contains('active')).toBe(true);
     });
 
     it('should make 1st tab active when clicked', () => {


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/32549172/f0966960-72bc-44bc-97c7-d81ae29ab48a)

## Main changes explained:
- Setting `activeTab` to the latest selected tab by using `localStorage` for saving and getting the `tabSelection` value when the component is re-rendered.
- Setting `activeTab` to "Last Week" as a default value.

## How to test:
1. check into current branch
2. do `npm run start:local` to run this PR locally
3. login as admin user
4. Reports -> Weekly Summaries Report
5. Verify that the default tab selected is "Last Week", and when any other tab is selected, refreshing the page stays on the same selected tab. Also, when the page is revisited, the default tab selected should be "Last Week".

## Screenshots or videos of changes:
### After

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/32549172/3600c369-7eb8-4be7-8512-0f52fea9ed87


