### PR TITLE
changed logic for the userHistory

### DIFF
--- a/src/components/UserProfile/VolunteeringTimeTab/HistoryModal.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/HistoryModal.jsx
@@ -7,7 +7,7 @@ const HistoryModal = ({ isOpen, toggle, userName, userHistory }) => {
       <Modal isOpen={isOpen} toggle={toggle}>
         <ModalHeader toggle={toggle}>Past Promised Hours</ModalHeader>
         <ModalBody>
-          {userHistory.length <= 1 ? (
+          {!userHistory || userHistory?.length <= 1 ? (
             <p>{userName} has never made any changes to the promised hours.</p>
           ) : (
             <Table striped>
@@ -18,14 +18,16 @@ const HistoryModal = ({ isOpen, toggle, userName, userHistory }) => {
                 </tr>
               </thead>
               <tbody>
-                {[...userHistory].reverse().map(item => (
-                  <tr key={item._id}>
-                    <td style={{ textAlign: 'center' }}>{item.hours}</td>
-                    <td style={{ textAlign: 'center' }}>
-                      {new Date(item.dateChanged).toLocaleDateString()}
-                    </td>
-                  </tr>
-                ))}
+                {userHistory?.length
+                  ? [...userHistory].reverse().map(item => (
+                      <tr key={item._id}>
+                        <td style={{ textAlign: 'center' }}>{item.hours}</td>
+                        <td style={{ textAlign: 'center' }}>
+                          {new Date(item.dateChanged).toLocaleDateString()}
+                        </td>
+                      </tr>
+                    ))
+                  : null}
               </tbody>
             </Table>
           )}


### PR DESCRIPTION
# Description
This is a quickfix. Before the userProfile page wasn't loading because of the HistoryModal. Now it's loading and the logic is correct.

## Main changes explained:
- Changed userHistory.length <= 1 to !userHistory || userHistory?.length <= 1

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as any user
4. access profile page
5. check if it's loading correctly
