### PR TITLE
Jinchao fixed project/task field of timeEntry component

### DIFF
--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -19,10 +19,6 @@ import checkNegativeNumber from 'utils/checkNegativeHours';
 
 const TimeEntry = ({ data, displayYear, userProfile }) => {
   const [modal, setModal] = useState(false);
-  const [projectName, setProjectName] = useState('');
-  const [projectCategory, setProjectCategory] = useState('');
-  const [taskName, setTaskName] = useState('');
-  const [taskClassification, setTaskClassification] = useState('');
 
   const toggle = () => setModal(modal => !modal);
 
@@ -37,29 +33,9 @@ const TimeEntry = ({ data, displayYear, userProfile }) => {
       .tz('America/Los_Angeles')
       .format('YYYY-MM-DD') === data.dateOfWork;
   const role = user.role;
-
+  const projectCategory = data.category?.toLowerCase() || '';
+  const taskClassification = data.classification?.toLowerCase() || '';
   const dispatch = useDispatch();
-
-  useEffect(() => {
-    axios
-      .get(ENDPOINTS.PROJECT_BY_ID(data.projectId))
-      .then(res => {
-        setProjectCategory(res?.data.category.toLowerCase() || '');
-        setProjectName(res?.data?.projectName || '');
-      })
-      .catch(err => console.log(err));
-  }, []);
-
-  useEffect(() => {
-    axios
-      // Note: Here taskId is stored in projectId since no taskId field in timeEntry schema
-      .get(ENDPOINTS.GET_TASK(data.projectId))
-      .then(res => {
-        setTaskClassification(res?.data?.classification.toLowerCase() || '');
-        setTaskName(res?.data?.taskName || '');
-      })
-      .catch(err => console.log(err));
-  }, []);
 
   const toggleTangibility = () => {
     const newData = {
@@ -72,7 +48,7 @@ const TimeEntry = ({ data, displayYear, userProfile }) => {
     //Update intangible hours property in userprofile
     const formattedHours = parseFloat(data.hours) + parseFloat(data.minutes) / 60;
     const { hoursByCategory } = userProfile;
-    if (projectName) {
+    if (data.projectName) {
       const isFindCategory = Object.keys(hoursByCategory).find(key => key === projectCategory);
       //change tangible to intangible
       if (data.isTangible) {
@@ -124,7 +100,7 @@ const TimeEntry = ({ data, displayYear, userProfile }) => {
             {data.hours}h {data.minutes}m
           </h4>
           <div className="text-muted">Project/Task:</div>
-          <h6> {projectName || taskName} </h6>
+          <h6> {data.projectName || data.taskName} </h6>
           <span className="text-muted">Tangible:&nbsp;</span>
           <input
             type="checkbox"


### PR DESCRIPTION
# Description
Currently the project/task field in timeEntry can only show project correctly. For those time logged under a task, the project/task is blank.
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/72902f97-a513-4a62-9d06-fa1719bed20a)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/04b39380-1f18-4bdf-b2a6-13c056d03e9f)

## Related PRS (if any):
This frontend PR is related to the [#403](https://github.com/OneCommunityGlobal/HGNRest/pull/403) backend PR.

## Main changes explained:
- Remove redundant states and axios requests in TimeEntry component. Now the component will get those data directly from the `data` parameter.

## How to test:
1. check into current branch on both FE and [BE](https://github.com/OneCommunityGlobal/HGNRest/pull/403)
2. do `npm run build` and `npm start` at BE
3. log as admin users->go to Timelog and log some time under both projects and tasks.
4. check if the project/task works for all timeEntries and this PR doesn't break anything relative to timeEntry component.
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/a018f939-0ee1-4991-a9f1-e98b1b5d3a08)
5. open the browser console to check if these bad request error are fixed(these errors are occured when we have a timeEntry logged under a task)
![Screenshot 2023-06-10 193315edit](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/79e0c174-87a7-4ffb-9d8b-b537f6e93384)

## Note:

- Currently there is a bug preventing you change the project/task for a timeEntry:

![Screenshot 2023-06-10 200700](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/7b6d68e6-3879-45e6-b9d6-3cb663374b17)
Please pass this feature when testing, I will fix this bug in another PR.

- This PR will improve the efficency of the timeEntry component since it remove two axios requests which are time cosuming:
![Screenshot 2023-06-10 193315edit2](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/f845b3b8-036b-4f24-834d-d9b59fcb0dbc) 
You can test the time on your loacalhost following these codes in TimeEntry.jsx on dev branch:
![Screenshot 2023-06-10 193350](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/f53b9330-fd7d-44c2-8348-9597e0c44d0f)

