### PR TITLE
Edwin - Make save changes button visible for admin links

### DIFF
--- a/src/components/UserProfile/UserLinkLayout.jsx
+++ b/src/components/UserProfile/UserLinkLayout.jsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import UserLinks from './UserLinks';
 import LinkModButton from './UserProfileEdit/LinkModButton';
+import hasPermission from '../../utils/permissions';
+import { useSelector } from 'react-redux';
+
 
 const UserLinkLayout = props => {
-  const { userProfile, updateLink, handleLinkModel } = props;
-
+  const { userProfile, updateLink, handleLinkModel, role} = props;
+  const { roles } = useSelector(state => state.role);
+  const userPermissions = useSelector(state => state.auth.user?.permissions?.frontPermissions);
+  const canEdit = hasPermission(role, 'adminLinks', roles, userPermissions, 'editLink') || hasPermission(role, 'editUserProfile', roles, userPermissions);
   const { adminLinks, personalLinks } = userProfile;
 
   return (
     <div data-testid="user-link">
       <p style={{ display: 'inline-block', marginRight: 10 }}>LINKS </p>
-      {props.canEdit ? (
-        <LinkModButton userProfile={userProfile} updateLink={updateLink} role={props.role} />
+      {canEdit ? (
+        <LinkModButton userProfile={userProfile} updateLink={updateLink} isUpdated={props.isUpdated}/>
       ) : null}
       <UserLinks linkSection="user" links={personalLinks} handleLinkModel={handleLinkModel} />
       <UserLinks linkSection="user" links={adminLinks} handleLinkModel={handleLinkModel} />

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -91,6 +91,8 @@ function UserProfile(props) {
   const [summarySelected, setSummarySelected] = useState(null);
   const [summaryName, setSummaryName] = useState('');
   const [showSummary, setShowSummary] = useState(false);
+  const [isUpdated, setIsUpdated] = useState(false);
+
 
   const userProfileRef = useRef();
 
@@ -539,13 +541,28 @@ function UserProfile(props) {
 
   const { userId: targetUserId } = props.match ? props.match.params : { userId: undefined };
   const { userid: requestorId, role: requestorRole } = props.auth.user;
+  const userPermissions = props.auth.user?.permissions?.frontPermissions;
 
   const authEmail = props.userProfile?.email;
+  const checkHasPermissions = hasPermission(
+    requestorRole,
+    'editUserProfile',
+    roles,
+    userPermissions,
+  );
+
+  const canManageAdminLinks = hasPermission(
+    requestorRole,
+    'adminLinks',
+    roles,
+    userPermissions,
+  );
+  
   const isUserSelf = targetUserId === requestorId;
 
   const canChangeUserStatus = props.hasPermission('changeUserStatus');
   const canAddDeleteEditOwners = props.hasPermission('addDeleteEditOwners');
-  const canPutUserProfile = props.hasPermission('putUserProfile');
+  const canPutUserProfile = props.hasPermission('editUserProfile');
   const canUpdatePassword = props.hasPermission('updatePassword');
 
   const targetIsDevAdminUneditable = cantUpdateDevAdminDetails(userProfile.email, authEmail);
@@ -585,6 +602,10 @@ function UserProfile(props) {
   const handleEndDate = async endDate => {
     setUserEndDate(endDate);
   };
+
+  const handleOnUpdate = () => {
+    setIsUpdated(true);
+  }
 
   return (
     <div>
@@ -751,6 +772,7 @@ function UserProfile(props) {
                 handleLinkModel={props.handleLinkModel}
                 role={requestorRole}
                 canEdit={canEdit}
+                isUpdated={handleOnUpdate}
               />
               <BlueSquareLayout
                 userProfile={userProfile}
@@ -954,7 +976,7 @@ function UserProfile(props) {
                           </Button>
                         </Link>
                       )}
-                      {canEdit && (activeTab == '1' || canPutUserProfile) && (
+                      {(canEdit || canManageAdminLinks) && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
                             className="mr-1 btn-bottom"
@@ -963,6 +985,7 @@ function UserProfile(props) {
                               !formValid.firstName ||
                               !formValid.lastName ||
                               !formValid.email ||
+                              !isUpdated || 
                               (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                             }
                             userProfile={userProfile}
@@ -1008,7 +1031,7 @@ function UserProfile(props) {
                 <ModalFooter>
                   <Row>
                     <div className="profileEditButtonContainer">
-                      {canEdit && (activeTab == '1' || canPutUserProfile) && (
+                      {(canEdit || canManageAdminLinks) && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
                             className="mr-1 btn-bottom"
@@ -1017,6 +1040,7 @@ function UserProfile(props) {
                               !formValid.firstName ||
                               !formValid.lastName ||
                               !formValid.email ||
+                              !isUpdated ||
                               (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                             }
                             userProfile={userProfile}
@@ -1067,7 +1091,7 @@ function UserProfile(props) {
                 <ModalFooter>
                   <Row>
                     <div className="profileEditButtonContainer">
-                      {canEdit && (activeTab == '1' || canPutUserProfile) && (
+                      {(canEdit || canManageAdminLinks) && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
                             className="mr-1 btn-bottom"
@@ -1076,6 +1100,7 @@ function UserProfile(props) {
                               !formValid.firstName ||
                               !formValid.lastName ||
                               !formValid.email ||
+                              !isUpdated ||
                               (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                             }
                             userProfile={userProfile}
@@ -1126,7 +1151,7 @@ function UserProfile(props) {
                 <ModalFooter>
                   <Row>
                     <div className="profileEditButtonContainer">
-                      {canEdit && (activeTab == '1' || canPutUserProfile) && (
+                      {(canEdit || canManageAdminLinks) && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
                             className="mr-1 btn-bottom"
@@ -1135,6 +1160,7 @@ function UserProfile(props) {
                               !formValid.firstName ||
                               !formValid.lastName ||
                               !formValid.email ||
+                              !isUpdated || 
                               (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                             }
                             userProfile={userProfile}
@@ -1172,7 +1198,7 @@ function UserProfile(props) {
                 <ModalFooter>
                   <Row>
                     <div className="profileEditButtonContainer">
-                      {canEdit && (activeTab == '1' || canPutUserProfile) && (
+                      {(canEdit || canManageAdminLinks) && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
                             className="mr-1 btn-bottom"
@@ -1181,6 +1207,7 @@ function UserProfile(props) {
                               !formValid.firstName ||
                               !formValid.lastName ||
                               !formValid.email ||
+                              !isUpdated ||
                               (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                             }
                             userProfile={userProfile}
@@ -1237,7 +1264,7 @@ function UserProfile(props) {
                   </Button>
                 </Link>
               )}
-              {canEdit && (activeTab === '1' || activeTab === '3' || canPutUserProfile) && (
+              {(canEdit || canManageAdminLinks) && (activeTab === '1' || activeTab === '3' || canPutUserProfile) && (
                 <>
                   <SaveButton
                     className="mr-1 btn-bottom"
@@ -1246,6 +1273,7 @@ function UserProfile(props) {
                       !formValid.firstName ||
                       !formValid.lastName ||
                       !formValid.email ||
+                      !isUpdated || 
                       (userStartDate > userEndDate && userEndDate !== '') ||
                       (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                     }

--- a/src/components/UserProfile/UserProfileEdit/LinkModButton.jsx
+++ b/src/components/UserProfile/UserProfileEdit/LinkModButton.jsx
@@ -8,6 +8,7 @@ const LinkModButton = props => {
   const toggleModal = () => {
     setModal(!modal);
   };
+   
   return (
     <React.Fragment>
       <EditLinkModal
@@ -17,6 +18,7 @@ const LinkModButton = props => {
         userProfile={userProfile}
         setChanged={setChanged}
         role={props.role}
+        isUpdated={props.isUpdated}
       />
       <span
         style={{

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -17,7 +17,7 @@ import { boxStyle } from 'styles';
 import { connect } from 'react-redux';
 
 const EditLinkModal = props => {
-  const { isOpen, closeModal, updateLink, userProfile } = props;
+  const { isOpen, closeModal, updateLink, userProfile, isUpdated } = props;
 
   const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
 
@@ -111,6 +111,7 @@ const EditLinkModal = props => {
   };
 
   const handleUpdate = async () => {
+    isUpdated()
     const updatable =
       (isValidUrl(googleLink.Link) && isValidUrl(mediaFolderLink.Link)) ||
       (googleLink.Link === '' && mediaFolderLink.Link === '') ||


### PR DESCRIPTION
# Description


<img width="594" alt="Screen Shot 2023-08-24 at 9 55 57 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/197f5ad4-7bb7-41b5-aac5-1bf2f23081b4">

## Main changes explained:

- Made code changes for save button to be visible when updating admin links when having the 'Manage Admin Links' permission
- Made code changes for save button to be visible when updating admin links when having 'Edit User Profile' permission

## How to test:

1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as Owner user
4.  Other Links -> Permissions Management -> Manage User Permissions -> Give "Manage Admin Links" permission to a non Admin/Owner user
5. Log into that user -> Click into any user -> Change the Edit button besides links in the bottom left -> Change admin links -> Update -> Save Changes button should appear and you should be able to click, refresh and changes should remain
6. Other Links -> Permissions Management -> Manage User Permissions -> Remove "Manage Admin Links" Permission and give "Edit User Profile" permissions to a non Admin/Owner user and repeat step 5. 

## Videos/Screenshots of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/e4b88f01-9c72-468c-98bf-2e2c515ad2de

