### PR TITLE
Ramya - Fix total hours logged  field in People report page

### DIFF
--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -262,11 +262,13 @@ class PeopleReport extends Component {
       toDate,
       timeEntries,
     } = this.state;
-    const { firstName, lastName, weeklycommittedHours, totalTangibleHrs } = userProfile;
+    const { firstName, lastName, weeklycommittedHours,hoursByCategory } = userProfile;
 
+  
     var totalTangibleHrsRound = 0;
-    if (totalTangibleHrs) {
-      totalTangibleHrsRound = totalTangibleHrs.toFixed(2);
+    if (hoursByCategory) {
+      const hours = hoursByCategory ? Object.values(hoursByCategory).reduce((prev, curr) => prev + curr, 0):0;
+      totalTangibleHrsRound = hours.toFixed(2);
     }
 
     const UserProject = props => {


### PR DESCRIPTION
# Description
The total hours  field  of a user in the People Report page is not  getting displayed with the correct value .  It ideally should be the same as shown in the User Profile-> Volunteering Time Tab  -> Total Tangible Hours field 



## Main changes explained:
- Used the _hoursByCategory_ attribute of the the _userProfile_ object to calculate the correct  value 

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin/ Owner  user
4. Go to Reports→ Reports→ People→ Choose a person 
5. The total hours logged should match the **Total Tangible hours** (Volunteering Times Tab) field in the user profile page

## Screenshots or videos of changes:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/89441435/90b3e6db-9c67-4ac8-97c4-4500ece5a36d


