### PR TITLE
Haohui - Make tasks list only suggest active members

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -27,7 +27,7 @@ function AddTaskModal(props) {
       return allProjects.projects.find(({ _id }) => _id === props.projectId).category;
     }  
   }, []);
-
+  console.log(allMembers)
   const [taskName, setTaskName] = useState('');
   const [priority, setPriority] = useState('Primary');
   const [resourceItems, setResourceItems] = useState([]);

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -27,7 +27,6 @@ function AddTaskModal(props) {
       return allProjects.projects.find(({ _id }) => _id === props.projectId).category;
     }  
   }, []);
-  console.log(allMembers)
   const [taskName, setTaskName] = useState('');
   const [priority, setPriority] = useState('Primary');
   const [resourceItems, setResourceItems] = useState([]);
@@ -338,7 +337,7 @@ function AddTaskModal(props) {
                   <div>
                     <TagsSearch
                       placeholder="Add resources"
-                      members={allMembers}
+                      members={allMembers.filter(user=>user.isActive)}
                       addResources={addResources}
                       removeResource={removeResource}
                       resourceItems={resourceItems}

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -290,7 +290,7 @@ const EditTaskModal = props => {
                   <div>
                     <TagsSearch
                       placeholder="Add resources"
-                      members={allMembers}
+                      members={allMembers.filter(user=>user.isActive)}
                       addResources={addResources}
                       removeResource={removeResource}
                       resourceItems={resourceItems}


### PR DESCRIPTION
# Description
(PRIORITY HIGH) Jae: Make tasks list only suggest active members(WIP Haohui)
Other Links -> Projects -> WBS -> Pick any -> Add Task -> Resources
Reminder a person has to be a member of the Project (can be added on Profile Page, Projects Management, or during setup) to be added to a task within the Project
This list used to show only active team members. Please help restore this limitation, no need to see inactive members in this list, it slows the selection process. 
Anyone taking this should be able to finish it this week. If not, I'll have Xiao W do it next week. It'll take him less than a couple hours.


## Main changes explained:
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin/owner user, call this User A
4. go to Other Links -> Projects -> WBS -> Pick any -> Add Task -> Resources…
5. log out then login another user, call the User B, inactive account in "View Profile" 
6. login user A, go to WBS and open Add Task form, check the User B if showing up.

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/78375725/a4b2bb6c-92e0-430e-86f2-92469f61c6a3


## Note:
Include the information the reviewers need to know.
