### PR TITLE
lawrence - make time logged to non tasks obvious

### DIFF
--- a/src/components/TeamMemberTasks/FilteredTimeEntries.jsx
+++ b/src/components/TeamMemberTasks/FilteredTimeEntries.jsx
@@ -28,11 +28,11 @@ const FilteredTimeEntries = ({ data, displayYear }) => {
       .format('YYYY-MM-DD');
 
     if (moment(dateOfWork).isSameOrAfter(pastTwentyFourHrs)) {
-      return <div className="color-bar" style={{ backgroundColor: hrsFilterBtnRed }}></div>;
+      return <div className="color-bar" style={{ backgroundColor: projectName ? 'white' : hrsFilterBtnRed, border: '5px solid ' + hrsFilterBtnRed }}></div>;
     } else if (moment(dateOfWork).isSameOrAfter(pastFortyEightHrs)) {
-      return <div className="color-bar" style={{ backgroundColor: hrsFilterBtnBlue }}></div>;
+      return <div className="color-bar" style={{ backgroundColor: projectName ? 'white' : hrsFilterBtnBlue, border: '5px solid ' + hrsFilterBtnBlue }}></div>;
     } else {
-      return <div className="color-bar" style={{ backgroundColor: 'green' }}></div>;
+      return <div className="color-bar" style={{ backgroundColor: projectName ? 'white' : 'green', border: '5px solid green' }}></div>;
     }
   };
 
@@ -78,7 +78,12 @@ const FilteredTimeEntries = ({ data, displayYear }) => {
             <h4 className="text-success">
               {data.hours}h {data.minutes}m
             </h4>
-            <div className="text-muted">Project/Task:</div>
+            <div className="text-muted">
+              {projectName ? <b>Project</b> : 'Project'}
+              /
+              {taskName ? <b>Task</b> : 'Task'}
+              :
+            </div>
             <h6> {projectName || taskName} </h6>
             <span className="text-muted">Tangible:&nbsp;</span>
             <h6>{data.isTangible ? 'Tangible' : 'Intangible'}</h6>


### PR DESCRIPTION
# Description

![Screenshot (2663)](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/46981223/3310054a-84f0-4c83-a2ba-7914eddb3120)

## Main changes explained:


- Added a white bar on the left of time entries that are projects
- Made the word "Project" in "Project/Task:" bolded if it's a project-type time entry
…

## How to test:
1. check into current branch
2. do `npm run start:local` to run this PR locally
3. log in as any user
4. go to dashboard → click on 72h button in the Tasks tab → scroll down to find time entries
5. Project time entries should have a white bar in on the left and have the word "Project" bolded in "Project/Task:"

## Screenshots or videos of changes:
Before:
![Screenshot (2662)](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/46981223/f9c3039b-c42b-465a-91f6-e1ca7de0eb32)

After:
![Screenshot (2661)](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/46981223/74479524-151d-4a8f-97d4-b51da4e4965e)


## Note:
Task time entries should have bolded "Task" in the "Project/Task" text, but task time entries are currently bugged so this will not work. Task time entries would also not have their task name displayed. Task time entries should not have a white bar on the left.
