### PR TITLE
Xiaow improve loading speed of wbs pages

### DIFF
--- a/src/__tests__/reducers/allTasksReducer.test.js
+++ b/src/__tests__/reducers/allTasksReducer.test.js
@@ -37,13 +37,14 @@ describe('Task Reducer', () => {
       );
       expect(allTasks).toMatchObject({
         taskItems: [],
+        fetchedData: [],
         fetched: true,
         fetching: false,
         error: 'none',
       });
     });
 
-    it('level 0', () => {
+    xit('level 0', () => {
       const allTasks = taskReducer(
         {},
         {
@@ -68,7 +69,7 @@ describe('Task Reducer', () => {
       });
     });
 
-    it('with mother task', () => {
+    xit('with mother task', () => {
       const allTasks = taskReducer(
         {
           taskItems: [
@@ -111,23 +112,23 @@ describe('Task Reducer', () => {
     const allTasks = taskReducer(
       {
         taskItems: [
-          { taskId: 5, level: 0, num: '1' },
-          { taskId: 0, level: 0, num: '2', _id: 0 },
-          { taskId: 1, level: 0, num: '3' },
+          { taskId: 5, level: 1, num: '1.0.0.0', _id: 1 },
+          { taskId: 0, level: 1, num: '2.0.0.0', _id: 0 },
+          { taskId: 1, level: 1, num: '3.0.0.0', _id: 2 },
         ],
       },
       {
         mother: 0,
         type: types.ADD_NEW_TASK,
-        newTask: { taskId: 2, level: 1, num: '2.1' },
+        newTask: { taskId: 2, level: 2, num: '2.1', _id: 3, mother: 0 },
       },
     );
     expect(allTasks).toMatchObject({
       taskItems: [
-        { taskId: 5, level: 0, num: '1' },
-        { taskId: 2, level: 1, num: '2.1.0.0.0', hasChildren: false },
-        { taskId: 0, level: 0, num: '2', _id: 0, hasChildren: false },
-        { taskId: 1, level: 0, num: '3', hasChildren: false },
+        { taskId: 5, level: 1, num: '1.0.0.0', _id: 1 },
+        { taskId: 0, level: 1, num: '2.0.0.0', _id: 0, hasChildren: true },
+        { taskId: 2, level: 2, num: '2.1.0.0', _id: 3, hasChildren: false, mother: 0 },
+        { taskId: 1, level: 1, num: '3.0.0.0', _id: 2, hasChildren: false },
       ],
       fetched: true,
       fetching: false,

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -53,9 +53,6 @@ function Task(props) {
   const [tableColNum, setTableColNum] = useState(16);
   const tableRowRef = createRef();
 
-  useEffect(() => {
-    ReactTooltip.rebuild();
-  }, []);
 
   useEffect(() => {
     if (tableRowRef.current) {

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -29,7 +29,6 @@ import * as Message from './../../../../../languages/en/messages';
 import { getPopupById } from './../../../../../actions/popupEditorAction';
 import { TASK_DELETE_POPUP_ID } from './../../../../../constants/popupId';
 import hasPermission from 'utils/permissions';
-import ReactTooltip from 'react-tooltip';
 
 function Task(props) {
   const [role] = useState(props.state ? props.state.auth.user.role : null);
@@ -53,6 +52,10 @@ function Task(props) {
   const [isCopied, setIsCopied] = useState(false);
   const [tableColNum, setTableColNum] = useState(16);
   const tableRowRef = createRef();
+
+  useEffect(() => {
+    ReactTooltip.rebuild();
+  }, []);
 
   useEffect(() => {
     if (tableRowRef.current) {
@@ -156,7 +159,6 @@ function Task(props) {
     <>
       {props.id ? (
         <>
-          <ReactTooltip/>
           <tr
             ref={tableRowRef}
             key={props.key}

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -63,6 +63,10 @@ function WBSTasks(props) {
   };
 
   useEffect(() => {
+    ReactTooltip.rebuild();
+  }, [props.state.tasks.taskItems]);
+
+  useEffect(() => {
     AutoOpenAll(openAll);
   }, [openAll]);
 
@@ -186,15 +190,18 @@ function WBSTasks(props) {
   };
 
   const LoadTasks = props.state.tasks.taskItems.slice(0).sort((a, b) => {
-    var former = a.num.split('.');
-    var latter = b.num.split('.');
-    for (var i = 0; i < 4; i++) {
-      var _former = +former[i] || 0;
-      var _latter = +latter[i] || 0;
-      if (_former === _latter) continue;
-      else return _former > _latter ? 1 : -1;
-    }
-    return 0;
+    // var former = a.num.split('.');
+    // var latter = b.num.split('.');
+    // for (var i = 0; i < 4; i++) {
+    //   var _former = +former[i] || 0;
+    //   var _latter = +latter[i] || 0;
+    //   if (_former === _latter) continue;
+    //   else return _former > _latter ? 1 : -1;
+    // }
+    // return 0;
+    const aNum = +a.num.replaceAll('.','');
+    const bNum = +b.num.replaceAll('.','');
+    return aNum - bNum;
   });
   const filteredTasks = filterTasks(LoadTasks, filterState);
 

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -347,7 +347,7 @@ function WBSTasks(props) {
               <td colSpan={14} />
             </tr>
 
-            {loadAll && filteredTasks.map((task, i) => (
+            {props.state.tasks.fetched && filteredTasks.map((task, i) => (
               <Task
                 key={`${task._id}${i}`}
                 id={task._id}
@@ -377,7 +377,7 @@ function WBSTasks(props) {
                 drop={dropTask}
                 drag={dragTask}
                 deleteWBSTask={deleteWBSTask}
-                hasChildren={task.hasChild}
+                hasChildren={task.hasChildren}
                 siblings={props.state.tasks.taskItems.filter(item => item.mother === task.mother)}
                 taskId={task.taskId}
                 whyInfo={task.whyInfo}

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -200,7 +200,7 @@ function WBSTasks(props) {
 
   return (
     <>
-      <ReactTooltip />
+      <ReactTooltip delayShow={250}/>
       <div className="container-tasks">
         <nav aria-label="breadcrumb">
           <ol className="breadcrumb">

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -62,6 +62,7 @@ function WBSTasks(props) {
     setTimeout(() => setIsShowImport(true), 1000);
   };
 
+  // rebuild tooltip for any changes from child component
   useEffect(() => {
     ReactTooltip.rebuild();
   }, [props.state.tasks.taskItems]);

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -188,22 +188,7 @@ function WBSTasks(props) {
       });
     }
   };
-
-  const LoadTasks = props.state.tasks.taskItems.slice(0).sort((a, b) => {
-    // var former = a.num.split('.');
-    // var latter = b.num.split('.');
-    // for (var i = 0; i < 4; i++) {
-    //   var _former = +former[i] || 0;
-    //   var _latter = +latter[i] || 0;
-    //   if (_former === _latter) continue;
-    //   else return _former > _latter ? 1 : -1;
-    // }
-    // return 0;
-    const aNum = +a.num.replaceAll('.','');
-    const bNum = +b.num.replaceAll('.','');
-    return aNum - bNum;
-  });
-  const filteredTasks = filterTasks(LoadTasks, filterState);
+  const filteredTasks = filterTasks(props.state.tasks.taskItems, filterState);
 
   return (
     <>
@@ -244,7 +229,7 @@ function WBSTasks(props) {
           Refresh{' '}
         </Button>
 
-        {loadAll === false ? (
+        {!loadAll ? (
 
           <Button color="warning" size="sm" className="ml-3">
 
@@ -362,7 +347,7 @@ function WBSTasks(props) {
               <td colSpan={14} />
             </tr>
 
-            {props.state.tasks.fetched && filteredTasks.map((task, i) => (
+            {loadAll && filteredTasks.map((task, i) => (
               <Task
                 key={`${task._id}${i}`}
                 id={task._id}

--- a/src/reducers/allTasksReducer.js
+++ b/src/reducers/allTasksReducer.js
@@ -11,11 +11,14 @@ const allTasksInital = {
   copiedTask: null,
 };
 
-const filterAndSort = tasks => {
+const filterAndSort = (tasks, level) => {
   return tasks.sort((a, b) => {
-    const aNum = +a.num.replaceAll('.', '');
-    const bNum = +b.num.replaceAll('.', '');
-    return aNum - bNum;
+    const aArr = a.num.split('.');
+    const bArr = b.num.split('.');
+    for (let i = 0; i < level; i++) {
+      if (+aArr[i] !== +bArr[i]) return +aArr[i] - +bArr[i];
+    }
+    return 0;
   });
 };
 
@@ -34,7 +37,7 @@ const sortByNum = tasks => {
     return { ...task, num };
   });
 
-  return filterAndSort(appendTasks);
+  return filterAndSort(appendTasks, 4);
 };
 
 export const taskReducer = (allTasks = allTasksInital, action) => {
@@ -78,11 +81,11 @@ export const taskReducer = (allTasks = allTasksInital, action) => {
         };
       } else {
         allTasks.fetchedData[action.level] = action.taskItems;
-        console.log('fetchedData', allTasks.fetchedData);
+        const newTaskItems = allTasks.fetchedData.flat();
         return {
           ...allTasks,
           fetchedData: [...allTasks.fetchedData],
-          taskItems: [...sortByNum(allTasks.fetchedData.flat())],
+          taskItems: sortByNum(newTaskItems),
           fetched: true,
           fetching: false,
           error: 'none',

--- a/src/reducers/allTasksReducer.js
+++ b/src/reducers/allTasksReducer.js
@@ -24,17 +24,17 @@ const filterAndSort = (tasks, level) => {
 
 const sortByNum = tasks => {
   const appendTasks = tasks.map(task => {
-    let num = task.num;
-    if (task.level === 1) {
-      num += '.0.0.0';
-    }
-    if (task.level === 2) {
-      num += '.0.0';
-    }
-    if (task.level === 3) {
-      num += '.0';
-    }
-    return { ...task, num };
+    /** Based on my observation, previous addTask functionality is not working properly,
+     * the created new task does not change its parent task property 'hasChild' from default false to true,
+     * so below are the temporary fix to create a 'hasChildren' property to represent the actual 'hasChild' value
+     * this should be fixed by future PR.
+     */
+    const hasChildren = tasks.some(item => item.mother === task._id);
+
+    const numOfNums = task.num.split('.').length;
+    const num = task.num.concat('.0'.repeat(4 - numOfNums));
+
+    return { ...task, num, hasChildren };
   });
 
   return filterAndSort(appendTasks, 4);
@@ -47,6 +47,7 @@ export const taskReducer = (allTasks = allTasksInital, action) => {
     case types.FETCH_TASKS_ERROR:
       return { ...allTasks, fetched: true, fetching: false, error: action.err };
     case types.RECEIVE_TASKS:
+      /** commemt out old code for future reference (mother parameter) --- PR#934 */
       // if (action.level === -1) {
       //   return { ...allTasks, taskItems: [], fetched: true, fetching: false, error: 'none' };
       // } else if (action.level === 0) {
@@ -75,7 +76,7 @@ export const taskReducer = (allTasks = allTasksInital, action) => {
           ...allTasks,
           taskItems: [],
           fetchedData: [],
-          fetched: false,
+          fetched: true,
           fetching: false,
           error: 'none',
         };
@@ -92,14 +93,10 @@ export const taskReducer = (allTasks = allTasksInital, action) => {
         };
       }
     case types.ADD_NEW_TASK:
-      const motherIndex = allTasks.taskItems.findIndex(item => item._id === action.newTask.mother);
-      const index = motherIndex + 1;
+      const newTaskItems = [action.newTask, ...allTasks.taskItems];
       return {
         ...allTasks,
-        taskItems: [
-          ...allTasks.taskItems.slice(0, index),
-          ...sortByNum([action.newTask, ...allTasks.taskItems.slice(index)]),
-        ],
+        taskItems: sortByNum(newTaskItems),
         fetched: true,
         fetching: false,
         error: 'none',
@@ -131,6 +128,7 @@ export const taskReducer = (allTasks = allTasksInital, action) => {
     case types.EMPTY_TASK_ITEMS:
       return {
         ...allTasks,
+        fetchedData: [],
         taskItems: [],
       };
     case types.UPDATE_TASK:

--- a/src/reducers/allTasksReducer.js
+++ b/src/reducers/allTasksReducer.js
@@ -27,10 +27,16 @@ const sortByNum = tasks => {
     /** Based on my observation, previous addTask functionality is not working properly,
      * the created new task does not change its parent task property 'hasChild' from default false to true,
      * so below are the temporary fix to create a 'hasChildren' property to represent the actual 'hasChild' value
-     * this should be fixed by future PR.
+     * this should be fixed by future PR. --- PR#934
      */
     const hasChildren = tasks.some(item => item.mother === task._id);
 
+    /** task.num from response data has different form for different level:
+     *    level 1: x
+     *    level 2: x.x
+     *    level 3: x.x.x
+     *  below is trying to make sure the num property in state is in the same form of x.x.x.x,
+     * */
     const numOfNums = task.num.split('.').length;
     const num = task.num.concat('.0'.repeat(4 - numOfNums));
 


### PR DESCRIPTION
# Description
![Screenshot 2023-06-22 175925](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/77769556/124d772e-2583-4156-94da-520ae36fecf6)

## Main changes explained:
1. Fix the freeze problem caused by `<ReactTooltip>`:  The reason why browser freeze is because each `<Task>` component has a `<ReactTooltip />` component which will create a `<div>` on the page, and when task number goes up, there will be hundreds of them.  This PR address the problem by running `ReactTooltip.rebuild()` on the parent component (`<WBSTasks>`) to represent all the tooltips of the children component (`<Task>`), so that only one `<div>` will be created;
2. Optimize the `allTasksReducer.js` logic: 

- Previously, app would send 5 requests for different levels of tasks, and the order of receiving responses is not consistent. Also, when making level 0 request, app will empty all previous cached tasks, which will cause tasks of other levels to be removed if their responses arrive earlier. This PR address this issue by adding a `fetchedData` buffer in the state, and the response data will have fixed position in the buffer based on their level. `sortByNum` function will combine and sort all the response data into `taskItems`.
- Because now the `sortByNum` function will handle the sorting for all tasks, for case like `case types.ADD_NEW_TASK:`, no need to find the index of mother task and insert at the specific position. Just add the new task into the `taskItems` and sort them again.
- Based on my observation, the `addTask` functionality now is not working properly, the created new task does not change its parent task property `hasChild` from default `false` to `true`. I did a temporary fix in the `sortByNum` function to create a `hasChildren` property representing the actual `hasChild` value, so that the tasks can have a folder icon/bold look on the page if they have any sub-tasks. This needs to be fixed in the future PR.
- I noticed there is a parameter called `mother` in the `case types.RECEIVE_TASKS:`, but I didn't find any code that use this parameter for `case types.RECEIVE_TASKS:`, except for the `allTasksReducer.test.js` test file so I commented out the old code for possible future reference.

3. Modify `allTasksReducer.test.js` test file:
- To cope with the newly added property in the `allTasksReducer.js` state, 
- I notice some code in previous version of `allTasksReducer.js` are just for passing the test file and does not have any real functional value. What I have seen so far in  are:
  - In `allTasksReducer.js`: 
     - `hasChildren` was created but never used except by `allTasksReducer.test.js` test files ; 
     - `taskId` property was not in the response data and it only showed up in the `allTasksReducer.test.js` test files;
     - `mother` parameter was never used outside of `allTasksReducer.test.js` test files; 
  -  In `allTasksReducer.test.js`;
     - `level: 0` was never used since all levels start from 1. 
- So I disabled some test cases and made some modification. 

4. Remove redundant sorting logic in `<WBSTasks>`

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Be sure to use Incognito mode or clear your cache before testing
4. log as admin user
5. go to dashboard → Other Links →  Projects →  WBS →  Pick any (try 'AAA USE THIS PROJECT' → 'Jae's WBS - USE THIS', which has 300+ tasks)
6. verify no more freezing or abnormal behavior of this page

## Note:
I noticed the filter functionality (unfold or fold tasks) is inconsistent upon refreshing or clicking the refresh button, but that is beyond the scope of this PR. Maybe this could be addressed in the future.