### PR TITLE
Restore ability to make active/inactive using dot by person’s name

### DIFF
--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -326,8 +326,8 @@ class UserManagement extends React.PureComponent {
    * Callback to trigger on the status (active/inactive) column click to show the confirmaton change the status
    */
   onActiveInactiveClick = user => {
-    const authRole = this.props.state.auth.user.role;
-    const canChangeUserStatus = props.hasPermission('changeUserStatus');
+    const authRole = this?.props?.state?.auth?.user.role||user.role
+    const canChangeUserStatus = hasPermission('changeUserStatus');
     if (!canChangeUserStatus) {
       //permission to change the status of any user on the user profile page or User Management Page.
       //By default only Admin and Owner can access the user management page and they have this permission.


### PR DESCRIPTION
# Description
Restore ability to make active/inactive using dot by person’s name

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to Other Links → User Management → Click Dot

## Screenshots or videos of changes:
![Screenshot from 2023-08-26 09-47-42](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/49270410/734212ac-14ec-4ccb-a662-1dde66efe978)

## Note:
Include the information the reviewers need to know.
