### PR TITLE
Leon fix congratulatory text in badge section of user profile

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -82,7 +82,11 @@ const Badge = props => {
                     color: '#285739',
                   }}
                 >
-                  Bravo! You Earned {totalBadge} Badges!{' '}
+                  {totalBadge
+                    ? `Bravo! You have earned ${totalBadge} ${
+                        totalBadge == 1 ? 'badge' : 'badges'
+                      }! `
+                    : 'You have no badges. '}
                   <i className="fa fa-info-circle" id="CountInfo" />
                 </CardText>
                 <Button className="btn--dark-sea-green float-right" onClick={toggle}>

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -35,6 +35,13 @@ export const Badges = props => {
   }, [isOpen, isAssignOpen]);
 
   const badgesEarned = props.userProfile.badgeCollection.length;
+  const subject = props.isUserSelf ? 'You have' : 'This person has';
+  const verb = badgesEarned ? `earned ${badgesEarned}` : 'no';
+  const object = badgesEarned == 1 ? 'badge' : 'badges';
+  let congratulatoryText = `${subject} ${verb} ${object}`;
+  congratulatoryText = badgesEarned
+    ? 'Bravo! ' + congratulatoryText + '! '
+    : congratulatoryText + '. ';
 
   return (
     <>
@@ -102,9 +109,7 @@ export const Badges = props => {
             color: '#285739',
           }}
         >
-          {`Bravo! ${props.isUserSelf ? "You've" : 'This person has'} earned ${badgesEarned} ${
-            badgesEarned == 1 ? 'badge' : 'badges'
-          }! `}
+          {congratulatoryText}
           <i className="fa fa-info-circle" id="CountInfo" />
         </CardFooter>
       </Card>

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -100,7 +100,9 @@ const Badges = props => {
             color: '#285739',
           }}
         >
-          Bravo! You've earned {props.userProfile.badgeCollection.length} badges!{' '}
+          {`Bravo! ${props.isUserSelf ? "You've" : 'This person has'} earned ${
+            props.userProfile.badgeCollection.length
+          } badges! `}
           <i className="fa fa-info-circle" id="CountInfo" />
         </CardFooter>
       </Card>

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -34,6 +34,7 @@ export const Badges = props => {
     }
   }, [isOpen, isAssignOpen]);
 
+  // Determines what congratulatory text should displayed.
   const badgesEarned = props.userProfile.badgeCollection.length;
   const subject = props.isUserSelf ? 'You have' : 'This person has';
   const verb = badgesEarned ? `earned ${badgesEarned}` : 'no';

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -17,7 +17,7 @@ import BadgeReport from '../Badge/BadgeReport';
 import AssignBadgePopup from './AssignBadgePopup';
 import { clearSelected } from 'actions/badgeManagement';
 
-const Badges = props => {
+export const Badges = props => {
   const [isOpen, setOpen] = useState(false);
   const [isAssignOpen, setAssignOpen] = useState(false);
   const permissionsUser = props.userProfile?.permissions?.frontPermissions;

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -34,6 +34,8 @@ const Badges = props => {
     }
   }, [isOpen, isAssignOpen]);
 
+  const badgesEarned = props.userProfile.badgeCollection.length;
+
   return (
     <>
       <Card id="badgeCard" style={{ backgroundColor: '#f6f6f3', marginTop: 20, marginBottom: 20 }}>
@@ -100,9 +102,9 @@ const Badges = props => {
             color: '#285739',
           }}
         >
-          {`Bravo! ${props.isUserSelf ? "You've" : 'This person has'} earned ${
-            props.userProfile.badgeCollection.length
-          } badges! `}
+          {`Bravo! ${props.isUserSelf ? "You've" : 'This person has'} earned ${badgesEarned} ${
+            badgesEarned == 1 ? 'badge' : 'badges'
+          }! `}
           <i className="fa fa-info-circle" id="CountInfo" />
         </CardFooter>
       </Card>

--- a/src/components/UserProfile/Badges.test.jsx
+++ b/src/components/UserProfile/Badges.test.jsx
@@ -49,6 +49,7 @@ describe('Badges Component', () => {
           },
         };
         const renderedBadges = render(<Badges {...props} />);
+        // This uses a regular expression that matches all postive numbers > 1.
         expect(renderedBadges.find('.card-footer').text()).toMatch(
           /Bravo! You have earned ([1-9]\d+|[2-9]) badges! /,
         );

