### PR TITLE
Weekly summary submission bug

### DIFF
--- a/src/actions/weeklySummaries.js
+++ b/src/actions/weeklySummaries.js
@@ -1,6 +1,9 @@
 import axios from 'axios';
 import * as actions from '../constants/weeklySummaries';
 import { ENDPOINTS } from '../utils/URL';
+import {
+  getUserProfile as getUserProfileActionCreator,
+} from '../constants/userProfile';
 
 /**
  * Action to set the 'loading' flag to true.
@@ -66,7 +69,7 @@ export const getWeeklySummaries = userId => {
  */
 export const updateWeeklySummaries = (userId, weeklySummariesData) => {
   const url = ENDPOINTS.USER_PROFILE(userId);
-  return async () => {
+  return async (dispatch) => {
     try {
       // Get the user's profile from the server.
       let response = await axios.get(url);
@@ -90,8 +93,12 @@ export const updateWeeklySummaries = (userId, weeklySummariesData) => {
         weeklySummariesCount,
       };
 
+
       // Update the user's profile on the server.
       response = await axios.put(url, userProfileUpdated);
+      if (response.status === 200) {
+        await dispatch(getUserProfileActionCreator(userProfileUpdated));
+      }
       return response.status;
     } catch (error) {
       return error.response.status;

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -36,7 +36,7 @@ const SummaryBar = props => {
   const [infringements, setInfringements] = useState(0);
   const [badges, setBadges] = useState(0);
   const [totalEffort, setTotalEffort] = useState(0);
-  const [weeklySummary, setWeeklySummary] = useState([]);
+  const [weeklySummary, setWeeklySummary] = useState(null);
 
   const [tasks, setTasks] = useState(undefined);
   const authenticateUser = useSelector(state => state.auth.user);
@@ -49,6 +49,8 @@ const SummaryBar = props => {
     : [];
 
   const matchUser = asUser == authenticateUserId ? true : false;
+
+  useEffect(()=>{setUserProfile(gsUserprofile)},[gsUserprofile])
 
   // Similar to UserProfile component function
   // Loads component depending on asUser passed as prop
@@ -173,7 +175,7 @@ const SummaryBar = props => {
   const authenticateUserRole = authenticateUser ? authenticateUser.role : '';
   if (userProfile !== undefined && summaryBarData !== undefined) {
     const weeklyCommittedHours = userProfile.weeklycommittedHours + (userProfile.missedHours ?? 0);
-    const weeklySummary = getWeeklySummary(userProfile);
+    //const weeklySummary = getWeeklySummary(userProfile);
     return (
       <Container
         fluid

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -380,6 +380,7 @@ export class WeeklySummary extends Component {
     formElements[editor.id] = content;
     this.setState({ formElements, errors });
   };
+  
   handleCheckboxChange = event => {
     event.persist();
     const { name, checked } = event.target;
@@ -393,7 +394,7 @@ export class WeeklySummary extends Component {
     this.setState({ formElements, errors });
   };
 
-  handleChangeInSummary = () => {
+  handleChangeInSummary = async() => {
     // Extract state variables for ease of access
     let {
       submittedDate,
@@ -466,6 +467,7 @@ export class WeeklySummary extends Component {
       modifiedWeeklySummaries,
     );
   };
+
   // Updates user profile and weekly summaries
   updateUserData = async userId => {
     await this.props.getUserProfile(userId);
@@ -498,13 +500,9 @@ export class WeeklySummary extends Component {
     if (errors) this.state.moveConfirm = false;
     if (errors) return;
 
-    const updateWeeklySummaries = this.handleChangeInSummary();
-    let saveResult;
-    if (updateWeeklySummaries) {
-      saveResult = await updateWeeklySummaries();
-    }
+    const result = await this.handleChangeInSummary();
 
-    if (saveResult === 200) {
+    if (result === 200) {
       await this.handleSaveSuccess(toastIdOnSave);
       if (closeAfterSave) {
         this.handleClose();
@@ -877,7 +875,7 @@ const mapStateToProps = ({ auth, weeklySummaries }) => ({
 const mapDispatchToProps = dispatch => {
   return {
     getWeeklySummaries: getWeeklySummaries,
-    updateWeeklySummaries: updateWeeklySummaries,
+    updateWeeklySummaries:(userId,weeklySummary)=> updateWeeklySummaries(userId,weeklySummary)(dispatch),
     getWeeklySummaries: userId => getWeeklySummaries(userId)(dispatch),
     getUserProfile: userId => getUserProfile(userId)(dispatch),
   };


### PR DESCRIPTION
# Description
(PRIORITY URGENT) Jae: Fix summary submission and improve speed 
Submitting a summary should change the red “!” to a green check
Please confirm for me it isn’t remembering and auto-filling the last summary input also. It should remain if already input, but only the media link should be remembered and auto-input for the following week. 
Please also see if you can improve the speed of the loading process, the process after clicking “Weekly Summary Due Date (click to add)” seems pretty slow
I’ve also seen a data error popup when submitting this
Fix having to refresh the app to be able to see the green check (submitted weekly summary)

## Main changes explained:
used useEffect to updated the summarybar check changes from red to green when week summary added.

## How to test:
1. check into current branch
2. do  `npm run start:local` to run this PR locally
3.  log in as any user, try to add week summaries for last week or week before last change media link, and save. refresh the page, reopen week summary submit, check if this week summary is getting  auto fill by any of last weeks summaries. if it does the bug persists, if not add summary for this week and save.
4.  check the summary "!" become green without the need of refreshing the page.
5. If there is a setItem  data error on console, that means your localstorage is full, and unable to store data of this app, so clear the localstorage to remove this data error.


## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/86232710/38a291ae-855d-4880-b3b7-12dfa1bfc94f



