### PR TITLE
fix media folder link in weekly summary report

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -48,9 +48,19 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit, canEditSummaryCount
           Open link to media files
         </a>
       );
-    } else {
-      return 'Not provided!';
+    } 
+    else if(summary.adminLinks) {
+      for (const link of summary.adminLinks) {
+        if (link.Name === 'Media Folder'){
+          return (
+            <a href={link.Link} target="_blank" rel="noopener noreferrer">
+              Open link to media files
+            </a>
+          )
+        }
+      }
     }
+    return ('Not provided!')
   };
 
   const getGoogleDocLink = summary => {


### PR DESCRIPTION
# Description
It's a bug that may not be in the bug list yet but need to fixed **ASAP**: the new created user doesn't show their **media folder link** (Dropbox link) in the **Weekly Summaries Report** page if they haven't submitted weekly summary yet.

So it only happens to new created users so far.

## Main changes explained:
- Add a process: if `summary` object doesn't have `mediaUrl`, it will go to `adminLinks` to find if the media folder link exist.

…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as admin user
4. go to Other Links→ User Management→ Create New User (on left top) -> create a new user (remember to fill **LInk to Media Files** )
5. go to  Reports→ Weekly Summaries Report→ Go to the new user you just created
6. verify that the **Media URL** is available, not 'Not Provided!'
7. (Optional) you can also go the the **User Profile** page, and check the **media folder** link is also available under the picture.

## Screenshots or videos of changes:
<img width="614" alt="Screenshot 2023-08-16 at 11 02 40 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/57503876/f9b72419-4f21-4a16-a23d-f3bf86ce129b">


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/57503876/75f6e983-07e9-4a75-a832-bc3667efe13e


## Note:
Remember to fill the media link when creating users.
# Don't forget to add "http://" to the URL you added
