### PR TITLE
Jonathan - Fixed Weekly Summary Color Change logic

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -127,8 +127,8 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
     };
     if (summary.weeklySummariesCount === 8) {
       return (
-        <p style={style}>
-          <b>Total Valid Weekly Summaries:</b>{' '}
+        <p>
+          <b style={style}>Total Valid Weekly Summaries:</b>{' '}
           {summary.weeklySummariesCount || 'No valid submissions yet!'}
         </p>
       );

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -121,10 +121,13 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
     );
   };
 
-  const getTotalValidWeeklySummaries = (summary, teamColor) => {
+  const getTotalValidWeeklySummaries = summary => {
+    const style = {
+      color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
+    };
     if (summary.weeklySummariesCount === 8) {
       return (
-        <p style={{ color: teamColor }}>
+        <p style={style}>
           <b>Total Valid Weekly Summaries:</b>{' '}
           {summary.weeklySummariesCount || 'No valid submissions yet!'}
         </p>
@@ -132,7 +135,7 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
     } else {
       return (
         <p>
-          <b style={{ color: teamColor }}>Total Valid Weekly Summaries:</b>{' '}
+          <b style={style}>Total Valid Weekly Summaries:</b>{' '}
           {summary.weeklySummariesCount || 'No valid submissions yet!'}
         </p>
       );
@@ -172,12 +175,15 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
     }
   };
 
-  const BioSwitch = (userId, bioPosted, weeklySummaryOption, teamColor) => {
+  const BioSwitch = (userId, bioPosted, summary) => {
     const [bioStatus, setBioStatus] = useState(bioPosted);
+    const style = {
+      color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
+    };
     return (
       <div>
         <div className="bio-toggle">
-          <b style={{ color: teamColor }}>Bio announcement:</b>
+          <b style={style}>Bio announcement:</b>
         </div>
         <div className="bio-toggle">
           <ToggleSwitch
@@ -193,10 +199,13 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
     );
   };
 
-  const BioLabel = (userId, bioPosted, weeklySummaryOption, teamColor) => {
+  const BioLabel = (userId, bioPosted, summary) => {
+    const style = {
+      color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
+    };
     return (
       <div>
-        <b style={{ color: teamColor }}>Bio announcement:</b>
+        <b style={style}>Bio announcement:</b>
         {bioPosted === 'default'
           ? ' Not requested/posted'
           : bioPosted === 'posted'
@@ -213,7 +222,6 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
       {alphabetize(summaries).map((summary, index) => {
         const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
         const googleDocLink = getGoogleDocLink(summary);
-        const teamColor = textColors[summary?.weeklySummaryOption] || textColors['Default'];
         return (
           <div
             style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
@@ -260,18 +268,30 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
               {' '}
               <b>Media URL:</b> {getMediaUrlLink(summary)}
             </div>
-            {bioFunction(summary._id, summary.bioPosted, summary.weeklySummaryOption, teamColor)}
-            {getTotalValidWeeklySummaries(summary, teamColor)}
+            {bioFunction(summary._id, summary.bioPosted, summary)}
+            {getTotalValidWeeklySummaries(summary)}
             {hoursLogged >= summary.weeklycommittedHours && (
               <p>
-                <b style={{ color: teamColor }}>Hours logged: </b>
+                <b
+                  style={{
+                    color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
+                  }}
+                >
+                  Hours logged:{' '}
+                </b>
                 {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
               </p>
             )}
             {hoursLogged < summary.weeklycommittedHours && (
               <p>
-                <b style={{ color: teamColor }}>Hours logged:</b> {hoursLogged.toFixed(2)} /{' '}
-                {summary.weeklycommittedHours}
+                <b
+                  style={{
+                    color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
+                  }}
+                >
+                  Hours logged:
+                </b>{' '}
+                {hoursLogged.toFixed(2)} / {summary.weeklycommittedHours}
               </p>
             )}
             {getWeeklySummaryMessage(summary)}


### PR DESCRIPTION
# Description
- Update "Bio announcement", "Total Valid Weekly Summaries", and "Hours logged" to reflect Weekly Summary Option color

# Changes Made
- Previously, the weekly summary color option was being passed down as a parameter into the component however, the changes were not being reflected on both the Main and Dev site. 
- So, I updated the logic so that the colors would be generated within each function based on the **summary** parameter that gets passed down to each component.

## PR Related
- [#970](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/970), [#1026](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1026)

## How to test:
1. check into `fix_weeklySummaryColorChange`
2. do `npm install` and `npm run start:local` to run this PR locally

For Current User:
1. log as admin user
2. go to Profile page → Volunteer Times tab → Weekly Summary Options → Change Team
3. logged in as an Admin → Reports → Weekly Summary Reports
4. verify if the **summary text**, **Bio Announcement**, **Total Valid Weekly Summaries**, & **Hours Logged** has changed color to the corresponding Weekly Summary Option

For New User:
1. log as admin user
2. go to Other Links → User Management → Create New User → Weekly Summary Options → Choose a Team
3. go to the _user you created_ Profile page → Volunteer Times tab
4. verify if Weekly Summary Option is the one you selected
7. log in as new user and submit a weekly summary
8. logged in as an Admin → Reports → Weekly Summary Reports
9. verify if the **summary text**, **Bio Announcement**, **Total Valid Weekly Summaries**, & **Hours Logged** has changed color to the corresponding Weekly Summary Option

## Screenshot of Changes
![PR # (2)](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/63978806/0f31996e-3f3c-4871-af57-0627fbc9c2ea)
![PR #1041 (3)](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/63978806/92f47d34-c36d-4649-a94a-d18f610b730f)


# Updated Logic
![PR # (0)](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/63978806/899e9237-aec7-42b8-8f0e-a4dc54f80ea9)
![PR # (1)](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/63978806/8220a4ac-6066-40b6-937d-552a9bd1c651)

