### PR TITLE
Leo - Make Teams list only suggest active members

### DIFF
--- a/src/components/Teams/MembersAutoComplete.jsx
+++ b/src/components/Teams/MembersAutoComplete.jsx
@@ -35,8 +35,9 @@ const MemberAutoComplete = props => {
           {props.userProfileData.userProfiles
             .filter(user => {
               if (
-                user.firstName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1 ||
-                user.lastName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1
+                user.isActive &&
+                (user.firstName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1 ||
+                user.lastName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1)
               ) {
                 return user;
               }
@@ -45,7 +46,6 @@ const MemberAutoComplete = props => {
             .map(item => (
               <div
                 className="user-auto-cpmplete"
-                key={item._id}
                 onClick={() => {
                   props.setSearchText(`${item.firstName} ${item.lastName}`);
                   toggle(false);


### PR DESCRIPTION
# Description
![Screenshot 2023-08-25 201238](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/49f2c3a4-0fe8-4ae7-a6f8-11ce5f5c87ef)


## Related PRS (if any):
…

## Main changes explained:
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin/owner user
4. go to Other Links -> Teams -> Choose Team → Members → Add
5. check if the list shows only active team members

## Screenshots or videos of changes:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/7f6fe9e9-d1a5-425a-842b-d8e71aad8590
## Note:
Include the information the reviewers need to know.
