### PR TITLE
Get user profile before time entry

### DIFF
--- a/src/__tests__/Timelog/TimeEntryForm.test.js
+++ b/src/__tests__/Timelog/TimeEntryForm.test.js
@@ -187,8 +187,8 @@ describe('<TimeEntryFormEdit />', () => {
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
     fireEvent.click(screen.getByRole('button', { name: /close/i }));
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    expect(actions.editTimeEntry).toHaveBeenCalledTimes(1);
     await waitFor(() => {
+      expect(actions.editTimeEntry).toHaveBeenCalledTimes(1);
       expect(toggle).toHaveBeenCalled();
     });
     //expect(screen.getByText(/You are about to edit your time*/i)).toBeInTheDocument();

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -453,6 +453,7 @@ const TimeEntryForm = props => {
     }
 
     //Update userprofile hoursByCategory
+    await dispatch(getUserProfile(userId));
 
     //Send the time entry to the server
     setSubmitting(true);


### PR DESCRIPTION
# Description
Prevents account roll-backs on time entry submit.

## Main changes explained:
- gets updated user profile before submitting a time entry

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. open app in other incognito window and log into a volunteer user
5. as both users, view the volunteer account
6. As the admin, make a change to the name/title (something the volunteer should also be able to change) of the volunteer account and save.
7. As the volunteer, do not refresh, verify changes have not been updated, and make a time entry.
8. refresh
9. verify that name/title changes made as admin were not overwritten

## Screenshots or videos of changes:
[timeEntry.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/d973f437-60dc-408a-8db8-d6aab03ca1d8)
