### PR TITLE
Nida Fix - Save changes for endDate

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.scss
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.scss
@@ -2,6 +2,10 @@ form-control {
   width: 0;
 }
 
+.border-error-validation {
+  border-color: red !important;
+}
+
 .saveChangesWarning {
   display: block;
   position: fixed;
@@ -86,6 +90,7 @@ form-control {
   background-color: #6d757d;
   border: none;
 }
+
 .teamsView {
   display: flex;
 }

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -44,7 +44,6 @@ import TimeEntryEditHistory from './TimeEntryEditHistory';
 import ActiveInactiveConfirmationPopup from '../UserManagement/ActiveInactiveConfirmationPopup';
 import { updateUserStatus } from '../../actions/userManagement';
 import { UserStatus } from '../../utils/enums';
-import { faSleigh, faCamera } from '@fortawesome/free-solid-svg-icons';
 import BlueSquareLayout from './BlueSquareLayout';
 import TeamWeeklySummaries from './TeamWeeklySummaries/TeamWeeklySummaries';
 
@@ -90,6 +89,9 @@ function UserProfile(props) {
 
   const isTasksEqual = JSON.stringify(originalTasks) === JSON.stringify(tasks);
   const isProfileEqual = JSON.stringify(userProfile) === JSON.stringify(originalUserProfile);
+
+  const [userStartDate, setUserStartDate] = useState('');
+  const [userEndDate, setUserEndDate] = useState('');
 
   /* useEffect functions */
   useEffect(() => {
@@ -214,6 +216,7 @@ function UserProfile(props) {
         phoneNumber: newUserProfile.phoneNumber[0],
         createdDate: newUserProfile?.createdDate.split('T')[0],
       });
+      setUserStartDate(newUserProfile?.createdDate.split('T')[0]);
       setShowLoading(false);
     } catch (err) {
       setShowLoading(false);
@@ -567,6 +570,14 @@ function UserProfile(props) {
     }),
   };
 
+  const handleStartDate = async startDate => {
+    setUserStartDate(startDate);
+  };
+
+  const handleEndDate = async endDate => {
+    setUserEndDate(endDate);
+  };
+
   return (
     <div>
       <ActiveInactiveConfirmationPopup
@@ -824,6 +835,7 @@ function UserProfile(props) {
                     setUserProfile={setUserProfile}
                     isUserSelf={isUserSelf}
                     role={requestorRole}
+                    onEndDate={handleEndDate}
                     loadUserProfile={loadUserProfile}
                     canEdit={hasPermission(
                       requestorRole,
@@ -831,6 +843,7 @@ function UserProfile(props) {
                       roles,
                       userPermissions,
                     )}
+                    onStartDate={handleStartDate}
                   />
                 }
               </TabPane>
@@ -1242,6 +1255,7 @@ function UserProfile(props) {
                         !formValid.firstName ||
                         !formValid.lastName ||
                         !formValid.email ||
+                        (userStartDate > userEndDate && userEndDate !== '') ||
                         (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                       }
                       userProfile={userProfile}

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.css
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.css
@@ -2,6 +2,10 @@
   display: none;
 }
 
+.end-date-field {
+  border-color: red;
+}
+
 @media (max-width: 1024px) {
   .volunteering-time-tab-desktop {
     display: none;
@@ -14,7 +18,7 @@
   .cols {
     margin-bottom: 10px;
   }
-  
+
   .rows {
     margin-bottom: 10px;
   }

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.css
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.css
@@ -2,10 +2,6 @@
   display: none;
 }
 
-.end-date-field {
-  border-color: red;
-}
-
 @media (max-width: 1024px) {
   .volunteering-time-tab-desktop {
     display: none;

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -9,6 +9,13 @@ import './timeTab.css';
 const MINIMUM_WEEK_HOURS = 0;
 const MAXIMUM_WEEK_HOURS = 168;
 
+const startEndDateValidation = props => {
+  console.log(props.userProfile.createdDate > props.userProfile.endDate);
+  return (
+    props.userProfile.createdDate > props.userProfile.endDate && props.userProfile.endDate !== ''
+  );
+};
+
 const StartDate = props => {
   if (!props.canEdit) {
     return <p>{moment(props.userProfile.createdDate).format('YYYY-MM-DD')}</p>;
@@ -18,9 +25,11 @@ const StartDate = props => {
       type="date"
       name="StartDate"
       id="startDate"
+      className={startEndDateValidation(props) ? 'border-error-validation' : null}
       value={moment(props.userProfile.createdDate).format('YYYY-MM-DD')}
       onChange={e => {
         props.setUserProfile({ ...props.userProfile, createdDate: e.target.value });
+        props.onStartDateComponent(e.target.value);
       }}
       placeholder="Start Date"
       invalid={!props.canEdit}
@@ -39,8 +48,10 @@ const EndDate = props => {
       </p>
     );
   }
+
   return (
     <Input
+      className={startEndDateValidation(props) ? 'border-error-validation' : null}
       type="date"
       name="EndDate"
       id="endDate"
@@ -49,6 +60,7 @@ const EndDate = props => {
       }
       onChange={e => {
         props.setUserProfile({ ...props.userProfile, endDate: e.target.value });
+        props.onEndDateComponent(e.target.value);
       }}
       placeholder="End Date"
       invalid={!props.canEdit}
@@ -187,6 +199,14 @@ const ViewTab = props => {
   const [totalTangibleHours, setTotalTangibleHours] = useState(0);
   const { hoursByCategory, totalIntangibleHrs } = userProfile;
 
+  const handleStartDates = async startDate => {
+    props.onStartDate(startDate);
+  };
+
+  const handleEndDates = async endDate => {
+    props.onEndDate(endDate);
+  };
+
   useEffect(() => {
     sumOfCategoryHours();
   }, [hoursByCategory]);
@@ -278,6 +298,7 @@ const ViewTab = props => {
             userProfile={userProfile}
             setUserProfile={setUserProfile}
             canEdit={canEdit}
+            onStartDateComponent={handleStartDates}
           />
         </Col>
       </Row>
@@ -292,6 +313,7 @@ const ViewTab = props => {
             userProfile={userProfile}
             setUserProfile={setUserProfile}
             canEdit={canEdit}
+            onEndDateComponent={handleEndDates}
           />
         </Col>
       </Row>

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -24,6 +24,7 @@ const StartDate = props => {
       }}
       placeholder="Start Date"
       invalid={!props.canEdit}
+      max={props.userProfile.endDate ? moment(props.userProfile.endDate).format('YYYY-MM-DD') : ''}
     />
   );
 };
@@ -51,6 +52,7 @@ const EndDate = props => {
       }}
       placeholder="End Date"
       invalid={!props.canEdit}
+      min={moment(props.userProfile.createdDate).format('YYYY-MM-DD')}
     />
   );
 };

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -10,7 +10,6 @@ const MINIMUM_WEEK_HOURS = 0;
 const MAXIMUM_WEEK_HOURS = 168;
 
 const startEndDateValidation = props => {
-  console.log(props.userProfile.createdDate > props.userProfile.endDate);
   return (
     props.userProfile.createdDate > props.userProfile.endDate && props.userProfile.endDate !== ''
   );

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -63,7 +63,7 @@ const EndDate = props => {
       }}
       placeholder="End Date"
       invalid={!props.canEdit}
-      min={moment(props.userProfile.createdDate).format('YYYY-MM-DD')}
+      min={props.userProfile.createdDate ? moment(props.userProfile.createdDate).format('YYYY-MM-DD') : ''}
     />
   );
 };


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/32549172/db193315-7925-4105-a3a8-7997a87420c8)

## Fixes (bug list priority medium)
Added `min` attribute to the endDate to disable the days before the start Date and `max` attribute to the startDate in order to disable any date after the endDate.

## Main changes explained:
- Added `min` and `max` attributes to the startDate and endDate components which ensures that: 
(i) The endDate is not earlier than the startDate, by disabling the days before the startDate when endDate field is edited
(ii) The StartDate is not later than endDate, by disabling the days after the endDate (if it is set) when StartDate field is edited.

## How to test:
1. Check into current branch
2. Log as admin user
3. Go to Admin login → User Profile Page → Volunteering time  → Set End Date 
4. Verify that when changing or entering a date into the End Date field, the date picker should not let the user select dates before the Start Date when editing the endDate field and should not let the user select dates after the End Date when editing startDate field.

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/32549172/5e2c0847-f97e-4608-8bb8-73672d1f75b8

