### PR TITLE
XiaoW hot fix of frequent refresh alert when adding new task

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -251,6 +251,7 @@ function AddTaskModal(props) {
       endstateInfo,
     };
     await props.addNewTask(newTask, props.wbsId, props.pageLoadTime);
+    props.load();
     toggle();
   };
 


### PR DESCRIPTION
# Description
This is a hot fix of the frequent refresh alert showing up when adding new tasks.

## Main changes explained:
- make app reload all tasks after adding new task
