### PR TITLE
Eduardo - Bug fix project report page freezes

### DIFF
--- a/src/components/Reports/TasksTable/selectors.js
+++ b/src/components/Reports/TasksTable/selectors.js
@@ -2,16 +2,13 @@ const get_task_by_wbsId = (WbsTasksID, tasks) => {
   var get_tasks = [];
   if (WbsTasksID.length > 0) {
     var i = 0;
-    while (i < WbsTasksID.length) {
-      if (tasks.fetched) {
-        var result = tasks.taskItems.filter(task => task.wbsId == WbsTasksID[i]);
-        get_tasks.push(result);
-        i += 1;
-      }
+    while (i < WbsTasksID.length && tasks.fetched) {
+      var result = tasks.taskItems.filter(task => task.wbsId == WbsTasksID[i]);
+      get_tasks.push(result);
+      i += 1;
     }
   }
 
-  // why just the second array?
   return get_tasks[1];
 };
 


### PR DESCRIPTION
# Description
When accessing Project Report's page the browser completely freezes.

## Main changes explained:
Added a termination condition to the while loop on the `get_task_by_wbsId function`.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as admin user
4. go to Reports -> Reports -> Projects -> Pick Any
5. verify if the page render correctly

## Screenshots or videos of changes:

BEFORE:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/afc7b8a0-8df1-4350-84e3-e09315ad63ea)

AFTER:
![Screenshot 2023-07-12 10-01-21](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/724378eb-c102-4f51-bdce-73e18eb4384b)
