### PR TITLE
Jianjun - only owner can deactivate another owner

### DIFF
--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -22,6 +22,7 @@ import UserSearchPanel from './UserSearchPanel';
 import NewUserPopup from './NewUserPopup';
 import ActivationDatePopup from './ActivationDatePopup';
 import { UserStatus, UserDeleteType, FinalDay } from '../../utils/enums';
+import hasPermission from '../../utils/permissions';
 import DeleteUserPopup from './DeleteUserPopup';
 import ActiveInactiveConfirmationPopup from './ActiveInactiveConfirmationPopup';
 import { Container } from 'reactstrap';
@@ -77,9 +78,9 @@ class UserManagement extends React.PureComponent {
             <div className="table-responsive">
               <Table className="table table-bordered noWrap">
                 <thead>
-                  <UserTableHeader 
-                  authRole={this.props.state.auth.user.role} 
-                  roleSearchText={this.state.roleSearchText}
+                  <UserTableHeader
+                    authRole={this.props.state.auth.user.role}
+                    roleSearchText={this.state.roleSearchText}
                   />
                   <UserTableSearchHeader
                     onFirstNameSearch={this.onFirstNameSearch}
@@ -88,7 +89,7 @@ class UserManagement extends React.PureComponent {
                     onEmailSearch={this.onEmailSearch}
                     onWeeklyHrsSearch={this.onWeeklyHrsSearch}
                     roles={roles}
-                    authRole={this.props.state.auth.user.role} 
+                    authRole={this.props.state.auth.user.role}
                     roleSearchText={this.state.roleSearchText}
                   />
                 </thead>
@@ -325,6 +326,21 @@ class UserManagement extends React.PureComponent {
    * Callback to trigger on the status (active/inactive) column click to show the confirmaton change the status
    */
   onActiveInactiveClick = user => {
+    const authRole = this.props.state.auth.user.role;
+    const userPermissions = this.props.state.auth.user?.permissions?.frontPermisssion;
+    const { roles } = this.props.state.role;
+    const canChangeUserStatus = hasPermission(authRole, 'changeUserStatus', roles, userPermissions);
+    if (!canChangeUserStatus) {
+      //permission to change the status of any user on the user profile page or User Management Page.
+      //By default only Admin and Owner can access the user management page and they have this permission.
+      alert('You are not authorized to change the active status.');
+      return;
+    }
+    if (user.role === 'Owner' && user.isActive && authRole !== 'Owner') {
+      //Owner user cannot be deactivated by another user that is not an Owner.
+      alert('You are not authorized to deactivate an owner.');
+      return;
+    }
     this.setState({
       activeInactivePopupOpen: true,
       selectedUser: user,

--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -22,7 +22,7 @@ import UserSearchPanel from './UserSearchPanel';
 import NewUserPopup from './NewUserPopup';
 import ActivationDatePopup from './ActivationDatePopup';
 import { UserStatus, UserDeleteType, FinalDay } from '../../utils/enums';
-import hasPermission from '../../utils/permissions';
+import hasPermission, { deactivateOwnerPermission } from '../../utils/permissions';
 import DeleteUserPopup from './DeleteUserPopup';
 import ActiveInactiveConfirmationPopup from './ActiveInactiveConfirmationPopup';
 import { Container } from 'reactstrap';
@@ -336,7 +336,7 @@ class UserManagement extends React.PureComponent {
       alert('You are not authorized to change the active status.');
       return;
     }
-    if (user.role === 'Owner' && user.isActive && authRole !== 'Owner') {
+    if (deactivateOwnerPermission(user, authRole)) {
       //Owner user cannot be deactivated by another user that is not an Owner.
       alert('You are not authorized to deactivate an owner.');
       return;

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -23,7 +23,7 @@ import classnames from 'classnames';
 import moment from 'moment';
 import Alert from 'reactstrap/lib/Alert';
 import axios from 'axios';
-import hasPermission from '../../utils/permissions';
+import hasPermission, { deactivateOwnerPermission } from '../../utils/permissions';
 import ActiveCell from '../UserManagement/ActiveCell';
 import { ENDPOINTS } from '../../utils/URL';
 import Loading from '../common/Loading';
@@ -642,11 +642,7 @@ function UserProfile(props) {
                 user={userProfile}
                 canChange={canChangeUserStatus}
                 onClick={() => {
-                  if (
-                    userProfile.role === 'Owner' &&
-                    userProfile.isActive &&
-                    requestorRole !== 'Owner'
-                  ) {
+                  if (deactivateOwnerPermission(userProfile, requestorRole)) {
                     //Owner user cannot be deactivated by another user that is not an Owner.
                     alert('You are not authorized to deactivate an owner.');
                     return;

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -642,6 +642,15 @@ function UserProfile(props) {
                 user={userProfile}
                 canChange={canChangeUserStatus}
                 onClick={() => {
+                  if (
+                    userProfile.role === 'Owner' &&
+                    userProfile.isActive &&
+                    requestorRole !== 'Owner'
+                  ) {
+                    //Owner user cannot be deactivated by another user that is not an Owner.
+                    alert('You are not authorized to deactivate an owner.');
+                    return;
+                  }
                   setActiveInactivePopupOpen(true);
                 }}
               />

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -20,4 +20,8 @@ const hasPermission = (role, action, roles, userPermissions) => {
   return false;
 };
 
+export const deactivateOwnerPermission = (user, authRole) => {
+  return user.role === 'Owner' && user.isActive && authRole !== 'Owner';
+};
+
 export default hasPermission;


### PR DESCRIPTION
# Description
**(PRIORITY HIGH) Make Admins so they can MAKE ACTIVATE inactive Owner accounts**
Admin login → User Management → Click gray dot
This should ONLY allow an Admin to make an Owner active (click gray dot), they should not be able to deactivate an Owner (click green dot)
This is needed in the event of some odd bug like the one above, or if an Owner somehow accidentally deactivated themselves or another Owner, then that other Owner could have an Admin reactivate them. 

## Main changes explained:
- Add a conditional check that any user that is not an owner (for example, admin) cannot deactivate an owner account.
- Anyone with 'changeUserStatus' permission (for example, admin) can activate an inactive user including an owner.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to dashboard→ Other links -> User Management -> Click gray dot (of an owner) ALERT-> Click green dot (of an owner) CAN CHANGE
5. go to an active owner user profile page -> Click green dot ALERT
6. go to an inactive owner user profile page -> Click gray dot CAN CHANGE

## Screenshots or videos of changes:
Login as an admin:
In the user management page:
<img width="886" alt="1" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/0ec4d910-95b8-412d-ae8f-fba4d9eb18ab">
<img width="906" alt="2" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/8774e2d8-a8a9-4814-abdc-3e7239b7781a">
In another user's profile page:
<img width="656" alt="3" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/6ec2b163-6e7e-477d-9364-3bb82c06f485">
