### PR TITLE
Edwin - Make intangible time in the leaderboard blue if intangible time was logged

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.css
+++ b/src/components/LeaderBoard/Leaderboard.css
@@ -24,3 +24,8 @@
     border-top-color: rgb(222, 226, 230);
   }
 }
+
+.boldClass {
+  color: #007bff;
+  font-weight: bold;
+}

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -318,7 +318,6 @@ const LeaderBoard = ({
                     fontWeight: item.totalintangibletime_hrs > 0
                     ? 'bold'
                     : null
-
                   }}>{item.totaltime}</span>
                 </td>
               </tr>

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -313,8 +313,12 @@ const LeaderBoard = ({
                   title="Total time"
                   style={{
                     color: item.totalintangibletime_hrs > 0 
-                    ? '#0000EE'
-                    : 'black' 
+                    ? '#007bff'
+                    : 'black',
+                    fontWeight: item.totalintangibletime_hrs > 0
+                    ? 'bold'
+                    : null
+
                   }}>{item.totaltime}</span>
                 </td>
               </tr>

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -4,7 +4,7 @@ import { isEqual } from 'lodash';
 import { Link } from 'react-router-dom';
 import { Table, Progress, Modal, ModalBody, ModalFooter, ModalHeader, Button } from 'reactstrap';
 import Alert from 'reactstrap/lib/Alert';
-import { hasLeaderboardPermissions, assignStarDotColors, showStar, showBlueTime } from 'utils/leaderboardPermissions';
+import { hasLeaderboardPermissions, assignStarDotColors, showStar } from 'utils/leaderboardPermissions';
 
 function useDeepEffect(effectFunc, deps) {
   const isFirst = useRef(true);
@@ -311,14 +311,8 @@ const LeaderBoard = ({
                 <td className="align-middle">
                   <span 
                   title="Total time"
-                  style={{
-                    color: item.totalintangibletime_hrs > 0 
-                    ? '#007bff'
-                    : 'black',
-                    fontWeight: item.totalintangibletime_hrs > 0
-                    ? 'bold'
-                    : null
-                  }}>{item.totaltime}</span>
+                  className={ item.totalintangibletime_hrs > 0 ? 'boldClass' : null }
+                  >{item.totaltime}</span>
                 </td>
               </tr>
             ))}

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -4,7 +4,7 @@ import { isEqual } from 'lodash';
 import { Link } from 'react-router-dom';
 import { Table, Progress, Modal, ModalBody, ModalFooter, ModalHeader, Button } from 'reactstrap';
 import Alert from 'reactstrap/lib/Alert';
-import { hasLeaderboardPermissions, assignStarDotColors, showStar } from 'utils/leaderboardPermissions';
+import { hasLeaderboardPermissions, assignStarDotColors, showStar, showBlueTime } from 'utils/leaderboardPermissions';
 
 function useDeepEffect(effectFunc, deps) {
   const isFirst = useRef(true);
@@ -298,7 +298,11 @@ const LeaderBoard = ({
                   </Link>
                 </th>
                 <td className="align-middle" id={`id${item.personId}`}>
-                  <span title="Tangible time">{item.tangibletime}</span>
+                  <span 
+                  title="Tangible time"
+                  style={{
+                    color: showBlueTime(loggedInUser.role, item.totalintangibletime_hrs)
+                  }}>{item.tangibletime}</span>
                 </td>
                 <td className="align-middle">
                   <Link
@@ -309,7 +313,11 @@ const LeaderBoard = ({
                   </Link>
                 </td>
                 <td className="align-middle">
-                  <span title="Total time">{item.totaltime}</span>
+                  <span 
+                  title="Total time"
+                  style={{
+                    color: showBlueTime(loggedInUser.role, item.totalintangibletime_hrs)
+                  }}>{item.totaltime}</span>
                 </td>
               </tr>
             ))}

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -298,11 +298,7 @@ const LeaderBoard = ({
                   </Link>
                 </th>
                 <td className="align-middle" id={`id${item.personId}`}>
-                  <span 
-                  title="Tangible time"
-                  style={{
-                    color: showBlueTime(loggedInUser.role, item.totalintangibletime_hrs)
-                  }}>{item.tangibletime}</span>
+                  <span title="Tangible time">{item.tangibletime}</span>
                 </td>
                 <td className="align-middle">
                   <Link

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -312,7 +312,9 @@ const LeaderBoard = ({
                   <span 
                   title="Total time"
                   style={{
-                    color: showBlueTime(loggedInUser.role, item.totalintangibletime_hrs)
+                    color: item.totalintangibletime_hrs > 0 
+                    ? '#0000EE'
+                    : 'black' 
                   }}>{item.totaltime}</span>
                 </td>
               </tr>

--- a/src/utils/leaderboardPermissions.js
+++ b/src/utils/leaderboardPermissions.js
@@ -29,11 +29,3 @@ export const showStar = (hoursLogged, weeklyCommittedHours) => {
     return (weeklyCommittedHours !== 0 && 
         hoursLogged >= weeklyCommittedHours * DARKGREEN_TIER)
 }
-
-export const showBlueTime = (authRole, intangibleHours) => {
-  return (
-    intangibleHours > 0 && 
-    (authRole === 'Owner' || authRole === 'Administrator')) 
-    ? '#0000EE' 
-    : 'black'
-}

--- a/src/utils/leaderboardPermissions.js
+++ b/src/utils/leaderboardPermissions.js
@@ -29,3 +29,11 @@ export const showStar = (hoursLogged, weeklyCommittedHours) => {
     return (weeklyCommittedHours !== 0 && 
         hoursLogged >= weeklyCommittedHours * DARKGREEN_TIER)
 }
+
+export const showBlueTime = (authRole, intangibleHours) => {
+  return (
+    intangibleHours > 0 && 
+    authRole === 'Owner' || authRole === 'Administrator') 
+    ? 'blue'
+    : 'black'
+}

--- a/src/utils/leaderboardPermissions.js
+++ b/src/utils/leaderboardPermissions.js
@@ -33,7 +33,7 @@ export const showStar = (hoursLogged, weeklyCommittedHours) => {
 export const showBlueTime = (authRole, intangibleHours) => {
   return (
     intangibleHours > 0 && 
-    authRole === 'Owner' || authRole === 'Administrator') 
-    ? 'blue'
+    (authRole === 'Owner' || authRole === 'Administrator')) 
+    ? '#0000EE' 
     : 'black'
 }


### PR DESCRIPTION
# Description

<img width="548" alt="Screen Shot 2023-06-25 at 5 03 26 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/e6a114a0-6f74-4f1b-a2cd-7677da52c97e">

## Main changes explained:
- Added a conditional check to see if there are any intangible hours logged and if the current authenticated user is an owner/admin

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. login with any account 
4. log intangible time and tangible time
5. The "Total Time" for that person in the leaderboard should be in blue instead of black

## Screenshots or videos of changes:

Volunteer Account: 

<img width="724" alt="Screen Shot 2023-06-25 at 3 43 48 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/9407ec9b-cbab-4612-89f4-108dc44a895c">

Admin/Owner Account: 

<img width="706" alt="Screen Shot 2023-06-25 at 3 44 44 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/bf28ce1d-51fe-4cc9-92c2-79808f34f2ce">

## Notes:

New changes requested by Jae: 
1. This will be visible for all user classes, there is no restriction for only Admin/Owners. 
2. Only the right number under "Total Time" should be blue
