### PR TITLE
Edwin - Dashboard css fix

### DIFF
--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -294,10 +294,10 @@ const SummaryBar = props => {
               {totalEffort >= weeklyCommittedHours && (
                 <div className="border-green col-4 bg--dark-green" >
                   <div className="py-1"> </div>
-                  <p className="large_text_summary text--black" >
+                  <p className="text-center large_text_summary text--black" >
                     ✓
                   </p>
-                  <font size="3">HOURS</font>
+                  <font className="text-center" size="3">HOURS</font>
                   <div className="py-2"> </div>
                 </div>
               )}
@@ -350,10 +350,10 @@ const SummaryBar = props => {
               ) : (
                 <div className="border-green col-4 bg--dark-green" >
                   <div className="py-1"> </div>
-                  <p className="large_text_summary text--black" >
+                  <p className="text-center large_text_summary text--black" >
                     ✓
                   </p>
-                  <font className="text--black" size="3">
+                  <font className="text-center text--black" size="3">
                     SUMMARY
                   </font>
                   <div className="py-2"> </div>


### PR DESCRIPTION
# Description
Fixed the Hours and Summary's css in the Dashboard.

## How to test:
1. check into current branch
2. do `npm install` and '...' to run this PR locally
3. log as any user
4. go to dashboard, make sure to submit your weekly summary video and complete for weekly hours 

## Screenshots or videos of changes:

Before:

<img width="1108" alt="Screen Shot 2023-08-25 at 5 22 53 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/8f74ce69-32f5-4ba4-9b47-053fa2209498">

After:

<img width="1128" alt="Screen Shot 2023-08-25 at 5 22 41 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/e0e80c14-ea87-421d-b4a3-e11720554d6d">