--- a/src/components/UserProfile/Badges.test.jsx
+++ b/src/components/UserProfile/Badges.test.jsx
@@ -19,37 +19,72 @@ describe('Badges Component', () => {
     userPermissions: [],
   };
   describe('Card Footer Text', () => {
-    it('should say "You have..." when user is viewing their own profile', () => {
-      const props = { ...badgeProps, isUserSelf: true };
-      const renderedBadges = render(<Badges {...props} />);
-      expect(renderedBadges.find('.card-footer').text()).toBe('You have no badges. ');
+    describe('When viewing your own profile', () => {
+      it('should display the correct text when you have no badges', () => {
+        const props = {
+          ...badgeProps,
+          isUserSelf: true,
+        };
+        const renderedBadges = render(<Badges {...props} />);
+        expect(renderedBadges.find('.card-footer').text()).toBe('You have no badges. ');
+      });
+
+      it('should display the correct text when you have exactly 1 badge', () => {
+        const props = {
+          ...badgeProps,
+          isUserSelf: true,
+          userProfile: { ...badgeProps.userProfile, badgeCollection: ['B1'] },
+        };
+        const renderedBadges = render(<Badges {...props} />);
+        expect(renderedBadges.find('.card-footer').text()).toBe('Bravo! You have earned 1 badge! ');
+      });
+
+      it('should display the correct text when you have amount of badges > 1', () => {
+        const props = {
+          ...badgeProps,
+          isUserSelf: true,
+          userProfile: {
+            ...badgeProps.userProfile,
+            badgeCollection: ['B1', 'B2', 'B3'],
+          },
+        };
+        const renderedBadges = render(<Badges {...props} />);
+        expect(renderedBadges.find('.card-footer').text()).toMatch(
+          /Bravo! You have earned ([1-9]\d+|[2-9]) badges! /,
+        );
+      });
     });
 
-    it('should say "This person has..." when user is viewing someone else\'s profile', () => {
-      const renderedBadges = render(<Badges {...badgeProps} />);
-      expect(renderedBadges.find('.card-footer').text()).toBe('This person has no badges. ');
-    });
+    describe("When viewing someone else's profile", () => {
+      it('should display the correct text when they have no badges', () => {
+        const renderedBadges = render(<Badges {...badgeProps} />);
+        expect(renderedBadges.find('.card-footer').text()).toBe('This person has no badges. ');
+      });
 
-    it('should use the singular version of badge when the user has exactly 1 badge', () => {
-      const props = {
-        ...badgeProps,
-        userProfile: { ...badgeProps.userProfile, badgeCollection: ['B1'] },
-      };
-      const renderedBadges = render(<Badges {...props} />);
-      expect(renderedBadges.find('.card-footer').text()).toBe(
-        'Bravo! This person has earned 1 badge! ',
-      );
-    });
+      it('should display the correct text when they have exactly 1 badge', () => {
+        const props = {
+          ...badgeProps,
+          userProfile: { ...badgeProps.userProfile, badgeCollection: ['B1'] },
+        };
+        const renderedBadges = render(<Badges {...props} />);
+        expect(renderedBadges.find('.card-footer').text()).toBe(
+          'Bravo! This person has earned 1 badge! ',
+        );
+      });
 
-    it('should use the plural version of badge when the user has any number of badges other than 1 ', () => {
-      const props = {
-        ...badgeProps,
-        userProfile: { ...badgeProps.userProfile, badgeCollection: ['B1', 'B2'] },
-      };
-      const renderedBadges = render(<Badges {...props} />);
-      expect(renderedBadges.find('.card-footer').text()).toBe(
-        'Bravo! This person has earned 2 badges! ',
-      );
+      it('should display the correct text when they have amount of badges > 1', () => {
+        const props = {
+          ...badgeProps,
+          userProfile: {
+            ...badgeProps.userProfile,
+            badgeCollection: ['B1', 'B2', 'B3'],
+          },
+        };
+        const renderedBadges = render(<Badges {...props} />);
+        expect(renderedBadges.find('.card-footer').text()).toMatch(
+          /Bravo! This person has earned ([1-9]\d+|[2-9]) badges! /,
+        );
+      });
     });
   });
 });

--- a/src/components/UserProfile/Badges.test.jsx
+++ b/src/components/UserProfile/Badges.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Badges } from './Badges';
+import { render } from 'enzyme';
+
+describe('Badges Component', () => {
+  const badgeProps = {
+    isUserSelf: false,
+    userProfile: {
+      badgeCollection: [],
+      _id: 'fakeid',
+      firstName: 'First Name',
+      lastName: 'Last Name',
+    },
+    setUserProfile: jest.fn(),
+    setOriginalUserProfile: jest.fn(),
+    role: null,
+    canEdit: true,
+    handleSubmit: jest.fn(),
+    userPermissions: [],
+  };
+  describe('Card Footer Text', () => {
+    it('should say "You\'ve earned..." when user is viewing their own profile', () => {
+      const props = { ...badgeProps, isUserSelf: true };
+      const renderedBadges = render(<Badges {...props} />);
+      expect(renderedBadges.find('.card-footer').text()).toBe("Bravo! You've earned 0 badges! ");
+    });
+
+    it('should say "This person has earned..." when user is viewing someone else\'s profile', () => {
+      const renderedBadges = render(<Badges {...badgeProps} />);
+      expect(renderedBadges.find('.card-footer').text()).toBe(
+        'Bravo! This person has earned 0 badges! ',
+      );
+    });
+
+    it('should use the singular version of badge when the user has exactly 1 badge', () => {
+      const props = {
+        ...badgeProps,
+        userProfile: { ...badgeProps.userProfile, badgeCollection: ['B1'] },
+      };
+      const renderedBadges = render(<Badges {...props} />);
+      expect(renderedBadges.find('.card-footer').text()).toBe(
+        'Bravo! This person has earned 1 badge! ',
+      );
+    });
+
+    it('should use the plural version of badge when the user has any number of badges other than 1 ', () => {
+      const props = {
+        ...badgeProps,
+        userProfile: { ...badgeProps.userProfile, badgeCollection: ['B1', 'B2'] },
+      };
+      const renderedBadges = render(<Badges {...props} />);
+      expect(renderedBadges.find('.card-footer').text()).toBe(
+        'Bravo! This person has earned 2 badges! ',
+      );
+    });
+  });
+});

--- a/src/components/UserProfile/Badges.test.jsx
+++ b/src/components/UserProfile/Badges.test.jsx
@@ -19,17 +19,15 @@ describe('Badges Component', () => {
     userPermissions: [],
   };
   describe('Card Footer Text', () => {
-    it('should say "You\'ve earned..." when user is viewing their own profile', () => {
+    it('should say "You have..." when user is viewing their own profile', () => {
       const props = { ...badgeProps, isUserSelf: true };
       const renderedBadges = render(<Badges {...props} />);
-      expect(renderedBadges.find('.card-footer').text()).toBe("Bravo! You've earned 0 badges! ");
+      expect(renderedBadges.find('.card-footer').text()).toBe('You have no badges. ');
     });
 
-    it('should say "This person has earned..." when user is viewing someone else\'s profile', () => {
+    it('should say "This person has..." when user is viewing someone else\'s profile', () => {
       const renderedBadges = render(<Badges {...badgeProps} />);
-      expect(renderedBadges.find('.card-footer').text()).toBe(
-        'Bravo! This person has earned 0 badges! ',
-      );
+      expect(renderedBadges.find('.card-footer').text()).toBe('This person has no badges. ');
     });
 
     it('should use the singular version of badge when the user has exactly 1 badge', () => {

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -707,6 +707,7 @@ function UserProfile(props) {
                 );
               })}
             <Badges
+              isUserSelf={isUserSelf}
               userProfile={userProfile}
               setUserProfile={setUserProfile}
               setOriginalUserProfile={setOriginalUserProfile}


### PR DESCRIPTION
# Description
- Currently, when viewing a user profile, the badge text was the same regardless of whether you are viewing your own profile or other people's profiles. For example it says “you’ve earned X badges” even when you are not looking at your own profile which doesn't make sense. 
- Currently, the logic for displaying the badge text does not take into account whether the number of badges earned is singular or plural. So if you've earned 1 badge, it says "you've earned 1 badges" which doesn't make sense. (This happens on the badge section on the user profile page and on the badge section on the Dashboard)

## Main changes explained:
- Pass a new prop `isUserSelf` to the Badges component to determine whether the profile being viewed is your own or someone else's and add new logic to display the text accordingly
- Add new logic to display "badge" or "badges" based on how many badges the user has earned.
- Wrote a unit test validating all this new behavior.

## How to test:
1. check into current branch via `git checkout -b leon_fix_bravo_text_in_badge_section origin/leon_fix_bravo_text_in_badge_section`
2. do `npm install` and `npm run start:local` to start the frontend
3. checkout the development branch on the backend, do `npm install`, `npm run build`, and `npm run start` to start the backend
4. login as any user role (Admin is easier to test though)
5. Go to your own profile. (you can test it by adding/removing badges if you are admin)
    - If you have 0 badges it should say "You have no badges."
    - If you have 1 badge it should say "Bravo! You have earned 1 badge!"  
    - If you have X >= 1 badges it should say "Bravo! You have earned X badges!"
7. Go to somebody else's profile (you can test it by adding/removing badges if you are admin)
    - If they have 0 badges it should say "This person has no badges."
    - If they have 1 badge it should say "Bravo! This person has earned 1 badge!"  
    - If they have X >= 1 badges it should say "Bravo! This person has earned X badges!"
8. Go to the dashboard and look at the Badges section
    - If you have 0 badges it should say "You have no badges."
    - If you have 1 badge it should say "Bravo! You have earned 1 badge!"  
    - If you have X >= 1 badges it should say "Bravo! You have earned X badges!"

## Screenshots or videos of changes:
Before (Assuming I am not logged in as user "AI user"): 
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/49804462/1e3d1cde-0d86-4d22-829c-d30e0adafb7a)

After (Assuming I am not logged in as user "AI user"): 
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/49804462/d98ae051-b68e-422d-9dff-3b32459f2bae)

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/49804462/8f2c66c4-5cc4-49aa-be67-12e7ac754635)

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/49804462/4df444a5-548a-408c-b957-80cb895d4495)


## Notes
I do not have much experience with writing unit tests, so any feedback on the unit test I've wrote is greatly appreciated
