### PR TITLE
Eduardo Fix the count of badges on profile is floating number instead of integer

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -49,19 +49,17 @@ const Badge = props => {
   };
 
   useEffect(() => {
-    const userId = props.userId;
-    let count = 0;
+    const uniqueBadges = new Set();
     if (props.userProfile.badgeCollection) {
       props.userProfile.badgeCollection.forEach(badge => {
-        if (badge?.badge?.badgeName === 'Personal Max' || badge?.badge?.type === 'Personal Max') {
-          count += 1;
-        } else {
-          count += Number(badge.count);
+        if (badge?.badge?._id) {
+          uniqueBadges.add(badge.badge._id);
         }
       });
+      const count = uniqueBadges.size;
       setTotalBadge(Math.round(count));
     }
-  }, [props.userProfile.badgeCollection, totalBadge]);
+  }, [props.userProfile.badgeCollection]); 
 
   return (
     <>

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -111,8 +111,18 @@ const SummaryBar = props => {
 
   //Get badges count from userProfile
   const getBadges = () => {
-    return userProfile && userProfile.badgeCollection ? userProfile.badgeCollection.reduce((acc, obj) => acc + Number(obj.count), 0) : 0;
+    if (userProfile && userProfile.badgeCollection) {
+      const uniqueBadges = new Set();
+      userProfile.badgeCollection.forEach(badge => {
+        if (badge?.badge?._id) {
+          uniqueBadges.add(badge.badge._id);
+        }
+      });
+      return uniqueBadges.size;
+    }
+    return 0;
   };
+  
 
   const getState = useSelector(state => {
     return state;

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -36,8 +36,14 @@ export const Badges = props => {
     }
   }, [isOpen, isAssignOpen]);
 
-  // Determines what congratulatory text should displayed.
-  const badgesEarned = props.userProfile.badgeCollection.reduce((acc, obj) => acc + Number(obj.count), 0);
+  const uniqueBadges = new Set();
+  props.userProfile.badgeCollection.forEach(obj => {
+    if (obj.badge && obj.badge._id) {
+      uniqueBadges.add(obj.badge._id);
+    }
+  });
+  const badgesEarned = uniqueBadges.size;
+  
   const subject = props.isUserSelf ? 'You have' : 'This person has';
   const verb = badgesEarned ? `earned ${badgesEarned}` : 'no';
   const object = badgesEarned == 1 ? 'badge' : 'badges';


### PR DESCRIPTION
# Description
Fix the count of badges on profile is floating number instead of integer.

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/a75307fd-8e1b-48da-a383-3b155f2f25c9)

Fixes the count of badges on profile, summary bar and dashboard.


## Main changes explained:
- Created Set to Store Unique Badge ID


## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as any user
4. go to dashboard→ view profile
5. verify if the number of badges is show properly

## Screenshots or videos of changes:

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/6b130577-80b5-4840-ac5c-6e5d9c1f4979)

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/71e1e987-cf12-4906-8b04-063fb5b280c2)

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/ade0d66e-6bfb-423f-afc4-ec51956d8a93)
