### PR TITLE
Edwin - Added user classes to weekly summary report

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -26,7 +26,7 @@ const textColors = {
   'Team Amethyst': '#9400D3',
 };
 
-const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
+const FormattedReport = ({ summaries, weekIndex, bioCanEdit,  }) => {
   const emails = [];
   //const bioCanEdit = role === 'Owner' || role === 'Administrator';
 
@@ -227,6 +227,9 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
 
               <span onClick={() => handleGoogleDocClick(googleDocLink)}>
                 <img className="google-doc-icon" src={google_doc_icon} alt="google_doc" />
+              </span>
+              <span>
+                <b>&nbsp;&nbsp;{summary.role !== 'Volunteer' && `(${summary.role})`}</b>
               </span>
               {showStar(hoursLogged, summary.weeklycommittedHours) && (
                 <i

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -26,7 +26,7 @@ const textColors = {
   'Team Amethyst': '#9400D3',
 };
 
-const FormattedReport = ({ summaries, weekIndex, bioCanEdit,  }) => {
+const FormattedReport = ({ summaries, weekIndex, bioCanEdit }) => {
   const emails = [];
   //const bioCanEdit = role === 'Owner' || role === 'Administrator';
 


### PR DESCRIPTION
# Description

<img width="516" alt="Screen Shot 2023-07-25 at 12 04 08 PM" src="https://github.com/OneCommunityGlobal/HGNRest/assets/42288987/9c2d188a-3b51-4357-a483-ae204e7f6991">

## Related PRS (if any):

This frontend PR is related to the BE PR [PR #458](https://github.com/OneCommunityGlobal/HGNRest/pull/458)

## Main changes explained:

- Made code changes to show the user class in the weekly summary report
- Added check to not display 'Volunteer' role
- Made slight changes to backend for weekly summary request to now include the users role

## How to test:

1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as any user that has the view weekly summary permission (Owner/Admin)
4. Dashboard -> Reports -> Weekly Summaries Report
5. Check that the user class for every user is shown on the right of the google docs icon
6. Users whose class is Volunteer, should not show since that is the default 

## Videos/Screenshots of changes:

<img width="813" alt="Screen Shot 2023-07-25 at 12 08 47 PM" src="https://github.com/OneCommunityGlobal/HGNRest/assets/42288987/7a51ea3e-ffaf-42a5-9387-08ccbb60c7df">
