### PR TITLE
yihan modify layout of “Create New User” form

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -112,7 +112,7 @@ class AddUserProfile extends Component {
           <Row>
             <Col md="12">
               <Form>
-                <Row className='userProfileAddRow'>
+                <Row className='user-add-row'>
                   <Col md={{ size: 2, offset: 2 }} className="text-md-right my-2">
                     <Label>Name</Label>
                   </Col>
@@ -145,7 +145,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row className='userProfileAddRow'>
+                <Row className='user-add-row'>
                   <Col md={{ size: 3, offset: 1 }} className="text-md-right my-2">
                     <Label>Job Title</Label>
                   </Col>
@@ -162,7 +162,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row className='userProfileAddRow'>
+                <Row className='user-add-row'>
                   <Col md={{ size: 2, offset: 2 }} className="text-md-right my-2">
                     <Label>Email</Label>
                   </Col>
@@ -186,7 +186,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row className='userProfileAddRow'>
+                <Row className='user-add-row'>
                   <Col md={{ size: 2, offset: 2 }} className="text-md-right my-2">
                     <Label>Phone</Label>
                   </Col>
@@ -212,7 +212,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row className='userProfileAddRow'>
+                <Row className='user-add-row'>
                   <Col md={{ size: 4 }} className="text-md-right my-2">
                     <Label>Weekly Committed Hours</Label>
                   </Col>
@@ -236,7 +236,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row className='userProfileAddRow'>
+                <Row className='user-add-row'>
                   <Col md={{ size: 2, offset: 2 }} className="text-md-right my-2">
                     <Label>Role</Label>
                   </Col>
@@ -263,7 +263,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row className='userProfileAddRow'> 
+                <Row className='user-add-row'> 
                   <Col md={{ size: 4 }} className="text-md-right my-2">
                     <Label className="weeklySummaryOptionsLabel">Weekly Summary Options</Label>
                   </Col>
@@ -283,7 +283,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row className='userProfileAddRow'>
+                <Row className='user-add-row'>
                   <Col md={{ size: 4 }} className="text-md-right my-2">
                     <Label>Video Call Preference</Label>
                   </Col>
@@ -300,7 +300,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row className='userProfileAddRow'>
+                <Row className='user-add-row'>
                   <Col md={{ size: 4}} className="text-md-right my-2">
                     <Label>Admin Document</Label>
                   </Col>
@@ -317,7 +317,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row className='userProfileAddRow'>
+                <Row className='user-add-row'>
                   <Col md={{ size: 4 }} className="text-md-right my-2">
                     <Label>Link to Media Files</Label>
                   </Col>
@@ -334,7 +334,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row className='userProfileAddRow'>
+                <Row className='user-add-row'>
                   <Col md={{ size: 4, offset: 0 }} className="text-md-right my-2">
                     <Label>Location</Label>
                   </Col>
@@ -359,7 +359,7 @@ class AddUserProfile extends Component {
                     </Row>
                   </Col>
                 </Row>
-                <Row className='userProfileAddRow'>
+                <Row className='user-add-row'>
                   <Col md={{ size: 3, offset: 1 }} className="text-md-right my-2">
                     <Label>Time Zone</Label>
                   </Col>

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -112,7 +112,7 @@ class AddUserProfile extends Component {
           <Row>
             <Col md="12">
               <Form>
-                <Row>
+                <Row className='userProfileAddRow'>
                   <Col md={{ size: 2, offset: 2 }} className="text-md-right my-2">
                     <Label>Name</Label>
                   </Col>
@@ -145,7 +145,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row>
+                <Row className='userProfileAddRow'>
                   <Col md={{ size: 3, offset: 1 }} className="text-md-right my-2">
                     <Label>Job Title</Label>
                   </Col>
@@ -162,7 +162,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row>
+                <Row className='userProfileAddRow'>
                   <Col md={{ size: 2, offset: 2 }} className="text-md-right my-2">
                     <Label>Email</Label>
                   </Col>
@@ -186,7 +186,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row>
+                <Row className='userProfileAddRow'>
                   <Col md={{ size: 2, offset: 2 }} className="text-md-right my-2">
                     <Label>Phone</Label>
                   </Col>
@@ -212,7 +212,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row>
+                <Row className='userProfileAddRow'>
                   <Col md={{ size: 4 }} className="text-md-right my-2">
                     <Label>Weekly Committed Hours</Label>
                   </Col>
@@ -236,7 +236,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row>
+                <Row className='userProfileAddRow'>
                   <Col md={{ size: 2, offset: 2 }} className="text-md-right my-2">
                     <Label>Role</Label>
                   </Col>
@@ -263,7 +263,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row>
+                <Row className='userProfileAddRow'> 
                   <Col md={{ size: 4 }} className="text-md-right my-2">
                     <Label className="weeklySummaryOptionsLabel">Weekly Summary Options</Label>
                   </Col>
@@ -283,7 +283,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row>
+                <Row className='userProfileAddRow'>
                   <Col md={{ size: 4 }} className="text-md-right my-2">
                     <Label>Video Call Preference</Label>
                   </Col>
@@ -300,7 +300,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row>
+                <Row className='userProfileAddRow'>
                   <Col md={{ size: 4}} className="text-md-right my-2">
                     <Label>Admin Document</Label>
                   </Col>
@@ -317,7 +317,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row>
+                <Row className='userProfileAddRow'>
                   <Col md={{ size: 4 }} className="text-md-right my-2">
                     <Label>Link to Media Files</Label>
                   </Col>
@@ -334,7 +334,7 @@ class AddUserProfile extends Component {
                     </FormGroup>
                   </Col>
                 </Row>
-                <Row>
+                <Row className='userProfileAddRow'>
                   <Col md={{ size: 4, offset: 0 }} className="text-md-right my-2">
                     <Label>Location</Label>
                   </Col>
@@ -359,7 +359,7 @@ class AddUserProfile extends Component {
                     </Row>
                   </Col>
                 </Row>
-                <Row>
+                <Row className='userProfileAddRow'>
                   <Col md={{ size: 3, offset: 1 }} className="text-md-right my-2">
                     <Label>Time Zone</Label>
                   </Col>

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.scss
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.scss
@@ -116,6 +116,6 @@ form-control {
   margin-left: 7px;
 }
 
-.userProfileAddRow {
+.user-add-row {
   width: auto;
 }

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.scss
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.scss
@@ -119,3 +119,28 @@ form-control {
 .user-add-row {
   width: auto;
 }
+
+.text-md-right {
+  white-space: nowrap;
+}
+
+@media only screen and (max-width: 1024px) {
+  .text-md-right {
+    padding: 0px !important;
+  }
+
+  label {
+    font-weight: normal;
+  }
+}
+
+@media only screen and (max-width: 992px) and (min-width: 768px) {
+  .user-add-row {
+    margin-right: -50px !important;
+    margin-left: -50px !important;
+    font-size: 14px;
+  }
+  .form-control {
+    max-width: 210px !important;
+  }
+}

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.scss
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.scss
@@ -115,3 +115,7 @@ form-control {
 .weeklySummaryOptionsLabel {
   margin-left: 7px;
 }
+
+.userProfileAddRow {
+  width: auto;
+}


### PR DESCRIPTION
# Description
In the form of creating new users, "Weekly  Committed hours" and "Weekly Summary Options" labels are presented in two lines. We need to correct the form to make both of these two labels on one line.
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/5b476b0d-a941-4110-a9af-85459e7fd7ae)

## Main changes explained:
- Update file UserProfileAdd.jsx for including Row component in "userProfileAddRow" class.
- Update file UserProfileAdd.scss for adding a width property on "userProfileAddRow" class.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to Other Links → User Management → Create New User
5. verify both "Weekly  Committed hours" and "Weekly Summary Options" are on 1 line.

## Screenshots or videos of changes:
<img width="753" alt="截屏2023-06-29 12 43 56" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/4c8c6eda-782d-436d-817b-bcf1984d8ff1">
