### PR TITLE
Nathan Fix key, tbody, and required prop warnings

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -76,7 +76,7 @@ const TeamMemberTasks = props => {
         await dispatch(fetchTeamMembersTask(userId, null));
         setUserRole(props.auth.user.role);
       }
-      setShouldRun(true)     
+      setShouldRun(true);
     };
     initialFetching();
   }, []);
@@ -392,7 +392,11 @@ const TeamMemberTasks = props => {
 
           <tbody>
             {isLoading ? (
-              <Loading />
+              <tr>
+                <td>
+                  <Loading />
+                </td>
+              </tr>
             ) : (
               teamList.map(user => {
                 if (!isTimeLogActive) {

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -401,15 +401,13 @@ const TeamMemberTasks = props => {
               teamList.map(user => {
                 if (!isTimeLogActive) {
                   return (
-                    <>
-                      <TeamMemberTask
-                        user={user}
-                        key={user.personId}
-                        handleOpenTaskNotificationModal={handleOpenTaskNotificationModal}
-                        handleMarkAsDoneModal={handleMarkAsDoneModal}
-                        userRole={userRole}
-                      />
-                    </>
+                    <TeamMemberTask
+                      user={user}
+                      key={user.personId}
+                      handleOpenTaskNotificationModal={handleOpenTaskNotificationModal}
+                      handleMarkAsDoneModal={handleMarkAsDoneModal}
+                      userRole={userRole}
+                    />
                   );
                 } else {
                   return (

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -772,10 +772,10 @@ TimeEntryForm.propTypes = {
   userId: PropTypes.string.isRequired,
   toggle: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
-  timer: PropTypes.any.isRequired,
+  timer: PropTypes.any,
   data: PropTypes.any.isRequired,
   userProfile: PropTypes.any.isRequired,
-  resetTimer: PropTypes.func.isRequired,
+  resetTimer: PropTypes.func,
 };
 
 export default TimeEntryForm;

--- a/src/components/Timelog/WeeklySummaries.jsx
+++ b/src/components/Timelog/WeeklySummaries.jsx
@@ -11,7 +11,7 @@ const WeeklySummaries = ({ userProfile }) => {
       return (
         <div>
           <h3>{title}</h3>
-          <p>{parse(summary)}</p>
+          {parse(summary)}
         </div>
       );
     } else {


### PR DESCRIPTION
# Description
This PR fixes 3 warnings on the dashboard view:

Warning: validateDOMNesting(...): \<div\> cannot appear as a child of \<tbody\>.

Warning: Each child in a list should have a unique "key" prop.

Warning: Failed prop type: The prop `timer` is marked as required in `TimeEntryForm`, but its value is `undefined`.
Warning: Failed prop type: The prop `resetTimer` is marked as required in `TimeEntryForm`, but its value is `undefined`.

## Main changes explained:
To fix validateDOMNesting(...) I wrapped \<Loading\/\> with a \<tr\> and \<td\>.
To fix the key error, I removed a \<\> wrapping the TeamMemberTask.
The timer and resetTimer props were not required in the case of intangible time entries, so I made them not required.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log in as any user
4. go to dashboard
5. Open dev tools console and make sure Errors are turned on.
6. verify none of these warnings appear in the dev tools console and the changes don't change any UI.

## Screenshots or videos of changes:
Before:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/3288b115-6774-46fb-8fc9-218ff4c8ce0e)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/8b1195b8-e992-426d-b135-12941a4c9a56)
After:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/bec79d8f-4a7e-47c7-bf55-95b0b18ce25c)

