### PR TITLE
Xiaoyu - Add “Media/DropBox Link” field to the new-user setup page 

### DIFF
--- a/src/actions/weeklySummaries.js
+++ b/src/actions/weeklySummaries.js
@@ -42,7 +42,14 @@ export const getWeeklySummaries = userId => {
       const response = await axios.get(url);
       // Only pick the fields related to weekly summaries from the userProfile.
       const { weeklySummariesCount, weeklySummaries, mediaUrl } = response.data;
-      dispatch(fetchWeeklySummariesSuccess({ weeklySummariesCount, weeklySummaries, mediaUrl }));
+      let weeklySummariesLink;
+      for (let link in response.data.adminLinks) {
+        if (response.data.adminLinks[link].Name === "Weekly Summaries Link") {
+          weeklySummariesLink = response.data.adminLinks[link].Link;
+          break; // This line is not mandatory, but it would optimize your code as it would break the loop once the link is found.
+        }
+      }
+      dispatch(fetchWeeklySummariesSuccess({ weeklySummariesCount, weeklySummaries, mediaUrl, weeklySummariesLink}));
       return response.status;
     } catch (error) {
       dispatch(fetchWeeklySummariesError(error));

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -307,8 +307,8 @@ class AddUserProfile extends Component {
                     <FormGroup>
                       <Input
                         type="text"
-                        name="googleDoc"
-                        id="googleDoc"
+                        name="weeklySummariesLink"
+                        id="weeklySummariesLink"
                         value={this.state.userProfile.googleDoc}
                         onChange={this.handleUserProfile}
                         placeholder="DropBox Folder of Folders"

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -301,7 +301,7 @@ class AddUserProfile extends Component {
                 </Row>
                 <Row>
                   <Col md={{ size: 3, offset: 1 }} className="text-md-right my-2">
-                    <Label>Google Doc</Label>
+                    <Label>Weekly Summaries Link</Label>
                   </Col>
                   <Col md="6">
                     <FormGroup>
@@ -311,7 +311,7 @@ class AddUserProfile extends Component {
                         id="googleDoc"
                         value={this.state.userProfile.googleDoc}
                         onChange={this.handleUserProfile}
-                        placeholder="Admin Document"
+                        placeholder="DropBox Folder of Folders"
                       />
                     </FormGroup>
                   </Col>
@@ -585,7 +585,7 @@ class AddUserProfile extends Component {
     this.setState({ formSubmitted: true });
 
     if (googleDoc) {
-      userData.adminLinks.push({ Name: 'Google Doc', Link: googleDoc });
+      userData.adminLinks.push({ Name: 'Weekly Summaries Link', Link: googleDoc });
     }
     if (this.fieldsAreValid()) {
       this.setState({ showphone: false });

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -308,7 +308,7 @@ class AddUserProfile extends Component {
                       <Input
                         type="text"
                         name="weeklySummariesLink"
-                        id="weeklySummariesLink"
+                        id="googleDoc"
                         value={this.state.userProfile.googleDoc}
                         onChange={this.handleUserProfile}
                         placeholder="DropBox Folder of Folders"
@@ -583,7 +583,6 @@ class AddUserProfile extends Component {
     };
 
     this.setState({ formSubmitted: true });
-
     if (googleDoc) {
       userData.adminLinks.push({ Name: 'Weekly Summaries Link', Link: googleDoc });
     }

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -74,7 +74,7 @@ export class WeeklySummary extends Component {
 
   async componentDidMount() {
     await this.props.getWeeklySummaries(this.props.asUser || this.props.currentUser.userid);
-    const { mediaUrl, weeklySummaries, weeklySummariesCount } = this.props.summaries;
+    const { mediaUrl, googleDocLink, weeklySummaries, weeklySummariesCount } = this.props.summaries;
     const summary = (weeklySummaries && weeklySummaries[0] && weeklySummaries[0].summary) || '';
     const summaryLastWeek =
       (weeklySummaries && weeklySummaries[1] && weeklySummaries[1].summary) || '';
@@ -125,7 +125,7 @@ export class WeeklySummary extends Component {
         summaryLastWeek,
         summaryBeforeLast,
         summaryThreeWeeksAgo,
-        mediaUrl: mediaUrl || '',
+        mediaUrl: googleDocLink || mediaUrl || '',
         weeklySummariesCount: weeklySummariesCount || 0,
         mediaConfirm: false,
       },

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -74,7 +74,7 @@ export class WeeklySummary extends Component {
 
   async componentDidMount() {
     await this.props.getWeeklySummaries(this.props.asUser || this.props.currentUser.userid);
-    const { mediaUrl, googleDocLink, weeklySummaries, weeklySummariesCount } = this.props.summaries;
+    const { mediaUrl, weeklySummariesLink, weeklySummaries, weeklySummariesCount } = this.props.summaries;
     const summary = (weeklySummaries && weeklySummaries[0] && weeklySummaries[0].summary) || '';
     const summaryLastWeek =
       (weeklySummaries && weeklySummaries[1] && weeklySummaries[1].summary) || '';
@@ -125,7 +125,7 @@ export class WeeklySummary extends Component {
         summaryLastWeek,
         summaryBeforeLast,
         summaryThreeWeeksAgo,
-        mediaUrl: googleDocLink || mediaUrl || '',
+        mediaUrl: weeklySummariesLink || mediaUrl || '',
         weeklySummariesCount: weeklySummariesCount || 0,
         mediaConfirm: false,
       },


### PR DESCRIPTION
# Description
1.(PRIORITY HIGH) Jae: Add “Media/DropBox Link” field to the new-user setup page (WIP Xiaoyu)
a.Admin Login → Other Links → User Management → Create New User
b.I’d like this link above the Google Doc field in the picture below
![Screenshot 2023-06-19 at 3 26 00 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/102696148/66db30b9-656a-4108-be54-b886df3cc84e)

i.Should be optional
ii. Should say “Weekly Summaries Link” on left and “DropBox Folder of Folders” in the field 

c.If entered, this media links should be auto-filled where the person enters their weekly summaries. 
i. If they go to edit it there, a popup should show that says: “Whoa Tiger! Are you sure you want to do that? This link was added by an Admin when you were set up as a member of the team. Only change this if you are SURE your new link is more correct than the one already here.”  
d.If entered, this media links should also be added as “WEEKLY SUMMARIES LINK” to the user’s profile with the other links:


## Main changes explained:
- Link mediaUrl to AdminLinks googleDocLink
- Modify mediaURL will popup warning
- Edit mediaUrl will update AdminLinks googleDocLink and Profile Link
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user create a user and enter the weekly summary link
4. log in as the created user and check the profile weekly summary link and try modify the summary link

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
Create a user with weekly summary link
![Screenshot 2023-06-19 at 3 02 28 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/102696148/00fd32a3-db1f-4803-8018-9be22bd566b9)
Then test like this:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/102696148/bec4e388-7a99-4fb9-ada5-6a6fee7d171b

