### PR TITLE
Shrey Fix the code from PR1085 to get correct data in dev branch without breaking the data in main

### DIFF
--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -15,13 +15,13 @@ export const getTimeEntriesForWeek = (userId, offset) => {
     .tz('America/Los_Angeles')
     .startOf('week')
     .subtract(offset, 'weeks')
-    .format('YYYY-MM-DD');
+    .format('YYYY-MM-DDTHH:mm:ss');
 
   const toDate = moment()
     .tz('America/Los_Angeles')
     .endOf('week')
     .subtract(offset, 'weeks')
-    .format('YYYY-MM-DD');
+    .format('YYYY-MM-DDTHH:mm:ss');
 
   const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate, toDate);
   return async dispatch => {
@@ -33,12 +33,18 @@ export const getTimeEntriesForWeek = (userId, offset) => {
       }
     });
     if (!loggedOut || !res || !res.data) {
-      await dispatch(setTimeEntriesForWeek(res.data, offset));
+      const filteredEntries = res.data.filter(entry => {
+        const entryDate = moment(entry.dateOfWork); // Convert the entry date to a moment object
+        return entryDate.isBetween(fromDate, toDate, 'day', '[]'); // Check if the entry date is within the range (inclusive)
+      });
+      await dispatch(setTimeEntriesForWeek(filteredEntries, offset));
+      // await dispatch(setTimeEntriesForWeek(res.data, offset));
     }
   };
 };
 
 export const getTimeEntriesForPeriod = (userId, fromDate, toDate) => {
+  toDate = moment(toDate).endOf('day').format('YYYY-MM-DDTHH:mm:ss');
   const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate, toDate);
   return async dispatch => {
     let loggedOut = false;
@@ -49,7 +55,16 @@ export const getTimeEntriesForPeriod = (userId, fromDate, toDate) => {
       }
     });
     if (!loggedOut || !res || !res.data) {
-      await dispatch(setTimeEntriesForPeriod(res.data));
+      const filteredEntries = res.data.filter(entry => {
+        const entryDate = moment(entry.dateOfWork); // Convert the entry date to a moment object
+        return entryDate.isBetween(fromDate, toDate, 'day', '[]'); // Check if the entry date is within the range (inclusive)
+      });
+      filteredEntries.sort((a, b) => {
+        return moment(b.dateOfWork).valueOf() - moment(a.dateOfWork).valueOf();
+      });
+
+      await dispatch(setTimeEntriesForPeriod(filteredEntries));
+      // await dispatch(setTimeEntriesForPeriod(res.data));
     }
   };
 };


### PR DESCRIPTION
# Description
To fix the weekly time log which do not fit the correct range in dev branch. The fix worked earlier in dev and broke the flow in main. 

## Related PRS (if any):
This frontend PR is related to the #1085 frontend PR.

## Main changes explained:
- Removed the extra .add(1) line from the code which might have created problem in the dev
- Filtered the data so that the date fits the correct range and do not miss Sunday at it recently happened when the last code got merged
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as any user
4. go to dashboard→ Tasks→ Current Week Timelog/ Last Week/ Week Before Last/ Search by Date Range
5. verify if the time logs are shown for the specified date range, in current week, last week, week before last, and specific range.

## Screenshots or videos of changes:
Before :
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/b1f882ae-9997-4bbe-a1c4-3a9e95e34356)

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/e11d90e3-aea6-4920-8bf7-9822ad67596e)

Changes caused issue in Main:
<img width="905" alt="Screenshot 2023-08-16 at 1 44 49 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/257db9ac-45ce-4207-9dfb-4d2a1f37f4a0">

![IMG_0868](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/6271b8d3-5728-4d49-b3be-c212a506370e)

After in Dev branch:
<img width="753" alt="Screenshot 2023-08-16 at 1 39 31 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/867ebe8a-50f2-4aea-8c68-36bdda792578">
<img width="770" alt="Screenshot 2023-08-16 at 1 39 08 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/25ff7e20-8dff-416e-8d34-83c920a7ef75">
<img width="771" alt="Screenshot 2023-08-16 at 1 39 03 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/f38dc2e4-88fc-4114-9770-7c8ed9e37c72">

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/76a22566-8cce-44a5-87af-f3b38658936e

## Note
The problem occured in main branch so the 



