### PR TITLE
Oleksandr - temporary summaries moving fix

### DIFF
--- a/src/actions/weeklySummaries.js
+++ b/src/actions/weeklySummaries.js
@@ -53,6 +53,7 @@ export const getWeeklySummaries = userId => {
         }
       }
       dispatch(fetchWeeklySummariesSuccess({ weeklySummariesCount, weeklySummaries, mediaUrl:summaryDocLink || mediaUrl}));
+      dispatch(getUserProfileActionCreator(response.data));
       return response.status;
     } catch (error) {
       dispatch(fetchWeeklySummariesError(error));


### PR DESCRIPTION
# Description
(Priority Most Urgent) Jae: Fix moving weekly summaries one week back triggered by time entries submitting.
- userProfile state has old data and rewrites the latest data in separate weeklySummaries state when time entry submitted.
- Make separate weeklySummaries state and userProfile.weeklySummaries having the latest data.   

## Main changes explained:
- Triggering getUserProfile action to set latest user profile information after sending a request by getWeeklySummaries. 


