### PR TITLE
Papia - Added approve button functionality on taskSuggestionPage

### DIFF
--- a/src/actions/task.js
+++ b/src/actions/task.js
@@ -105,16 +105,22 @@ export const addNewTask = (newTask, wbsId) => async (dispatch, getState) => {
   await dispatch(postNewTask(task, status));
 };
 
-export const updateTask = (taskId, updatedTask, hasPermission) => async (dispatch, getState) => {
+export const updateTask = (taskId, updatedTask, hasPermission, prevTask) => async (dispatch, getState) => {
   let status = 200;
   try {
     const state = getState();
-    const oldTask = selectUpdateTaskData(state, taskId);
-    //dispatch(fetchTeamMembersTaskBegin());
+    
+    let oldTask 
+    if(prevTask){
+      oldTask = prevTask
+    }else{
+      oldTask = selectUpdateTaskData(state, taskId);
+    }
+    
     if (hasPermission) {
       await axios.put(ENDPOINTS.TASK_UPDATE(taskId), updatedTask);
       const userIds = updatedTask.resources.map(resource => resource.userID);
-      await createOrUpdateTaskNotificationHTTP(taskId, oldTask, userIds);
+      await createOrUpdateTaskNotificationHTTP(taskId, oldTask, userIds);   
     } else {
       await createTaskEditSuggestionHTTP(taskId, selectUserId(state), oldTask, updatedTask);
     }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -41,22 +41,24 @@ import {
 import { Logout } from '../Logout/Logout';
 import './Header.css';
 import hasPermission from '../../utils/permissions';
-import { fetchTaskEditSuggestionCount } from 'components/TaskEditSuggestions/thunks';
+import { fetchTaskEditSuggestions } from 'components/TaskEditSuggestions/thunks';
 
 export const Header = props => {
   const [isOpen, setIsOpen] = useState(false);
   const [logoutPopup, setLogoutPopup] = useState(false);
   const { isAuthenticated, user, firstName, profilePic } = props.auth;
-
   const dispatch = useDispatch();
-
   const userPermissions = props.auth.user?.permissions?.frontPermissions;
+
   useEffect(() => {
     if (props.auth.isAuthenticated) {
       props.getHeaderData(props.auth.user.userid);
       props.getTimerData(props.auth.user.userid);
+      if(props.auth.user.role === "Administrator"){
+        dispatch(fetchTaskEditSuggestions());
+      }
     }
-  }, []);
+  }, [props.auth.isAuthenticated]);
 
   useEffect(() => {
     if (roles.length === 0) {

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -25,11 +25,13 @@ const EditTaskModal = props => {
 
   // get this task by id
   const [thisTask, setThisTask] = useState();
+  const [oldTask, setOldTask] = useState();
   useEffect(() => {
     const fetchTaskData = async () => {
       try {
         const res = await axios.get(ENDPOINTS.GET_TASK(props.taskId));
         setThisTask(res?.data || {});
+        setOldTask(res?.data || {});
         setCategory(res.data.category);
         setAssigned(res.data.isAssigned);
       } catch (error) {
@@ -221,6 +223,7 @@ const EditTaskModal = props => {
       props.taskId,
       updatedTask,
       hasPermission(role, 'editTask', roles, userPermissions),
+      oldTask
     );
     setTimeout(() => {
       props.fetchAllTasks(props.wbsId);

--- a/src/components/TaskEditSuggestions/Components/TaskEditSuggestionRow.jsx
+++ b/src/components/TaskEditSuggestions/Components/TaskEditSuggestionRow.jsx
@@ -11,11 +11,18 @@ export const TaskEditSuggestionRow = ({
       <td>{datetimeToDate(taskEditSuggestion.dateSuggested)}</td>
       <td>{taskEditSuggestion.user}</td>
       <td>
-        {
-          <Link to={`/wbs/tasks/${taskEditSuggestion.oldTask._id}`}>
-            {taskEditSuggestion.oldTask.taskName}
-          </Link>
-        }
+        {taskEditSuggestion.oldTask.taskName}
+      </td>
+      <td>
+        <button onClick={handleToggleTaskEditSuggestionModal} 
+                style={{
+                  backgroundColor:'#007bff',
+                  borderRadius:'5px',
+                  padding:'5px 10px',
+                  color:'white'
+                }}>
+          View Suggestion
+        </button>
       </td>
     </tr>
   );

--- a/src/components/TaskEditSuggestions/Components/TaskEditSuggestionsModal.jsx
+++ b/src/components/TaskEditSuggestions/Components/TaskEditSuggestionsModal.jsx
@@ -11,6 +11,10 @@ import {
 import DiffedText from 'components/TeamMemberTasks/components/DiffedText';
 import { useDispatch } from 'react-redux';
 import { rejectTaskEditSuggestion } from '../thunks';
+import { updateTask } from 'actions/task';
+import hasPermission from 'utils/permissions';
+import { useSelector, useStore} from 'react-redux';
+import { useState, } from 'react';
 
 export const TaskEditSuggestionsModal = ({
   isTaskEditSuggestionModalOpen,
@@ -18,6 +22,24 @@ export const TaskEditSuggestionsModal = ({
   handleToggleTaskEditSuggestionModal,
 }) => {
   const dispatch = useDispatch();
+
+  const { getState } = useStore()
+  const alldata = getState()
+
+  const [role] = useState(alldata.auth ? alldata.auth.user.role : null);
+  const userPermissions = alldata.auth.user?.permissions?.frontPermissions;
+  const { roles } = alldata.role;
+
+  const approveTask = () => {
+    console.log('mainproblem',taskEditSuggestion)
+    updateTask(
+      taskEditSuggestion.taskId,
+      taskEditSuggestion.newTask,
+      hasPermission(role, 'editTask', roles, userPermissions),
+    )(dispatch, getState);
+    dispatch(rejectTaskEditSuggestion(taskEditSuggestion._id));
+    handleToggleTaskEditSuggestionModal();
+  };
 
   return (
     <Modal
@@ -209,7 +231,9 @@ export const TaskEditSuggestionsModal = ({
       <ModalFooter>
         <Row>
           <Col>
-            <Button color="success">Approve</Button>
+          <Button color="success" onClick={approveTask}>
+              Approve
+            </Button>
           </Col>
           <Col style={{ display: 'flex' }}>
             <Button

--- a/src/components/TaskEditSuggestions/TaskEditSuggestions.jsx
+++ b/src/components/TaskEditSuggestions/TaskEditSuggestions.jsx
@@ -5,9 +5,8 @@ import { Container, Table } from 'reactstrap';
 import { TaskEditSuggestionRow } from './Components/TaskEditSuggestionRow';
 import { TaskEditSuggestionsModal } from './Components/TaskEditSuggestionsModal';
 import { getTaskEditSuggestionsData } from './selectors';
-import { fetchTaskEditSuggestions } from './thunks';
 import { toggleDateSuggestedSortDirection, toggleUserSortDirection } from './actions';
-import hasPermission from 'utils/permissions';
+
 
 export const TaskEditSuggestions = () => {
   const [isTaskEditSuggestionModalOpen, setIsTaskEditSuggestionModalOpen] = useState(false);
@@ -22,9 +21,6 @@ export const TaskEditSuggestions = () => {
   } = useSelector(getTaskEditSuggestionsData);
 
   const dispatch = useDispatch();
-  useEffect(() => {
-    dispatch(fetchTaskEditSuggestions());
-  }, []);
 
   const handleToggleTaskEditSuggestionModal = currentTaskEditSuggestion => {
     setCurrentTaskEditSuggestion(currentTaskEditSuggestion);
@@ -33,9 +29,9 @@ export const TaskEditSuggestions = () => {
 
   const SortArrow = ({ sortDirection }) => {
     if (sortDirection === 'asc') {
-      return <i class="fa fa-arrow-up"></i>;
+      return <i className="fa fa-arrow-up"></i>;
     } else if (sortDirection === 'desc') {
-      return <i class="fa fa-arrow-down"></i>;
+      return <i className="fa fa-arrow-down"></i>;
     } else {
       return <></>;
     }
@@ -47,6 +43,7 @@ export const TaskEditSuggestions = () => {
       {/* {isUserPermitted ? <h1>Task Edit Suggestions</h1> : <h1>{userRole} is not permitted to view this</h1>} */}
       {isLoading && <Loading />}
       {!isLoading && taskEditSuggestions && (
+        <div style={{overflowX: 'auto'}}>
         <Table>
           <thead>
             <tr>
@@ -57,6 +54,7 @@ export const TaskEditSuggestions = () => {
                 User <SortArrow sortDirection={userSortDirection} />
               </th>
               <th>Task</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -69,6 +67,7 @@ export const TaskEditSuggestions = () => {
             ))}
           </tbody>
         </Table>
+        </div>
       )}
       <TaskEditSuggestionsModal
         isTaskEditSuggestionModalOpen={isTaskEditSuggestionModalOpen}

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -72,7 +72,7 @@ export const ENDPOINTS = {
   `${APIEndpoint}/tasknotification/${userId}/${taskId}`,
   TASK_EDIT_SUGGESTION: () => `${APIEndpoint}/taskeditsuggestion`,
   REJECT_TASK_EDIT_SUGGESTION: taskEditSuggestionId =>
-    `${ENDPOINTS.TASK_EDIT_SUGGESTION()}/${taskEditSuggestionId}`,
+  `${APIEndpoint}/taskeditsuggestion/${taskEditSuggestionId}`,
 
   TIMEZONE_KEY: `${APIEndpoint}/timezone`,
   GEOCODE_URI: (location, key) =>


### PR DESCRIPTION
# Description
(PRIORITY HIGH) Yiyun/Jae: Create the ability for admin/owner users to approve and apply “suggested” changes on a task.
This was started here: [PR #721](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/721)
Managers and Mentor classes can suggest changes on a task. These suggestions should create a notification (see below) for all Admins/Owners letting them know they need to be reviewed and approved. Once approved, a red bell should show up for anyone assigned the task AND for the person who made the original edits/suggestions
Any class that is other than a Volunteer AND on the same team should see the bell.

## Main changes explained:
moved fetchTaskEditSuggestion to Header component, to fetch latest notification on admin user log in, added approve button functionality.

## How to test:
1. check into current branch
2. do npm install  and npm run start:local to run this PR locally
3. log in as  manager , make a suggestion on any team member task, by clicking the task name on task tab.
4. log in as admin, see the notification count on header. click on it to go to the taskEditSuggeston page.
5. click on view suggestion button, you should see the suggestion you made as manager. 
6. on approving, will see a red bell for all member assigned with the task. and the suggestion will be deleted from suggestion list.

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/86232710/793238c9-20ea-46b8-9209-d6a6198b1e6d



