### PR TITLE
Bada - Bk/fix warnings

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -81,7 +81,7 @@ const LeaderBoard = ({
           total hours they have completed.
           {/*The color and length of that bar
           changes based on what percentage of the total committed hours for the week have been
-          completed: 0-20%: Red, 20-40%: Orange, 40-60% hrs: Green, 60-80%: Blue, 80-100%:Indigo, 
+          completed: 0-20%: Red, 20-40%: Orange, 40-60% hrs: Green, 60-80%: Blue, 80-100%:Indigo,
           and Equal or More than 100%: Purple.*/}
         </li>
         <li>
@@ -215,7 +215,7 @@ const LeaderBoard = ({
               <td />
               <th scope="row">{organizationData.name}</th>
               <td className="align-middle">
-                <span title="Tangible time">{organizationData.tangibletime}</span>
+                <span title="Tangible time">{organizationData.tangibletime || ''}</span>
               </td>
               <td className="align-middle">
                 <Progress

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -46,7 +46,9 @@ import hasPermission from '../../utils/permissions';
 import WeeklySummaries from './WeeklySummaries';
 import { boxStyle } from 'styles';
 
-const doesUserHaveTaskWithWBS = (tasks, userId) => {
+const doesUserHaveTaskWithWBS = (tasks = [], userId) => {
+  if (!Array.isArray(tasks)) return false;
+
   for (let task of tasks) {
     for (let resource of task.resources) {
       if (resource.userID == userId && resource.completedTask == false) {

--- a/src/reducers/weeklySummariesReducer.js
+++ b/src/reducers/weeklySummariesReducer.js
@@ -1,7 +1,7 @@
 import * as actions from '../constants/weeklySummaries';
 
 const initialState = {
-  summaries: [],
+  summaries: {},
   loading: false,
   fetchError: null,
 };


### PR DESCRIPTION
# Description
Fixes three simple warnings that are logged to the console the first time logging in.

## Main changes explained:
- Set the correct initial value for `summaries`.
- Do not render `NaN` in place of a string.
- Ensure `null` is not evaluated in place of an array.

## How to test:
1. Start the app with the dev branch.
2. Close all incognito/private windows, then open a new incognito/private tab.
3. Load the app and open the console before logging in.
4. Log in and check the warning logs (screenshot included below).
5. Restart the app with this branch.
6. Repeat steps 2 through 4.

## Screenshots or videos of changes:
Videos and a screenshot of the warnings in the console:
| CHROME | SAFARI |
|--------|--------|
| ![Cell](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/104a4664-2eeb-489b-bd54-b3b7b4480e93) | ![Cell](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/00d9c096-d8ec-4e1c-bc18-4ade4413b847) |

![Warning logs](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/545a3a78-19b1-41b3-b765-4da00faf481d)
