### PR TITLE
yihan fix dueDate issue

### DIFF
--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -137,16 +137,13 @@ export class WeeklySummary extends Component {
     // and then setting the due date to the end of the ISO week (Saturday) for each respective week
     const dueDateLastWeek = moment(dueDate)
       .subtract(1, 'weeks')
-      .startOf('isoWeek')
-      .add(5, 'days');
+      .toISOString();
     const dueDateBeforeLast = moment(dueDate)
       .subtract(2, 'weeks')
-      .startOf('isoWeek')
-      .add(5, 'days');
+      .toISOString();
     const dueDateThreeWeeksAgo = moment(dueDate)
       .subtract(3, 'weeks')
-      .startOf('isoWeek')
-      .add(5, 'days');
+      .toISOString();
 
     const uploadDateXWeeksAgo = x => {
       const summaryList = [summary, summaryLastWeek, summaryBeforeLast, summaryThreeWeeksAgo];
@@ -413,18 +410,18 @@ export class WeeklySummary extends Component {
     if (diffInSubmittedCount !== 0) {
       this.setState({ summariesCountShowing: newformElements.weeklySummariesCount + 1 });
     }
-    const updateSummary = (summary, uploadDate) => {
+    const updateSummary = (summary, uploadDate, dueDate) => {
       if (newformElements[summary] !== newOriginSummaries[summary]) {
         newOriginSummaries[summary] = newformElements[summary];
-        newUploadDatesElements[uploadDate] = submittedDate;
+        newUploadDatesElements[uploadDate] = newformElements[summary] == '' ? dueDate : submittedDate;
         this.setState({ formElements: newformElements, uploadDatesElements: newUploadDatesElements, originSummaries: newOriginSummaries });
       }
     };
     // Loop through summaries and update state variables
     for (let i = 0; i < summaries.length; i++) {
-      updateSummary(summaries[i], uploadDates[i]);
+      updateSummary(summaries[i], uploadDates[i], dueDates[i]);
     }
-    
+
     // Construct the modified weekly summaries
     const modifiedWeeklySummaries = {
       mediaUrl: newformElements.mediaUrl.trim(),


### PR DESCRIPTION
# Description
When we submit weekly summary, the dueDate property of "Last week", "Week before last" and "Three weeks ago" is not accurate. The correct value of dueDate should be "SundayT06:59:59.999Z", but the current value is "SaturdayT04:00:00.000Z". 
<img width="533" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/eeb67aa3-f540-4ba8-be84-5f5ac5052376">

## Main changes explained:
- Update WeeklySummary.jsx for (1) correcting value of dueDate, (2) set value of uploadDate as of dueDate when summary is an empty String.

## Screenshots or videos of changes:
<img width="529" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/94303659/f6d33582-b438-4d05-aee7-6dd574267367">

## Note:
Correct value: "SundayT06:59:59.999Z"(UDT) = "SaturdayT23:59:59.999Z"(PDT)
Current value: "SaturdayT04:00:00.000Z"(UDT) = "FridayT21:00:00.000Z"(PDT)
