### PR TITLE
Olga_ fix_redirection_to_dashboard_on_logout

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -230,7 +230,7 @@ export const Header = props => {
                       {UPDATE_PASSWORD}
                     </DropdownItem>}
                   <DropdownItem divider />
-                  <DropdownItem tag={Link} to="/#" onClick={openModal}>
+                  <DropdownItem onClick={openModal}>
                     {LOGOUT}
                   </DropdownItem>
                 </DropdownMenu>

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -35,8 +35,7 @@ export class Login extends Form {
         const url = `/forcePasswordUpdate/${this.props.auth.user.userId}`;
         this.props.history.push(url);
       } else if (this.props.auth.isAuthenticated) {
-        const { state } = this.props.location;
-        this.props.history.push(state ? state.from.pathname : '/dashboard');
+        this.props.history.push('/dashboard');
       }
     }
 


### PR DESCRIPTION
# Description

(PRIORITY LOW):  When a user makes an attempt to log out from any page except “/”,  it always redirects to the "/" page before asking for confirmation of logout.

### Before the changes:
Upon clicking 'logout' button in the dropdown menu from any page other than dashboard you can see the page redirecting to dashboard before the modal appears.

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/107726913/9c81d5c3-86d1-4db4-96b6-6bc5ecfd5a37



## Main changes explained:
- Updated appropriate DropdownItem in Header component not to include redirection link
- Updated Login component so the same user is always taken to dashboard on login, but not the page they previously logged out from

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log in as any user
4. go to any page other than dashboard (for example reports, user profile etc...)
5. from here click on Welcome -> dropdown menu  opens-> Logout
6. verify that the page is not redirecting to dashboard when you click logout (before the modal appears)
7. log out and then log back in with the same user
8. verify that you are taken to the dashboard and not the page that you logged out from

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/107726913/89ee3ed3-5244-44a8-a61b-953dbefc75d1


