### PR TITLE
update user permission management

### DIFF
--- a/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
+++ b/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
@@ -12,11 +12,12 @@ import axios from 'axios';
 import { ENDPOINTS } from 'utils/URL';
 import { boxStyle } from 'styles';
 
-const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers }) => {
+const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles }) => {
   const [searchText, onInputChange] = useState('');
   const [actualUserProfile, setActualUserProfile] = useState();
   const [isOpen, setIsOpen] = useState(false);
   const [isInputFocus, setIsInputFocus] = useState(false);
+  const [actualUserRolePermission, setActualUserRolePermission] = useState();
 
   //no onchange, always change this state;
   const onChangeCheck = data => {
@@ -59,12 +60,25 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers }) => {
     const allUserInfo = await axios.get(url).then(res => res.data);
     setActualUserProfile(allUserInfo);
   };
+
   useEffect(() => {
     getAllUsers();
+    if (actualUserProfile?.role && roles) {
+      const roleIndex = roles?.findIndex(({ roleName }) => roleName === actualUserProfile?.role);
+      let permissions = [];
+      if (roleIndex !== -1) {
+        permissions = roles[roleIndex].permissions;
+      }
+      setActualUserRolePermission(permissions);
+    }
   }, [actualUserProfile]);
 
   const isPermissionChecked = permission =>
     actualUserProfile?.permissions?.frontPermissions.some(perm => perm === permission);
+
+  const isPermissionDefault = permission => {
+    return actualUserRolePermission?.includes(permission);
+  };
 
   const updateProfileOnSubmit = async e => {
     e.preventDefault();
@@ -164,10 +178,15 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers }) => {
           {Object.entries(permissionLabel).map(([key, value]) => {
             return (
               <li key={key} className="user-role-tab__permission">
-                <div style={{ color: isPermissionChecked(key) ? 'green' : 'red', padding: '14px' }}>
+                <div
+                  style={{
+                    color: isPermissionChecked(key) || isPermissionDefault(key) ? 'green' : 'red',
+                    padding: '14px',
+                  }}
+                >
                   {value}
                 </div>
-                {isPermissionChecked(key) ? (
+                {isPermissionDefault(key) ? null : isPermissionChecked(key) ? (
                   <Button
                     type="button"
                     color="danger"

--- a/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
+++ b/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
@@ -65,10 +65,7 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles }) =
     getAllUsers();
     if (actualUserProfile?.role && roles) {
       const roleIndex = roles?.findIndex(({ roleName }) => roleName === actualUserProfile?.role);
-      let permissions = [];
-      if (roleIndex !== -1) {
-        permissions = roles[roleIndex].permissions;
-      }
+      const permissions = roleIndex !== -1 ? roles[roleIndex].permissions : [];
       setActualUserRolePermission(permissions);
     }
   }, [actualUserProfile]);

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -430,7 +430,11 @@ const BasicInformationTab = props => {
                 <select
                   value={userProfile.role}
                   onChange={e => {
-                    setUserProfile({ ...userProfile, role: e.target.value });
+                    setUserProfile({
+                      ...userProfile,
+                      role: e.target.value,
+                      permissions: { ...userProfile.permissions, frontPermissions: [] },
+                    });
                   }}
                   id="role"
                   name="role"
@@ -438,7 +442,11 @@ const BasicInformationTab = props => {
                 >
                   {roles.map(({ roleName }) => {
                     if (roleName === 'Owner') return;
-                    return <option value={roleName}>{roleName}</option>;
+                    return (
+                      <option key={roleName} value={roleName}>
+                        {roleName}
+                      </option>
+                    );
                   })}
                   {hasPermission(role, 'addDeleteEditOwners', roles, userPermissions) && (
                     <option value="Owner">Owner</option>
@@ -691,7 +699,7 @@ const BasicInformationTab = props => {
                 >
                   {roles.map(({ roleName }) => {
                     if (roleName === 'Owner') return;
-                    return <option value={roleName}>{roleName}</option>;
+                    return <option key={roleName} value={roleName}>{roleName}</option>;
                   })}
                   {hasPermission(role, 'addDeleteEditOwners', roles, userPermissions) && (
                     <option value="Owner">Owner</option>


### PR DESCRIPTION
# Description
7. (PRIORITY MEDIUM) Oleksandr/Jae: Make Manage User Permissions modal window show existing
If the user chosen is an Admin or other class with permissions, those permissions should show.
Changing that person's permissions should save the person as having custom permissions.
If the person's role is then changed though, it should reset that person's permissions to whatever their new role is

## Main changes explained:
- Show the permissions (from the role itself) in the list of the 'Manage User Permissions' modal, if the permission is not included in the role, an Owner can add/remove (customize) the frontPermissions to a specific user without changing the rules for the whole group of this role.
- Reset all the permissions to default if a person's role is changed (remove the customized frontPermissions)
- add key to the option in the list to avoid the warning

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as Owner user (only owner role can edit)
4. go to dashboard→ Other Links -› Permissions Management -› 'Manage User Permissions' Button
5. select any user to see its permission list

## Screenshots or videos of changes:
go to dashboard→ Other Links -› Permissions Management -› click the 'Manager' to view its default permission:
<img width="474" alt="2" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/d12ecd3a-3db2-4512-ac1d-874287ace065">
Permissions Management -› 'Manage User Permissions' Button ->select a user who is a manager:
<img width="500" alt="1" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/856cf69c-1efd-4c5c-858a-c4639c84ee7e">
As the screen shot above shows: it will show the default permissions as well as the permissions that can be edit. The changes (add/remove) saved in this component will not affect the whole manager group but just this user.


However, if a user who has some customized permissions changes its role in the user profile page, for example from manager to volunteer, the front permissions saved before will be all removed and the user will have default permissions as a volunteer.
<img width="598" alt="3" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/74fc0287-30b5-48b1-a0a2-e027d76aa03d">

