### PR TITLE
Jonathan - Update Weekly Summaries Color

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -264,7 +264,7 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
             {getTotalValidWeeklySummaries(summary, teamColor)}
             {hoursLogged >= summary.weeklycommittedHours && (
               <p>
-                <b style={{ color: teamColor }}>Hours logged:</b>
+                <b style={{ color: teamColor }}>Hours logged: </b>
                 {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
               </p>
             )}

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -13,6 +13,19 @@ import { ENDPOINTS } from '../../utils/URL';
 
 import { assignStarDotColors, showStar } from 'utils/leaderboardPermissions';
 
+const textColors = {
+  Default: '#000000',
+  'Not Required': '#708090',
+  Team: '#FF00FF',
+  'Team Fabulous': '#FF00FF',
+  'Team Marigold': '#FF7F00',
+  'Team Luminous': '#C4AF18',
+  'Team Lush': '#00FF00',
+  'Team Sky': '#0000FF',
+  'Team Azure': '#4B0082',
+  'Team Amethyst': '#9400D3',
+};
+
 const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
   const emails = [];
   //const bioCanEdit = role === 'Owner' || role === 'Administrator';
@@ -58,20 +71,7 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
     return googleDocLink;
   };
 
-const getWeeklySummaryMessage = summary => {
-    const textColors = {
-      "Default": "#000000",
-      "Not Required": "#708090",
-      "Team": "#FF00FF",
-      "Team Fabulous": "#FF00FF",
-      "Team Marigold": "#FF7F00",
-      "Team Luminous": "#C4AF18",
-      "Team Lush": "#00FF00",
-      "Team Sky": "#0000FF",
-      "Team Azure": "#4B0082",
-      "Team Amethyst": "#9400D3"
-    }
-
+  const getWeeklySummaryMessage = summary => {
     if (!summary) {
       return (
         <p>
@@ -82,23 +82,21 @@ const getWeeklySummaryMessage = summary => {
 
     const summaryText = summary?.weeklySummaries[weekIndex]?.summary;
     let summaryDate = moment()
-                        .tz('America/Los_Angeles')
-                        .endOf('week')
-                        .subtract(weekIndex, 'week')
-                        .format('YYYY-MMM-DD')
+      .tz('America/Los_Angeles')
+      .endOf('week')
+      .subtract(weekIndex, 'week')
+      .format('YYYY-MMM-DD');
     let summaryDateText = `Weekly Summary (${summaryDate}):`;
     const summaryContent = (() => {
-   
       if (summaryText) {
-       
         const style = {
-          color: textColors[summary?.weeklySummaryOption] || textColors["Default"]
-        }
+          color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
+        };
 
         summaryDate = moment(summary.weeklySummaries[weekIndex]?.uploadDate)
-                      .tz('America/Los_Angeles')
-                      .format('YYYY-MMM-DD')
-        summaryDateText =`Summary Submitted On (${summaryDate}):`
+          .tz('America/Los_Angeles')
+          .format('YYYY-MMM-DD');
+        summaryDateText = `Summary Submitted On (${summaryDate}):`;
 
         return <div style={style}>{ReactHtmlParser(summaryText)}</div>;
       } else {
@@ -106,7 +104,7 @@ const getWeeklySummaryMessage = summary => {
           summary?.weeklySummaryOption === 'Not Required' ||
           (!summary?.weeklySummaryOption && summary.weeklySummaryNotReq)
         ) {
-          return <p style={{ color: textColors["Not Required"] }}>Not required for this user</p>;
+          return <p style={{ color: textColors['Not Required'] }}>Not required for this user</p>;
         } else {
           return <span style={{ color: 'red' }}>Not provided!</span>;
         }
@@ -123,10 +121,10 @@ const getWeeklySummaryMessage = summary => {
     );
   };
 
-  const getTotalValidWeeklySummaries = summary => {
+  const getTotalValidWeeklySummaries = (summary, teamColor) => {
     if (summary.weeklySummariesCount === 8) {
       return (
-        <p style={{ color: 'blue' }}>
+        <p style={{ color: teamColor }}>
           <b>Total Valid Weekly Summaries:</b>{' '}
           {summary.weeklySummariesCount || 'No valid submissions yet!'}
         </p>
@@ -134,9 +132,7 @@ const getWeeklySummaryMessage = summary => {
     } else {
       return (
         <p>
-          <b style={summary.weeklySummaryOption === 'Team' ? { color: 'magenta' } : {}}>
-            Total Valid Weekly Summaries:
-          </b>{' '}
+          <b style={{ color: teamColor }}>Total Valid Weekly Summaries:</b>{' '}
           {summary.weeklySummariesCount || 'No valid submissions yet!'}
         </p>
       );
@@ -176,14 +172,12 @@ const getWeeklySummaryMessage = summary => {
     }
   };
 
-  const BioSwitch = (userId, bioPosted, weeklySummaryOption) => {
+  const BioSwitch = (userId, bioPosted, weeklySummaryOption, teamColor) => {
     const [bioStatus, setBioStatus] = useState(bioPosted);
     return (
       <div>
         <div className="bio-toggle">
-          <b style={weeklySummaryOption === 'Team' ? { color: 'magenta' } : {}}>
-            Bio announcement:
-          </b>
+          <b style={{ color: teamColor }}>Bio announcement:</b>
         </div>
         <div className="bio-toggle">
           <ToggleSwitch
@@ -199,10 +193,10 @@ const getWeeklySummaryMessage = summary => {
     );
   };
 
-  const BioLabel = (userId, bioPosted, weeklySummaryOption) => {
+  const BioLabel = (userId, bioPosted, weeklySummaryOption, teamColor) => {
     return (
       <div>
-        <b style={weeklySummaryOption === 'Team' ? { color: 'magenta' } : {}}>Bio announcement:</b>
+        <b style={{ color: teamColor }}>Bio announcement:</b>
         {bioPosted === 'default'
           ? ' Not requested/posted'
           : bioPosted === 'posted'
@@ -219,7 +213,7 @@ const getWeeklySummaryMessage = summary => {
       {alphabetize(summaries).map((summary, index) => {
         const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
         const googleDocLink = getGoogleDocLink(summary);
-
+        const teamColor = textColors[summary?.weeklySummaryOption] || textColors['Default'];
         return (
           <div
             style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
@@ -266,19 +260,18 @@ const getWeeklySummaryMessage = summary => {
               {' '}
               <b>Media URL:</b> {getMediaUrlLink(summary)}
             </div>
-            {bioFunction(summary._id, summary.bioPosted, summary.weeklySummaryOption)}
-            {getTotalValidWeeklySummaries(summary)}
+            {bioFunction(summary._id, summary.bioPosted, summary.weeklySummaryOption, teamColor)}
+            {getTotalValidWeeklySummaries(summary, teamColor)}
             {hoursLogged >= summary.weeklycommittedHours && (
               <p>
-                <b style={summary.weeklySummaryOption === 'Team' ? { color: 'magenta' } : {}}>
-                  Hours logged:
-                </b>
+                <b style={{ color: teamColor }}>Hours logged:</b>
                 {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
               </p>
             )}
             {hoursLogged < summary.weeklycommittedHours && (
-              <p style={{ color: 'red' }}>
-                <b>Hours logged:</b> {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
+              <p>
+                <b style={{ color: teamColor }}>Hours logged:</b> {hoursLogged.toFixed(2)} /{' '}
+                {summary.weeklycommittedHours}
               </p>
             )}
             {getWeeklySummaryMessage(summary)}

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -106,7 +106,9 @@ export class WeeklySummary extends Component {
 
   async componentDidMount() {
     await this.props.getWeeklySummaries(this.props.asUser || this.props.currentUser.userid);
+
     const { mediaUrl, weeklySummaries, weeklySummariesCount } = this.props.summaries;
+
     const summary = (weeklySummaries && weeklySummaries[0] && weeklySummaries[0].summary) || '';
     const summaryLastWeek =
       (weeklySummaries && weeklySummaries[1] && weeklySummaries[1].summary) || '';
@@ -141,6 +143,7 @@ export class WeeklySummary extends Component {
     const dueDateLastWeek = moment(dueDate)
       .subtract(1, 'weeks')
       .toISOString();
+
     const dueDateBeforeLast = moment(dueDate)
       .subtract(2, 'weeks')
       .toISOString();


### PR DESCRIPTION
# Description
- Update "Bio announcement", "Total Valid Weekly Summaries", and "Hours logged" to reflect Weekly Summary Option color

## PR Related
- [#970 ](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/970)

## How to test:
1. check into `jonathan_impl_weekly_summary_color_options`
2. do `npm install` and `npm run start:local` to run this PR locally

For Current User:
1. log as admin user
2. go to Profile page → Volunteer Times tab → Weekly Summary Options → Change Team
3. logged in as an Admin → Reports → Weekly Summary Reports
4. verify if summary text has changed color to the corresponding Weekly Summary Option

For New User:
1. log as admin user
2. go to Other Links → User Management → Create New User → Weekly Summary Options → Choose a Team
3. go to the _user you created_ Profile page → Volunteer Times tab
4. verify if Weekly Summary Option is the one you selected
5. log in as new user and submit a weekly summary
6. logged in as an Admin → Reports → Weekly Summary Reports
7. verify if summary text has changed color to the corresponding Weekly Summary Option

Video/Screenshot of Changes

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/63978806/46687182-a5e5-4c31-8b84-15d7590ada16

![Capture (1)](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/63978806/5a0e1a91-28e5-47f5-8e26-87d32fb6ce94)
![Capture (2)](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/63978806/c0b25712-bc99-428c-ad15-2281d996b16f)
