### PR TITLE
Conditionally color titles in WeeklySummaryReports

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -69,17 +69,17 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
 
     const summaryText = summary?.weeklySummaries[weekIndex]?.summary;
     let summaryDate = moment()
-                        .tz('America/Los_Angeles')
-                        .endOf('week')
-                        .subtract(weekIndex, 'week')
-                        .format('YYYY-MMM-DD')
+      .tz('America/Los_Angeles')
+      .endOf('week')
+      .subtract(weekIndex, 'week')
+      .format('YYYY-MMM-DD');
     let summaryDateText = `Weekly Summary (${summaryDate}):`;
     const summaryContent = (() => {
       if (summaryText) {
         summaryDate = moment(summary.weeklySummaries[weekIndex]?.uploadDate)
-                      .tz('America/Los_Angeles')
-                      .format('YYYY-MMM-DD')
-        summaryDateText =`Summary Submitted On (${summaryDate}):`
+          .tz('America/Los_Angeles')
+          .format('YYYY-MMM-DD');
+        summaryDateText = `Summary Submitted On (${summaryDate}):`;
         const style = {};
         switch (summary?.weeklySummaryOption) {
           case 'Team':
@@ -120,12 +120,23 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
   };
 
   const getTotalValidWeeklySummaries = summary => {
-    return (
-      <p style={summary.weeklySummariesCount === 8 ? { color: 'blue' } : {}}>
-        <b>Total Valid Weekly Summaries:</b>{' '}
-        {summary.weeklySummariesCount || 'No valid submissions yet!'}
-      </p>
-    );
+    if (summary.weeklySummariesCount === 8) {
+      return (
+        <p style={{ color: 'blue' }}>
+          <b>Total Valid Weekly Summaries:</b>{' '}
+          {summary.weeklySummariesCount || 'No valid submissions yet!'}
+        </p>
+      );
+    } else {
+      return (
+        <p>
+          <b style={summary.weeklySummaryOption === 'Team' ? { color: 'magenta' } : {}}>
+            Total Valid Weekly Summaries:
+          </b>{' '}
+          {summary.weeklySummariesCount || 'No valid submissions yet!'}
+        </p>
+      );
+    }
   };
 
   const handleGoogleDocClick = googleDocLink => {
@@ -161,12 +172,14 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
     }
   };
 
-  const bioSwitch = (userId, bioPosted) => {
+  const bioSwitch = (userId, bioPosted, weeklySummaryOption) => {
     const [bioStatus, setBioStatus] = useState(bioPosted);
     return (
       <div>
         <div className="bio-toggle">
-          <b>Bio announcement:</b>
+          <b style={weeklySummaryOption === 'Team' ? { color: 'magenta' } : {}}>
+            Bio announcement:
+          </b>
         </div>
         <div className="bio-toggle">
           <ToggleSwitch
@@ -182,10 +195,10 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
     );
   };
 
-  const bioLabel = (userId, bioPosted) => {
+  const bioLabel = (userId, bioPosted, weeklySummaryOption) => {
     return (
       <div>
-        <b>Bio announcement:</b>
+        <b style={weeklySummaryOption === 'Team' ? { color: 'magenta' } : {}}>Bio announcement:</b>
         {bioPosted === 'default'
           ? ' Not requested/posted'
           : bioPosted === 'posted'
@@ -249,11 +262,14 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
               {' '}
               <b>Media URL:</b> {getMediaUrlLink(summary)}
             </div>
-            {bioFunction(summary._id, summary.bioPosted)}
+            {bioFunction(summary._id, summary.bioPosted, summary.weeklySummaryOption)}
             {getTotalValidWeeklySummaries(summary)}
             {hoursLogged >= summary.weeklycommittedHours && (
               <p>
-                <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
+                <b style={summary.weeklySummaryOption === 'Team' ? { color: 'magenta' } : {}}>
+                  Hours logged:
+                </b>
+                {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
               </p>
             )}
             {hoursLogged < summary.weeklycommittedHours && (


### PR DESCRIPTION
Change the color of the following titles in each member card in the Weekly Summary Report page to be pink if the member's weekly summary option is set to "Team":
- "Bio Annoucement"
- "Total Valid Weekly Summaries"
- "Hours Logged

# Description
Please include the exact bug/functionality description and a summary of the changes/ related issues. Please also include any other relevant motivation and context:
Fixes # (bug list priority high/medium/low x.y.z)
Or Implements # (WBS) 

## Related PRS (if any):
This frontend PR is related to the #XXX backend PR.
To test this backend PR you need to checkout the #XXX frontend PR.
…

## Main changes explained:
- Delete file A for removing unused components …
- Update file B for including new pattern …
- Create file C for introducing new components …
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to dashboard→ Tasks→ task→…
5. verify function “A” (feel free to include screenshot here)

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
