### PR TITLE
yihan make task summary refresh after edit and save

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -229,6 +229,7 @@ const EditTaskModal = props => {
     if (props.tasks.error === 'none') {
       toggle();
     }
+    window.location.reload();
   };
 
   const handleAssign = value => {


### PR DESCRIPTION
# Description
<img width="741" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/e1cad38a-a3ab-4740-95c9-c69db7a8d3eb">

## Main changes explained:
- Update file EditTaskModal.jsx for executing reload function after clicking on "update" button.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to Tasks Tab → Click Task → edit Hours/Estimated → Update
5. verify if page auto-refresh and shows the correct data.
