### PR TITLE
add to protectedEmails

### DIFF
--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -25,7 +25,12 @@ export const cantUpdateDevAdminDetails = (devAdminEmail, authEmail) => {
                          'one.community@me.com',
                          'jsabol@me.com'
                         ]
-  return devAdminEmail === 'devadmin@hgn.net' && !allowedEmails.includes(authEmail);
+  const protectedEmails = ['jae@onecommunityglobal.org',
+                           'one.community@me.com',
+                           'jsabol@me.com',
+                           'devadmin@hgn.net'
+                          ]
+  return protectedEmails.includes(devAdminEmail) && !allowedEmails.includes(authEmail);
 };
 
 


### PR DESCRIPTION
# Description
Adds Jae's accounts to be protected like the devadmin account.

## Related PRS (if any):
[Backend PR#467](https://github.com/OneCommunityGlobal/HGNRest/pull/467/)