### PR TITLE
Olga Reconcile values of tangible hours in userprofile data

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -31,6 +31,7 @@ import { ENDPOINTS } from '../../../utils/URL';
 import hasPermission from 'utils/permissions';
 import { getTimeEntryFormData } from './selectors';
 import checkNegativeNumber from 'utils/checkNegativeHours';
+import fixDiscrepancy from 'utils/fixDiscrepancy';
 import { boxStyle } from 'styles';
 
 /**
@@ -291,10 +292,17 @@ const TimeEntryForm = props => {
     setErrors(result);
     return isEmpty(result);
   };
+
+
   //Update hoursByCategory when submitting new time entry
   const updateHoursByCategory = async (userProfile, timeEntry, hours, minutes) => {
     const { hoursByCategory } = userProfile;
     const { projectId, isTangible, personId } = timeEntry;
+
+    //fix discrepancy in hours in userProfile if any
+
+     fixDiscrepancy(userProfile);
+
     //Format hours && minutes
     const volunteerTime = parseFloat(hours) + parseFloat(minutes) / 60;
 

--- a/src/utils/fixDiscrepancy.js
+++ b/src/utils/fixDiscrepancy.js
@@ -1,0 +1,22 @@
+  //this reconciles total hoursByCategory with total savedTangibleHrs and with totalTangibleHrs after the numbers got messed up as a result of a previous bug
+
+  const fixDiscrepancy = userProfile => {
+
+    const { savedTangibleHrs, hoursByCategory } = userProfile;
+
+    const sumOfsavedTangibleHrs = savedTangibleHrs.reduce((acc, curr) => acc + curr, 0);
+
+    if (userProfile.totalTangibleHrs < sumOfsavedTangibleHrs) {
+      userProfile.totalTangibleHrs = sumOfsavedTangibleHrs
+    };
+
+    const sumOfhoursByCategory = Object.values(hoursByCategory).reduce((acc, curr) => acc + curr, 0);
+
+    if (sumOfhoursByCategory < userProfile.totalTangibleHrs) {
+      let difference = userProfile.totalTangibleHrs - sumOfhoursByCategory
+      hoursByCategory['unassigned'] += difference
+    }
+
+  }
+
+export default fixDiscrepancy;

--- a/src/utils/fixDiscrepancy.js
+++ b/src/utils/fixDiscrepancy.js
@@ -1,22 +1,21 @@
-  //this reconciles total hoursByCategory with total savedTangibleHrs and with totalTangibleHrs after the numbers got messed up as a result of a previous bug
+  //this function reconciles total hoursByCategory with total savedTangibleHrs and with totalTangibleHrs after the numbers got messed up as a result of a previous bug
 
   const fixDiscrepancy = userProfile => {
 
     const { savedTangibleHrs, hoursByCategory } = userProfile;
 
     const sumOfsavedTangibleHrs = savedTangibleHrs.reduce((acc, curr) => acc + curr, 0);
-
-    if (userProfile.totalTangibleHrs < sumOfsavedTangibleHrs) {
-      userProfile.totalTangibleHrs = sumOfsavedTangibleHrs
-    };
-
+   
+    //the following is needed because currently totalTangibleHrs shows a random number which may be more or less than actual sumOfsavedTangibleHrs
+    
+    userProfile.totalTangibleHrs = sumOfsavedTangibleHrs
+    
     const sumOfhoursByCategory = Object.values(hoursByCategory).reduce((acc, curr) => acc + curr, 0);
 
     if (sumOfhoursByCategory < userProfile.totalTangibleHrs) {
       let difference = userProfile.totalTangibleHrs - sumOfhoursByCategory
       hoursByCategory['unassigned'] += difference
     }
-
   }
 
 export default fixDiscrepancy;


### PR DESCRIPTION
# Description

 (PRIORITY MEDIUM) Shihao: Fix hours totals/summary on profile page (WIP Olga)
The value of totalTangibleHrs in profile page data doesn’t match the summation of hoursByCategory

### EXPLANATION OF THE PROBLEM

**>>>Please check if you observe the following behavior in your userProfile and if you do, then review the PR. This will not be happening to newer team members, so they won't be able to test this PR.<<<**

On Beta site go to your own user Profile page -> volunteering times tab -> right click to open dev tools -> open React Components and expand userProfile data:


![Screen Shot 2023-08-24 at 11 33 21 AM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/107726913/87ab54ac-5930-48b6-99d9-7ff4dcbeb438)

Those who have been with HGN more than a month,  may notice that Total Tangible Hours (#1 on the screenshot) on your profile page may show less hours than you’ve actually worked.  

If you look at the screenshot you will see that 1 (Total Tangible Hours in Volunteering Times Tab on user Profile page) is equal to the sum of elements in 2 (userProfile.hoursByCategory), but it is less than sum of elements in 3(userProfile.savedTangibleHrs), and 5 (userProfile.totalTangibleHrs) is a totally random number. This probably happened due to the bug affecting weekly summaries and blue squares - at some point some entries in the userProfile data stopped incrementing. As a result the number displayed on the user profile on the webpage is incorrect for some users. The correct numbers should be  as follows:

1 (Total Tangible Hours in Volunteering Times Tab on user Profile page) must be equal to 2 (userProfile.hoursByCategory) -  this is currently correct;
2 (userProfile.hoursByCategory) must be equal to the sum of 3 (userProfile.savedTangibleHrs)  + 4 (userProfile.tangibleHoursReportedThisWeek)
5 (userProfile.totalTangibleHrs) must be equal to the sum of all elements in 3 (userProfile.savedTangibleHrs), 

( NOTE: 5 is incremented by the value in 4 at the start of a new week when weekly summaries and blue squares are processed)


## Main changes explained:

Created a helper function to reconcile all the numbers if they are in disarray. The function will run when a new time entry is entered and should fix the numbers in userProfile data before they are incremented by a new time entry. If the hoursBycategory was smaller than actual total hours (which is the sum of savedTangibleHours) then the missing hours will be added into ‘unassigned’ category, because there is now way to find out which category those missed hours belonged to.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Log in as any user that has existed for a while and has a few time entries, not a newly created one. 
Open their profile page. Open React dev tools and expand the userProfile entry. Check the numbers in the above mentioned entries. Check if the numbers are in disarray as explained above. ***You may see that on localhost savedTangibleHrs array is super long, much longer than the total number of your weeks, disregard this for now. 
4. Add a new tangible timeentry through the dashboard. Refresh the page. Check the userProfile in dev tools again - check that:
1 (Total Tangible Hours in Volunteering Times Tab on user Profile page) is equal to 2 (userProfile.hoursByCategory) -  this is currently correct;
2 (userProfile.hoursByCategory) is equal to the total of 3 (userProfile.savedTangibleHrs)  + 4 (userProfile.tangibleHoursReportedThisWeek)
5 (userProfile.totalTangibleHrs) is equal to the sum of all elements in 3 (userProfile.savedTangibleHrs), 
The hours that were previously missing (the difference between the TotalTangbileHrs and total HoursBy Category) have been added to hoursBycategory under ‘unassigned’

## User Profile data after the fix (all above entries must be reconciled):

![TASK255_test_result](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/107726913/e3b60413-2884-4f86-b6cb-2bb80badb11e)


## Video how to test: 

https://www.loom.com/share/55f6ec79beb2438fb2b6d1deecabbaa0



