### PR TITLE
truncate user tasks

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -11,8 +11,7 @@ import './style.css';
 import ReactTooltip from 'react-tooltip';
 import { boxStyle } from 'styles';
 
-const MIN_NUM_TASKS_CAN_TRUNCATE = 5;
-const NUM_TASKS_SHOW_TRUNCATE = 3;
+const NUM_TASKS_SHOW_TRUNCATE = 6;
 
 const TeamMemberTask = React.memo(({
   user,
@@ -54,7 +53,7 @@ const TeamMemberTask = React.memo(({
     return [totalHoursRemaining, activeTasks];
   }, [user]);
 
-  const canTruncate = activeTasks.length >= MIN_NUM_TASKS_CAN_TRUNCATE;
+  const canTruncate = activeTasks.length > NUM_TASKS_SHOW_TRUNCATE;
   const [isTruncated, setIsTruncated] = useState(canTruncate);
   const [infoTaskIconModal, setInfoTaskIconModal] = useState(false);
 

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBell, faCircle, faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
 import CopyToClipboard from 'components/common/Clipboard/CopyToClipboard';
@@ -11,6 +11,9 @@ import './style.css';
 import ReactTooltip from 'react-tooltip';
 import { boxStyle } from 'styles';
 
+const MIN_NUM_TASKS_CAN_TRUNCATE = 5;
+const NUM_TASKS_SHOW_TRUNCATE = 3;
+
 const TeamMemberTask = React.memo(({
   user,
   handleMarkAsDoneModal,
@@ -21,35 +24,49 @@ const TeamMemberTask = React.memo(({
   roles,
   userPermissions,
 }) => {
+  const [totalHoursRemaining, activeTasks] = useMemo(() => {
+    let totalHoursRemaining = 0;
+
+    if (user.tasks) {
+      user.tasks = user.tasks.map(task => {
+        task.hoursLogged = task.hoursLogged ? task.hoursLogged : 0;
+        task.estimatedHours = task.estimatedHours ? task.estimatedHours : 0;
+        return task;
+      });
+
+      for (const task of user.tasks) {
+        if (task.status !== 'Complete' && task.isAssigned !== 'false') {
+          totalHoursRemaining = totalHoursRemaining + (task.estimatedHours - task.hoursLogged);
+        }
+      }
+    }
+
+    const activeTasks = user.tasks.filter((task) => {
+      let isActiveTaskForUser = true;
+      if (task?.resources) {
+        isActiveTaskForUser = !task.resources?.find(
+          resource => resource.userID === user.personId,
+        ).completedTask;
+      }
+      return task.wbsId && task.projectId && isActiveTaskForUser;
+    });
+
+    return [totalHoursRemaining, activeTasks];
+  }, [user]);
+
+  const canTruncate = activeTasks.length >= MIN_NUM_TASKS_CAN_TRUNCATE;
+  const [isTruncated, setIsTruncated] = useState(canTruncate);
   const [infoTaskIconModal, setInfoTaskIconModal] = useState(false);
 
   const infoTaskIconContent = `Red Bell Icon: When clicked, this will show any task changes\n
   Green Checkmark Icon: When clicked, this will mark the task as completed\n
   X Mark Icon: When clicked, this will remove the user from that task`;
 
-  let totalHoursLogged = 0;
-  let totalHoursRemaining = 0;
   const thisWeekHours = user.totaltangibletime_hrs;
   const rolesAllowedToResolveTasks = ['Administrator', 'Owner'];
   const rolesAllowedToSeeDeadlineCount = ['Manager', 'Mentor', 'Administrator', 'Owner'];
   const isAllowedToResolveTasks = rolesAllowedToResolveTasks.includes(userRole);
   const isAllowedToSeeDeadlineCount = rolesAllowedToSeeDeadlineCount.includes(userRole);
-
-  if (user.tasks) {
-    user.tasks = user.tasks.map(task => {
-      task.hoursLogged = task.hoursLogged ? task.hoursLogged : 0;
-      task.estimatedHours = task.estimatedHours ? task.estimatedHours : 0;
-      return task;
-    });
-    totalHoursLogged = user.tasks
-      .map(task => task.hoursLogged)
-      .reduce((previousValue, currentValue) => previousValue + currentValue, 0);
-    for (const task of user.tasks) {
-      if (task.status !== 'Complete' && task.isAssigned !== 'false') {
-        totalHoursRemaining = totalHoursRemaining + (task.estimatedHours - task.hoursLogged);
-      }
-    }
-  }
 
   const toggleInfoTaskIconModal = () => {
     setInfoTaskIconModal(!infoTaskIconModal);
@@ -60,6 +77,7 @@ const TeamMemberTask = React.memo(({
   };
 
   const hasRemovePermission = hasPermission(userRole, 'removeUserFromTask', roles, userPermissions);
+  const numTasksToShow = isTruncated ? NUM_TASKS_SHOW_TRUNCATE : activeTasks.length;
 
   return (
     <>
@@ -98,15 +116,8 @@ const TeamMemberTask = React.memo(({
           <Table borderless className="team-member-tasks-subtable">
             <tbody>
               {user.tasks &&
-                user.tasks.map((task, index) => {
-                  let isActiveTaskForUser = true;
-                  if (task?.resources) {
-                    isActiveTaskForUser = !task.resources?.find(
-                      resource => resource.userID === user.personId,
-                    ).completedTask;
-                  }
-                  if (task.wbsId && task.projectId && isActiveTaskForUser) {
-                    return (
+                activeTasks.slice(0, numTasksToShow).map((task, index) => {
+                  return (
                       <tr key={`${task._id}${index}`} className="task-break">
                         <td data-label="Task(s)" className="task-align">
                           <Link to={task.projectId ? `/wbs/tasks/${task._id}` : '/'}>
@@ -224,8 +235,14 @@ const TeamMemberTask = React.memo(({
                         )}
                       </tr>
                     );
-                  }
                 })}
+                {canTruncate && <tr key="truncate-button-row" className="task-break">
+                  <td className="task-align">
+                    <button onClick={() => setIsTruncated(!isTruncated)}>
+                      {isTruncated ? `Show All (${activeTasks.length}) Tasks` : 'Truncate Tasks'}
+                    </button>
+                  </td>
+                </tr>}
             </tbody>
           </Table>
         </td>


### PR DESCRIPTION
# Description
Introduce a feature to truncate or show all tasks.
Some accounts on dev have 100s of tasks and it can take a minute or two for the dashboard to load.
This is an attempt to load the dashboard faster.
With this change, the dashboard loads in about 15 seconds.

## Main changes explained:
If an account has more than four tasks, truncate it and show only three.
Add a button to show all tasks and to truncate the tasks.

## How to test:
1. Log into the dev branch and see which accounts have more than 4 tasks.
2. Log into this branch and check those accounts again.
3. Click "Show All (6) Tasks" to see all tasks.
4. Click "Truncate Tasks" to show only the first three tasks.

NOTE: Accounts with 100s of tasks are still slow.

## Screenshots or videos of changes:
| Truncate/Show SIX | Truncate/Show TWENTY |
|--------|--------|
| ![SIX](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/97439fc6-1227-41fa-b62a-39e19f2bd8a7) | ![TWENTY](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/1c3c6b4a-2213-46e6-b145-2fce4e82de63) | 

| LOAD BEFORE | LOAD AFTER |
|--------|--------|
| ![LOAD BEFORE](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/6bdf2170-a633-4be9-a254-66cfbfab8c85) | ![LOAD AFTER](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/e7d7d67e-0b20-45a9-a506-c690b93a6bc1) |

| 101 Tasks | 562 Tasks |
|--------|--------|
| <img width="617" alt="TASKS 101" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/fa8a7126-5820-4b55-805c-f6fa64d3b268"> | <img width="620" alt="TASKS 562" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/5bca900e-44db-4ec8-a925-e5394ab73d71"> | 