### PR TITLE
reduce renders in the TeamMemberTasks and the TeamMeberTask components

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -11,7 +11,7 @@ import './style.css';
 import ReactTooltip from 'react-tooltip';
 import { boxStyle } from 'styles';
 
-const TeamMemberTask = ({
+const TeamMemberTask = React.memo(({
   user,
   handleMarkAsDoneModal,
   handleRemoveFromTaskModal,
@@ -23,7 +23,7 @@ const TeamMemberTask = ({
 }) => {
   const [infoTaskIconModal, setInfoTaskIconModal] = useState(false);
 
-  const infoTaskIconContent = `Red Bell Icon: When clicked, this will show any task changes\n 
+  const infoTaskIconContent = `Red Bell Icon: When clicked, this will show any task changes\n
   Green Checkmark Icon: When clicked, this will mark the task as completed\n
   X Mark Icon: When clicked, this will remove the user from that task`;
 
@@ -208,7 +208,7 @@ const TeamMemberTask = ({
                             <div>
                               <span>
                                 {`${parseFloat(task.hoursLogged.toFixed(2))}
-                            of 
+                            of
                           ${parseFloat(task.estimatedHours.toFixed(2))}`}
                               </span>
                               <Progress
@@ -232,6 +232,6 @@ const TeamMemberTask = ({
       </tr>
     </>
   );
-};
+});
 
 export default TeamMemberTask;

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -2,7 +2,7 @@ import { faClock, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { Table } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { fetchTeamMembersTask, deleteTaskNotification } from 'actions/task';
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useDispatch, useSelector, connect } from 'react-redux';
 import SkeletonLoading from '../common/SkeletonLoading';
 import { TaskDifferenceModal } from './components/TaskDifferenceModal';
@@ -20,7 +20,7 @@ import { hrsFilterBtnRed, hrsFilterBtnBlue } from 'constants/colors';
 import { toast } from 'react-toastify';
 import InfiniteScroll from 'react-infinite-scroller';
 
-const TeamMemberTasks = props => {
+const TeamMemberTasks = React.memo(props => {
   const [showTaskNotificationModal, setTaskNotificationModal] = useState(false);
   const [currentTaskNotifications, setCurrentTaskNotifications] = useState([]);
   const [currentTask, setCurrentTask] = useState();
@@ -106,7 +106,7 @@ const TeamMemberTasks = props => {
     setCurrentUserId('');
   };
 
-  const onUpdateTask = (taskId, updatedTask) => {
+  const onUpdateTask = useCallback((taskId, updatedTask) => {
     const newTask = {
       updatedTask,
       taskId,
@@ -114,7 +114,7 @@ const TeamMemberTasks = props => {
     submitTasks(newTask);
     dispatch(fetchTeamMembersTask(userId, props.auth.user.userid, false));
     props.handleUpdateTask();
-  };
+  }, []);
 
   const submitTasks = async updatedTasks => {
     const url = ENDPOINTS.TASK_UPDATE(updatedTasks.taskId);
@@ -125,28 +125,28 @@ const TeamMemberTasks = props => {
     }
   };
 
-  const handleOpenTaskNotificationModal = (userId, task, taskNotifications = []) => {
+  const handleOpenTaskNotificationModal = useCallback((userId, task, taskNotifications = []) => {
     setCurrentUserId(userId);
     setCurrentTask(task);
     setCurrentTaskNotifications(taskNotifications);
     setTaskNotificationModal(!showTaskNotificationModal);
-  };
+  }, []);
 
-  const handleMarkAsDoneModal = (userId, task) => {
+  const handleMarkAsDoneModal = useCallback((userId, task) => {
     setCurrentUserId(userId);
     setCurrentTask(task);
     setClickedToShowModal(true);
-  };
+  }, []);
 
-  const handleRemoveFromTaskModal = (userId, task) => {
+  const handleRemoveFromTaskModal = useCallback((userId, task) => {
     setCurrentUserId(userId);
     setCurrentTask(task);
     setClickedToShowModal(true);
-  };
+  }, []);
 
-  const handleTaskModalOption = option => {
+  const handleTaskModalOption = useCallback(option => {
     setTaskModalOption(option);
-  };
+  }, []);
 
   const handleTaskNotificationRead = (userId, taskId, taskNotificationId) => {
     //if the authentitated user is seeing it's own notification
@@ -490,13 +490,15 @@ const TeamMemberTasks = props => {
       </div>
     </div>
   );
-};
+});
 
 const mapStateToProps = state => ({
   auth: state.auth,
   userId: state.userProfile.id,
   managingTeams: state.userProfile.teams,
   teamsInfo: state.managingTeams,
+  roles: state.role.roles,
+  userPermissions: state.auth?.permissions?.frontPermissions,
 });
 
 export default connect(mapStateToProps, {

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
   Container,
   Row,
@@ -341,9 +341,9 @@ const Timelog = props => {
   };
   const [state, setState] = useState(initialState);
 
-  const handleUpdateTask = () => {
+  const handleUpdateTask = useCallback(() => {
     setIsTaskUpdated(!isTaskUpdated);
-  };
+  }, []);
 
   useEffect(() => {
     // Does not run again (except once in development): load data
@@ -733,8 +733,6 @@ const Timelog = props => {
                       <TeamMemberTasks
                         asUser={props.asUser}
                         handleUpdateTask={handleUpdateTask}
-                        roles={role.roles}
-                        userPermissions={userPermissions}
                       />
                     </TabPane>
                     <TabPane tabId={1}>{currentWeekEntries}</TabPane>


### PR DESCRIPTION
# Description
EDIT: The `Cheng-Yun Admin` data was [removed by another dev](https://highest-good.slack.com/archives/CSCN20FA5/p1690582946816339?thread_ts=1690228096.920209&cid=CSCN20FA5). This PR is now just a performance improvement. But if another user with a large number of tasks happens again, this should prevent a future crash.

- [The landing page was freezing.](https://highest-good.slack.com/archives/CSCN20FA5/p1690228096920209)
- [Some investigation showed that components were re-rendering hundreds of times.](https://highest-good.slack.com/archives/CSCN20FA5/p1690402894622109?thread_ts=1690228096.920209&cid=CSCN20FA5)
- [An infinite scroll was added and unblocked other devs, but if you scrolled down far enough, it was still freezing because the users with high number of tasks was still causing too many unnecessary re-renders.](https://highest-good.slack.com/archives/CSCN20FA5/p1690509421751569?thread_ts=1690228096.920209&cid=CSCN20FA5)

I'm adding memoization to further avoid unnecessary re-renders and prevent crashing.

## Main changes explained:
- Use component and prop memoization in the `TeamMemberTasks` and the `TeamMemberTask` components.
- Remove unnecessary prop passing from `Timelog` to `TeamMemberTasks`.

## How to test:
1. Log in and wait for the team member tasks to finish loading.
2. Scroll down to the Cs like `Cheng-Yun Admin`.
3. If you can scroll past the long list of tasks and make it to the Ds, it's working as intended.

## Screenshots or videos of changes:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/4c6690f3-9adc-49b5-918c-108ff1b3fb08
