### PR TITLE
Lucile fix user filter if found users is less than 10

### DIFF
--- a/src/components/UserManagement/UserTableFooter.jsx
+++ b/src/components/UserManagement/UserTableFooter.jsx
@@ -85,18 +85,22 @@ const PageSizeDropDown = React.memo(props => {
  * Stateless component to display the page summary labels.
  */
 const PageSummaryLabel = React.memo(props => {
+  let firstUserOfPage = (props.selectedPage - 1) * props.pageSize + 1;
+  let totalUsersFind = props.datacount;
+  let lastUserOfPage = props.selectedPage * props.pageSize;
+
+  const displayedUsers =
+    totalUsersFind < 10 || lastUserOfPage > totalUsersFind
+      ? `Showing ${firstUserOfPage} - ${totalUsersFind} of ${totalUsersFind}`
+      : `Showing ${firstUserOfPage} - ${lastUserOfPage} of ${totalUsersFind}`;
+
   return (
     <div
       id="user_table_footer"
       className="table-summary col-md-4 col-sm-4 col-xs-4 ember-view"
       style={{ marginBottom: '25px' }}
     >
-      {props.datacount < 10
-        ? `Showing ${(props.selectedPage - 1) * props.pageSize + 1} - ${
-            props.datacount
-          } of ${props.selectedPage * props.pageSize} `
-        : `${(props.selectedPage - 1) * props.pageSize + 1} - ${props.selectedPage *
-            props.pageSize} of ${props.datacount}`}
+      {displayedUsers}
     </div>
   );
 });

--- a/src/components/UserManagement/UserTableFooter.jsx
+++ b/src/components/UserManagement/UserTableFooter.jsx
@@ -91,7 +91,9 @@ const PageSummaryLabel = React.memo(props => {
 
   const displayedUsers =
     totalUsersFind < 10 || lastUserOfPage > totalUsersFind
-      ? `Showing ${firstUserOfPage} - ${totalUsersFind} of ${totalUsersFind}`
+      ? totalUsersFind === 0
+        ? `Showing 0 - ${totalUsersFind} of ${totalUsersFind}`
+        : `Showing ${firstUserOfPage} - ${totalUsersFind} of ${totalUsersFind}`
       : `Showing ${firstUserOfPage} - ${lastUserOfPage} of ${totalUsersFind}`;
 
   return (

--- a/src/components/UserManagement/UserTableFooter.jsx
+++ b/src/components/UserManagement/UserTableFooter.jsx
@@ -91,11 +91,12 @@ const PageSummaryLabel = React.memo(props => {
       className="table-summary col-md-4 col-sm-4 col-xs-4 ember-view"
       style={{ marginBottom: '25px' }}
     >
-      {`Show `}
-      {props.datacount > props.selectedPage * props.pageSize
-        ? `${props.selectedPage * props.pageSize}`
-        : `${props.datacount}`}
-      {` of ${props.datacount}`}
+      {props.datacount < 10
+        ? `Showing ${(props.selectedPage - 1) * props.pageSize + 1} - ${
+            props.datacount
+          } of ${props.selectedPage * props.pageSize} `
+        : `${(props.selectedPage - 1) * props.pageSize + 1} - ${props.selectedPage *
+            props.pageSize} of ${props.datacount}`}
     </div>
   );
 });

--- a/src/components/UserManagement/UserTableFooter.jsx
+++ b/src/components/UserManagement/UserTableFooter.jsx
@@ -91,8 +91,11 @@ const PageSummaryLabel = React.memo(props => {
       className="table-summary col-md-4 col-sm-4 col-xs-4 ember-view"
       style={{ marginBottom: '25px' }}
     >
-      {`Show ${(props.selectedPage - 1) * props.pageSize + 1} -
-    ${props.selectedPage * props.pageSize} of ${props.datacount}`}
+      {`Show `}
+      {props.datacount > props.selectedPage * props.pageSize
+        ? `${props.selectedPage * props.pageSize}`
+        : `${props.datacount}`}
+      {` of ${props.datacount}`}
     </div>
   );
 });


### PR DESCRIPTION
# Description
9.  (PRIORITY LOW) Aaron/Jae: Fix user filter if found users is less than 10 (WIP Lucile)
Filtering users displays the wrong number of users if number of users is less than 10
Admin/Owner login -> Other Links -> User Management -> search for users (ex. devadmin)
Notice how it says 1-10 when there's only 4 users

## Main changes explained:
- Changed the conditional rendering In UserTableFooter

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as admin user
4. go to dashboard→ Other Links -> User Management -> search for users (ex. devadmin)
5. verify that the filtering displays the right number with different choices of filter ( 10 / 25 / 50 )

## Screenshots or videos of changes:

Before 
<img width="1291" alt="Screenshot 2023-07-20 at 13 58 28" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/9179eb26-21bd-4dd1-89be-dd39e8635cf6">


After
<img width="1676" alt="Screenshot 2023-07-20 at 13 52 44" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/21a623fd-ac86-44b6-b275-b8f0d7ffc85d">
<img width="1586" alt="Screenshot 2023-07-20 at 13 57 32" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/1fb5010c-2f04-4474-acdc-dc16beeedd4b">
