### PR TITLE
Tim fix modify own badge amount

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -26,7 +26,6 @@ const Badge = props => {
   const [isOpen, setOpen] = useState(false);
   const [isOpenTypes, setOpenTypes] = useState(false);
   const [totalBadge, setTotalBadge] = useState(0);
-  console.log("🚀 ~ file: Badge.jsx:29 ~ Badge ~ totalBadge:", totalBadge)
 
   const toggle = () => {
     if (isOpen) {
@@ -51,7 +50,6 @@ const Badge = props => {
   };
 
   useEffect(() => {
-    console.log("useEffect invoked")
     const userId = props.userId;
     let count = 0;
     if (props.userProfile.badgeCollection) {

--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -22,7 +22,6 @@ import { getUserProfile } from '../../actions/userProfile';
 import { boxStyle } from 'styles';
 
 const Badge = props => {
-  console.log("🚀 ~ file: Badge.jsx:25 ~ Badge ~ props:", props)
   const [isOpen, setOpen] = useState(false);
   const [isOpenTypes, setOpenTypes] = useState(false);
   const [totalBadge, setTotalBadge] = useState(0);

--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -22,9 +22,11 @@ import { getUserProfile } from '../../actions/userProfile';
 import { boxStyle } from 'styles';
 
 const Badge = props => {
+  console.log("🚀 ~ file: Badge.jsx:25 ~ Badge ~ props:", props)
   const [isOpen, setOpen] = useState(false);
   const [isOpenTypes, setOpenTypes] = useState(false);
   const [totalBadge, setTotalBadge] = useState(0);
+  console.log("🚀 ~ file: Badge.jsx:29 ~ Badge ~ totalBadge:", totalBadge)
 
   const toggle = () => {
     if (isOpen) {
@@ -35,7 +37,7 @@ const Badge = props => {
           if (badge?.badge?.badgeName === 'Personal Max' || badge?.badge?.type === 'Personal Max') {
             count += 1;
           } else {
-            count += badge.count;
+            count += Number(badge.count);
           }
         });
         setTotalBadge(Math.round(count));
@@ -49,6 +51,7 @@ const Badge = props => {
   };
 
   useEffect(() => {
+    console.log("useEffect invoked")
     const userId = props.userId;
     let count = 0;
     if (props.userProfile.badgeCollection) {
@@ -56,7 +59,7 @@ const Badge = props => {
         if (badge?.badge?.badgeName === 'Personal Max' || badge?.badge?.type === 'Personal Max') {
           count += 1;
         } else {
-          count += badge.count;
+          count += Number(badge.count);
         }
       });
       setTotalBadge(Math.round(count));

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -112,7 +112,7 @@ const SummaryBar = props => {
 
   //Get badges count from userProfile
   const getBadges = () => {
-    return userProfile && userProfile.badgeCollection ? userProfile.badgeCollection.length : 0;
+    return userProfile && userProfile.badgeCollection ? userProfile.badgeCollection.reduce((acc, obj) => acc + Number(obj.count), 0) : 0;
   };
 
   const getState = useSelector(state => {

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -19,6 +19,7 @@ import { clearSelected } from 'actions/badgeManagement';
 import { boxStyle } from 'styles';
 
 export const Badges = props => {
+  console.log("🚀 ~ file: Badges.jsx:22 ~ Badges ~ props:", props)
   const [isOpen, setOpen] = useState(false);
   const [isAssignOpen, setAssignOpen] = useState(false);
   const permissionsUser = props.userProfile?.permissions?.frontPermissions;
@@ -36,7 +37,7 @@ export const Badges = props => {
   }, [isOpen, isAssignOpen]);
 
   // Determines what congratulatory text should displayed.
-  const badgesEarned = props.userProfile.badgeCollection.length;
+  const badgesEarned = props.userProfile.badgeCollection.reduce((acc, obj) => acc + Number(obj.count), 0);
   const subject = props.isUserSelf ? 'You have' : 'This person has';
   const verb = badgesEarned ? `earned ${badgesEarned}` : 'no';
   const object = badgesEarned == 1 ? 'badge' : 'badges';

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -19,7 +19,6 @@ import { clearSelected } from 'actions/badgeManagement';
 import { boxStyle } from 'styles';
 
 export const Badges = props => {
-  console.log("🚀 ~ file: Badges.jsx:22 ~ Badges ~ props:", props)
   const [isOpen, setOpen] = useState(false);
   const [isAssignOpen, setAssignOpen] = useState(false);
   const permissionsUser = props.userProfile?.permissions?.frontPermissions;

--- a/src/components/UserProfile/Badges.test.jsx
+++ b/src/components/UserProfile/Badges.test.jsx
@@ -33,7 +33,7 @@ describe('Badges Component', () => {
         const props = {
           ...badgeProps,
           isUserSelf: true,
-          userProfile: { ...badgeProps.userProfile, badgeCollection: ['B1'] },
+          userProfile: { ...badgeProps.userProfile, badgeCollection: [{ count: 1 }] },
         };
         const renderedBadges = render(<Badges {...props} />);
         expect(renderedBadges.find('.card-footer').text()).toBe('Bravo! You have earned 1 badge! ');
@@ -45,7 +45,7 @@ describe('Badges Component', () => {
           isUserSelf: true,
           userProfile: {
             ...badgeProps.userProfile,
-            badgeCollection: ['B1', 'B2', 'B3'],
+            badgeCollection: [{ count: 1 }, { count: 2 }, { count: 3 }],
           },
         };
         const renderedBadges = render(<Badges {...props} />);
@@ -65,7 +65,7 @@ describe('Badges Component', () => {
       it('should display the correct text when they have exactly 1 badge', () => {
         const props = {
           ...badgeProps,
-          userProfile: { ...badgeProps.userProfile, badgeCollection: ['B1'] },
+          userProfile: { ...badgeProps.userProfile, badgeCollection: [ { count: 1 }] },
         };
         const renderedBadges = render(<Badges {...props} />);
         expect(renderedBadges.find('.card-footer').text()).toBe(
@@ -78,7 +78,7 @@ describe('Badges Component', () => {
           ...badgeProps,
           userProfile: {
             ...badgeProps.userProfile,
-            badgeCollection: ['B1', 'B2', 'B3'],
+            badgeCollection: [{ count: 1 }, { count: 2 }, { count: 3 }],
           },
         };
         const renderedBadges = render(<Badges {...props} />);


### PR DESCRIPTION
# Description
(Priority Medium) Vitor/Jae: Fix the “Modify Badge Amount” permission from the Manage User Permissions Component on Permission Management Page. Even after adding the permission, the user is not able to modify the amount of badges assigned to a user.

## Related PRS (if any):
N/A

## Main changes explained:
This PR fixes the remaining issues with allowing all users of a permitted role to modify the count of their own badges. Owner/Admin users are allowed by default to edit their own badge counts. Currently on the development branch, Volunteer and Mentor users have also have this ability enabled.
- Fixes an issue where modifying the badge count using the **User Profile > Select Featured modal** gives a concatenated result instead of a summed result in **Dashboard > Badges**

<img width="398" alt="modify-badge-amount-bug1" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/98129080/f27c8a48-4c00-416a-ad79-bfa0780c3dc7">

- Fixes an issue where the sum of unique badges was being displayed instead of the sum of total badges in **Dashboard > SummaryBar** and **User Profile > Featured Badges**

<img width="738" alt="modify-badge-amount-bug2" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/98129080/2b708b64-1399-416f-85a2-d55ebf2370e0">

## How to test:

- `git checkout Tim_fix_modify_own_badge_amount` to check into current branch
- `npm install` to ensure your modules are up to date (no new modules are added in this PR)
- `npm run start:local` to run this PR locally
- (optional) if you do not have a volunteer or mentor user with assigned badges, log in first as an admin and use the **Assign Badges** modal on their User Profile page to award some badges
- log in as an either a volunteer or mentor user and navigate to **User Profile**
- use the **Featured Badges > Select Featured** modal to add or subtract to the badge count
  - note: setting a badge count to 0 will delete the badge
- check the badge count displays in the following locations are accurate:
  - **Dashboard > Summary Bar > Badges Earned**
  - **Dashboard > Badges > 'Bravo...' summary**
  - **User Profile > Select Featured > 'Bravo...' summary**

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/98129080/bcb9257f-269d-4793-95c0-1d9a6afef8e2

## Note:
Here are some of the issues I encountered while working on this fix:
- The first badges awarded by an admin to a new user will not be reflected on that user's dashboard the badge count has been modified at least one time.
- Attempting to modify badge counts using the **Dashboard > Badges > Badge Report** modal results in an error that freezes the app. The page must be refreshed, and the changes are not saved.
- The **User Profile > Featured Badges > Select Featured** modal currently allows negative numbers and numbers of infinite size to be manually added into the Count input.
- When editing badge counts in User Profile, exiting out of the modal without clicking Save Changes leaves any changes made in state rather than reverting the modal to its previous state.