### PR TITLE
fixed spacing issue in People Reports Page

### DIFF
--- a/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
+++ b/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
@@ -16,7 +16,7 @@
 }
 
 .report-page-profile {
-  padding: 24px 24px 0 24px;
+  padding: 24px;
   background-color: #f1ebf7;
   border-top-left-radius: 25px;
 }


### PR DESCRIPTION
# Description
(PRIORITY LOW) Jae: Fix formatting on People Reports page
Reports → Reports → People → Choose person
The bottom of the area in the section below should match the top so it looks uniform/good. 


## Main changes explained:
- Fixed padding around the user card so the background is longer than the card.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to dashboard→ Reports→ Reports→ People→ Choose Person
5. verify that the background is even

## Screenshots or videos of changes:

Before
![People Reports page BEFORE](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/108101478/895ec03d-afb8-40a4-8f83-9f72edea0a41)

After
![People Reports page AFTER](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/108101478/d0870900-02f2-43df-9308-11fe6e535c69)

[People Reports page padding issue.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/108101478/c32f304c-d6b7-49c5-8225-21020d8958ac)


