### PR TITLE
Lucile reusable user change

### DIFF
--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -56,3 +56,14 @@ export const updateUserProfile = (userId, userProfile) => {
     return res.status;
   };
 };
+
+export const updateUserProfileProperty = (userProfile, key, value) => {
+  const url = ENDPOINTS.USER_PROFILE_PROPERTY(userProfile._id);
+  return async dispatch => {
+    const res = await axios.patch(url, {key: key, value: value});
+    if (res.status === 200) {
+      await dispatch(getUserProfileActionCreator(userProfile));
+    }
+    return res.status;
+  };
+};

--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -5,7 +5,7 @@ import { Button, Dropdown, DropdownButton } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { FiUser } from 'react-icons/fi';
-import { updateUserProfile, getUserProfile, getUserTask } from '../../../actions/userProfile';
+import { updateUserProfileProperty, getUserProfile, getUserTask } from '../../../actions/userProfile';
 import { getUserProjects } from '../../../actions/userProjects';
 import { getWeeklySummaries, updateWeeklySummaries } from '../../../actions/weeklySummaries';
 import moment from 'moment';
@@ -140,14 +140,19 @@ class PeopleReport extends Component {
     });
   }
 
-  setRehireable(rehireValue) {
+  async setRehireable(rehireValue) {
     this.setState(state => {
       return {
         isRehireable: rehireValue,
       };
     });
-    this.props.userProfile.isRehireable = rehireValue;
-    this.props.updateUserProfile(this.props.userProfile._id, this.props.userProfile);
+
+    try {
+      await this.props.updateUserProfileProperty(this.props.userProfile, 'isRehireable',rehireValue);
+      toast.success(`You have changed the rehireable status of this user to ${rehireValue}`);
+    } catch (err) {
+      alert('An error occurred while attempting to save the rehireable status of this user.');
+    }
   }
 
   setPriority(priorityValue) {
@@ -505,24 +510,21 @@ class PeopleReport extends Component {
     );
 
     const onChangeBioPosted = async (bio) => {
-      const userId = this.state.userId || this.props.match?.params?.userId;
       const bioStatus = bio;
       this.setState(state => {
         return {
           bioStatus: bioStatus,
         };
       });
-      console.log(bioStatus)
+
       try {
-        await this.props.updateUserProfile(userId, {
-          ...this.state.userProfile,
-          bioPosted: bioStatus,
-        });
+        await  this.props.updateUserProfileProperty(this.props.userProfile, 'bioPosted',bioStatus);
         toast.success('You have changed the bio announcement status of this user.');
       } catch (err) {
         alert('An error occurred while attempting to save the bioPosted change to the profile.');
       }
     };
+
 
     return (
       <ReportPage renderProfile={renderProfileInfo}>
@@ -604,7 +606,7 @@ class PeopleReport extends Component {
 }
 export default connect(getPeopleReportData, {
   getUserProfile,
-  updateUserProfile,
+  updateUserProfileProperty,
   getWeeklySummaries,
   updateWeeklySummaries,
   getUserTask,

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -6,6 +6,7 @@ let GeocodeAPIEndpoint = 'https://api.opencagedata.com/geocode/v1/json';
 export const ENDPOINTS = {
   APIEndpoint: () => APIEndpoint,
   USER_PROFILE: userId => `${APIEndpoint}/userprofile/${userId}`,
+  USER_PROFILE_PROPERTY: userId => `${APIEndpoint}/userprofile/${userId}/property`,
   USER_PROFILES: `${APIEndpoint}/userprofile/`,
   USER_PROFILE_BY_NAME: userName => `${APIEndpoint}/userProfile/name/${userName}`,
   USER_TEAM: userId => `${APIEndpoint}/userprofile/teammembers/${userId}`,


### PR DESCRIPTION
###Description
After a concerning bug, this PR has been made in order to change only a part of the User Profile without the use of putUserProfile function
In this PR this new code is used for isRehireable and Bio Status on the report page. 

###Related PR
To test this frontend PR you need to checkout the #411 backend PR.
https://github.com/OneCommunityGlobal/HGNRest/pull/411

###Mainly changes explained:
1 - Add the reusable updateUserProfileProperty 

###Before 

https://github.com/OneCommunityGlobal/HGNRest/assets/111132148/78cd8ce5-fd98-4d84-8cb3-f738ae8ad811



###After 


https://github.com/OneCommunityGlobal/HGNRest/assets/111132148/6b44e983-7a0a-4c74-a86e-90b51f4b615b



###How to test:
Git checkout Lucile-reusable-user-change in the backend
do "npm pull" and "npm install" and "npm run build" and "npm start" to run this PR locally

Git checkout Lucile-reusable-user-change in the frontend
do "npm install" and "npm run start:local"

Admin or Owner login → Reports → Reports → People → Choose someone with an end date 
You should be able to check and checkout the rehireable check box and the bio status on the right.
The chosen check should remain even if the page is refreshed.

Admin or Owner login → Reports → Reports → People → Choose someone without an end date 
You should not see the rehireable checkbox

