### PR TITLE
Fix memory leaks when submitting time entry

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -494,13 +494,14 @@ const TimeEntryForm = props => {
       }));
     }
 
-    if (isOpen) toggle();
     if (fromTimer) clearForm();
     setReminder(initialReminder);
 
     if (!props.edit) setInputs(initialFormValues);
 
     await getUserProfile(userId)(dispatch);
+    if (isOpen) toggle();
+
   };
 
   const handleInputChange = event => {

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -501,7 +501,6 @@ const TimeEntryForm = props => {
 
     await getUserProfile(userId)(dispatch);
     if (isOpen) toggle();
-
   };
 
   const handleInputChange = event => {


### PR DESCRIPTION
# Description

This PR focuses on fixing the memory leaks that occur when logging time via the timer. 

## Main changes explained:

- Moved time entry form modal closing function to the very end of the handleSubmit function
- Having the modal closing function in between the handleSubmit caused the memory leak to happen since states were still changing although the modal was unmounted

## How to test:

1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as any user
4. Dashboard -> let the timer run -> log time
5. Memory leak console log should not appear anymore

## Videos/Screenshots of changes:

Before:

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/2f82c362-9c7e-4485-b865-6e390e24f03c)

After:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/4c0bcf13-3b46-4449-a392-cfda6919dae9


