### PR TITLE
Shrey - Fix the time entry range bug

### DIFF
--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -15,12 +15,14 @@ export const getTimeEntriesForWeek = (userId, offset) => {
     .tz('America/Los_Angeles')
     .startOf('week')
     .subtract(offset, 'weeks')
+    .add(1, 'days') // Adjust the start of the week to Sunday
     .format('YYYY-MM-DD');
 
   const toDate = moment()
     .tz('America/Los_Angeles')
     .endOf('week')
     .subtract(offset, 'weeks')
+    .add(1, 'days') // Adjust the end of the week to Saturday
     .format('YYYY-MM-DD');
 
   const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate, toDate);
@@ -39,6 +41,7 @@ export const getTimeEntriesForWeek = (userId, offset) => {
 };
 
 export const getTimeEntriesForPeriod = (userId, fromDate, toDate) => {
+  toDate = moment(toDate).endOf('day').format('YYYY-MM-DDTHH:mm:ss');
   const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate, toDate);
   return async dispatch => {
     let loggedOut = false;
@@ -49,7 +52,15 @@ export const getTimeEntriesForPeriod = (userId, fromDate, toDate) => {
       }
     });
     if (!loggedOut || !res || !res.data) {
-      await dispatch(setTimeEntriesForPeriod(res.data));
+      const filteredEntries = res.data.filter(entry => {
+        const entryDate = moment(entry.dateOfWork); // Convert the entry date to a moment object
+        return entryDate.isBetween(fromDate, toDate, 'day','[]'); // Check if the entry date is within the range (inclusive)
+      });
+      filteredEntries.sort((a, b) => {
+        return moment(b.dateOfWork).valueOf() - moment(a.dateOfWork).valueOf();
+      });
+
+      await dispatch(setTimeEntriesForPeriod(filteredEntries));
     }
   };
 };


### PR DESCRIPTION
# Description
Fixed the bug in the dev branch where the time logs where not displayed for the correct date range. Check the Screenshots below for the before and after change.

## Main changes explained:
- Update file timeEntries.js to get the correct time logs for given date range.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as any user
4. go to dashboard→ Tasks→ Current Week Timelog/ Last Week/ Week Before Last/ Search by Date Range 
5. verify if the time logs are shown for the specified date range.

## Screenshots or videos of changes:
Before change
https://www.dropbox.com/s/dtw9eecotbjvvmg/Time%20Entry%20Range%20Bug%20Analysis.pages?dl=0
<img width="756" alt="Screenshot 2023-08-03 at 6 09 41 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/e6a7eda7-4ea9-4c2c-a2ce-d28b9d3e498c">
<img width="764" alt="Screenshot 2023-08-03 at 6 11 05 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/5bc4e592-9988-41b1-835d-c19b55b6755c">


After Change
<img width="839" alt="Screenshot 2023-08-03 at 5 22 42 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/a1e4ba00-4540-4cae-9af2-8a6bfef97153">

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/75f0bfe6-f209-4085-b36e-da363ccfdf08
