### PR TITLE
Jonathan - Add Edit Weekly Summary Options to Permissions

### DIFF
--- a/src/components/PermissionsManagement/UserRoleTab.jsx
+++ b/src/components/PermissionsManagement/UserRoleTab.jsx
@@ -51,6 +51,7 @@ export const permissionLabel = {
   changeBioAnnouncement: 'Change the Bio Announcement Status',
   seeAllReports: 'See All the Reports Tab',
   removeUserFromTask: 'View and Interact with Task “X”',
+  editWeeklySummaryOptions: 'Edit Weekly Summary Options',
 };
 
 const UserRoleTab = props => {


### PR DESCRIPTION
# Description
![Edit Weekly Summaries Options](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/63978806/c547c406-906f-40ef-ae70-aa066a01352a)


## Related PRS (if any):
This frontend PR is related to the [#970](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/970)


## Main changes explained:
- Added Edit Weekly Summary Options under the roles in UserRoleTab.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Log as Owner user
4. Other Links → Permissions Management → Manage User’s Permissions
5. Verify that "Edit Weekly Summary Options" is being displayed.

## Screenshots or videos of changes:
![Screenshot](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/63978806/bb1de22b-8d94-457d-a3e7-a72b09175226)

