### PR TITLE
Lucile_bug_rehireable_reports

### DIFF
--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -147,6 +147,11 @@ class PeopleReport extends Component {
       };
     });
     this.props.userProfile.isRehireable = rehireValue;
+    let endDate = new Date(this.props.userProfile.endDate);
+    let year = endDate.toLocaleString('default', { year: 'numeric' });
+    let month = endDate.toLocaleString('default', { month: '2-digit' });
+    let day = endDate.toLocaleString('default', { day: '2-digit' });
+    this.props.userProfile.endDate = year + '-' + month + '-' + day;
     this.props.updateUserProfile(this.props.userProfile._id, this.props.userProfile);
   }
 
@@ -488,14 +493,15 @@ class PeopleReport extends Component {
           </div>
           {this.state.bioStatus ? (
             <div>
-              <h5>Bio {this.state.bioStatus === "default" ? "not requested" : this.state.bioStatus}</h5>{' '}
+              <h5>
+                Bio {this.state.bioStatus === 'default' ? 'not requested' : this.state.bioStatus}
+              </h5>{' '}
               {this.state.authRole === 'Administrator' || this.state.authRole === 'Owner' ? (
                 <ToggleSwitch
-                  fontSize={"13px"}
+                  fontSize={'13px'}
                   switchType="bio"
                   state={this.state.bioStatus}
-                  handleUserProfile={
-                    (bio) => onChangeBioPosted(bio)}
+                  handleUserProfile={bio => onChangeBioPosted(bio)}
                 />
               ) : null}
             </div>
@@ -504,7 +510,7 @@ class PeopleReport extends Component {
       </ReportPage.ReportHeader>
     );
 
-    const onChangeBioPosted = async (bio) => {
+    const onChangeBioPosted = async bio => {
       const userId = this.state.userId || this.props.match?.params?.userId;
       const bioStatus = bio;
       this.setState(state => {
@@ -512,7 +518,6 @@ class PeopleReport extends Component {
           bioStatus: bioStatus,
         };
       });
-      console.log(bioStatus)
       try {
         await this.props.updateUserProfile(userId, {
           ...this.state.userProfile,

--- a/src/components/Reports/ReportTableSearchPanel.jsx
+++ b/src/components/Reports/ReportTableSearchPanel.jsx
@@ -18,7 +18,7 @@ function ReportTableSearchPanel(props) {
         aria-label="Search"
         placeholder="Search Text"
         id="team-profiles-wild-card-search"
-        onChange={(e) => {
+        onChange={e => {
           props.onSearch(e.target.value);
         }}
       />

--- a/src/components/UserProfile/AssignBadgePopup.jsx
+++ b/src/components/UserProfile/AssignBadgePopup.jsx
@@ -64,7 +64,7 @@ const AssignBadgePopup = props => {
           onSearch(e.target.value);
         }}
       />
-      <div style={{ overflowY: 'scroll', height: '75vh'}}>
+      <div style={{ overflowY: 'scroll', height: '75vh' }}>
         <Table>
           <thead>
             <tr>
@@ -78,9 +78,9 @@ const AssignBadgePopup = props => {
                   style={{ backgroundColor: '#666', color: '#fff' }}
                 >
                   <p className="badge_info_icon_text">
-                    Hmmm, little blank boxes... what could they mean? Yep, you guessed it, check those
-                    boxes to select the badges you wish to assign a person. Click the "Confirm" button
-                    at the bottom when you've selected all you wish to add.
+                    Hmmm, little blank boxes... what could they mean? Yep, you guessed it, check
+                    those boxes to select the badges you wish to assign a person. Click the
+                    "Confirm" button at the bottom when you've selected all you wish to add.
                   </p>
                   <p className="badge_info_icon_text">
                     Want to assign multiple of the same badge to a person? Repeat the process!!
@@ -91,7 +91,7 @@ const AssignBadgePopup = props => {
           </thead>
           <tbody>
             {filteredBadges.map((value, index) => (
-              <AssignTableRow badge={value} index={index} key={index}/>
+              <AssignTableRow badge={value} index={index} key={index} />
             ))}
           </tbody>
         </Table>


### PR DESCRIPTION
# Description
The End date is sent to backend in the right format. After this PR was merged due to a bug issue, I had to manage the date in the front : 
https://github.com/OneCommunityGlobal/HGNRest/pull/405/files


###Description
9. (PRIORITY MEDIUM) Jae: Add work confirmation improvements to People Report (WIP Lucile)
Admin or Owner login → Reports → Reports → People → Choose
Remove “hours logged this week” section: If a user is INACTIVE (has an end date), then the “Hours Logged This Week” square should not show. Center the remaining ones.
Please also add the User’s Title under their name.
Please also add a “Rehireable” section under their name that can be clicked as Yes or No

11. (PRIORITY LOW): In smaller view widths (<=1200px), the tops of the report blocks are cut off. (WIP Lucile)

###Related PR
To test this frontend PR you need to checkout the  #405 backend PR.
https://github.com/OneCommunityGlobal/HGNRest/pull/405
do "npm install" and "npm run build" and "npm start" to run this PR locally


###Mainly changes explained:
1 - Was added a new set State in setRehireable in PeapleReport

###Before (sorry for my slow connexion)

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/e92b0a4c-9f38-4129-963b-645cdada4b9d

###After (sorry for my slow connexion)


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/ae80a0ca-568f-454f-93f5-adfaa0bd0eef





###How to test:
Git checkout Lucile_add_work_confirmation_improvements_to_people_report in the frontend
do npm install and npm run start:local to run this PR locally

Git checkout Lucile_End_Date_Issue
do npm install and npm run build and npm start



Admin or Owner login → Reports → Reports → People → Choose someone with an end date 
You should not see "hours logged this week" section
You should see the User’s Title under their name
You should be able to checkout and checkout the rehireable check box on the right.
The chosen check should remain even if the page is refreshed.
The tops of the report blocks should not be cut off in smaller views

Admin or Owner login → Reports → Reports → People → Choose someone without an end date 
You should see "hours logged this week" section
You should see the User’s Title under their name
You should not see the rehireable checkbox
The tops of the report blocks should not be cut off in smaller views
