### PR TITLE
Omar - Display only active users on create task modal

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -17,7 +17,8 @@ function AddTaskModal(props) {
   // members
   const [members, setMembers] = useState([]);
   useEffect(() => {
-    setMembers(props.projectMembers.members);
+    const activeUsers = props.projectMembers.members.filter(member => member.isActive);
+    setMembers(activeUsers);
   }, [props.projectMembers.members]);
 
   // modal
@@ -29,7 +30,7 @@ function AddTaskModal(props) {
   const setToggle = () => {
     try {
       props.openChild();
-    } catch {}
+    } catch { }
     toggle();
   };
 
@@ -52,7 +53,7 @@ function AddTaskModal(props) {
   const [assigned, setAssigned] = useState(true);
 
   // status
-  const [status, setStatus] = useState('Started');
+  const [status, setStatus] = useState(true);
 
   // hour best
   const [hoursBest, setHoursBest] = useState(0);
@@ -309,6 +310,7 @@ function AddTaskModal(props) {
       if (props.tasks.error === 'none') {
         toggle();
         getNewNum();
+        setTaskName('');
       }
     }, 1000);
   };
@@ -410,7 +412,8 @@ function AddTaskModal(props) {
                         id="true"
                         name="Assigned"
                         value={true}
-                        onChange={() => setAssigned(true)}
+                        checked={assigned}
+                        onClick={() => setAssigned(true)}
                       />
                       <label className="form-check-label" htmlFor="true">
                         Yes
@@ -423,7 +426,8 @@ function AddTaskModal(props) {
                         id="false"
                         name="Assigned"
                         value={false}
-                        onChange={() => setAssigned(false)}
+                        checked={!assigned}
+                        onClick={() => setAssigned(false)}
                       />
                       <label className="form-check-label" htmlFor="false">
                         No
@@ -443,7 +447,8 @@ function AddTaskModal(props) {
                         id="started"
                         name="started"
                         value={true}
-                        onChange={() => setStatus(true)}
+                        checked={status}
+                        onClick={() => setStatus(true)}
                       />
                       <label className="form-check-label" htmlFor="started">
                         Started
@@ -456,7 +461,8 @@ function AddTaskModal(props) {
                         id="notStarted"
                         name="started"
                         value={false}
-                        onChange={() => setStatus(false)}
+                        checked={!status}
+                        onClick={() => setStatus(false)}
                       />
                       <label className="form-check-label" htmlFor="notStarted">
                         Not Started


### PR DESCRIPTION
# Description

Make the Task Resources section only show active users

## Main changes explained:
- Filter out the inactive users.
- Use correct values for Assigned and Status fields.
- Use onclick events to update values.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. Admin Login → Other Links → Projects → Choose Project → Click WBS Icon → Choose WBS → Add Task
5. Check that only active users are shown
6. Assigned and Status fields are selected by default


## Screenshots or videos of changes:


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9827488/f6efbc30-4d90-48b5-a286-baf9be78a7b1



## Note:
We should have an API to get only active users.
