### PR TITLE
Lucile T make cursor start in fields second part

### DIFF
--- a/src/components/Admin/Admin.jsx
+++ b/src/components/Admin/Admin.jsx
@@ -28,6 +28,7 @@ const Admin = props => {
           </div>
 
           <input
+            autoFocus
             type="text"
             className="form-control"
             onChange={e => setKeyword(e.target.value)}

--- a/src/components/Badge/AssignBadge.jsx
+++ b/src/components/Badge/AssignBadge.jsx
@@ -108,6 +108,7 @@ const AssignBadge = props => {
   };
 
   const FirstInputProps = {
+    autofocus: 'autofocus',
     placeholder: ' first name',
     value: props.firstName,
     onChange: onFirstChange,
@@ -162,7 +163,6 @@ const AssignBadge = props => {
           </UncontrolledTooltip>
           <div style={{ marginRight: '5px' }}>
             <Autosuggest
-              autoFocus={true}
               suggestions={firstSuggestions}
               onSuggestionsFetchRequested={onFirstSuggestionsFetchRequested}
               onSuggestionsClearRequested={onFirstSuggestionsClearRequested}

--- a/src/components/Badge/AssignBadge.jsx
+++ b/src/components/Badge/AssignBadge.jsx
@@ -108,10 +108,10 @@ const AssignBadge = props => {
   };
 
   const FirstInputProps = {
-    autofocus: 'autofocus',
     placeholder: ' first name',
     value: props.firstName,
     onChange: onFirstChange,
+    autoFocus: true,
   };
   const LastInputProps = {
     placeholder: ' last name',

--- a/src/components/Badge/AssignBadge.jsx
+++ b/src/components/Badge/AssignBadge.jsx
@@ -162,6 +162,7 @@ const AssignBadge = props => {
           </UncontrolledTooltip>
           <div style={{ marginRight: '5px' }}>
             <Autosuggest
+              autoFocus={true}
               suggestions={firstSuggestions}
               onSuggestionsFetchRequested={onFirstSuggestionsFetchRequested}
               onSuggestionsClearRequested={onFirstSuggestionsClearRequested}

--- a/src/components/Projects/WBS/AddWBS/AddWBS.jsx
+++ b/src/components/Projects/WBS/AddWBS/AddWBS.jsx
@@ -33,6 +33,7 @@ const AddWBS = props => {
           </div>
 
           <input
+            autoFocus
             type="text"
             className="form-control"
             aria-label="WBS WBS"

--- a/src/components/Teams/CreateNewTeamPopup.jsx
+++ b/src/components/Teams/CreateNewTeamPopup.jsx
@@ -12,13 +12,14 @@ const CreateNewTeamPopup = React.memo(props => {
     onNewName(props.teamName);
   }, [props.open, props.teamName]);
   return (
-    <Modal isOpen={props.open} toggle={closePopup}>
+    <Modal autoFocus={false} isOpen={props.open} toggle={closePopup}>
       <ModalHeader toggle={closePopup}>
         {props.isEdit ? 'Update Team Name' : 'Create New Team'}
       </ModalHeader>
       <ModalBody style={{ textAlign: 'start' }}>
         <label>Name of the Team</label>
         <Input
+          autoFocus
           id="teamName"
           placeholder="Please enter a new team name"
           value={newTeam}

--- a/src/components/Teams/MembersAutoComplete.jsx
+++ b/src/components/Teams/MembersAutoComplete.jsx
@@ -13,6 +13,7 @@ const MemberAutoComplete = props => {
       style={{ width: '100%', marginRight: '5px' }}
     >
       <Input
+        autoFocus
         type="text"
         value={props.searchText}
         onChange={e => {

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -32,7 +32,7 @@ const TeamMembersPopup = React.memo(props => {
 
   return (
     <Container fluid>
-      <Modal isOpen={props.open} toggle={closePopup}>
+      <Modal isOpen={props.open} toggle={closePopup} autoFocus={false}>
         <ModalHeader toggle={closePopup}>{`Members of ${props.selectedTeamName}`}</ModalHeader>
         <ModalBody style={{ textAlign: 'center' }}>
           {hasPermission(

--- a/src/components/UserManagement/ResetPasswordPopup.jsx
+++ b/src/components/UserManagement/ResetPasswordPopup.jsx
@@ -47,12 +47,13 @@ const ResetPasswordPopup = React.memo(props => {
   };
 
   return (
-    <Modal isOpen={props.open} toggle={closePopup}>
+    <Modal isOpen={props.open} toggle={closePopup} autoFocus={false}>
       <ModalHeader toggle={closePopup}>Reset Password</ModalHeader>
       <ModalBody>
         <FormGroup>
           <Label for="newpassword">New Password</Label>
           <Input
+            autoFocus
             type="password"
             name="newpassword"
             id="newpassword"

--- a/src/components/UserManagement/SetUpFinalDayPopUp.jsx
+++ b/src/components/UserManagement/SetUpFinalDayPopUp.jsx
@@ -22,10 +22,11 @@ const SetUpFinalDayPopUp = React.memo(props => {
   };
 
   return (
-    <Modal isOpen={props.open} toggle={closePopup}>
+    <Modal isOpen={props.open} toggle={closePopup} autoFocus={false}>
       <ModalHeader toggle={closePopup}>Set Your Final Day</ModalHeader>
       <ModalBody>
         <Input
+          autoFocus
           type="date"
           name="inactiveDate"
           id="inactiveDate"


### PR DESCRIPTION
# Description 
(PRIORITY LOW) 
I’d like to have the cursor start in the available fields so it is more efficient when using these pages. Modals with individual empty fields automatically put the cursor in the empty field, so I can immediately start typing rather than having to manually put the cursor in the field and then do my typing. 

Make cursor start in fields on : 
Other Links → User Management → Set Final Date
Other Links → User Management → Reset Password
Other Links → Badge Management
Other Links → Projects → click WBS icon
Other Links → Teams → click Members icon
Other Links → Teams → Create New Team
Other Links → Popup Management

## Main changes explained:
- Autofocus was added on inputs 

## How to test:
1. git checkout Lucile_T_make_cursor_start_in_fields_second_part
2. git pull
3. `npm install` and `npm run start:local` to run this PR locally
4. log as admin user
5. go to dashboard→ 
Other Links → User Management → Set Final Date
Other Links → User Management → Reset Password (If reset password unusable, the problem is on Development too)
Other Links → Badge Management
Other Links → Projects → click WBS icon
Other Links → Teams → click Members icon
Other Links → Teams → Create New Team
Other Links → Popup Management


## Screenshots :
<img width="1674" alt="Screenshot 2023-07-31 at 10 38 31" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/581cdad1-7dcd-47b7-be3f-85c9e9aa9113">
<img width="1676" alt="Screenshot 2023-07-31 at 10 55 28" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/7d4e5d1a-07c5-48fc-922c-9d422c4d6566">
<img width="1623" alt="Screenshot 2023-07-31 at 10 56 21" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/564dd8d1-ec35-493f-8aad-393b2035b904">
<img width="1673" alt="Screenshot 2023-07-31 at 10 56 37" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/38e3f9e0-623b-4410-b32e-2c7a295be0d3">
<img width="1670" alt="Screenshot 2023-07-31 at 10 56 55" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/7870e6d3-e5e3-471c-9387-5c11f4dfe832">
<img width="1673" alt="Screenshot 2023-07-31 at 10 57 12" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/3c01cf30-8034-4b02-aa47-b31aa2cefb87">

