### PR TITLE
Oleksandr leaderboard refresh animation

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.css
+++ b/src/components/LeaderBoard/Leaderboard.css
@@ -29,3 +29,16 @@
   color: #007bff;
   font-weight: bold;
 }
+
+.animation {
+  animation: l-animation 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+}
+
+@keyframes l-animation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -154,7 +154,7 @@ const LeaderBoard = ({
       'toolbar=no, location=no, statusbar=no, menubar=no, scrollbars=1, resizable=0, width=580, height=600, top=30',
     );
   };
-  const updateLeaderboard = async () => {
+  const updateLeaderboardHandler = async () => {
     setIsLoading(true);
     await getLeaderboardData(userId);
     setIsLoading(false);
@@ -172,7 +172,7 @@ const LeaderBoard = ({
           style={{ fontSize: 24, cursor: 'pointer' }}
           aria-hidden="true"
           className={`fa fa-refresh ${isLoading ? 'animation' : ''}`}
-          onClick={updateLeaderboard}
+          onClick={updateLeaderboardHandler}
         />
         &nbsp;&nbsp;
         <i

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -11,6 +11,7 @@ import {
 } from 'utils/leaderboardPermissions';
 import hasPermission from 'utils/permissions';
 import MouseoverTextTotalTimeEditButton from 'components/mouseoverText/MouseoverTextTotalTimeEditButton';
+import { toast } from 'react-toastify';
 
 function useDeepEffect(effectFunc, deps) {
   const isFirst = useRef(true);
@@ -43,7 +44,7 @@ const LeaderBoard = ({
 }) => {
   const userId = asUser ? asUser : loggedInUser.userId;
   const hasSummaryIndicatorPermission = hasPermission('seeSummaryIndicator'); //??? this permission doesn't exist?
-  const hasVisibilityIconPermission = hasPermission('seeVisibilityIcon');     //??? this permission doesn't exist?
+  const hasVisibilityIconPermission = hasPermission('seeVisibilityIcon'); //??? this permission doesn't exist?
   const isOwner = ['Owner'].includes(loggedInUser.role);
 
   const [mouseoverTextValue, setMouseoverTextValue] = useState(totalTimeMouseoverText);
@@ -79,6 +80,7 @@ const LeaderBoard = ({
 
   const [isOpen, setOpen] = useState(false);
   const [modalContent, setContent] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   const toggle = () => setOpen(isOpen => !isOpen);
 
@@ -152,6 +154,12 @@ const LeaderBoard = ({
       'toolbar=no, location=no, statusbar=no, menubar=no, scrollbars=1, resizable=0, width=580, height=600, top=30',
     );
   };
+  const updateLeaderboard = async () => {
+    setIsLoading(true);
+    await getLeaderboardData(userId);
+    setIsLoading(false);
+    toast.success('Successfuly updated leaderboard');
+  };
 
   return (
     <div>
@@ -163,10 +171,8 @@ const LeaderBoard = ({
           title="Click to refresh the leaderboard"
           style={{ fontSize: 24, cursor: 'pointer' }}
           aria-hidden="true"
-          className="fa fa-refresh"
-          onClick={() => {
-            getLeaderboardData(userId);
-          }}
+          className={`fa fa-refresh ${isLoading ? 'animation' : ''}`}
+          onClick={updateLeaderboard}
         />
         &nbsp;&nbsp;
         <i


### PR DESCRIPTION
# Description
(PRIORITY LOW) Jae: Create indicator leaderboard refresh worked 
Right now when I click the little refresh icon, I don’t know it worked unless I scroll down and notice changes. I’d like some indicator without scrolling that the refresh happened.


## Main changes explained:
- Adding a loading state
- Adding a function that changes loading state, triggers a getLeaderboardData request and makes notification
- Adding animation class to icon when isLoading true
- Adding css animation to Leaderboard.css 

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. open incognito browser page and login as any other user
5. submit some time entry
6. go back to admin user and find the user which you submitted hours in
7. check previous number and number after updating


## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/108314277/e222eb0c-c084-4f3d-81b8-1387254839ef

