### PR TITLE
Edwin - Added new permission seeAllReports to allow users with this permissio…

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -37,7 +37,6 @@ import {
   DropdownToggle,
   DropdownMenu,
   DropdownItem,
-  Dropdown,
 } from 'reactstrap';
 import { Logout } from '../Logout/Logout';
 import './Header.css';

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -37,6 +37,7 @@ import {
   DropdownToggle,
   DropdownMenu,
   DropdownItem,
+  Dropdown,
 } from 'reactstrap';
 import { Logout } from '../Logout/Logout';
 import './Header.css';
@@ -111,23 +112,30 @@ export const Header = props => {
                   <span className="dashboard-text-link">{TIMELOG}</span>
                 </NavLink>
               </NavItem>
+              {hasPermission(user.role, "seeAllReports", roles, userPermissions) ||
+               hasPermission(user.role, "seeWeeklySummaryReports", roles, userPermissions) ? (
               <UncontrolledDropdown nav inNavbar>
                 <DropdownToggle nav caret>
                   <span className="dashboard-text-link">{REPORTS}</span>
                 </DropdownToggle>
                 <DropdownMenu>
-                  <DropdownItem tag={Link} to="/reports">
-                    {REPORTS}
-                  </DropdownItem>
-                  {hasPermission(user.role, 'seeWeeklySummaryReports', roles, userPermissions) ? (
+                  {hasPermission(user.role, "seeAllReports", roles, userPermissions) ? (
+                    <>
+                      <DropdownItem tag={Link} to="/reports">
+                        {REPORTS}
+                      </DropdownItem>
+                      <DropdownItem tag={Link} to="/weeklysummariesreport">
+                        {WEEKLY_SUMMARIES_REPORT}
+                      </DropdownItem>
+                    </>
+                  ) : (
                     <DropdownItem tag={Link} to="/weeklysummariesreport">
                       {WEEKLY_SUMMARIES_REPORT}
                     </DropdownItem>
-                  ) : (
-                    <React.Fragment></React.Fragment>
                   )}
                 </DropdownMenu>
               </UncontrolledDropdown>
+              ) : null}
               <NavItem>
                 <NavLink tag={Link} to={`/timelog/${user.userid}`}>
                   <i className="fa fa-bell i-large">

--- a/src/components/PermissionsManagement/UserRoleTab.jsx
+++ b/src/components/PermissionsManagement/UserRoleTab.jsx
@@ -31,7 +31,7 @@ export const permissionLabel = {
   createTeam: 'Create Team',
   assignTeamToUser: 'Assign Team to User',
   editTimelogInfo: 'Edit Timelog Information',
-  addTimeEntryOthers: '  Time Entry (Others)',
+  addTimeEntryOthers: 'Add Time Entry (Others)',
   deleteTimeEntryOthers: 'Delete Time Entry (Others)',
   toggleTangibleTime: 'Toggle Tangible Time',
   changeIntangibleTimeEntryDate: 'Change Date on Intangible Time Entry',

--- a/src/components/PermissionsManagement/UserRoleTab.jsx
+++ b/src/components/PermissionsManagement/UserRoleTab.jsx
@@ -31,7 +31,7 @@ export const permissionLabel = {
   createTeam: 'Create Team',
   assignTeamToUser: 'Assign Team to User',
   editTimelogInfo: 'Edit Timelog Information',
-  addTimeEntryOthers: 'Add Time Entry (Others)',
+  addTimeEntryOthers: '  Time Entry (Others)',
   deleteTimeEntryOthers: 'Delete Time Entry (Others)',
   toggleTangibleTime: 'Toggle Tangible Time',
   changeIntangibleTimeEntryDate: 'Change Date on Intangible Time Entry',
@@ -49,6 +49,7 @@ export const permissionLabel = {
   seePermissionsManagement: 'See Permissions Management Tab',
   submitWeeklySummaryForOthers: 'Submit Weekly Summary For Others',
   changeBioAnnouncement: 'Change the Bio Announcement Status',
+  seeAllReports: "See All the Reports Tab", 
 };
 
 const UserRoleTab = props => {

--- a/src/components/common/ProtectedRoute/ProtectedRoute.jsx
+++ b/src/components/common/ProtectedRoute/ProtectedRoute.jsx
@@ -12,11 +12,22 @@ const ProtectedRoute = ({
 }) => {
   const permissions = roles?.find(({ roleName }) => roleName === auth.user.role)?.permissions;
   const userPermissions = auth.user?.permissions?.frontPermissions;
-  let hasPermissionToAccess = permissions?.some(perm => perm === routePermissions);
+  let hasPermissionToAccess = permissions?.some(perm => perm === routePermissions); 
+  
+  if (Array.isArray(routePermissions)) {
+    if (permissions?.some(perm => routePermissions.includes(perm))) {
+      hasPermissionToAccess = true;
+    }
+
+    if (userPermissions?.some(perm => routePermissions.includes(perm))) {
+      hasPermissionToAccess = true;
+    }
+  }
   
   if (userPermissions?.some(perm => perm === routePermissions)) {
     hasPermissionToAccess = true;
   }
+  
   return (
     <Route
       {...rest}

--- a/src/routes.js
+++ b/src/routes.js
@@ -49,7 +49,6 @@ export default (
       <ProtectedRoute path="/admin" component={Admin} />
       <ProtectedRoute path="/timelog/" exact component={Timelog} />
       <ProtectedRoute path="/timelog/:userId" exact component={Timelog} />
-      <ProtectedRoute path="/reports" exact component={Reports} />
       <ProtectedRoute path="/peoplereport/:userId" component={PeopleReport} />
       <ProtectedRoute path="/projectreport/:projectId" component={ProjectReport} />
       <ProtectedRoute path="/teamreport/:teamId" component={TeamReport} />
@@ -77,6 +76,17 @@ export default (
           UserRole.Owner,
           UserRole.Mentor,
         ]}
+        routePermissions={[RoutePermissions.weeklySummariesReport, RoutePermissions.reports]}
+      />
+      <ProtectedRoute
+        path="/reports"
+        exact
+        component={Reports}
+        allowedRoles={[
+          UserRole.Administrator,
+          UserRole.Owner
+        ]}
+        routePermissions={RoutePermissions.reports}
       />
       <ProtectedRoute
         path="/projects"

--- a/src/routes.js
+++ b/src/routes.js
@@ -82,10 +82,6 @@ export default (
         path="/reports"
         exact
         component={Reports}
-        allowedRoles={[
-          UserRole.Administrator,
-          UserRole.Owner
-        ]}
         routePermissions={RoutePermissions.reports}
       />
       <ProtectedRoute

--- a/src/utils/routePermissions.js
+++ b/src/utils/routePermissions.js
@@ -10,4 +10,5 @@ export const RoutePermissions = {
   permissionsManagement: 'seePermissionsManagement',
   permissionsManagementRole: 'seePermissionsManagement',
   teams: 'seeTeamsManagement',
+  reports: 'seeAllReports',
 };


### PR DESCRIPTION
# Description

<img width="577" alt="Screen Shot 2023-06-08 at 4 17 49 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/273e0dcf-5843-4f69-ba9a-6103ea49fec8">

## Related PRS (if any):
This frontend PR is related to the BE PR [#397](https://github.com/OneCommunityGlobal/HGNRest/pull/397)

## Main changes explained:
-Added new permission See All the Reports Tabs
- Fixed a bug that allowed users who did not have permission to see weekly summaries report to view it by manually changing the URL to that route
- See weekly summaries report permission only allows users to see the weekly summaries report tab but not any other tabs under Reports
- See all reports tabs permission allows  users to see all tabs under Reports

## How to test:

1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as Owner user
4.  go to Other Links --> Permissions Management
--> 1) click the blue button 'Manage User Permissions' --> search and select a user to change their permission of "See All the Reports Tab --> the ability to view its respective tabs under Reports will change

<img width="700" alt="Screen Shot 2023-06-08 at 4 49 07 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/9cea7a70-db28-4d32-a633-9ab8f303bc07">

<img width="712" alt="Screen Shot 2023-06-08 at 4 04 44 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/d4277508-006a-400d-b222-2c2058df4c0f">

<img width="578" alt="Screen Shot 2023-06-08 at 4 05 39 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/a09aaff7-25a7-4d2e-9735-c78fc47d427f">

--> 2) click the blue button  'Manage User Permitssions' --> search and select the same user to delete their permission of "See All the Reports Tab" and allow the "See Weekly Summaries Report" permission --> user should only be able to see "Weekly Summaries Report" option in the Reports tab but not the Reports option. 
<img width="523" alt="Screen Shot 2023-06-08 at 4 17 18 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/57b5fcf9-f38f-4c17-bbca-f03f16dab06c">


--> 3) if the user has no "See Weekly Summaries Report" and "See All the Reports Tab", users shouldn't be able to see the Reports tab at all. 

<img width="607" alt="Screen Shot 2023-06-08 at 4 47 58 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/e136e26d-5cae-43ef-9d70-72401c3c0147">
