### PR TITLE
Yubo- Media Folder link Saved to mediaUrl in userProfile

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -440,10 +440,11 @@ function UserProfile(props) {
     if (activeTab !== tab) setActiveTab(tab);
   };
 
-  const updateLink = (personalLinksUpdate, adminLinksUpdate) => {
+  const updateLink = (personalLinksUpdate, adminLinksUpdate, mediaUrlUpdate) => {
     setShowModal(false);
     setUserProfile({
       ...userProfile,
+      mediaUrl:mediaUrlUpdate !== undefined ? mediaUrlUpdate : userProfile.mediaUrl,
       personalLinks: personalLinksUpdate,
       adminLinks: adminLinksUpdate,
     });

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -110,7 +110,7 @@ const EditLinkModal = props => {
     }
   };
 
-  const handleUpdate = () => {
+  const handleUpdate = async () => {
     const updatable =
       (isValidUrl(googleLink.Link) && isValidUrl(mediaFolderLink.Link)) ||
       (googleLink.Link === '' && mediaFolderLink.Link === '') ||
@@ -118,7 +118,12 @@ const EditLinkModal = props => {
       (isValidUrl(mediaFolderLink.Link) && googleLink.Link === '');
     if (updatable) {
       // * here the 'adminLinks' should be the total of 'googleLink' and 'adminLink'
-      updateLink(personalLinks, [googleLink, mediaFolderLink, ...adminLinks]);
+      // Media Folder link should update the mediaUrl in userProfile
+      if (mediaFolderLink.Link){
+        await updateLink(personalLinks, [googleLink, mediaFolderLink, ...adminLinks],mediaFolderLink.Link);
+      } else {
+        await updateLink(personalLinks, [googleLink, mediaFolderLink, ...adminLinks]);
+      }
       setIsValidLink(true);
       setIsChanged(true);
       closeModal();


### PR DESCRIPTION
# Description
Now updating `Media Folder` link in Profile will sync it to `mediaUrl` in the user's profile, and will be reflected in Weekly Summaries Report.

## Related PRS (if any):
#1132 

## Main changes explained:
- Update the `updateLink` method to include `mediaUrl` in `UserProfile.jsx` file.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user, make sure the user you choose has submitted at least one weekly summary along with a dropbox link.
4. go to the userProfile page -> Edit Link-> change `Media Folder` link to another link -> update -> **click Save changes**
5. Go to **Weekly Summaries Report** page and find the user's media URL, it should be the new link

## Screenshots or videos of changes:

## Note:

