### PR TITLE
set the default pageNum to 0 and prevent NaN start value

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -284,7 +284,7 @@ const TeamMemberTasks = React.memo(props => {
     }
   };
 
-  const loadFunc = useCallback(pageNum => {
+  const loadFunc = useCallback((pageNum = 0) => {
     if (teamList.length <= displayData.length) {
       setHasMore(false);
       return;


### PR DESCRIPTION
# Description
The Tasks list in the Dashboard was crashing.
Debugging showed the crush was caused by a `NaN` passed to `slice` within the `loadFunc` function.
The `NaN` was happening because the `loadFunc` function is not always called with an argument.
The `pageNum` param is used used to calculate an argument for a `slice`.
Setting the `pageNum` param of the function `loadFunc` to `0` fixes the crash.

## Main changes explained:
Set the `pageNum` param's default to `0` and prevent the `start` value from being `NaN`.

## How to test:
1. In the development branch, log in as a volunteer.
2. The Tasks in the Dashboard crashes.
3. Check out this branch and log in as the same user.
4. The Tasks should load.

## Screenshots or videos of changes:

| |
|--------|
| **BEFORE** ![TASKS - BEFORE](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/30085122-5ac4-4aa8-acb6-112f8bf7251e) |
| **The culprit** ![TASKS - arguments - code](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/d610d746-f535-4b54-991e-81d59672d001) |
| **The output** <img width="630" alt="TASKS - arguments - output" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/70026bd6-7e07-4d0a-84cd-119164436a27"> |
| **AFTER** ![TASKS - AFTER](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/cc982b00-6ca9-4a39-9654-ba7abeb1265f) | 
