### PR TITLE
Bailey - Remove owner as creation and fix start date input field (Hot Fix)

### DIFF
--- a/src/components/Reports/reportsPage.css
+++ b/src/components/Reports/reportsPage.css
@@ -96,7 +96,6 @@
   display: flex;
   flex-direction: column;
   margin: 8px 0;
-  margin-right: 24px;
 }
 
 .date-picker-label {

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -91,7 +91,9 @@ class AddUserProfile extends Component {
       formSubmitted: false,
     };
 
-    this.canAddDeleteEditOwners = hasPermission('addDeleteEditOwners');
+    
+    const { user } = this.props.auth;
+    this.canAddDeleteEditOwners = user && user.role === 'Owner'
   }
 
   popupClose = () => {

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -6,6 +6,11 @@ const hasPermission = (action) => {
     const userRole = state.auth.user.role;
     const userPermissions = state.auth.user.permissions?.frontPermissions;
 
+    //Check user role
+    if (userRole === 'Owner') {
+      return true;
+    }
+
     if (userRole && rolePermissions && rolePermissions.length != 0) {
       const roleIndex = rolePermissions?.findIndex(({ roleName }) => roleName === userRole);
       let permissions = [];


### PR DESCRIPTION
# Description
Removed the option that allows admins to be able to create owner roles/accounts. Created a conditional check in the permissions to check the users role to see if they are an owner. If they are an owner it checks the permissions and allows them to create/edit/delete owner roles, but if you are not an owner it will come up false and will not allow you to create an owner role.

For the start date input field I removed the margin right on the .date-picker-item because it was messing with the container size and not allowing that input field to be 100% of its size.
