### PR TITLE
Yubo-create media folder link using mediaUrl in Weekly Summary

### DIFF
--- a/src/actions/weeklySummaries.js
+++ b/src/actions/weeklySummaries.js
@@ -81,11 +81,18 @@ export const updateWeeklySummaries = (userId, weeklySummariesData) => {
       const {mediaUrl, weeklySummaries, weeklySummariesCount } = weeklySummariesData;
       console.log('respon get', response.data)
       // update the changes on weekly summaries link into admin links
+      let doesMediaFolderExist = false;
       for (const link of adminLinks) {
         if (link.Name === 'Media Folder') {
           link.Link = mediaUrl;
+          doesMediaFolderExist = true;
           break; 
         }
+      }
+      if(!doesMediaFolderExist && mediaUrl){
+        adminLinks.push(
+          {Name:'Media Folder',Link:mediaUrl}
+        )
       }
       const userProfileUpdated = {
         ...userProfile,


### PR DESCRIPTION
# Description
This is also a bug that needs to be fixed **ASAP** but may not be in the bug list yet. 

Now for a user has empty `Media Folder` link in their **admin links** and hasn't submitted weekly summary yet, the media URL they submit along with their first weekly summary will create the `Media Folder` link in their **admin links** ( check in their User Profile page).

## Related PRs:
It's related to PR #1132 . Now with this PR, the `mediaUrl` submitted in Weekly Summary has been created a bi-direction relationship to `Media Folder` link in `adminLinks`.

## Main changes explained:
- Adding a process  that if current user has empty `Media Folder` link when submitting the weekly summary (usually for a new created user), it will create the `Media Folder` for such user.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as admin user or a user who has empty `Media Folder` link and hasn't submitted weekly summary yet. 
4. **(if you log as new created user, jumpt to 6)** find another user has empty `Media Folder` link (you can also delete one in advance), and not submitted any weekly summary.
5. go to Dashboard, find the user -> click the red dot on the right side of their name to go to their view of Dashboard
6. Submit a weekly summary (for the user) with the media url.  **(If you can't find the input, it's possible this user has submitted weekly summary, please create another user to test)**
7.  Verify that in the **User Profile** page, the **media folder** link is available under the picture.

## Screenshots or videos of changes:
### If you are submitting weekly summary for another user:
<img width="646" alt="Screenshot 2023-08-20 at 12 06 38 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/57503876/96f22473-84a5-4b64-bcad-8d1e9d3b3037">

### Test Video:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/57503876/0a88ba3d-223b-4a00-9a7c-87e944238a2f


