### PR TITLE
Jianjun - Fix the permission of changing user status

### DIFF
--- a/src/__tests__/UserManagement/UserTableData.test.js
+++ b/src/__tests__/UserManagement/UserTableData.test.js
@@ -17,7 +17,6 @@ describe('User Table Data', () => {
         <tbody>
           <UserTableData
             isActive
-            canChange={true}//add to enable the test of 'change the user status' functionality in line37 and 82.
             index={0}
             user={userProfileMock}
             onActiveInactiveClick={onActiveInactiveClick}

--- a/src/__tests__/UserManagement/UserTableData.test.js
+++ b/src/__tests__/UserManagement/UserTableData.test.js
@@ -17,6 +17,7 @@ describe('User Table Data', () => {
         <tbody>
           <UserTableData
             isActive
+            canChange={true}//add to enable the test of 'change the user status' functionality in line37 and 82.
             index={0}
             user={userProfileMock}
             onActiveInactiveClick={onActiveInactiveClick}

--- a/src/__tests__/mockAdminState.js
+++ b/src/__tests__/mockAdminState.js
@@ -1632,6 +1632,8 @@ export default {
             "toggleSubmitForm",
             "seePermissionsManagement",
             "changeBioAnnouncement",
+            'changeUserStatus',
+            'submitWeeklySummaryForOthers',
           ],
           permissionsBackEnd: [
             "seeBadges",
@@ -1817,6 +1819,8 @@ export default {
             "toggleSubmitForm",
             "seePermissionsManagement",
             "changeBioAnnouncement",
+            'changeUserStatus',
+            'submitWeeklySummaryForOthers',
           ],
           permissionsBackEnd: [
             "seeBadges",

--- a/src/__tests__/mockStates.js
+++ b/src/__tests__/mockStates.js
@@ -1051,6 +1051,8 @@ export const rolesMock = {
           "toggleSubmitForm",
           "seePermissionsManagement",
           "changeBioAnnouncement",
+          'changeUserStatus',
+          'submitWeeklySummaryForOthers',
         ],
         permissionsBackEnd: [
           "seeBadges",

--- a/src/components/UserManagement/ActiveCell.jsx
+++ b/src/components/UserManagement/ActiveCell.jsx
@@ -3,11 +3,12 @@
  * @param {bool} props.isActive
  * @param {int} props.index Used when rendering this component using the .map function
  * @param {func} props.onClick
+ * @param {bool} props.canChange The permission to change the status via onClick
  */
 const ActiveCell = props => {
   return (
     <span
-      style={{ fontSize: '1.5rem' }}
+      style={{ fontSize: '1.5rem', cursor: props.canChange ? 'pointer' : 'default' }}
       className={props.isActive ? 'isActive' : 'isNotActive'}
       id={props.index === undefined ? undefined : `active_cell_${props.index}`}
       title={

--- a/src/components/UserManagement/ActiveCell.jsx
+++ b/src/components/UserManagement/ActiveCell.jsx
@@ -10,8 +10,14 @@ const ActiveCell = props => {
       style={{ fontSize: '1.5rem' }}
       className={props.isActive ? 'isActive' : 'isNotActive'}
       id={props.index === undefined ? undefined : `active_cell_${props.index}`}
-      title="Click here to change the user status"
-      onClick={props.onClick}
+      title={
+        props.canChange
+          ? 'Click here to change the user status'
+          : props.isActive
+          ? 'Active'
+          : 'Inactive'
+      }
+      onClick={props.canChange ? props.onClick : () => {}}
     >
       <i className="fa fa-circle" aria-hidden="true" />
     </span>

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -37,6 +37,7 @@ const UserTableData = React.memo(props => {
       <td className="usermanagement__active--input">
         <ActiveCell
           isActive={props.isActive}
+          canChange={true}
           key={`active_cell${props.index}`}
           index={props.index}
           onClick={() => props.onActiveInactiveClick(props.user)}

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -637,16 +637,14 @@ function UserProfile(props) {
                 className="fa fa-info-circle"
                 onClick={toggleInfoModal}
               />{' '}
-              <>
-                <ActiveCell
-                  isActive={userProfile.isActive}
-                  user={userProfile}
-                  canChange={canChangeUserStatus}
-                  onClick={() => {
-                    setActiveInactivePopupOpen(true);
-                  }}
-                />
-              </>
+              <ActiveCell
+                isActive={userProfile.isActive}
+                user={userProfile}
+                canChange={canChangeUserStatus}
+                onClick={() => {
+                  setActiveInactivePopupOpen(true);
+                }}
+              />
               {canEdit && (
                 <i
                   data-toggle="tooltip"

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -541,6 +541,12 @@ function UserProfile(props) {
       ? hasPermission(requestorRole, 'addDeleteEditOwners', roles, userPermissions)
       : hasPermission(requestorRole, 'editUserProfile', roles, userPermissions);
   const canEdit = canEditProfile || isUserSelf;
+  const canChangeUserStatus = hasPermission(
+    requestorRole,
+    'changeUserStatus',
+    roles,
+    userPermissions,
+  );
 
   const customStyles = {
     control: (base, state) => ({
@@ -631,17 +637,16 @@ function UserProfile(props) {
                 className="fa fa-info-circle"
                 onClick={toggleInfoModal}
               />{' '}
-              {canEdit && (
-                <>
-                  <ActiveCell
-                    isActive={userProfile.isActive}
-                    user={userProfile}
-                    onClick={() => {
-                      setActiveInactivePopupOpen(true);
-                    }}
-                  />
-                </>
-              )}
+              <>
+                <ActiveCell
+                  isActive={userProfile.isActive}
+                  user={userProfile}
+                  canChange={canChangeUserStatus}
+                  onClick={() => {
+                    setActiveInactivePopupOpen(true);
+                  }}
+                />
+              </>
               {canEdit && (
                 <i
                   data-toggle="tooltip"


### PR DESCRIPTION
# Description
Fix bug 5. (PRIORITY MEDIUM) Vitor/Jae: **Fix the "Change User Status” permission**
<img width="728" alt="img" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/22527d5a-81ea-4cc7-91a8-8f6150ba9987">

## Related PRS (if any):
This frontend PR is related to the backend [PR401](https://github.com/OneCommunityGlobal/HGNRest/pull/401).

## Main changes explained:
- By default only admin an owner can edit the user status (active/inactive) by clicking the green dot on the profile page.
- The editing permission (`changeUserStatus`) can be managed for each class/user from the permission management page.
- The one without the editing ability will just see the data-tip when hover the mouse over the green dot.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user --> view other user's profile --> can click the green dot to change the status
4. log as other roles --> view other user's profile --> see the green dot with data-tip but cannot click it.
5. log as owner user --> permission management --> can change the permission of 'change user status' for any user/class. (admin can see the role for a class but not edit it)

## Screenshots or videos of changes:
Before:
<img width="849" alt="1" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/d6f56cd2-829c-400f-8300-cdc92b2a122b">
After:
<img width="621" alt="2" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/04e94b93-bcb6-45e9-896a-66ac084cf50b">
If someone view other's profile without edit permission:
<img width="322" alt="3" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/0c19020c-7657-4c60-a0a9-5c3f5782a17b">
If someone view other's profile with edit permission:
<img width="481" alt="4" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/b0e96cd4-2ca4-45da-8d4b-291e7fff8c14">

## Note
The one-line change in UserTableData.jsx is not related to the bug fix of `changUserStatus` permission, but needed to pass the test of UserTableData component (otherwise the `props.canChange` undefined and the test case cannot find the title). It will not make any differences to the functionality because before or after this PR, the `ActiveCell` in the `UserTableData` does not need to satisfy any condition and always renders with editing permission.