### PR TITLE
aaron hotfix naming issue for permission for seeing weekly reports tab

### DIFF
--- a/src/components/PermissionsManagement/UserRoleTab.jsx
+++ b/src/components/PermissionsManagement/UserRoleTab.jsx
@@ -7,7 +7,7 @@ import { useHistory } from 'react-router-dom';
 
 export const permissionLabel = {
   seeAllReports: 'See All the Reports Tab',
-  seeWeeklySummaryReports: 'See Weekly Summary Reports Tab',
+  getWeeklySummaries: 'See Weekly Summary Reports Tab',
   seeUserManagement: 'See User Management Tab (Full Functionality)',
   seeUserManagementTab: 'See User Management Tab (ONLY create Users)',
   seeBadgeManagement: 'See Badge Management Tab (Full Functionality)',


### PR DESCRIPTION
# Description
Permission for viewing Weekly Summary Reports does not work

## Related PRS (if any):
N/A

## Main changes explained:
- renamed permission to `getWeeklySummaries` match the default permission

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. login as owner 
4. go to Other -> Permissions Management 
5. add "See Weekly Summary Reports Tab" to a user who doesn't have the permission
6. log into that user's account and verify you can see the "Reports" tab in the header

