### PR TITLE
scroll account into view when truncating tasks

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef, useCallback } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBell, faCircle, faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
 import CopyToClipboard from 'components/common/Clipboard/CopyToClipboard';
@@ -23,6 +23,8 @@ const TeamMemberTask = React.memo(({
   roles,
   userPermissions,
 }) => {
+  const ref = useRef(null);
+
   const [totalHoursRemaining, activeTasks] = useMemo(() => {
     let totalHoursRemaining = 0;
 
@@ -78,9 +80,20 @@ const TeamMemberTask = React.memo(({
   const hasRemovePermission = hasPermission(userRole, 'removeUserFromTask', roles, userPermissions);
   const numTasksToShow = isTruncated ? NUM_TASKS_SHOW_TRUNCATE : activeTasks.length;
 
+  const handleTruncateTasksButtonClick = () => {
+    if (!isTruncated) {
+      ref.current?.scrollIntoView({ behavior: 'smooth' });
+      setTimeout(() => {
+        setIsTruncated(!isTruncated);
+      }, 0);
+    } else {
+      setIsTruncated(!isTruncated);
+    }
+  };
+
   return (
     <>
-      <tr className="table-row" key={user.personId}>
+      <tr ref={ref} className="table-row" key={user.personId}>
         {/* green if member has met committed hours for the week, red if not */}
         <td>
           <div className="committed-hours-circle">
@@ -237,7 +250,7 @@ const TeamMemberTask = React.memo(({
                 })}
                 {canTruncate && <tr key="truncate-button-row" className="task-break">
                   <td className="task-align">
-                    <button onClick={() => setIsTruncated(!isTruncated)}>
+                    <button onClick={handleTruncateTasksButtonClick}>
                       {isTruncated ? `Show All (${activeTasks.length}) Tasks` : 'Truncate Tasks'}
                     </button>
                   </td>


### PR DESCRIPTION
# Description
Scroll the account into view when truncating tasks.

## Main changes explained:
Set reference to the table row and scroll into view when truncating the tasks list.

## How to test:
1. Log in on the dev branch.
2. Find an account with truncated tasks list, like `XiaoWang Mentor`, which has 20 tasks.
3. Click Show All, then Truncate. The page should not move.
4. Repeat steps 1~3 with this branch. This time the page should scroll up to show the account when truncating.

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/b7a0b6e1-f49a-4f59-9e5a-13c58248ef58

