### PR TITLE
hotfix: restore the width of yellow warning

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -328,10 +328,7 @@ const FormattedReport = ({
               ? badgeThisWeek.map(
                   (value, index) =>
                     value?.showReport && (
-                      <td
-                        className="badge-td"
-                        key={weekIndex + '_' + summary._id + '_' + index}
-                      >
+                      <td className="badge-td" key={weekIndex + '_' + summary._id + '_' + index}>
                         {' '}
                         <img src={value.imageUrl} id={'popover_' + value._id} />
                         <UncontrolledPopover trigger="hover" target={'popover_' + value._id}>
@@ -429,20 +426,20 @@ const FormattedReport = ({
                 </i>
               )}
             </div>
+            <div>
+              {' '}
+              <b>Media URL:</b> {getMediaUrlLink(summary)}
+            </div>
+            {bioFunction(
+              summary._id,
+              summary.bioPosted,
+              summary,
+              summary.weeklySummaryOption,
+              summary.totalTangibleHrs,
+              summary.daysInTeam,
+            )}
             <div className="nonsummary-wrapper">
               <div>
-                <div>
-                  {' '}
-                  <b>Media URL:</b> {getMediaUrlLink(summary)}
-                </div>
-                {bioFunction(
-                  summary._id,
-                  summary.bioPosted,
-                  summary,
-                  summary.weeklySummaryOption,
-                  summary.totalTangibleHrs,
-                  summary.daysInTeam,
-                )}
                 {getTotalValidWeeklySummaries(summary)}
                 {hoursLogged >= summary.promisedHoursByWeek[weekIndex] && (
                   <p>


### PR DESCRIPTION
# Description
The yellow bar that warns a user's bio should be posted is supposed to go all the way across the screen.

## Screenshots or videos of changes:
<img width="1468" alt="1" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/532f5762-b6fe-40f6-9a86-f72ba47d1789">
