### PR TITLE
Eduardo Fix the count of badges on profile is floating number instead of integer

### DIFF
--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -111,8 +111,21 @@ const SummaryBar = props => {
 
   //Get badges count from userProfile
   const getBadges = () => {
-    return userProfile && userProfile.badgeCollection ? userProfile.badgeCollection.reduce((acc, obj) => acc + Number(obj.count), 0) : 0;
-  };
+    if (!userProfile || !userProfile.badgeCollection) {
+      return 0;
+    }
+  
+    let totalBadges = 0;
+    userProfile.badgeCollection.forEach(badge => {
+      if (badge?.badge?.badgeName === 'Personal Max' || badge?.badge?.type === 'Personal Max') {
+        totalBadges += 1;
+      } else {
+        totalBadges += Math.round(Number(badge.count));        
+      }
+    });
+  
+    return totalBadges;
+  };  
 
   const getState = useSelector(state => {
     return state;

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -37,7 +37,13 @@ export const Badges = props => {
   }, [isOpen, isAssignOpen]);
 
   // Determines what congratulatory text should displayed.
-  const badgesEarned = props.userProfile.badgeCollection.reduce((acc, obj) => acc + Number(obj.count), 0);
+  const badgesEarned = props.userProfile.badgeCollection.reduce((acc, badge) => {
+    if (badge?.badge?.badgeName === 'Personal Max' || badge?.badge?.type === 'Personal Max') {
+      return acc + 1;
+    }
+    return acc + Math.round(Number(badge.count));
+  }, 0);
+  
   const subject = props.isUserSelf ? 'You have' : 'This person has';
   const verb = badgesEarned ? `earned ${badgesEarned}` : 'no';
   const object = badgesEarned == 1 ? 'badge' : 'badges';


### PR DESCRIPTION
# Description
Fix the count of badges on profile is floating number instead of integer.

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/00a1acf3-d54a-4df0-b8b9-3df7ffef327b)

## Main changes explained:
- Personal Max Badge should be counted as 1 badge instead of it's Hours Logged Value (floating number)

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as admin/any user
4. go to dashboard → check the summary bar for the correct output of badge count
5. go to dashboard → view profile → check for the correct output of badge count

## Before
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/44e87b54-00cd-4b63-ba9d-ac0283fea0cf)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/ccb22911-cae1-4815-b4ab-02bb9765f124)

## After
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/053227c3-ae86-4291-83cd-41ffa628f37c)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/d55ff086-0f45-4cbc-ba9e-47ec34a4d8c3)
