### PR TITLE
Jerry - See User Management Tab (Full Functionality)

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -51,6 +51,7 @@ export const Header = props => {
   // Reports
   const canGetWeeklySummaries = props.hasPermission('getWeeklySummaries');
   // Users
+  const canSeeUserManagement = props.hasPermission('seeUserManagement');
   const canPostUserProfile = props.hasPermission('postUserProfile');
   const canDeleteUserProfile = props.hasPermission('deleteUserProfile');
   const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
@@ -167,7 +168,8 @@ export const Header = props => {
                   </i>
                 </NavLink>
               </NavItem>
-              {(canPostUserProfile ||
+              {(canSeeUserManagement ||
+                canPostUserProfile ||
                 canDeleteUserProfile ||
                 canPutUserProfileImportantInfo ||
                 canCreateBadges ||
@@ -181,7 +183,8 @@ export const Header = props => {
                     <span className="dashboard-text-link">{OTHER_LINKS}</span>
                   </DropdownToggle>
                   <DropdownMenu>
-                    {canPostUserProfile ||
+                    {canSeeUserManagement ||
+                    canPostUserProfile ||
                     canDeleteUserProfile ||
                     canPutUserProfileImportantInfo ? (
                       <DropdownItem tag={Link} to="/usermanagement">

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -543,6 +543,7 @@ function UserProfile(props) {
   const authEmail = props.userProfile?.email;
   const isUserSelf = targetUserId === requestorId;
 
+  const canSeeUserManagementFullFunctionality = props.hasPermission('seeUserManagement');
   const canChangeUserStatus = props.hasPermission('changeUserStatus');
   const canAddDeleteEditOwners = props.hasPermission('addDeleteEditOwners');
   const canPutUserProfile = props.hasPermission('putUserProfile');
@@ -556,8 +557,7 @@ function UserProfile(props) {
     : userProfile.role === 'Owner'
     ? canAddDeleteEditOwners
     : canPutUserProfile;
-
-  const canEdit = canEditUserProfile || isUserSelf;
+    const canEdit = canEditUserProfile || isUserSelf || canSeeUserManagementFullFunctionality;
 
   const customStyles = {
     control: (base, state) => ({
@@ -832,7 +832,7 @@ function UserProfile(props) {
                   setFormValid={setFormValid}
                   isUserSelf={isUserSelf}
                   canEdit={canEdit}
-                  canEditRole={canEditUserProfile}
+                  canEditRole={canEditUserProfile || canSeeUserManagementFullFunctionality}
                   roles={roles}
                 />
               </TabPane>

--- a/src/routes.js
+++ b/src/routes.js
@@ -107,7 +107,7 @@ export default (
         path="/usermanagement"
         exact
         component={UserManagement}
-        routePermissions={RoutePermissions.userManagement}
+        routePermissions={[RoutePermissions.userManagement, RoutePermissions.userManagementFullFunctionality]}
       />
       <ProtectedRoute
         path="/badgemanagement"

--- a/src/utils/routePermissions.js
+++ b/src/utils/routePermissions.js
@@ -5,6 +5,7 @@ export const RoutePermissions = {
   inventoryProjectWbs: '',
   weeklySummariesReport: 'getWeeklySummaries',
   projects: 'postProject',
+  userManagementFullFunctionality: 'seeUserManagement',
   userManagement: 'postUserProfile',
   badgeManagement: 'createBadges',
   permissionsManagement: 'putRole',


### PR DESCRIPTION
# Description

<img width="747" alt="see user management tab description" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/55968519/cc7bb46b-a72f-4798-952a-7a39c9121e66">

**EDIT (Sept 20, 2023)**: Please checkout PR #1312 and follow the instructions to run that PR. That PR should address the problems that many of your have faced with this PR. Thank you!

The main motivation of this pull request is to allow an Owner account to assign the “_See User Management Tab (Full Functionality)_” permission to an account that does not have that permission by default (e.g. a Volunteer account).

## Related PRS (if any):

None. But similar code changes in FE PR #1189 . 


## Main changes explained:
- Conditionally render `Other Links->User Management` option in the header for a Volunteer account that had the “_See User Management Tab (Full Functionality)_” permission added by an Owner account.
- Similarly, an Owner account can remove a Volunteer account’s “_See User Management Tab (Full Functionality)_” permission and the `Other Links->User Management` option in the header will no longer be visible/accessible.
- Added `RoutePermissions.userManagementFullFunctionality` to the `routePermissions` prop of the `ProtectedRoute` component (`src/routes.js`).
- Added “userManagementFullFunctionality” key-value pair to `RoutePermissions` in `src/utils/routePermissions.js`
- For the “_See User Management Tab (Full Functionality)_” permission on the Permissions Management page, updated the "i" description to: _Make the "Other Links" -> "User Management" button appear/accessible and be able to create, delete, and update users_.

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. Log in as Owner -> Other LInks -> Permissions Management -> Manage User Permissions
4. Enter the username of an account that does not have the “_See User Management Tab (Full Functionality)_” permission by default (i.e., a Volunteer account). Click on Submit.
5. Login the Volunteer account (if already logged in, make sure to log out and log back in). The “Reports” button should appear with ONLY the “User Management” option visible/accessible.
6. The volunteer account can create, delete, and update users in the User Management page.
7. The Owner account can also remove the “_See User Management Tab (Full Functionality)_” permission. Click on Submit. Log into the Volunteer account and see that the "Reports" button is no longer visible/accessible.

## Screenshots or videos of changes:

Development branch:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/55968519/3029034e-9976-4620-97a9-192fd334b4d6


Current branch:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/55968519/14cca011-fbb7-4f7a-b950-6f988ab04ad2


## Note:

Due to a general problem, your Owner account may have the “Other Links” button in the header disappeared. You can try Empty Cache and Hard Reset (instructions in the screenshot below):

<img width="315" alt="Screenshot 2023-08-29 at 3 07 09 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/55968519/cb5161ae-90b8-48fb-b3d9-6f352235947a">

Or create a new Owner account. I had issues creating new accounts in localhost, so I created a new Owner account in the HGN dev app. Hopefully your new Owner account will have the “Other Links” button in the header.
