### PR TITLE
yihan correct text on info modal on the Projects page

### DIFF
--- a/src/components/Projects/ProjectInfoModal.jsx
+++ b/src/components/Projects/ProjectInfoModal.jsx
@@ -6,7 +6,7 @@ const ProjectInfoModal = ({ isOpen, toggle }) => (
     <Modal isOpen={isOpen} toggle={toggle}>
       <ModalHeader toggle={toggle}>HOW TO IMPORT A NEW WORK BREAKDOWN STRUCTURE (WBS)</ModalHeader>
       <ModalBody>
-        <ol type="1">
+        <ol type="1" className="project_info_modal_ol">
           <li>As an Admin, go to Other Links → Projects </li>
           <li>
             Choose the Project you want to import the WBS to and click on the WBS Icon for that
@@ -22,7 +22,7 @@ const ProjectInfoModal = ({ isOpen, toggle }) => (
           <li>
             Click “Import Tasks” and read the “Import Tasks” warning. Check your Google Sheet to
             confirm:
-            <ol type="a">
+            <ol type="a" className="project_info_modal_ol">
               <li>All numbers (for the tasks) are sequential</li>
               <li>No dots/periods at the end of numbers, double periods in numbers, etc.</li>
               <li>
@@ -36,7 +36,7 @@ const ProjectInfoModal = ({ isOpen, toggle }) => (
           <li>
             On the popup that happens next, double check the Rows listed match the rows being
             imported.
-            <ol type="a">
+            <ol type="a" className="project_info_modal_ol">
               <li>If they do, click “Upload” and you are done! </li>
               <li>
                 If they don’t, go back and double check all numbers are sequential, no additional

--- a/src/components/Projects/projects.css
+++ b/src/components/Projects/projects.css
@@ -90,7 +90,7 @@ thead {
   display: none;
 }
 
-ol {
+.project_info_modal_ol{
   padding-left: 20px;
 }
 

--- a/src/components/Projects/projects.css
+++ b/src/components/Projects/projects.css
@@ -90,6 +90,10 @@ thead {
   display: none;
 }
 
+ol {
+  padding-left: 20px;
+}
+
 tr:hover {
   background: #e9f6ff;
 }


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/251204a8-16a9-49bf-a737-5d1f83d07f6f)

## Main changes explained:
- Update file projects.css for adding padding-left property on `ol` element.

## How to test:
1. check into current branch
2. do `npm run start:local` to run this PR locally
3. log as admin user
4. go to Other Links > Projects > Projects header (i) button
5. verify the text is properly aligned and hangs off left edge of modal.

## Screenshots or videos of changes:
![Visibility_issue](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/b795dc75-ff9d-4602-8654-f396f17da9fa)
