### PR TITLE
Bk/fix modal backdrop

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -1,14 +1,14 @@
 import React, { useState, useMemo, useRef } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBell, faCircle, faCheck, faTimes, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { faBell, faCircle, faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
 import CopyToClipboard from 'components/common/Clipboard/CopyToClipboard';
-import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Table, Progress } from 'reactstrap';
+import { Table, Progress } from 'reactstrap';
 
 import { Link } from 'react-router-dom';
 import { getProgressColor, getProgressValue } from '../../utils/effortColors';
 import hasPermission from 'utils/permissions';
 import './style.css';
-import { boxStyle } from 'styles';
+import TeamMemberTaskIconsInfo from './TeamMemberTaskIconsInfo';
 
 const NUM_TASKS_SHOW_TRUNCATE = 6;
 
@@ -47,25 +47,12 @@ const TeamMemberTask = React.memo(({
 
   const canTruncate = activeTasks.length > NUM_TASKS_SHOW_TRUNCATE;
   const [isTruncated, setIsTruncated] = useState(canTruncate);
-  const [infoTaskIconModal, setInfoTaskIconModal] = useState(false);
-
-  const infoTaskIconContent = `Red Bell Icon: When clicked, this will show any task changes\n
-  Green Checkmark Icon: When clicked, this will mark the task as completed\n
-  X Mark Icon: When clicked, this will remove the user from that task`;
 
   const thisWeekHours = user.totaltangibletime_hrs;
   const rolesAllowedToResolveTasks = ['Administrator', 'Owner'];
   const rolesAllowedToSeeDeadlineCount = ['Manager', 'Mentor', 'Administrator', 'Owner'];
   const isAllowedToResolveTasks = rolesAllowedToResolveTasks.includes(userRole);
   const isAllowedToSeeDeadlineCount = rolesAllowedToSeeDeadlineCount.includes(userRole);
-
-  const toggleInfoTaskIconModal = () => {
-    setInfoTaskIconModal(!infoTaskIconModal);
-  };
-
-  const handleModalOpen = () => {
-    setInfoTaskIconModal(true);
-  };
 
   const hasRemovePermission = hasPermission(userRole, 'removeUserFromTask', roles, userPermissions);
   const numTasksToShow = isTruncated ? NUM_TASKS_SHOW_TRUNCATE : activeTasks.length;
@@ -176,35 +163,7 @@ const TeamMemberTask = React.memo(({
                               }}
                             />
                           )}
-                          <FontAwesomeIcon
-                            className="team-member-task-info"
-                            icon={faInfoCircle}
-                            title="Click this icon to learn about the task icons"
-                            onClick={() => {
-                              handleModalOpen();
-                            }}
-                          />
-                          <Modal backdropClassName="task-info-modal-backdrop" isOpen={infoTaskIconModal} toggle={toggleInfoTaskIconModal}>
-                            <ModalHeader toggle={toggleInfoTaskIconModal}>
-                              Task Icons Info
-                            </ModalHeader>
-                            <ModalBody>
-                              {infoTaskIconContent.split('\n').map((item, i) => (
-                                <p key={i}>{item}</p>
-                              ))}
-                            </ModalBody>
-                            <ModalFooter>
-                              <Button
-                                onClick={toggleInfoTaskIconModal}
-                                color="secondary"
-                                className="float-left"
-                                style={boxStyle}
-                              >
-                                {' '}
-                                Ok{' '}
-                              </Button>
-                            </ModalFooter>
-                          </Modal>
+                          <TeamMemberTaskIconsInfo />
                         </td>
                         {task.hoursLogged != null && task.estimatedHours != null && (
                           <td data-label="Progress" className="team-task-progress">

--- a/src/components/TeamMemberTasks/TeamMemberTaskIconsInfo.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTaskIconsInfo.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+
+import { boxStyle } from 'styles';
+import './style.css';
+
+const infoTaskIconContent = `Red Bell Icon: When clicked, this will show any task changes\n
+  Green Checkmark Icon: When clicked, this will mark the task as completed\n
+  X Mark Icon: When clicked, this will remove the user from that task`;
+
+const TeamMemberTaskInfo = React.memo(() => {
+    const [infoTaskIconModal, setInfoTaskIconModal] = useState(false);
+
+    const toggleInfoTaskIconModal = () => {
+        setInfoTaskIconModal(!infoTaskIconModal);
+    };
+
+    const handleModalOpen = () => {
+        setInfoTaskIconModal(true);
+    };
+
+    return (
+        <>
+        <FontAwesomeIcon
+            className="team-member-task-info"
+            icon={faInfoCircle}
+            title="Click this icon to learn about the task icons"
+            onClick={() => {
+                handleModalOpen();
+            }}
+        />
+        <Modal backdropClassName="task-info-modal-backdrop" isOpen={infoTaskIconModal} toggle={toggleInfoTaskIconModal}>
+            <ModalHeader toggle={toggleInfoTaskIconModal}>
+                Task Icons Info
+            </ModalHeader>
+            <ModalBody>
+                {infoTaskIconContent.split('\n').map((item, i) => (
+                <p key={i}>{item}</p>
+                ))}
+            </ModalBody>
+            <ModalFooter>
+                <Button
+                    onClick={toggleInfoTaskIconModal}
+                    color="secondary"
+                    className="float-left"
+                    style={boxStyle}
+                    >
+                    {' '}
+                    Ok{' '}
+                </Button>
+            </ModalFooter>
+        </Modal>
+        </>
+    )
+});
+
+export default TeamMemberTaskInfo;

--- a/src/components/TeamMemberTasks/TeamMemberTaskIconsInfo.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTaskIconsInfo.jsx
@@ -5,10 +5,7 @@ import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
 import { boxStyle } from 'styles';
 import './style.css';
-
-const infoTaskIconContent = `Red Bell Icon: When clicked, this will show any task changes\n
-  Green Checkmark Icon: When clicked, this will mark the task as completed\n
-  X Mark Icon: When clicked, this will remove the user from that task`;
+import { infoTaskIconContent } from './infoTaskIconContent';
 
 const TeamMemberTaskInfo = React.memo(() => {
     const [infoTaskIconModal, setInfoTaskIconModal] = useState(false);
@@ -27,18 +24,14 @@ const TeamMemberTaskInfo = React.memo(() => {
             className="team-member-task-info"
             icon={faInfoCircle}
             title="Click this icon to learn about the task icons"
-            onClick={() => {
-                handleModalOpen();
-            }}
+            onClick={handleModalOpen}
         />
         <Modal backdropClassName="task-info-modal-backdrop" isOpen={infoTaskIconModal} toggle={toggleInfoTaskIconModal}>
             <ModalHeader toggle={toggleInfoTaskIconModal}>
                 Task Icons Info
             </ModalHeader>
             <ModalBody>
-                {infoTaskIconContent.split('\n').map((item, i) => (
-                <p key={i}>{item}</p>
-                ))}
+                {infoTaskIconContent}
             </ModalBody>
             <ModalFooter>
                 <Button
@@ -46,9 +39,8 @@ const TeamMemberTaskInfo = React.memo(() => {
                     color="secondary"
                     className="float-left"
                     style={boxStyle}
-                    >
-                    {' '}
-                    Ok{' '}
+                >
+                    Ok
                 </Button>
             </ModalFooter>
         </Modal>

--- a/src/components/TeamMemberTasks/infoTaskIconContent.js
+++ b/src/components/TeamMemberTasks/infoTaskIconContent.js
@@ -1,0 +1,3 @@
+export const infoTaskIconContent = `Red Bell Icon: When clicked, this will show any task changes\n
+  Green Checkmark Icon: When clicked, this will mark the task as completed\n
+  X Mark Icon: When clicked, this will remove the user from that task`.split('\n').map((item, i) => <p key={i}>{item}</p>);


### PR DESCRIPTION
# Description
Clicking the info icon for a task opens a modal for every task of an account because the same modal toggle boolean was being passed to each modal.
Each modal has 0.5 background opacity.
When an account has more than a few tasks, this makes the background appear black.

## Main changes explained:
Move the info icon and the modal to a separate component to allow each modal to be triggered by its own boolean.

## How to test:
1. Log into the dev branch.
2. Click the info icon for a task where the account only has one task. Inspect the modal to see there is only one modal element.
3. Click the info icon for a task where the account has several tasks. Inspect the modal to see there are multiple modal elements. Try deleting the modal elements in the inspector to see how the background opacity changes.
4. Log into this branch.
5. Click the info icons again and inspect to see there is only one modal element created even when the account has several tasks.

## Screenshots or videos of changes:
| BEFORE | AFTER |
|--------|--------|
| ![](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/f6fc8ba7-59fa-4401-98b4-f3eac46637b5) | ![](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/15364639/575b7101-5664-4737-924e-7a7cc0b1baad) | 
