### PR TITLE
Hot fix of category inheritance

### DIFF
--- a/src/components/Projects/Project/Project.jsx
+++ b/src/components/Projects/Project/Project.jsx
@@ -64,9 +64,7 @@ const Project = props => {
               setCategory(e.target.value);
             }}
           >
-            <option default value="Unspecified">
-              {category}
-            </option>
+            <option default value="Unspecified">Unspecified</option>
             <option value="Food">Food</option>
             <option value="Energy">Energy</option>
             <option value="Housing">Housing</option>

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -10,6 +10,7 @@ import { DUE_DATE_MUST_GREATER_THAN_START_DATE } from '../../../../../languages/
 import 'react-day-picker/lib/style.css';
 import TagsSearch from '../components/TagsSearch';
 import { boxStyle } from 'styles';
+import { useMemo } from 'react';
 
 function AddTaskModal(props) {
   /*
@@ -19,6 +20,14 @@ function AddTaskModal(props) {
   const { tasks, copiedTask, allMembers, allProjects, error } = props;
 
   // states from hooks
+  const defaultCategory = useMemo(() => {
+    if (props.level >= 1) {
+      return tasks.find(({ _id }) => _id === props.taskId).category;
+    } else {
+      return allProjects.projects.find(({ _id }) => _id === props.projectId).category;
+    }  
+  }, []);
+
   const [taskName, setTaskName] = useState('');
   const [priority, setPriority] = useState('Primary');
   const [resourceItems, setResourceItems] = useState([]);
@@ -30,7 +39,7 @@ function AddTaskModal(props) {
   const [hoursEstimate, setHoursEstimate] = useState(0);
   const [link, setLink] = useState('');
   const [links, setLinks] = useState([]);
-  const [category, setCategory] = useState('Housing');
+  const [category, setCategory] = useState(defaultCategory);
   const [whyInfo, setWhyInfo] = useState('');
   const [intentInfo, setIntentInfo] = useState('');
   const [startedDate, setStartedDate] = useState('');
@@ -44,11 +53,12 @@ function AddTaskModal(props) {
   const priorityRef = useRef(null);
 
   const categoryOptions = [
+    { value: 'Unspecified', label: 'Unspecified' },
     { value: 'Housing', label: 'Housing' },
     { value: 'Food', label: 'Food' },
     { value: 'Energy', label: 'Energy' },
     { value: 'Education', label: 'Education' },
-    { value: 'Soceity', label: 'Soceity' },
+    { value: 'Society', label: 'Society' },
     { value: 'Economics', label: 'Economics' },
     { value: 'Stewardship', label: 'Stewardship' },
     { value: 'Other', label: 'Other' },
@@ -173,7 +183,7 @@ function AddTaskModal(props) {
     setTaskName('');
     setPriority('Primary');
     setResourceItems([]);
-    setAssigned(false);
+    setAssigned(true);
     setStatus('Started');
     setHoursBest(0);
     setHoursWorst(0);
@@ -185,7 +195,7 @@ function AddTaskModal(props) {
     setWhyInfo('');
     setIntentInfo('');
     setEndstateInfo('');
-    setCategory('');
+    setCategory(defaultCategory);
   };
 
   const paste = () => {
@@ -247,18 +257,6 @@ function AddTaskModal(props) {
   /*
   * -------------------------------- useEffects -------------------------------- 
   */
-  useEffect(() => {
-    if (props.level >= 1) {
-      const categoryMother = tasks.find(({ _id }) => _id === props.taskId).category;
-      if (categoryMother) {
-        setCategory(categoryMother);
-      }
-    } else {
-      const res = allProjects.projects.filter(({ _id }) => _id === props.projectId)[0];
-      setCategory(res.category);
-    }
-  }, [props.level]);
-
   useEffect(() => {
     setNewTaskNum(getNewNum());
   }, [modal]);

--- a/src/reducers/allProjectsReducer.js
+++ b/src/reducers/allProjectsReducer.js
@@ -49,6 +49,7 @@ export const allProjectsReducer = (allProjects = allProjectsInital, action) => {
         projects: Object.assign([
           ...allProjects.projects.slice(0, index),
           {
+            category: action.category,
             _id: action.projectId,
             isActive: action.isActive,
             projectName: action.projectName,


### PR DESCRIPTION
# Description
This is a hot fix of task improvement system where new task does not have its project category as default value when creating. Add "Unspecified" option to task category list so that it matches project category list. 

## Main changes explained:
- Make AddTask component to get its mother task category (or project category if level one task) when mounting, and set it as the default category in modal
- Make AddTask component's default Assigned value to be true
- fix misspelling bugs
- fix a project reducer bug


## How to test:
1. check into current branch 
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as admin user
4. go to dashboard → Projects → remember a project's category and click into that project → click into any wbs 
6. try adding a new level one task (use the AddTask button on top of  tasks table) and check if its default category is the same as the project's in modal
7. change an existing task's category to something other than project's category, and try creating a subtask under it, check if the subtask's default category is the same as its mother in the modal.

## Screenshots or videos of changes:
Project category
![project category](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/77769556/a7c03d42-a8f9-4efb-a284-5a2bbf701c07)
New level one task category
![new level one task category](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/77769556/dcbd792e-e8b0-4db4-9ab8-ccb62cee6510)
Subtask category under housing mother task
![subtask category under housing mother task](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/77769556/f99e2e32-2a81-413a-a32c-494f20184178)

