### PR TITLE
add the missing word in the popup text

### DIFF
--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -383,7 +383,7 @@ export class WeeklySummary extends Component {
     formElements[editor.id] = content;
     this.setState({ formElements, errors });
   };
-  
+
   handleCheckboxChange = event => {
     event.persist();
     const { name, checked } = event.target;
@@ -730,7 +730,7 @@ export class WeeklySummary extends Component {
                         <ModalBody>
                           Whoa Tiger! Are you sure you want to do that? This link was added by an
                           Admin when you were set up as a member of the team. Only change this if
-                          you are SURE your new link is more than the one already here.
+                          you are SURE your new link is more correct than the one already here.
                         </ModalBody>
                         <ModalFooter>
                           <Button onClick={this.handleMediaChange} style={boxStyle}>


### PR DESCRIPTION
# Description
Add the missing word in the weekly summary dropbox link warning popup text.

## Main changes explained:
There was a word missing.

## How to test:

| Header | Header |
|--------|--------|
| 1. In the dev branch, click the Weekly Summary submit link to access the dropbox link input field. | ![Screenshot 2023-07-31 at 12 04 46](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/b7287eb0-fe06-4b45-82da-8332d5acb930) |
| 2. Type in the dropbox link input field to trigger the popup. | ![Screenshot 2023-07-31 at 12 06 07](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/abc1d55a-e8e4-4785-87d1-3faf22efe0c7) |
| 3. Verify the popup is missing the word "correct". | ![Screenshot 2023-07-31 at 12 06 57](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/531d7746-92dd-4012-9a8a-87812542c6fb) |
| 4. Check out this branch and repeat the process to see the missing word added. | ![Screenshot 2023-07-31 at 12 08 55](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/a520075a-203e-405d-9463-2f6c48fc308d) | 
