### PR TITLE
XiaoW - optimize the request for user tasks to one post request

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -183,9 +183,7 @@ const TeamMemberTasks = props => {
     setFortyEightHoursTimeEntries([...fortyEightList]);
     setTwentyFourHoursTimeEntries([...twentyFourList]);
 
-    if (usersListTasks.length && twentyFourList.length && fortyEightList.length) {
-      setFinishLoading(true);
-    }
+    setFinishLoading(true);
   };
 
   //Display timelogs based on selected period

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -26,7 +26,7 @@ export const ENDPOINTS = {
   ORG_DATA: `${APIEndpoint}/dashboard/leaderboard/org/data`,
   TIME_ENTRIES_PERIOD: (userId, fromDate, toDate) =>
     `${APIEndpoint}/TimeEntry/user/${userId}/${fromDate}/${toDate}`,
-  TIME_ENTRIES_USER_LIST: users => `${APIEndpoint}/TimeEntry/users?members=${users}`,
+  TIME_ENTRIES_USER_LIST: `${APIEndpoint}/TimeEntry/users`,
   TIME_ENTRY: () => `${APIEndpoint}/TimeEntry`,
   TIME_ENTRY_CHANGE: timeEntryId => `${APIEndpoint}/TimeEntry/${timeEntryId}`,
   WBS_ALL: `${APIEndpoint}/wbs`,
@@ -82,7 +82,8 @@ export const ENDPOINTS = {
   OWNERMESSAGE_BY_ID: ownerMessageId => `${APIEndpoint}/ownerMessage/${ownerMessageId}`,
 
   OWNERSTANDARDMESSAGE: () => `${APIEndpoint}/ownerStandardMessage`,
-  OWNERSTANDARDMESSAGE_BY_ID: ownerStandardMessageId => `${APIEndpoint}/ownerStandardMessage/${ownerStandardMessageId}`
+  OWNERSTANDARDMESSAGE_BY_ID: ownerStandardMessageId =>
+    `${APIEndpoint}/ownerStandardMessage/${ownerStandardMessageId}`,
 };
 
 export const ApiEndpoint = APIEndpoint;


### PR DESCRIPTION
# Description
When loading dashboard, app will send a get request for each user for its task and for admin there will be hundreds of requests. This PR integrates all the request into one post request.

## Related PRS (if any):
This frontend PR is related to the [#402](https://github.com/OneCommunityGlobal/HGNRest/pull/402#issue-1751172814) backend PR. backend PR.
To test this backend PR you need to checkout the [#402](https://github.com/OneCommunityGlobal/HGNRest/pull/402#issue-1751172814) backend PR.frontend PR.
…

## Main changes explained:
- collect required userId into one array
- change the requst to post with a body of userIds
…

## How to test:
1. check into current branch as front end
2. check into [#402](https://github.com/OneCommunityGlobal/HGNRest/pull/402#issue-1751172814) backend PR. branch as back end
3. do `npm install` and `npm run start:local` to run this PR locally
4. log as admin user
5. check the developer tool - network, check the request of `.../TimeEntry/users`, this is the request for all the tasks that used to be hundreds of requests
6. see if there is any freezing as before when loading, or any potential bugs caused by this PR.

