### PR TITLE
Edwin - Create way to show how many times a deadline has been updated 

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -68,6 +68,8 @@ const EditTaskModal = props => {
   const [hoursMost, setHoursMost] = useState(thisTask?.hoursMost);
   // hour estimate
   const [hoursEstimate, setHoursEstimate] = useState(thisTask?.estimatedHours);
+  //deadline count 
+  const [deadlineCount, setDeadlineCount] = useState(thisTask?.deadlineCount)
   // hours warning
   const [hoursWarning, setHoursWarning] = useState(false);
 
@@ -102,6 +104,7 @@ const EditTaskModal = props => {
     setHoursWorst(thisTask?.hoursWorst);
     setHoursMost(thisTask?.hoursMost);
     setHoursEstimate(thisTask?.estimatedHours);
+    setDeadlineCount(thisTask?.deadlineCount);
     setLinks(thisTask?.links);
     setCategory(thisTask?.category);
     setWhyInfo(thisTask?.whyInfo);
@@ -198,6 +201,13 @@ const EditTaskModal = props => {
 
   // helper for updating task
   const updateTask = () => {
+
+    let newDeadlineCount = deadlineCount
+    if (thisTask?.estimatedHours !== hoursEstimate) {
+      newDeadlineCount = deadlineCount + 1
+      setDeadlineCount(newDeadlineCount);
+    }
+
     const updatedTask = {
       taskName,
       priority,
@@ -208,6 +218,7 @@ const EditTaskModal = props => {
       hoursWorst: parseFloat(hoursWorst),
       hoursMost: parseFloat(hoursMost),
       estimatedHours: parseFloat(hoursEstimate),
+      deadlineCount: parseFloat(newDeadlineCount),
       startedDatetime: startedDate,
       dueDatetime: dueDate,
       links,

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -30,7 +30,9 @@ const TeamMemberTask = ({
   let totalHoursRemaining = 0;
   const thisWeekHours = user.totaltangibletime_hrs;
   const rolesAllowedToResolveTasks = ['Administrator', 'Owner'];
+  const rolesAllowedToSeeDeadlineCount = ['Manager', 'Mentor', 'Administrator', 'Owner'];
   const isAllowedToResolveTasks = rolesAllowedToResolveTasks.includes(userRole);
+  const isAllowedToSeeDeadlineCount = rolesAllowedToSeeDeadlineCount.includes(userRole);
 
   if (user.tasks) {
     user.tasks = user.tasks.map(task => {
@@ -107,7 +109,7 @@ const TeamMemberTask = ({
                     return (
                       <tr key={`${task._id}${index}`} className="task-break">
                         <td data-label="Task(s)" className="task-align">
-                          <p>
+                          <p style={{position: 'relative'}}>
                             <Link to={task.projectId ? `/wbs/tasks/${task._id}` : '/'}>
                               <span>{`${task.num} ${task.taskName}`} </span>
                             </Link>
@@ -192,6 +194,13 @@ const TeamMemberTask = ({
                         </td>
                         {task.hoursLogged != null && task.estimatedHours != null && (
                           <td data-label="Progress" className="team-task-progress">
+                            {isAllowedToSeeDeadlineCount && 
+                              <span 
+                                className="deadlineCount" 
+                                title="Deadline Follow-up Count">
+                                  {task.deadlineCount === undefined ? 0 : task.deadlineCount}
+                              </span>
+                            }
                             <div>
                               <span>
                                 {`${parseFloat(task.hoursLogged.toFixed(2))}

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -109,7 +109,7 @@ const TeamMemberTask = ({
                     return (
                       <tr key={`${task._id}${index}`} className="task-break">
                         <td data-label="Task(s)" className="task-align">
-                          <p style={{position: 'relative'}}>
+                          <p>
                             <Link to={task.projectId ? `/wbs/tasks/${task._id}` : '/'}>
                               <span>{`${task.num} ${task.taskName}`} </span>
                             </Link>

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -17,6 +17,8 @@ import moment from 'moment';
 import TeamMemberTask from './TeamMemberTask';
 import FilteredTimeEntries from './FilteredTimeEntries';
 import { hrsFilterBtnRed, hrsFilterBtnBlue } from 'constants/colors';
+import { toast } from 'react-toastify';
+
 
 const TeamMemberTasks = props => {
   const [showTaskNotificationModal, setTaskNotificationModal] = useState(false);

--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -74,7 +74,7 @@
   height: 25px;
   font-size: 15px;
   width: 25px;
-  top: 1px;
+  top: 3px;
   right: 0;
 }
 

--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -44,6 +44,7 @@
 }
 
 .team-task-progress {
+  position: relative;
   width: 35%;
 }
 
@@ -61,6 +62,20 @@
 
 .team-member-tasks-user-name {
   width: 70%;
+}
+
+.deadlineCount {
+  position: absolute;
+  text-align: center;
+  vertical-align: middle;
+  background: #ff4d4f;
+  border-radius: 40px;
+  color: #fff;
+  height: 25px;
+  font-size: 15px;
+  width: 25px;
+  top: 1px;
+  right: 0;
 }
 
 .team-clocks {


### PR DESCRIPTION
# Description

<img width="554" alt="Screen Shot 2023-06-29 at 6 03 50 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/1da0b8f5-271b-4bf9-a12c-dbfb3fee111a">

## Related PRS (if any):
This frontend PR is related to the BE PR [#429](https://github.com/OneCommunityGlobal/HGNRest/pull/429)

## Main changes explained:

- Added a new backend property for a task to track `deadlineCount`
- When estimated hours of a task is edited and updated, increase the `deadlineCount` by one 
- Display this deadlineCount in the team member tasks component in the progress bar

## How to test:

1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as Admin/Owner user
4. go to Dashboard -> Team Member Tasks
5. click on any task you want to edit -> edit -> update "Estimated Hours" in the edit modal and click update
6. go to Dashboard -> Team Member Tasks
7. The notification icon on top of the progress bar should increment

## Videos/Screenshots of changes:

Admin/Owner account:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/19f5cd0e-b22c-46a2-a1b2-aaa9edda02b2

## Notes:

If the task itself is edited but the estimated hours remain the same, the deadlineCount **Should Not** increment, thus the notification icon should remain with the same count
