### PR TITLE
Shrey: Fix alignment of i's on permission management

### DIFF
--- a/src/components/PermissionsManagement/RolePermissions.jsx
+++ b/src/components/PermissionsManagement/RolePermissions.jsx
@@ -264,62 +264,38 @@ function RolePermissions(props) {
         <h2 className="user-role-tab__h2">Permission List</h2>
       </header>
       <ul className="user-role-tab__permissionList">
-        {props.permissionsList.map(permission => (
+        {props.permissionsList.map((permission) => (
           <li className="user-role-tab__permissions" key={permission}>
             <p style={{ color: permissions.includes(permission) ? 'green' : 'red' }}>
               {permission}
             </p>
-            {permissions.includes(permission) ? (
-              <div>
-                <i
-                  data-toggle="tooltip"
-                  data-placement="center"
-                  title="Click for more information"
-                  style={{ fontSize: 24, cursor: 'pointer' }}
-                  aria-hidden="true"
-                  className="fa fa-info-circle"
-                  onClick={() => {
-                    handleModalOpen(permission);
-                  }}
-                />{' '}
-                &nbsp;&nbsp;
-                <Button
-                  color="danger"
-                  onClick={() => {
-                    onRemovePermission(permission), setChanged(true);
-                  }}
-                  disabled={props?.userRole !== 'Owner' ? true : false}
-                  style={boxStyle}
-                >
-                  Delete
-                </Button>
-              </div>
-            ) : (
-              <div>
-                <i
-                  data-toggle="tooltip"
-                  data-placement="center"
-                  title="Click for more information"
-                  style={{ fontSize: 24, cursor: 'pointer' }}
-                  aria-hidden="true"
-                  className="fa fa-info-circle"
-                  onClick={() => {
-                    handleModalOpen(permission);
-                  }}
-                />{' '}
-                &nbsp;&nbsp;
-                <Button
-                  color="success"
-                  onClick={() => {
-                    onAddPermission(permission), setChanged(true);
-                  }}
-                  disabled={props?.userRole !== 'Owner' ? true : false}
-                  style={boxStyle}
-                >
-                  Add
-                </Button>
-              </div>
-            )}
+            <div className="icon-button-container">
+              <i
+                data-toggle="tooltip"
+                data-placement="center"
+                title="Click for more information"
+                aria-hidden="true"
+                className="fa fa-info-circle"
+                onClick={() => {
+                  handleModalOpen(permission);
+                }}
+              />
+              &nbsp;&nbsp;
+              <Button
+                className="icon-button"
+                color={permissions.includes(permission) ? 'danger' : 'success'}
+                onClick={() => {
+                  permissions.includes(permission)
+                    ? onRemovePermission(permission)
+                    : onAddPermission(permission);
+                  setChanged(true);
+                }}
+                disabled={props?.userRole !== 'Owner'}
+                style={boxStyle}
+              >
+                {permissions.includes(permission) ? 'Delete' : 'Add'}
+              </Button>
+            </div>
           </li>
         ))}
       </ul>

--- a/src/components/PermissionsManagement/UserRoleTab.css
+++ b/src/components/PermissionsManagement/UserRoleTab.css
@@ -85,3 +85,24 @@
   color: red;
   margin-right: 0.6rem;
 }
+
+.icon-button-container {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-wrap: nowrap;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.icon-button-container i {
+  display: flex;
+  align-items: center; /* This ensures vertical alignment with the button */
+  margin-right: 10px; /* Optional: Adds some spacing between the icon and the button */
+}
+
+.icon-button { /* This is the new class */
+  height: 40px; /* You can adjust this value */
+  line-height: 40px; /* This should be the same as the height */
+  min-width: 80px; /* Optional: Sets a minimum width for the button */
+}


### PR DESCRIPTION
# Description
Fix the alignment of i's on the permission management page, to make them vertically aligned with each other, and taking care of them in all the screen size. 

## Main changes explained:
1. In the permission management page, i was not vertically aligned. And specially it got misaligned when the screen size narrowed down.
2. made changes in the RolePermission.jsx where i fixed the button size.
3. made changes in the UserRoleTab.css file.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
4. log in as any user owner/admin to check if it works for any of these user type.
5. go to ADMIN LOGIN → Other Links → Permissions Management → Choose Role
6. verify if i's are vertically aligned for all screen sizes and also by manually decreasing the window size.

## Screenshots or videos of changes:
Before:
<img width="630" alt="Screenshot 2023-08-10 at 4 21 57 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/4ea28664-fff1-476e-acee-7b4a81c16425">
<img width="541" alt="Screenshot 2023-08-10 at 4 21 47 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/48b79de8-6cd6-4fa0-bb44-904af977280a">
<img width="579" alt="Screenshot 2023-08-10 at 4 21 25 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/e00e8dfc-628b-4b3a-91da-3d26c1b0094c">
<img width="791" alt="Screenshot 2023-08-10 at 4 21 11 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/9b8f9863-3e82-49a7-8b9b-56ace590a370">


After:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/6db3422f-16f6-4bf8-a022-79a2af2a42f9


