### PR TITLE
Aaron fix any users being able to change roles

### DIFF
--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -425,7 +425,7 @@ const BasicInformationTab = props => {
             <Label>Role</Label>
           </Col>
           <Col>
-            {canEditRole ? (
+            {canEditRole && !isUserSelf ? (
               <FormGroup>
                 <select
                   value={userProfile.role}


### PR DESCRIPTION
# Description

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/38c14830-6d41-4a60-b914-829f0308fb94)

Fixes users being able to change their own role (high)

## Main changes explained:
- disable all users from being able to edit their own role

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log in as any user
  a. go to dashboard → user profile → Basic Information tab
  b. verify your role is displayed as text and not as an editable dropdown
4. log in as admin/owner
  a. go to dashboard → Leaderboard → click any user's profile → Basic Information tab
  b. if owner, verify you can change their role
  c. if admin, verify you can change their role unless they are owner

## Screenshots or videos of changes:

<b>Before</b>

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/5226344e-afd0-4feb-8510-fe57b98981f2

- as a "Volunteer", I can change my role to "Admin" which shouldn't be allowed

<b>After</b>

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/16174258-e1b5-4410-8794-f3888a6cc8a1




