### PR TITLE
Edwin - Hotfix for reports tab permission not rendering even though permissio…

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -50,6 +50,8 @@ export const Header = props => {
 
   // Reports
   const canGetWeeklySummaries = props.hasPermission('getWeeklySummaries');
+  const canSeeAllReportsTab = props.hasPermission('seeAllReports')
+  const canSeeWeeklySummaryReportsTab = props.hasPermission("seeWeeklySummaryReports")
   // Users
   const canPostUserProfile = props.hasPermission('postUserProfile');
   const canDeleteUserProfile = props.hasPermission('deleteUserProfile');
@@ -134,13 +136,13 @@ export const Header = props => {
                   <span className="dashboard-text-link">{TIMELOG}</span>
                 </NavLink>
               </NavItem>
-              {canGetWeeklySummaries || canGetWeeklySummaries ? (
+              {canGetWeeklySummaries || canGetWeeklySummaries || canSeeAllReportsTab || canSeeWeeklySummaryReportsTab ? (
                 <UncontrolledDropdown nav inNavbar>
                   <DropdownToggle nav caret>
                     <span className="dashboard-text-link">{REPORTS}</span>
                   </DropdownToggle>
                   <DropdownMenu>
-                    {canGetWeeklySummaries ? (
+                    {canGetWeeklySummaries || canSeeAllReportsTab ? (
                       <>
                         <DropdownItem tag={Link} to="/reports">
                           {REPORTS}

--- a/src/utils/routePermissions.js
+++ b/src/utils/routePermissions.js
@@ -4,6 +4,7 @@ export const RoutePermissions = {
   inventoryProject: '',
   inventoryProjectWbs: '',
   weeklySummariesReport: 'getWeeklySummaries',
+  weeklySummariesReport: 'seeWeeklySummaryReports',
   projects: 'postProject',
   userManagement: 'postUserProfile',
   badgeManagement: 'createBadges',
@@ -11,4 +12,5 @@ export const RoutePermissions = {
   permissionsManagementRole: 'putRole',
   teams: 'putTeam',
   reports: 'getWeeklySummaries',
+  reports: 'seeAllReports'
 };


### PR DESCRIPTION
# Description

Fix the Reports Tab not rendering even though the user has the correct permissions

https://www.loom.com/share/1bfaac76124e4caba5adf759bb39c24f?sid=6c0f72a6-a2c2-424c-bab3-fbb75cc13973

## How to test:
1. check into current branch
2. do `npm install` and '...' to run this PR locally
3. log as Owner
4. Other Links -> Permission Management -> Manage user Permissions -> select a user -> grant them "See All the Reports Tab" permission
5. Log as that user, check you are able to see the reports tab along with the reports and weekly summary tab
6. Repeat step 4 but now give them ONLY the "See Weekly Summary Reports Tab" permission
7. Log as that user, check that you are able to see the reports tab along with ONLY the weekly summary tab

## Screenshots

Before:

https://www.loom.com/share/1bfaac76124e4caba5adf759bb39c24f?sid=6c0f72a6-a2c2-424c-bab3-fbb75cc13973

After:

<img width="1680" alt="Screen Shot 2023-08-26 at 8 47 09 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/99a9c20f-8b6b-43bb-99be-7704a3ed1124">
