### PR TITLE
Yubo-Warning of Editing Media Folder link & Autosave

### DIFF
--- a/src/components/UserProfile/UserLinkLayout.jsx
+++ b/src/components/UserProfile/UserLinkLayout.jsx
@@ -3,7 +3,7 @@ import UserLinks from './UserLinks';
 import LinkModButton from './UserProfileEdit/LinkModButton';
 
 const UserLinkLayout = props => {
-  const { userProfile, updateLink, handleLinkModel } = props;
+  const { userProfile, updateLink, handleLinkModel, handleSubmit } = props;
 
   const { adminLinks, personalLinks } = userProfile;
 
@@ -11,7 +11,7 @@ const UserLinkLayout = props => {
     <div data-testid="user-link">
       <p style={{ display: 'inline-block', marginRight: 10 }}>LINKS </p>
       {props.canEdit ? (
-        <LinkModButton userProfile={userProfile} updateLink={updateLink} role={props.role} />
+        <LinkModButton userProfile={userProfile} updateLink={updateLink} role={props.role} handleSubmit={handleSubmit}/>
       ) : null}
       <UserLinks linkSection="user" links={personalLinks} handleLinkModel={handleLinkModel} />
       <UserLinks linkSection="user" links={adminLinks} handleLinkModel={handleLinkModel} />

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -749,6 +749,7 @@ function UserProfile(props) {
                 userProfile={userProfile}
                 updateLink={updateLink}
                 handleLinkModel={props.handleLinkModel}
+                handleSubmit={handleSubmit}
                 role={requestorRole}
                 canEdit={canEdit}
               />

--- a/src/components/UserProfile/UserProfileEdit/LinkModButton.jsx
+++ b/src/components/UserProfile/UserProfileEdit/LinkModButton.jsx
@@ -3,7 +3,7 @@ import EditLinkModal from '../UserProfileModal/EditLinkModal';
 import './UserProfileEdit.scss';
 
 const LinkModButton = props => {
-  const { updateLink, userProfile, setChanged } = props;
+  const { updateLink, userProfile, setChanged, handleSubmit } = props;
   const [modal, setModal] = useState(false);
   const toggleModal = () => {
     setModal(!modal);
@@ -15,6 +15,7 @@ const LinkModButton = props => {
         isOpen={modal}
         closeModal={toggleModal}
         userProfile={userProfile}
+        handleSubmit={handleSubmit}
         setChanged={setChanged}
         role={props.role}
       />

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.css
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.css
@@ -5,8 +5,11 @@
   }
 }
 
-.invalid-help-context {
+.invalid-help-context,
+.warning-help-context {
   color: red;
   font-size: 0.8rem;
   margin-top: 0.5rem;
+  margin-bottom: auto;
+  padding-left: 0.4rem;
 }

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -165,9 +165,9 @@ const EditLinkModal = props => {
                   <Label style={{ display: 'flex', margin: '5px' }}>Admin Links:</Label>
                   {mediaFolderDiffWarning && (
                     <span className="warning-help-context">
-                      Media Folder link is differnt from mediaUrl:
+                      <strong>Media Folder link must be a working DropBox link</strong>
                       <p>
-                        <a href={userProfile.mediaUrl}>{userProfile.mediaUrl}</a>
+                        Current Media URL: <a href={userProfile.mediaUrl}>{userProfile.mediaUrl}</a>
                       </p>
                     </span>
                   )}

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -17,7 +17,7 @@ import { boxStyle } from 'styles';
 import { connect } from 'react-redux';
 
 const EditLinkModal = props => {
-  const { isOpen, closeModal, updateLink, userProfile } = props;
+  const { isOpen, closeModal, updateLink, userProfile, handleSubmit } = props;
 
   const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
 
@@ -140,6 +140,7 @@ const EditLinkModal = props => {
       } else {
         await updateLink(personalLinks, [googleLink, mediaFolderLink, ...adminLinks]);
       }
+      handleSubmit();
       setIsValidLink(true);
       setIsChanged(true);
       closeModal();

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useReducer } from 'react';
+import React, { useState, useReducer, useEffect } from 'react';
 import {
   Button,
   Modal,
@@ -52,6 +52,7 @@ const EditLinkModal = props => {
   );
 
   const [isChanged, setIsChanged] = useState(false);
+  const [mediaFolderDiffWarning, setMediaFolderDiffWarning] = useState(false);
   const [isValidLink, setIsValidLink] = useState(true);
 
   const handleNameChanges = (e, links, index, setLinks) => {
@@ -68,7 +69,10 @@ const EditLinkModal = props => {
   };
 
   const addNewLink = (links, setLinks, newLink, clearInput) => {
-    if (isDuplicateLink([googleLink,mediaFolderLink,...links], newLink) || !isValidUrl(newLink.Link)) {
+    if (
+      isDuplicateLink([googleLink, mediaFolderLink, ...links], newLink) ||
+      !isValidUrl(newLink.Link)
+    ) {
       setIsValidLink(false);
     } else {
       const newLinks = [...links, { Name: newLink.Name, Link: newLink.Link }];
@@ -85,6 +89,14 @@ const EditLinkModal = props => {
     });
     setLinks(newLinks);
     setIsChanged(true);
+  };
+
+  const isDifferentMediaUrl = () => {
+    if (userProfile.mediaUrl !== mediaFolderLink.Link) {
+      setMediaFolderDiffWarning(true);
+    } else {
+      setMediaFolderDiffWarning(false);
+    }
   };
 
   const isDuplicateLink = (links, newLink) => {
@@ -119,8 +131,12 @@ const EditLinkModal = props => {
     if (updatable) {
       // * here the 'adminLinks' should be the total of 'googleLink' and 'adminLink'
       // Media Folder link should update the mediaUrl in userProfile
-      if (mediaFolderLink.Link){
-        await updateLink(personalLinks, [googleLink, mediaFolderLink, ...adminLinks],mediaFolderLink.Link);
+      if (mediaFolderLink.Link) {
+        await updateLink(
+          personalLinks,
+          [googleLink, mediaFolderLink, ...adminLinks],
+          mediaFolderLink.Link,
+        );
       } else {
         await updateLink(personalLinks, [googleLink, mediaFolderLink, ...adminLinks]);
       }
@@ -132,6 +148,10 @@ const EditLinkModal = props => {
     }
   };
 
+  useEffect(() => {
+    isDifferentMediaUrl();
+  }, [mediaFolderLink.Link, userProfile.mediaUrl]);
+
   return (
     <React.Fragment>
       <Modal isOpen={isOpen} toggle={closeModal}>
@@ -142,6 +162,14 @@ const EditLinkModal = props => {
               <CardBody>
                 <Card style={{ padding: '16px' }}>
                   <Label style={{ display: 'flex', margin: '5px' }}>Admin Links:</Label>
+                  {mediaFolderDiffWarning && (
+                    <span className="warning-help-context">
+                      Media Folder link is differnt from mediaUrl:
+                      <p>
+                        <a href={userProfile.mediaUrl}>{userProfile.mediaUrl}</a>
+                      </p>
+                    </span>
+                  )}
                   <div>
                     <div style={{ display: 'flex', margin: '5px' }} className="link-fields">
                       <input


### PR DESCRIPTION
# Description
This a feature that may not in the bug list.

## Main changes explained:
- Add a warning will show up if the input in `Media Folder` link is different from `mediaUrl` that is related to your weekly summary.
- Remove additional save that's mentioned in #1001 , now only click `update`, the links will be saved automatically.



## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as admin user -> go to other user's profile page -> click link **Edit** under picture.
4. Try to change the `Media Folder` link and see if the warning shows up.
5. Click `update` to save the changed `Media Folder` link to the profile and refresh to check if autosave works properly.


## Screenshots or videos of changes:
<img width="517" alt="Screenshot 2023-08-26 at 4 27 32 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/57503876/4e32f55c-7687-4ae6-b738-67a6a62be4de">

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/57503876/cb3f08ce-2d52-47ae-b445-feb4b0e7beb1


