### PR TITLE
Fix badge earned date

### DIFF
--- a/src/actions/badgeManagement.js
+++ b/src/actions/badgeManagement.js
@@ -11,6 +11,7 @@ import {
   CLOSE_ALERT,
 } from '../constants/badge';
 import { ENDPOINTS } from '../utils/URL';
+import moment from 'moment';
 
 const getAllBadges = allBadges => ({
   type: GET_ALL_BADGE_DATA,
@@ -185,21 +186,14 @@ export const assignBadgesByUserID = (userId, selectedBadges) => {
 
     selectedBadges.forEach(badgeId => {
       let included = false;
-      const today = new Date();
-      const yyyy = today.getFullYear();
-      // Add 1 beacuse the month start at zero
-      let mm = today.getMonth() + 1;
-      let dd = today.getDate();
-
-      mm < 10 ? (mm = `0${  mm}`) : mm;
-      dd < 10 ? (dd = `0${  dd}`) : dd;
-      const formatedDate = `${yyyy  }-${  mm  }-${  dd}`;
+      const formatedDate = moment().format('YYYY-MM-DD')
+    
 
       badgeCollection.forEach(badgeObj => {
         if (badgeId === badgeObj.badge) {
           badgeObj.count++;
-          badgeObj.lastModified = Date.now();
-          badgeObj.earnedDate = [...earnedDate, formatedDate];
+          badgeObj.lastModified = moment().format('YYYY-MM-DD');
+          badgeObj.earnedDate = [...badgeObj.earnedDate, formatedDate];
           included = true;
         }
       });
@@ -210,7 +204,7 @@ export const assignBadgesByUserID = (userId, selectedBadges) => {
           badge: badgeId,
           count: 1,
           earnedDate: dates,
-          lastModified: Date.now(),
+          lastModified: Date(),
         });
       }
     });

--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -208,6 +208,7 @@ const BadgeReport = props => {
     mm < 10 ? (mm = '0' + mm) : mm;
     dd < 10 ? (dd = '0' + dd) : dd;
     const formatedDate = `${yyyy}-${mm}-${dd}`;
+    
     newBadges.map((bdg, i) => {
       if (newValue > bdg.count && i === index) {
         bdg.earnedDate.push(formatedDate);


### PR DESCRIPTION
# Description
DASHBOARD COMPONENT 2 - (PRIORITY MEDIUM) Jae: Need a “Details” button or other way to see when specific badges were earned. Some badges are earned multiple times, so the button needs to show all dates when they were earned.
Dashboard → Badges Section → Badges Report

## Related PRS (if any):
This frontend PR is related to the #311 backend PR and #755 Frontend PR.

## Main changes explained:
- Fixed dropdown button in the Badge Report modal and user profile section that show all dates for each earned Badge.
- Removed some code that used the built in Date method and replaced it with moment js.


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to dashboard→ View Profile→ Featured Badges→ Assign Badge→ Confirm→ Select Featured→ Save Changes
5. go to dashboard→ Scroll the screen→ Badges→ Badge Report Button
6. verify that the "Dates" button lists the earned dates.

## Screenshots or videos of changes:

Adding Badges in View Profile

[_Details_ button test in user profile.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/108101478/3e86274b-ca43-4454-9d78-32c4393533ba)

Verifying Badges in Badge Report

[_Details_ Badge report on dashboard.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/108101478/4a281f4c-4a9b-45ca-aff4-5627c2394ed8)


