### PR TITLE
Xiaoyu add editable role info modal  on profile/permission

### DIFF
--- a/src/actions/roleInfo.js
+++ b/src/actions/roleInfo.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+
+const roleInfo = () => {
+  const dispatch = useDispatch();
+  
+  const handleTextChange = (e) => {
+    dispatch({ type: 'SET_ROLEINFO', payload: e.target.value });
+  };
+  
+  return <input type="text" onChange={handleTextChange} />;
+};
+
+export default roleInfo;

--- a/src/components/PermissionsManagement/PermissionsManagement.jsx
+++ b/src/components/PermissionsManagement/PermissionsManagement.jsx
@@ -10,10 +10,16 @@ import { getAllUserProfile } from 'actions/userManagement';
 import UserPermissionsPopUp from './UserPermissionsPopUp';
 import { useHistory } from 'react-router-dom';
 import { boxStyle } from 'styles';
+import RoleInfoModal from '../RoleInfo/roleInfoModal'
 
 const PermissionsManagement = ({ getAllRoles, roles, auth, getUserRole, userProfile }) => {
   const [isNewRolePopUpOpen, setIsNewRolePopUpOpen] = useState(false);
   const [isUserPermissionsOpen, setIsUserPermissionsOpen] = useState(false);
+  //add roleInfo
+  const [roleInfoModalOpen, setroleInfoModalOpen] = useState(false);
+  const toggleRoleInfoModal = () => {
+    setroleInfoModalOpen(!roleInfoModalOpen);
+  }
   let history = useHistory();
 
   const togglePopUpNewRole = () => {
@@ -49,9 +55,23 @@ const PermissionsManagement = ({ getAllRoles, roles, auth, getUserRole, userProf
                 className="role-name"
               >
                 {roleName}
-              </button>
-            );
-          })}
+                <i
+                data-toggle="tooltip"
+                      data-placement="right"
+                      title="Click for user class information"
+                      style={{ fontSize: 25, cursor: 'pointer', color: '#00CCFF'}}
+                      aria-hidden="true"
+                      className="fa fa-info-circle"
+                      onMouseOver={() => {toggleRoleInfoModal(true); // open modal
+                          }}
+                    /> 
+                    <RoleInfoModal 
+                        role={userProfile?.role} 
+                        isOpen={roleInfoModalOpen} 
+                        toggle={toggleRoleInfoModal} 
+                      />
+              </button>                
+            )})};
         </div>
         {userProfile?.role === 'Owner' && (
           <div className="buttons-container">

--- a/src/components/PermissionsManagement/PermissionsManagement.test.js
+++ b/src/components/PermissionsManagement/PermissionsManagement.test.js
@@ -17,6 +17,7 @@ describe('permissions management page structure', () => {
   beforeEach(() => {
     store = mockStore({
       role: rolesMock.role,
+      roleInfo: { roleInfo: {} },
     });
     store.dispatch = jest.fn();
 

--- a/src/components/RoleInfo/roleInfoModal.jsx
+++ b/src/components/RoleInfo/roleInfoModal.jsx
@@ -1,0 +1,112 @@
+// // RoleInfoModal.js
+// import React, { useState, useEffect } from 'react';
+// import { useSelector, useDispatch } from 'react-redux';
+// import { Modal, ModalHeader, ModalBody } from 'reactstrap';
+
+// const RoleInfoModal = ({ role, isOpen, toggle }) => {
+//   const dispatch = useDispatch();
+//   // Get the text from the store
+//   const storedText = useSelector(state => state.roleInfo.roleInfo);
+
+//   // Local state for the input
+//   const [inputText, setInputText] = useState(storedText);
+
+//   // Update the input field when the stored text changes
+//   useEffect(() => {
+//     setInputText(storedText);
+//   }, [storedText]);
+
+//   // Handle input change
+//   const handleInputChange = (event) => {
+//     setInputText(event.target.value);
+//   };
+
+//   // Update the stored text when save button is clicked
+//   const handleSave = () => {
+//     dispatch({ type: 'SET_TEXT', payload: inputText });
+//     toggle(false);
+//   };
+
+//   if (!isOpen) {
+//     return null;
+//   }
+
+//   return (
+//     <div>
+//       <Modal toggle={toggle} isOpen={isOpen}>
+//         <span className="close" onClick={() => toggle(false)}>&times;</span>
+//         <input type="text" value={inputText} onChange={handleInputChange} />
+//         <button onClick={handleSave}>Save</button>
+//       </Modal>
+//     </div>
+//   );
+// };
+
+// export default RoleInfoModal;// TextModal.js
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Modal, ModalBody, Input, ModalHeader, Button, ModalFooter } from 'reactstrap';
+
+class RoleInfoModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      roleInfo: this.props.roleInfo,
+      role: this.props.role,
+      editing: false,
+    };
+  }
+  handleEditing = () => {
+      this.setState({editing:!this.state.editing});
+  }
+  handleInputChange = (event) => {
+    const newRoleInfo = event.target.value;
+    this.setState({ roleInfo: newRoleInfo });
+  };
+
+  handleSave = () => {
+    this.setState({editing:false})
+    this.props.setRoleInfo(this.state.roleInfo);
+  }
+
+  render(){
+    const { isOpen, toggle} = this.props;
+    const { roleInfo } = this.state;
+
+    return (
+      <Modal isOpen={isOpen} toggle={toggle}>
+        <ModalHeader>Welcome to Role Class Information Page!</ModalHeader>
+        <ModalBody>
+          <Input 
+            disabled={!this.state.editing}
+            value={roleInfo}
+            onChange={this.handleInputChange}
+          />
+        </ModalBody>
+        <ModalFooter>
+          {(this.state.role === 'Owner')&&(!this.state.editing)&&
+            (<Button onClick={this.handleEditing}>
+              Edit
+              </Button> 
+            )}
+          {(this.state.editing)&&
+            (<Button onClick={this.handleSave}>Save</Button> 
+            )}
+          <Button onClick={toggle}>Close</Button> 
+        </ModalFooter>
+      </Modal>
+    );
+  }
+}
+
+// map Redux state to component props
+const mapStateToProps = (state) => ({
+  roleInfo: state.roleInfo.roleInfo,
+});
+
+// map Redux dispatch to component props
+const mapDispatchToProps = (dispatch) => ({
+  setRoleInfo: (roleInfo) => dispatch({ type: 'SET_ROLEINFO', payload: roleInfo }),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(RoleInfoModal);

--- a/src/components/RoleInfo/roleInfoModal.jsx
+++ b/src/components/RoleInfo/roleInfoModal.jsx
@@ -1,51 +1,7 @@
-// // RoleInfoModal.js
-// import React, { useState, useEffect } from 'react';
-// import { useSelector, useDispatch } from 'react-redux';
-// import { Modal, ModalHeader, ModalBody } from 'reactstrap';
-
-// const RoleInfoModal = ({ role, isOpen, toggle }) => {
-//   const dispatch = useDispatch();
-//   // Get the text from the store
-//   const storedText = useSelector(state => state.roleInfo.roleInfo);
-
-//   // Local state for the input
-//   const [inputText, setInputText] = useState(storedText);
-
-//   // Update the input field when the stored text changes
-//   useEffect(() => {
-//     setInputText(storedText);
-//   }, [storedText]);
-
-//   // Handle input change
-//   const handleInputChange = (event) => {
-//     setInputText(event.target.value);
-//   };
-
-//   // Update the stored text when save button is clicked
-//   const handleSave = () => {
-//     dispatch({ type: 'SET_TEXT', payload: inputText });
-//     toggle(false);
-//   };
-
-//   if (!isOpen) {
-//     return null;
-//   }
-
-//   return (
-//     <div>
-//       <Modal toggle={toggle} isOpen={isOpen}>
-//         <span className="close" onClick={() => toggle(false)}>&times;</span>
-//         <input type="text" value={inputText} onChange={handleInputChange} />
-//         <button onClick={handleSave}>Save</button>
-//       </Modal>
-//     </div>
-//   );
-// };
-
-// export default RoleInfoModal;// TextModal.js
+// export default RoleInfoModal;
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Modal, ModalBody, Input, ModalHeader, Button, ModalFooter } from 'reactstrap';
+import { Modal, ModalBody, Input, ModalHeader, Button, ModalFooter, CustomInput } from 'reactstrap';
 
 class RoleInfoModal extends Component {
   constructor(props) {
@@ -74,10 +30,12 @@ class RoleInfoModal extends Component {
     const { roleInfo } = this.state;
 
     return (
-      <Modal isOpen={isOpen} toggle={toggle}>
+      <Modal isOpen={isOpen} toggle={toggle} size="lg">
         <ModalHeader>Welcome to Role Class Information Page!</ModalHeader>
         <ModalBody>
-          <Input 
+          <Input
+            rows={10}
+            type='textarea'
             disabled={!this.state.editing}
             value={roleInfo}
             onChange={this.handleInputChange}

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -12,6 +12,7 @@ import hasPermission from 'utils/permissions';
 import SetUpFinalDayButton from 'components/UserManagement/SetUpFinalDayButton';
 import styles from './BasicInformationTab.css';
 import { boxStyle } from 'styles';
+import RoleInfoModal from 'components/RoleInfo/roleInfo';
 
 const Name = props => {
   const { userProfile, setUserProfile, formValid, setFormValid, canEdit } = props;

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -440,6 +440,7 @@ const BasicInformationTab = props => {
                   id="role"
                   name="role"
                   className="form-control"
+                  style={{width:"100px"}}
                 >
                   {roles.map(({ roleName }) => {
                     if (roleName === 'Owner') return;
@@ -454,16 +455,15 @@ const BasicInformationTab = props => {
               `${userProfile.role}`
             )}
             {(userProfile.role !== 'Volunteer') &&(
-            <div>
+              <>
               <i
               data-toggle="tooltip"
                     data-placement="right"
                     title="Click for user class information"
-                    style={{ fontSize: 24, cursor: 'pointer', color: '#00CCFF'}}
+                    style={{ fontSize: 20, cursor: 'pointer', color: '#00CCFF'}}
                     aria-hidden="true"
                     className="fa fa-info-circle"
-                    onClick={() => { // populate roleInfo state with role
-                          toggleRoleInfoModal(true); // open modal
+                    onClick={() => {toggleRoleInfoModal(true); // open modal
                         }}
                   /> 
                   <RoleInfoModal 
@@ -471,8 +471,8 @@ const BasicInformationTab = props => {
                       isOpen={roleInfoModalOpen} 
                       toggle={toggleRoleInfoModal} 
                     />
-            </div>
-          )}
+
+              </>)}
           </Col>
         </Row>
         {canEdit && (

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -12,7 +12,7 @@ import hasPermission from 'utils/permissions';
 import SetUpFinalDayButton from 'components/UserManagement/SetUpFinalDayButton';
 import styles from './BasicInformationTab.css';
 import { boxStyle } from 'styles';
-import RoleInfoModal from 'components/RoleInfo/roleInfo';
+import RoleInfoModal from '../../RoleInfo/roleInfoModal';
 
 const Name = props => {
   const { userProfile, setUserProfile, formValid, setFormValid, canEdit } = props;
@@ -277,6 +277,10 @@ const BasicInformationTab = props => {
   const [timeZoneFilter, setTimeZoneFilter] = useState('');
   const [location, setLocation] = useState('');
   const key = useSelector(state => state.timeZoneAPI.userAPIKey);
+  const [roleInfoModalOpen, setroleInfoModalOpen] = useState(false);
+  const toggleRoleInfoModal = () => {
+    setroleInfoModalOpen(!roleInfoModalOpen);
+  }
 
   const onClickGetTimeZone = () => {
     if (!location) {
@@ -449,6 +453,26 @@ const BasicInformationTab = props => {
             ) : (
               `${userProfile.role}`
             )}
+            {(userProfile.role !== 'Volunteer') &&(
+            <div>
+              <i
+              data-toggle="tooltip"
+                    data-placement="right"
+                    title="Click for user class information"
+                    style={{ fontSize: 24, cursor: 'pointer', color: '#00CCFF'}}
+                    aria-hidden="true"
+                    className="fa fa-info-circle"
+                    onClick={() => { // populate roleInfo state with role
+                          toggleRoleInfoModal(true); // open modal
+                        }}
+                  /> 
+                  <RoleInfoModal 
+                      role={role} 
+                      isOpen={roleInfoModalOpen} 
+                      toggle={toggleRoleInfoModal} 
+                    />
+            </div>
+          )}
           </Col>
         </Row>
         {canEdit && (

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -440,7 +440,6 @@ const BasicInformationTab = props => {
                   id="role"
                   name="role"
                   className="form-control"
-                  style={{width:"100px"}}
                 >
                   {roles.map(({ roleName }) => {
                     if (roleName === 'Owner') return;
@@ -454,16 +453,17 @@ const BasicInformationTab = props => {
             ) : (
               `${userProfile.role}`
             )}
+            </Col>
             {(userProfile.role !== 'Volunteer') &&(
               <>
               <i
               data-toggle="tooltip"
                     data-placement="right"
                     title="Click for user class information"
-                    style={{ fontSize: 20, cursor: 'pointer', color: '#00CCFF'}}
+                    style={{ fontSize: 25, cursor: 'pointer', color: '#00CCFF'}}
                     aria-hidden="true"
                     className="fa fa-info-circle"
-                    onClick={() => {toggleRoleInfoModal(true); // open modal
+                    onMouseOver={() => {toggleRoleInfoModal(true); // open modal
                         }}
                   /> 
                   <RoleInfoModal 
@@ -473,7 +473,7 @@ const BasicInformationTab = props => {
                     />
 
               </>)}
-          </Col>
+          
         </Row>
         {canEdit && (
           <Row>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -26,7 +26,7 @@ import { taskEditSuggestionsReducer } from 'components/TaskEditSuggestions/reduc
 import { roleReducer } from './roleReducer';
 import { ownerMessageReducer } from './ownerMessageReducer';
 import { ownerStandardMessageReducer } from './ownerStandardMessageReducer';
-import roleInfoReducer from './roleInfoReducer';
+import { roleInfoReducer} from './roleInfoReducer';
 
 export default combineReducers({
   auth: authReducer,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -26,6 +26,7 @@ import { taskEditSuggestionsReducer } from 'components/TaskEditSuggestions/reduc
 import { roleReducer } from './roleReducer';
 import { ownerMessageReducer } from './ownerMessageReducer';
 import { ownerStandardMessageReducer } from './ownerStandardMessageReducer';
+import roleInfoReducer from './roleInfoReducer';
 
 export default combineReducers({
   auth: authReducer,
@@ -56,5 +57,6 @@ export default combineReducers({
   taskEditSuggestions: taskEditSuggestionsReducer,
   role: roleReducer,
   ownerMessage: ownerMessageReducer,
-  ownerStandardMessage: ownerStandardMessageReducer
+  ownerStandardMessage: ownerStandardMessageReducer,
+  roleInfo: roleInfoReducer,
 });

--- a/src/reducers/roleInfoReducer.js
+++ b/src/reducers/roleInfoReducer.js
@@ -1,0 +1,16 @@
+// reducers/textReducer.js
+const initialState = {
+  roleInfo: "",
+};
+
+export default function roleInfoReducer(state = initialState, action) {
+  switch (action.type) {
+    case 'SET_ROLEINFO':
+      return {
+        ...state,
+        roleInfo: action.payload,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/reducers/roleInfoReducer.js
+++ b/src/reducers/roleInfoReducer.js
@@ -3,7 +3,7 @@ const initialState = {
   roleInfo: "",
 };
 
-export default function roleInfoReducer(state = initialState, action) {
+export const roleInfoReducer = (state = initialState, action) => {
   switch (action.type) {
     case 'SET_ROLEINFO':
       return {


### PR DESCRIPTION
# Description

![Screenshot 2023-07-11 at 4 30 47 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/102696148/19f9abd8-2f32-48eb-958d-83b97446247c)

## Main changes explained:
- Create RoleInfo Reducer to store roleInfo text
- Make an editable model
- Change the visibility and editability
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
Log in as Owner:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/102696148/bbdafbfa-376e-4d94-9ba4-624372672975

Login as manager:


![Screenshot 2023-07-11 at 4 35 05 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/102696148/4cc3e84f-2d31-443a-a3e7-a7b5ef545ee8)
Login as volunteer:
![Screenshot 2023-07-11 at 4 35 30 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/102696148/37657e84-0f46-4bf7-b4e4-2abd1b5eaea8)


## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
