### PR TITLE
Jinchao update ESLint and Prettier config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,7 +14,7 @@ src/utils/**
 src/__tests__/**
 
 
-#src/components/Admin/**
+src/components/Admin/**
 src/components/App.jsx
 src/components/AutoReload/**
 src/components/AutoUpdate/**

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,23 @@ module.exports = {
     es6: true,
     node: true,
   },
-  extends: ['plugin:react/recommended', 'airbnb'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.jsx'],
+      },
+    },
+  },
+  extends: [
+    'plugin:react/recommended', // Uses the recommended rules from @eslint-plugin-react
+    'plugin:react-hooks/recommended',
+    'plugin:react/jsx-runtime',
+    'plugin:import/recommended',
+    'prettier',
+  ],
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
@@ -21,6 +37,8 @@ module.exports = {
   rules: {
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
     'no-underscore-dangle': 'off',
+    'react/prop-types': 'off',
+    'react-hooks/exhaustive-deps': 'off',
   },
   overrides: [
     {

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,7 +14,7 @@ src/utils/**
 src/__tests__/**
 
 
-#src/components/Admin/**
+src/components/Admin/**
 src/components/App.jsx
 src/components/AutoReload/**
 src/components/AutoUpdate/**

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,5 +5,6 @@
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
   "tabWidth": 2,
-  "semi": true
+  "semi": true,
+  "endOfLine": "auto"
 }

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     "test:coverage": "cross-env CI=true react-scripts test --env=jest-environment-jsdom-sixteen --coverage",
     "eject": "react-scripts eject",
     "start:local": "react-scripts start",
-    "format:check": "npx eslint --ext js,jsx src && npx prettier src/** --check",
-    "format": "npx eslint --ext js,jsx src && npx prettier src/** --write"
+    "format:check": "npx prettier src/** --check && npx eslint --ext js,jsx src",
+    "format": "npx eslint --fix --ext js,jsx src && npx prettier src/** --write"
   },
   "browserslist": [
     ">0.2%",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
     "test:watch": " react-scripts test --env=jest-environment-jsdom-sixteen",
     "test:coverage": "cross-env CI=true react-scripts test --env=jest-environment-jsdom-sixteen --coverage",
     "eject": "react-scripts eject",
-    "start:local": "react-scripts start"
+    "start:local": "react-scripts start",
+    "format:check": "npx eslint --ext js,jsx src && npx prettier src/** --check",
+    "format": "npx eslint --ext js,jsx src && npx prettier src/** --write"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
# Description

This pull request aims to update the configuration files to ensure that the codebase aligns with the majority of ESLINT rules while making minimal changes. The goal is to maintain consistency and adhere to the recommended coding standards as closely as possible.

## Related PRS (if any):
This PR comes from [Yiyun](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/compare/Yiyun-experi_formatting) and [Nicolle](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/compare/development...nicolle_re_enable_eslint)'s previous work

For a smooth and less error-prone update process, this PR intentionally excludes changes to the .vscode/settings.json file and husky configuration. By focusing on ESlint and Prettier configs of the codebase, we aim to minimize any potential bugs and ensure a seamless transition while still implementing the necessary updates.

## Main changes explained:
Compared with previous ESLint rules, this PR:

- Includes minimum plugins: (`react/recommended`,`react-hooks/recommended`,`react/jsx-runtime`, `import/recommended`)
- Turns some rules off (`react/prop-types` and `react-hooks/exhaustive-deps`)

Compared with previous prettier rules, this PR:
- set `endOfLine` to `auto` to make windows user won't be bothered by end of line errors(CRLF/LF):

Add combined commands:

- `npm run format:check` to check if the codes follows esLint rules and matches prettier styles.
- `npm run format` to do an auto fix. (Some esLint rules still need to be addressed manually)

## How to test:
1. check into current branch
2. do `npm install`
3. Currently all component docs and major code files are included in .eslintignore and .prettierignore. Open any files to make sure there is no error/warn message from esLint or Prettier. Run `npm run format:check` to see the result:![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/71685647-d146-4c62-be1f-8266e4ad0c2c)
4. Add `#` to some files in `.eslintignore` and `.prettierignore`. Run `npm run format:check` again to see the result:![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94319381/ad55e915-cbe6-4840-aeee-51b18f576cda)
5. Run `npm run format` to do an auto fix(Some eslint errors need a manual fix)

## Note:
Include the information the reviewers need to know.
