### PR TITLE
use FontAwesomeIcon for the info circle

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useRef, useCallback } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBell, faCircle, faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faBell, faCircle, faCheck, faTimes, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import CopyToClipboard from 'components/common/Clipboard/CopyToClipboard';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Table, Progress } from 'reactstrap';
 
@@ -177,12 +177,10 @@ const TeamMemberTask = React.memo(({
                               }}
                             />
                           )}
-                          <i
-                            className="fa fa-info-circle"
-                            style={{ cursor: 'pointer', marginLeft: '10px' }}
-                            data-tip
-                            data-for="taskIconTip"
-                            aria-hidden="true"
+                          <FontAwesomeIcon
+                            className="team-member-task-info"
+                            icon={faInfoCircle}
+                            title="Click this icon to learn about the task icons"
                             onClick={() => {
                               handleModalOpen();
                             }}

--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -29,6 +29,11 @@
   cursor: pointer;
 }
 
+.team-member-task-info {
+  margin-left: 10px;
+  cursor: pointer;
+}
+
 .committed-hours-circle {
   padding: 0.75rem;
 }


### PR DESCRIPTION
# Description
The Team Member Tasks on dev is slow and often freezes.
Improve the Team Member Tasks performance.

## Main changes explained:
Use `FontAwesomeIcon` for the `Info Circle` icon rather than the `i` tag and `ReactTooltip`.
I am not sure why this combo was causing so much lag and freezing the page.

## How to test:
1. Log into the dev branch and wait for the Team Member Tasks to finish loading. It takes 10 to 15 seconds for me.
2. Scroll to the bottom of the page to find `Zuhang AdminTest`, which has 101 tasks.
3. Click `Show All (101) Tasks`, then scroll to the bottom again and click `Truncate Tasks`. Move the mouse around to highlight different rows.
4. Repeat steps 1~3 with this branch.

## Screenshots or videos of changes:
**No lags or freezes**:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/2a497448-e6d6-42c0-97a7-f72dc58392c1