### PR TITLE
Shihao - Improve Summary Loading Performance

### DIFF
--- a/src/components/UserProfile/EditableModal/roleInfoModal.jsx
+++ b/src/components/UserProfile/EditableModal/roleInfoModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { 
+import {
   Button,
   Modal,
   ModalBody,
@@ -8,7 +8,7 @@ import {
  } from 'reactstrap';
 
 const RoleInfoModal = ({info}) => {
-    const [isOpen, setOpen] = useState(false);  
+    const [isOpen, setOpen] = useState(false);
     const {infoContent, CanRead} = {...info};
     const handleMouseOver = () => {
       setOpen(true);
@@ -18,7 +18,7 @@ const RoleInfoModal = ({info}) => {
       setOpen(false);
     }
     if(CanRead){
-      return (<div>
+      return (<span>
         <i
           data-toggle="tooltip"
           data-placement="right"
@@ -32,8 +32,8 @@ const RoleInfoModal = ({info}) => {
           <Modal isOpen={isOpen} size="lg">
           <ModalHeader>Welcome to Information Page!</ModalHeader>
           <ModalBody>
-           <div 
-              style={{ paddingLeft: '20px' }} 
+           <div
+              style={{ paddingLeft: '20px' }}
               dangerouslySetInnerHTML={{ __html: infoContent }}/>
           </ModalBody>
           <ModalFooter>
@@ -41,12 +41,12 @@ const RoleInfoModal = ({info}) => {
           </ModalFooter>
           </Modal>
         )}
-      </div>)
+      </span>)
     }
     return (
         <>
         </>
-        
+
     )
 }
 

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -20,9 +20,10 @@ import {
   CardImg,
   CardText,
   UncontrolledPopover,
+  ListGroup,
+  ListGroupItem as LGI
 } from 'reactstrap';
 import RoleInfoModal from 'components/UserProfile/EditableModal/roleInfoModal';
-import { Input, ListGroup, ListGroupItem as LGI } from 'reactstrap';
 import useIsInViewPort from 'utils/useIsInViewPort';
 
 const textColors = {

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -353,9 +353,9 @@ const Index = ({summary, weekIndex, allRoleInfo}) => {
       <span>
         <b>&nbsp;&nbsp;{summary.role !== 'Volunteer' && `(${summary.role})`}</b>
       </span>
-      {summary.role !== 'Volunteer' && <div>
+      {summary.role !== 'Volunteer' &&
         <RoleInfoModal info={allRoleInfo.find(item => item.infoName === `${summary.role}`+'Info')} />
-      </div>}
+      }
       {showStar(hoursLogged, summary.promisedHoursByWeek[weekIndex]) && (
         <i
           className="fa fa-star"

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import 'moment-timezone';
 import ReactHtmlParser from 'react-html-parser';
 import { Link } from 'react-router-dom';
 import google_doc_icon from './google_doc_icon.png';
-import google_doc_icon_gray from './google_doc_icon_gray.png'; 
+import google_doc_icon_gray from './google_doc_icon_gray.png';
 import './WeeklySummariesReport.css';
 import { toast } from 'react-toastify';
 import ToggleSwitch from '../UserProfile/UserProfileEdit/ToggleSwitch';
@@ -13,7 +13,8 @@ import axios from 'axios';
 import { ENDPOINTS } from '../../utils/URL';
 import { assignStarDotColors, showStar } from 'utils/leaderboardPermissions';
 import RoleInfoModal from 'components/UserProfile/EditableModal/roleInfoModal';
-import { Input } from 'reactstrap';
+import { Input, ListGroup, ListGroupItem as LGI } from 'reactstrap';
+import useIsInViewPort from 'utils/useIsInViewPort';
 
 const textColors = {
   Default: '#000000',
@@ -28,6 +29,7 @@ const textColors = {
   'Team Amethyst': '#9400D3',
 };
 
+const ListGroupItem = ({children}) => <LGI className='px-0 border-0 py-1'>{children}</LGI>
 
 const FormattedReport = ({ summaries, weekIndex, bioCanEdit, canEditSummaryCount, allRoleInfo }) => {
   const emails = [];
@@ -38,11 +40,30 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit, canEditSummaryCount
     }
   });
 
-  //Necessary because our version of node is outdated
-  //and doesn't have String.prototype.replaceAll
-  let emailString = [...new Set(emails)].toString();
-  while (emailString.includes(',')) emailString = emailString.replace(',', '\n');
-  while (emailString.includes('\n')) emailString = emailString.replace('\n', ', ');
+  return (
+    <>
+      <ListGroup flush>
+        {summaries.map(summary => (
+          <ReportDetails
+            key={summary._id}
+            summary={summary}
+            weekIndex={weekIndex}
+            bioCanEdit={bioCanEdit}
+            canEditSummaryCount={canEditSummaryCount}
+            allRoleInfo={allRoleInfo}
+          />
+        ))}
+      </ListGroup>
+      <h4>Emails</h4>
+      <p>{emails.join(', ')}</p>
+    </>
+  )
+}
+
+
+const ReportDetails = ({ summary, weekIndex, bioCanEdit, canEditSummaryCount, allRoleInfo }) => {
+  const ref = useRef(null)
+  const isInViewPort = useIsInViewPort(ref)
 
   const getMediaUrlLink = summary => {
     if (summary.mediaUrl) {
@@ -51,7 +72,7 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit, canEditSummaryCount
           Open link to media files
         </a>
       );
-    } 
+    }
     else if(summary.adminLinks) {
       for (const link of summary.adminLinks) {
         if (link.Name === 'Media Folder'){
@@ -66,145 +87,169 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit, canEditSummaryCount
     return ('Not provided!')
   };
 
-  const getGoogleDocLink = summary => {
-    if (!summary.adminLinks) {
-      return undefined;
-    }
+  const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
 
-    const googleDocLink = summary.adminLinks.find(link => link.Name === 'Google Doc');
+  return (
+    <li className='list-group-item px-0' ref={ref}>
+      <ListGroup className='px-0' flush>
+        <Index summary={summary} weekIndex={weekIndex} allRoleInfo={allRoleInfo} />
+        {isInViewPort && <>
+          <ListGroupItem>
+            <b>Media URL:</b> {getMediaUrlLink(summary)}
+          </ListGroupItem>
+          <ListGroupItem>
+            <Bio
+              bioCanEdit={bioCanEdit}
+              userId={summary._id}
+              bioPosted={summary.bioPosted}
+              summary={summary}
+              totalTangibleHrs={summary.totalTangibleHrs}
+              daysInTeam={summary.daysInTeam}
+            />
+          </ListGroupItem>
+          <ListGroupItem>
+            <TotalValidWeeklySummaries summary={summary} canEditSummaryCount={canEditSummaryCount} />
+          </ListGroupItem>
+          {hoursLogged >= summary.promisedHoursByWeek[weekIndex] && (
+            <ListGroupItem>
+              <p>
+                <b
+                  style={{
+                    color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
+                  }}
+                >
+                  Hours logged:{' '}
+                </b>
+                {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
+              </p>
+            </ListGroupItem>
+          )}
+          {hoursLogged < summary.promisedHoursByWeek[weekIndex] && (
+            <ListGroupItem>
+              <b style={{color: textColors[summary?.weeklySummaryOption] || textColors['Default']}} >
+                Hours logged:
+              </b>
+              <span className='ml-2'>{hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}</span>
+            </ListGroupItem>
+          )}
+          <ListGroupItem>
+            <WeeklySummaryMessage summary={summary} weekIndex={weekIndex} />
+          </ListGroupItem>
+        </>}
+      </ListGroup>
+    </li>
+  );
+};
 
-    return googleDocLink;
-  };
-
-  const getWeeklySummaryMessage = summary => {
-    const textColors = {
-      Default: '#000000',
-      'Not Required': '#708090',
-      Team: '#FF00FF',
-      'Team Fabulous': '#FF00FF',
-      'Team Marigold': '#FF7F00',
-      'Team Luminous': '#C4AF18',
-      'Team Lush': '#00FF00',
-      'Team Skye': '#29C5F6',
-      'Team Azure': '#2B35AF',
-      'Team Amethyst': '#9400D3',
-    };
-    
-    if (!summary) {
-      return (
-        <p>
-          <b>Weekly Summary:</b> Not provided!
-        </p>
-      );
-    }
-
-    const summaryText = summary?.weeklySummaries[weekIndex]?.summary;
-    let summaryDate = moment()
-      .tz('America/Los_Angeles')
-      .endOf('week')
-      .subtract(weekIndex, 'week')
-      .format('YYYY-MMM-DD');
-    let summaryDateText = `Weekly Summary (${summaryDate}):`;
-    const summaryContent = (() => {
-      if (summaryText) {
-        const style = {
-          color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
-        };
-
-        summaryDate = moment(summary.weeklySummaries[weekIndex]?.uploadDate)
-          .tz('America/Los_Angeles')
-          .format('YYYY-MMM-DD');
-        summaryDateText = `Summary Submitted On (${summaryDate}):`;
-
-        return <div style={style}>{ReactHtmlParser(summaryText)}</div>;
-      } else {
-        if (
-          summary?.weeklySummaryOption === 'Not Required' ||
-          (!summary?.weeklySummaryOption && summary.weeklySummaryNotReq)
-        ) {
-          return <p style={{ color: textColors['Not Required'] }}>Not required for this user</p>;
-        } else {
-          return <span style={{ color: 'red' }}>Not provided!</span>;
-        }
-      }
-    })();
-
+const WeeklySummaryMessage = ({summary, weekIndex}) => {
+  if (!summary) {
     return (
-      <>
-        <p>
-          <b>{summaryDateText}</b>
-        </p>
-        {summaryContent}
-      </>
+      <p>
+        <b>Weekly Summary:</b> Not provided!
+      </p>
     );
-  };
+  }
 
-  const getTotalValidWeeklySummaries = summary => {
+  const summaryText = summary?.weeklySummaries[weekIndex]?.summary;
+  let summaryDate = moment()
+    .tz('America/Los_Angeles')
+    .endOf('week')
+    .subtract(weekIndex, 'week')
+    .format('YYYY-MMM-DD');
+  let summaryDateText = `Weekly Summary (${summaryDate}):`;
+  const summaryContent = (() => {
+    if (summaryText) {
+      const style = {
+        color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
+      };
 
-    const style = {
-      color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
-    };
-    
-    const [weeklySummariesCount, setWeeklySummariesCount] = useState(parseInt(summary.weeklySummariesCount));
-    
-    const handleOnChange = async (userProfileSummary, count) => {
-      const url = ENDPOINTS.USER_PROFILE_PROPERTY(userProfileSummary._id)
-      try {
-        await axios.patch(url, {key: 'weeklySummariesCount', value: count});
-      } catch (err) {
-        alert('An error occurred while attempting to save the new weekly summaries count change to the profile.');
-      }
-    };
+      summaryDate = moment(summary.weeklySummaries[weekIndex]?.uploadDate)
+        .tz('America/Los_Angeles')
+        .format('YYYY-MMM-DD');
+      summaryDateText = `Summary Submitted On (${summaryDate}):`;
 
-    const handleWeeklySummaryCountChange = e => {
-        setWeeklySummariesCount(e.target.value);
-        handleOnChange(summary, e.target.value);
-      }
-    
-    return (
-      <div className='total-valid-wrapper'>
-        {weeklySummariesCount === 8 ? 
-        <div className='total-valid-text' style={style}>
-          <b>Total Valid Weekly Summaries:</b>{' '}
-        </div> : 
-        <div className='total-valid-text'>
-          <b style={style}>
-            Total Valid Weekly Summaries:
-          </b>{' '}
-        </div>
-        }
-        {canEditSummaryCount ? 
-        <div style={{width: '150px', paddingLeft: "5px"}}>
-          <Input 
-              type='number' 
-              name='weeklySummaryCount' 
-              step='1'
-              value={weeklySummariesCount} 
-              onChange={e => handleWeeklySummaryCountChange(e)}
-              min='0'
-          />
-        </div> : 
-        <div>&nbsp;{weeklySummariesCount || 'No valid submissions yet!'}</div>
-        } 
-      </div>
-    )
-  };
-
-  const handleGoogleDocClick = googleDocLink => {
-    const toastGoogleLinkDoesNotExist = 'toast-on-click';
-    if (googleDocLink && googleDocLink.Link && googleDocLink.Link.trim() !== '') {
-      window.open(googleDocLink.Link);
+      return <div style={style}>{ReactHtmlParser(summaryText)}</div>;
     } else {
-      toast.error(
-        'Uh oh, no Google Doc is present for this user! Please contact an Admin to find out why.',
-        {
-          toastId: toastGoogleLinkDoesNotExist,
-          pauseOnFocusLoss: false,
-          autoClose: 3000,
-        },
-      );
+      if (
+        summary?.weeklySummaryOption === 'Not Required' ||
+        (!summary?.weeklySummaryOption && summary.weeklySummaryNotReq)
+      ) {
+        return <p style={{ color: textColors['Not Required'] }}>Not required for this user</p>;
+      } else {
+        return <span style={{ color: 'red' }}>Not provided!</span>;
+      }
+    }
+  })();
+
+  return (
+    <>
+      <p>
+        <b>{summaryDateText}</b>
+      </p>
+      {summaryContent}
+    </>
+  );
+};
+
+const TotalValidWeeklySummaries = ({summary, canEditSummaryCount}) => {
+
+  const style = {
+    color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
+  };
+
+  const [weeklySummariesCount, setWeeklySummariesCount] = useState(parseInt(summary.weeklySummariesCount));
+
+  const handleOnChange = async (userProfileSummary, count) => {
+    const url = ENDPOINTS.USER_PROFILE_PROPERTY(userProfileSummary._id)
+    try {
+      await axios.patch(url, {key: 'weeklySummariesCount', value: count});
+    } catch (err) {
+      alert('An error occurred while attempting to save the new weekly summaries count change to the profile.');
     }
   };
+
+  const handleWeeklySummaryCountChange = e => {
+      setWeeklySummariesCount(e.target.value);
+      handleOnChange(summary, e.target.value);
+    }
+
+  return (
+    <div className='total-valid-wrapper'>
+      {weeklySummariesCount === 8 ?
+      <div className='total-valid-text' style={style}>
+        <b>Total Valid Weekly Summaries:</b>{' '}
+      </div> :
+      <div className='total-valid-text'>
+        <b style={style}>
+          Total Valid Weekly Summaries:
+        </b>{' '}
+      </div>
+      }
+      {canEditSummaryCount ?
+      <div style={{width: '150px', paddingLeft: "5px"}}>
+        <Input
+          type='number'
+          name='weeklySummaryCount'
+          step='1'
+          value={weeklySummariesCount}
+          onChange={e => handleWeeklySummaryCountChange(e)}
+          min='0'
+        />
+      </div> :
+      <div>&nbsp;{weeklySummariesCount || 'No valid submissions yet!'}</div>
+      }
+    </div>
+  )
+};
+
+const Bio = ({bioCanEdit, ...props}) => {
+  return bioCanEdit ? <BioSwitch {...props} /> : <BioLabel {...props} />
+}
+
+const BioSwitch = ({userId, bioPosted, summary, totalTangibleHrs, daysInTeam}) => {
+  const [bioStatus, setBioStatus] = useState(bioPosted);
+  const isMeetCriteria = totalTangibleHrs > 80 && daysInTeam > 60 && bioPosted !== "posted"
+  const style = { color: textColors[summary?.weeklySummaryOption] || textColors['Default'] };
 
   const handleChangeBioPosted = async (userId, bioStatus) => {
     try {
@@ -223,147 +268,120 @@ const FormattedReport = ({ summaries, weekIndex, bioCanEdit, canEditSummaryCount
     }
   };
 
-  const BioSwitch = (userId, bioPosted, summary, weeklySummaryOption, totalTangibleHrs, daysInTeam) => {
-    const [bioStatus, setBioStatus] = useState(bioPosted);
-    const isMeetCriteria = totalTangibleHrs > 80 && daysInTeam > 60 && bioPosted !== "posted"
-    const style = {
-      color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
-    };
-    return (
-      <div style={isMeetCriteria ? {backgroundColor: "yellow"}: {}}> 
-        <div className="bio-toggle">
-          <b style={style}>Bio announcement:</b>
-        </div>
-        <div className="bio-toggle">
-          <ToggleSwitch
-            switchType="bio"
-            state={bioStatus}
-            handleUserProfile={bio => {
-              setBioStatus(bio);
-              handleChangeBioPosted(userId, bio);
-            }}
-          />
-        </div>
-      </div>
-    );
-  };
-
-  const BioLabel = (userId, bioPosted, summary) => {
-    const style = {
-      color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
-    };
-    return (
-      <div>
-        <b style={style}>Bio announcement:</b>
-        {bioPosted === 'default'
-          ? ' Not requested/posted'
-          : bioPosted === 'posted'
-          ? ' Posted'
-          : ' Requested'}
-      </div>
-    );
-  };
-
-  const bioFunction = bioCanEdit ? BioSwitch : BioLabel;
-
   return (
-    <>
-      {summaries.map((summary, index) => {
-        const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
-
-        const googleDocLink = getGoogleDocLink(summary);
-        // Determine whether to use grayscale or color icon based on googleDocLink
-        const googleDocIcon = googleDocLink && googleDocLink.Link.trim() !== ''
-          ? google_doc_icon
-          : google_doc_icon_gray;
-        return (
-          <div
-            style={{ padding: '20px 0', marginTop: '5px', borderBottom: '1px solid #DEE2E6' }}
-            key={'summary-' + index}
-          >
-            <div style={{display:'flex'}}>
-              <b>Name: </b>
-              <Link style={{marginLeft:'5px'}}
-                to={`/userProfile/${summary._id}`} title="View Profile">
-                {summary.firstName} {summary.lastName}
-              </Link>
-
-              <span onClick={() => handleGoogleDocClick(googleDocLink)}>
-                <img className="google-doc-icon" src={googleDocIcon } alt="google_doc" />
-              </span>
-              <span>
-                <b>&nbsp;&nbsp;{summary.role !== 'Volunteer' && `(${summary.role})`}</b>
-              </span>
-               <div>
-                    {(summary.role !== 'Volunteer')&& <RoleInfoModal info={allRoleInfo.find(item => item.infoName === `${summary.role}`+'Info')} />}
-               </div>
-              {showStar(hoursLogged, summary.promisedHoursByWeek[weekIndex]) && (
-                <i
-                  className="fa fa-star"
-                  title={`Weekly Committed: ${summary.promisedHoursByWeek[weekIndex]} hours`}
-                  style={{
-                    color: assignStarDotColors(hoursLogged, summary.promisedHoursByWeek[weekIndex]),
-                    fontSize: '55px',
-                    marginLeft: '10px',
-                    verticalAlign: 'middle',
-                    position: 'relative',
-                  }}
-                >
-                  <span
-                    style={{
-                      position: 'absolute',
-                      top: '50%',
-                      left: '50%',
-                      transform: 'translate(-50%, -50%)',
-                      color: 'white',
-                      fontWeight: 'bold',
-                      fontSize: '10px',
-                    }}
-                  >
-                    +{Math.round((hoursLogged / summary.promisedHoursByWeek[weekIndex] - 1) * 100)}%
-                  </span>
-                </i>
-              )}
-            </div>
-            <div>
-              {' '}
-              <b>Media URL:</b> {getMediaUrlLink(summary)}
-            </div>
-            {bioFunction(summary._id, summary.bioPosted, summary, summary.weeklySummaryOption, summary.totalTangibleHrs, summary.daysInTeam)}
-            {getTotalValidWeeklySummaries(summary)}
-            {hoursLogged >= summary.promisedHoursByWeek[weekIndex] && (
-              <p>
-                <b
-                  style={{
-                    color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
-                  }}
-                >
-                  Hours logged:{' '}
-                </b>
-                {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
-              </p>
-            )}
-            {hoursLogged < summary.promisedHoursByWeek[weekIndex] && (
-              <p>
-                <b
-                  style={{
-                    color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
-                  }}
-                >
-                  Hours logged:
-                </b>{' '}
-                {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
-              </p>
-            )}
-            {getWeeklySummaryMessage(summary)}
-          </div>
-        );
-      })}
-      <h4>Emails</h4>
-      <p>{emailString}</p>
-    </>
+    <div style={isMeetCriteria ? {backgroundColor: "yellow"}: {}}>
+      <div className="bio-toggle">
+        <b style={style}>Bio announcement:</b>
+      </div>
+      <div className="bio-toggle">
+        <ToggleSwitch
+          switchType="bio"
+          state={bioStatus}
+          handleUserProfile={bio => {
+            setBioStatus(bio);
+            handleChangeBioPosted(userId, bio);
+          }}
+        />
+      </div>
+    </div>
   );
 };
+
+const BioLabel = ({bioPosted, summary}) => {
+  const style = {
+    color: textColors[summary?.weeklySummaryOption] || textColors['Default'],
+  };
+  return (
+    <div>
+      <b style={style}>Bio announcement:</b>
+      {bioPosted === 'default'
+        ? ' Not requested/posted'
+        : bioPosted === 'posted'
+        ? ' Posted'
+        : ' Requested'}
+    </div>
+  );
+};
+
+const Index = ({summary, weekIndex, allRoleInfo}) => {
+  const handleGoogleDocClick = googleDocLink => {
+    const toastGoogleLinkDoesNotExist = 'toast-on-click';
+    if (googleDocLink && googleDocLink.Link && googleDocLink.Link.trim() !== '') {
+      window.open(googleDocLink.Link);
+    } else {
+      toast.error(
+        'Uh oh, no Google Doc is present for this user! Please contact an Admin to find out why.',
+        {
+          toastId: toastGoogleLinkDoesNotExist,
+          pauseOnFocusLoss: false,
+          autoClose: 3000,
+        },
+      );
+    }
+  };
+
+  const getGoogleDocLink = summary => {
+    if (!summary.adminLinks) {
+      return undefined;
+    }
+    const googleDocLink = summary.adminLinks.find(link => link.Name === 'Google Doc');
+    return googleDocLink;
+  };
+
+  const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
+
+  const googleDocLink = getGoogleDocLink(summary);
+  // Determine whether to use grayscale or color icon based on googleDocLink
+  const googleDocIcon = googleDocLink && googleDocLink.Link.trim() !== ''
+    ? google_doc_icon
+    : google_doc_icon_gray;
+
+  return (
+    <ListGroupItem>
+      <b>Name: </b>
+      <Link className='ml-2'
+        to={`/userProfile/${summary._id}`} title="View Profile">
+        {summary.firstName} {summary.lastName}
+      </Link>
+
+      <span onClick={() => handleGoogleDocClick(googleDocLink)}>
+        <img className="google-doc-icon" src={googleDocIcon } alt="google_doc" />
+      </span>
+      <span>
+        <b>&nbsp;&nbsp;{summary.role !== 'Volunteer' && `(${summary.role})`}</b>
+      </span>
+      <div>
+          {(summary.role !== 'Volunteer') && <RoleInfoModal info={allRoleInfo.find(item => item.infoName === `${summary.role}`+'Info')} />}
+      </div>
+      {showStar(hoursLogged, summary.promisedHoursByWeek[weekIndex]) && (
+        <i
+          className="fa fa-star"
+          title={`Weekly Committed: ${summary.promisedHoursByWeek[weekIndex]} hours`}
+          style={{
+            color: assignStarDotColors(hoursLogged, summary.promisedHoursByWeek[weekIndex]),
+            fontSize: '55px',
+            marginLeft: '10px',
+            verticalAlign: 'middle',
+            position: 'relative',
+          }}
+        >
+          <span
+            style={{
+              position: 'absolute',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              color: 'white',
+              fontWeight: 'bold',
+              fontSize: '10px',
+            }}
+          >
+            +{Math.round((hoursLogged / summary.promisedHoursByWeek[weekIndex] - 1) * 100)}%
+          </span>
+        </i>
+      )}
+    </ListGroupItem>)
+}
 
 FormattedReport.propTypes = {
   summaries: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -65,37 +65,17 @@ const ReportDetails = ({ summary, weekIndex, bioCanEdit, canEditSummaryCount, al
   const ref = useRef(null)
   const isInViewPort = useIsInViewPort(ref)
 
-  const getMediaUrlLink = summary => {
-    if (summary.mediaUrl) {
-      return (
-        <a href={summary.mediaUrl} target="_blank" rel="noopener noreferrer">
-          Open link to media files
-        </a>
-      );
-    }
-    else if(summary.adminLinks) {
-      for (const link of summary.adminLinks) {
-        if (link.Name === 'Media Folder'){
-          return (
-            <a href={link.Link} target="_blank" rel="noopener noreferrer">
-              Open link to media files
-            </a>
-          )
-        }
-      }
-    }
-    return ('Not provided!')
-  };
-
   const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
 
   return (
     <li className='list-group-item px-0' ref={ref}>
       <ListGroup className='px-0' flush>
-        <Index summary={summary} weekIndex={weekIndex} allRoleInfo={allRoleInfo} />
+        <ListGroupItem>
+          <Index summary={summary} weekIndex={weekIndex} allRoleInfo={allRoleInfo} />
+        </ListGroupItem>
         {isInViewPort && <>
           <ListGroupItem>
-            <b>Media URL:</b> {getMediaUrlLink(summary)}
+            <b>Media URL:</b> <MediaUrlLink summary={summary} />
           </ListGroupItem>
           <ListGroupItem>
             <Bio
@@ -191,6 +171,29 @@ const WeeklySummaryMessage = ({summary, weekIndex}) => {
   );
 };
 
+const MediaUrlLink = ({summary}) => {
+  if (summary.mediaUrl) {
+    return (
+      <a href={summary.mediaUrl} target="_blank" rel="noopener noreferrer">
+        Open link to media files
+      </a>
+    );
+  }
+
+  if(summary.adminLinks) {
+    for (const link of summary.adminLinks) {
+      if (link.Name === 'Media Folder'){
+        return (
+          <a href={link.Link} target="_blank" rel="noopener noreferrer">
+            Open link to media files
+          </a>
+        )
+      }
+    }
+  }
+  return ('Not provided!')
+};
+
 const TotalValidWeeklySummaries = ({summary, canEditSummaryCount}) => {
 
   const style = {
@@ -222,11 +225,11 @@ const TotalValidWeeklySummaries = ({summary, canEditSummaryCount}) => {
       <div className='total-valid-text'>
         <b style={style}>
           Total Valid Weekly Summaries:
-        </b>{' '}
+        </b>
       </div>
       }
       {canEditSummaryCount ?
-      <div style={{width: '150px', paddingLeft: "5px"}}>
+      <div className='pl-2' style={{width: '150px'}}>
         <Input
           type='number'
           name='weeklySummaryCount'
@@ -337,7 +340,7 @@ const Index = ({summary, weekIndex, allRoleInfo}) => {
     : google_doc_icon_gray;
 
   return (
-    <ListGroupItem>
+    <>
       <b>Name: </b>
       <Link className='ml-2'
         to={`/userProfile/${summary._id}`} title="View Profile">
@@ -350,9 +353,9 @@ const Index = ({summary, weekIndex, allRoleInfo}) => {
       <span>
         <b>&nbsp;&nbsp;{summary.role !== 'Volunteer' && `(${summary.role})`}</b>
       </span>
-      <div>
-          {(summary.role !== 'Volunteer') && <RoleInfoModal info={allRoleInfo.find(item => item.infoName === `${summary.role}`+'Info')} />}
-      </div>
+      {summary.role !== 'Volunteer' && <div>
+        <RoleInfoModal info={allRoleInfo.find(item => item.infoName === `${summary.role}`+'Info')} />
+      </div>}
       {showStar(hoursLogged, summary.promisedHoursByWeek[weekIndex]) && (
         <i
           className="fa fa-star"
@@ -380,7 +383,7 @@ const Index = ({summary, weekIndex, allRoleInfo}) => {
           </span>
         </i>
       )}
-    </ListGroupItem>)
+    </>)
 }
 
 FormattedReport.propTypes = {

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -11,8 +11,6 @@ import FormattedReport from './FormattedReport';
 import GeneratePdfReport from './GeneratePdfReport';
 import hasPermission from '../../utils/permissions';
 import { getInfoCollections } from '../../actions/information';
-import axios from 'axios';
-import { ENDPOINTS } from '../../utils/URL';
 
 const navItems = [
   'This Week',
@@ -43,20 +41,6 @@ export class WeeklySummariesReport extends Component {
     this.canPutUserProfileImportantInfo = this.props.hasPermission('putUserProfileImportantInfo');
     this.bioEditPermission = this.canPutUserProfileImportantInfo;
     this.canEditSummaryCount = this.canPutUserProfileImportantInfo;
-
-    const now = moment().tz('America/Los_Angeles')
-
-    const summaryPromise = this.props.summaries.map(async summary => {
-      const url = ENDPOINTS.USER_PROFILE(summary._id);
-      const response = await axios.get(url);
-      const startDate = moment(response.data.createdDate).tz('America/Los_Angeles')
-      const diff = now.diff(startDate, "days")
-      summary.daysInTeam = diff
-      const totalHours = Object.values(response.data.hoursByCategory).reduce((prev, curr) => prev + curr, 0);
-      summary.totalTangibleHrs = totalHours
-    })
-
-    await Promise.all(summaryPromise)
 
     // 2. shallow copy and sort
     let summariesCopy = [...this.props.summaries];

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Alert, Container, Row, Col, TabContent, TabPane, Nav, NavItem, NavLink } from 'reactstrap';
 import './WeeklySummariesReport.css';
-import classnames from 'classnames';
 import moment from 'moment';
 import 'moment-timezone';
 import SkeletonLoading from '../common/SkeletonLoading';
@@ -15,6 +14,13 @@ import { getInfoCollections } from '../../actions/information';
 import axios from 'axios';
 import { ENDPOINTS } from '../../utils/URL';
 
+const navItems = [
+  'This Week',
+  'Last Week',
+  'Week Before Last',
+  'Three Weeks Ago'
+]
+
 export class WeeklySummariesReport extends Component {
   constructor(props) {
     super(props);
@@ -23,7 +29,7 @@ export class WeeklySummariesReport extends Component {
       error: null,
       loading: true,
       summaries: [],
-      activeTab: '2',
+      activeTab: navItems[1],
     };
 
     this.weekDates = Array(4)
@@ -72,7 +78,7 @@ export class WeeklySummariesReport extends Component {
       summaries: summariesCopy,
       activeTab:
         sessionStorage.getItem('tabSelection') === null
-          ? '2'
+          ? navItems[1]
           : sessionStorage.getItem('tabSelection'),
     });
     await this.props.getInfoCollections();
@@ -82,8 +88,8 @@ export class WeeklySummariesReport extends Component {
     const allRoleInfo = [];
     if (Array.isArray(infoCollections)) {
       infoCollections.forEach((info) => {
-        if(roleInfoNames.includes(info.infoName)) {
-          let visible = (info.visibility === '0') || 
+        if(roleInfoNames?.includes(info.infoName)) {
+          let visible = (info.visibility === '0') ||
           (info.visibility === '1' && (role==='Owner' || role==='Administrator')) ||
           (info.visibility=== '2' && (role !== 'Volunteer'));
           info.CanRead = visible;
@@ -205,144 +211,46 @@ export class WeeklySummariesReport extends Component {
         <Row>
           <Col lg={{ size: 10, offset: 1 }}>
             <Nav tabs>
-              <NavItem>
-                <NavLink
-                  className={classnames({ active: activeTab === '1' })}
-                  data-testid="tab-1"
-                  onClick={() => this.toggleTab('1')}
-                >
-                  This Week
-                </NavLink>
-              </NavItem>
-              <NavItem>
-                <NavLink
-                  className={classnames({ active: activeTab === '2' })}
-                  data-testid="tab-2"
-                  onClick={() => this.toggleTab('2')}
-                >
-                  Last Week
-                </NavLink>
-              </NavItem>
-              <NavItem>
-                <NavLink
-                  className={classnames({ active: activeTab === '3' })}
-                  data-testid="tab-3"
-                  onClick={() => this.toggleTab('3')}
-                >
-                  Week Before Last
-                </NavLink>
-              </NavItem>
-              <NavItem>
-                <NavLink
-                  className={classnames({ active: activeTab === '4' })}
-                  data-testid="tab-4"
-                  onClick={() => this.toggleTab('4')}
-                >
-                  Three Weeks Ago
-                </NavLink>
-              </NavItem>
+              {navItems.map(item => (
+                <NavItem key={item}>
+                  <NavLink
+                    href='#'
+                    data-testid={item}
+                    active={item === activeTab}
+                    onClick={() => this.toggleTab(item)}
+                  >
+                    {item}
+                  </NavLink>
+                </NavItem>))}
             </Nav>
             <TabContent activeTab={activeTab} className="p-4">
-              <TabPane tabId="1">
-                <Row>
-                  <Col sm="12" md="8" className="mb-2">
-                    From <b>{this.weekDates[0].fromDate}</b> to <b>{this.weekDates[0].toDate}</b>
-                  </Col>
-                  <Col sm="12" md="4">
-                    <GeneratePdfReport
-                      summaries={summaries}
-                      weekIndex={0}
-                      weekDates={this.weekDates[0]}
-                    />
-                  </Col>
-                </Row>
-                <Row>
-                  <Col>
-                    <FormattedReport
-                      summaries={summaries}
-                      weekIndex={0}
-                      bioCanEdit={this.bioEditPermission}
-                      canEditSummaryCount={this.canEditSummaryCount}
-                      allRoleInfo={this.state.allRoleInfo}
-                    />
-                  </Col>
-                </Row>
-              </TabPane>
-              <TabPane tabId="2">
-                <Row>
-                  <Col sm="12" md="8" className="mb-2">
-                    From <b>{this.weekDates[1].fromDate}</b> to <b>{this.weekDates[1].toDate}</b>
-                  </Col>
-                  <Col sm="12" md="4">
-                    <GeneratePdfReport
-                      summaries={summaries}
-                      weekIndex={1}
-                      weekDates={this.weekDates[1]}
-                    />
-                  </Col>
-                </Row>
-                <Row>
-                  <Col>
-                    <FormattedReport
-                      summaries={summaries}
-                      weekIndex={1}
-                      bioCanEdit={this.bioEditPermission}
-                      canEditSummaryCount={this.canEditSummaryCount}
-                      allRoleInfo={this.state.allRoleInfo}
-                    />
-                  </Col>
-                </Row>
-              </TabPane>
-              <TabPane tabId="3">
-                <Row>
-                  <Col sm="12" md="8" className="mb-2">
-                    From <b>{this.weekDates[2].fromDate}</b> to <b>{this.weekDates[2].toDate}</b>
-                  </Col>
-                  <Col sm="12" md="4">
-                    <GeneratePdfReport
-                      summaries={summaries}
-                      weekIndex={2}
-                      weekDates={this.weekDates[2]}
-                    />
-                  </Col>
-                </Row>
-                <Row>
-                  <Col>
-                    <FormattedReport
-                      summaries={summaries}
-                      weekIndex={2}
-                      bioCanEdit={this.bioEditPermission}
-                      canEditSummaryCount={this.canEditSummaryCount}
-                      allRoleInfo={this.state.allRoleInfo}
-                    />
-                  </Col>
-                </Row>
-              </TabPane>
-              <TabPane tabId="4">
-                <Row>
-                  <Col sm="12" md="8" className="mb-2">
-                    From <b>{this.weekDates[3].fromDate}</b> to <b>{this.weekDates[3].toDate}</b>
-                  </Col>
-                  <Col sm="12" md="4">
-                    <GeneratePdfReport
-                      summaries={summaries}
-                      weekIndex={3}
-                      weekDates={this.weekDates[3]}
-                    />
-                  </Col>
-                </Row>
-                <Row>
-                  <Col>
-                    <FormattedReport
-                      summaries={summaries}
-                      weekIndex={3}
-                      bioCanEdit={this.bioEditPermission}
-                      canEditSummaryCount={this.canEditSummaryCount}
-                      allRoleInfo={this.state.allRoleInfo}
-                    />
-                  </Col>
-                </Row>
-              </TabPane>
+              {navItems.map((item, index) => (
+                <WeeklySummariesReportTab tabId={item} key={item} hidden={item !== activeTab}>
+                  <Row>
+                    <Col sm="12" md="8" className="mb-2">
+                      From <b>{this.weekDates[index].fromDate}</b> to <b>{this.weekDates[index].toDate}</b>
+                    </Col>
+                    <Col sm="12" md="4">
+                      <GeneratePdfReport
+                        summaries={summaries}
+                        weekIndex={index}
+                        weekDates={this.weekDates[index]}
+                      />
+                    </Col>
+                  </Row>
+                  <Row>
+                    <Col>
+                      <FormattedReport
+                        summaries={summaries}
+                        weekIndex={index}
+                        bioCanEdit={this.bioEditPermission}
+                        canEditSummaryCount={this.canEditSummaryCount}
+                        allRoleInfo={this.state.allRoleInfo}
+                      />
+                    </Col>
+                  </Row>
+                </WeeklySummariesReportTab>
+              ))}
             </TabContent>
           </Col>
         </Row>
@@ -366,5 +274,11 @@ const mapStateToProps = state => ({
   summaries: state.weeklySummariesReport.summaries,
   infoCollections:state.infoCollections.infos,
 });
+
+const WeeklySummariesReportTab = ({tabId, hidden, children}) => {
+  return (
+    <TabPane tabId={tabId}>{!hidden && children}</TabPane>
+  )
+};
 
 export default connect(mapStateToProps, { getWeeklySummariesReport, hasPermission, getInfoCollections })(WeeklySummariesReport);

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.test.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.test.jsx
@@ -72,28 +72,29 @@ describe('WeeklySummariesReport page', () => {
     });
 
     it('should have second tab set to "active" by default', () => {
-      expect(screen.getByTestId('tab-2').classList.contains('active')).toBe(true);
+      expect(screen.getByTestId('Last Week').classList.contains('active')).toBe(true);
+      expect(screen.getBy)
     });
 
     it('should make 1st tab active when clicked', () => {
       // First tab click.
-      fireEvent.click(screen.getByTestId('tab-1'));
-      expect(screen.getByTestId('tab-1').classList.contains('active')).toBe(true);
+      fireEvent.click(screen.getByTestId('This Week'));
+      expect(screen.getByTestId('This Week').classList.contains('active')).toBe(true);
     });
     it('should make 2nd tab active when clicked', () => {
       // Second tab click.
-      fireEvent.click(screen.getByTestId('tab-2'));
-      expect(screen.getByTestId('tab-2').classList.contains('active')).toBe(true);
+      fireEvent.click(screen.getByTestId('Last Week'));
+      expect(screen.getByTestId('Last Week').classList.contains('active')).toBe(true);
     });
     it('should make 3rd tab active when clicked', () => {
       // Third tab click.
-      fireEvent.click(screen.getByTestId('tab-3'));
-      expect(screen.getByTestId('tab-3').classList.contains('active')).toBe(true);
+      fireEvent.click(screen.getByTestId('Week Before Last'));
+      expect(screen.getByTestId('Week Before Last').classList.contains('active')).toBe(true);
     });
     it('should make 4th tab active when clicked', () => {
       // Fourth tab click.
-      fireEvent.click(screen.getByTestId('tab-4'));
-      expect(screen.getByTestId('tab-4').classList.contains('active')).toBe(true);
+      fireEvent.click(screen.getByTestId('Three Weeks Ago'));
+      expect(screen.getByTestId('Three Weeks Ago').classList.contains('active')).toBe(true);
     });
   });
 });

--- a/src/utils/useIsInViewPort.js
+++ b/src/utils/useIsInViewPort.js
@@ -1,0 +1,23 @@
+const { useMemo, useEffect, useState } = require("react");
+
+/**
+ * Check if the dom is in view port
+ * @returns {boolean} setIsIntersecting
+*/
+const useIsInViewPort = (ref) => {
+  const [isIntersecting, setIsIntersecting] = useState(false);
+
+  const observer = useMemo(() =>
+    new IntersectionObserver(([entry]) => setIsIntersecting(entry.isIntersecting))
+  , []);
+
+  useEffect(() => {
+    observer.observe(ref.current);
+
+    return () => observer.disconnect();
+  }, [ref, observer]);
+
+  return isIntersecting;
+}
+
+export default useIsInViewPort


### PR DESCRIPTION
# Description
![Screenshot 2023-08-24 at 17 51 20](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/62367016/48acf93f-bc50-4a9c-b3df-745561cee84f)


## Related PRS (if any):
This frontend PR is related to the [#484](https://github.com/OneCommunityGlobal/HGNRest/pull/484) backend PR.

## Main changes explained:
- Refactor `FormattedReport` component
- Adjust query to reduce HTTP request
- Add an observer to check if the dom is visible

## How to test:
1. check into `development` first
2. log as owner user
3. go to dashboard→ Reports→ Weekly Summaries Report
4. wait for page fully loaded


1. then check into current branch
6. log as owner user
7. go to dashboard→ Reports→ Weekly Summaries Report
8. check if the page load faster than dev branch

## Screenshots or videos of changes:
**Dev branch**

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/62367016/422d6e50-7070-4294-a1c3-692c0960f6a9

**After changes**

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/62367016/0e6aca47-9f33-4ca9-a12f-27e541f825ab
