### PR TITLE
XiaoW_hotfix_of_weekly_summaries_reports_page

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -39,7 +39,7 @@ export class WeeklySummariesReport extends Component {
   async componentDidMount() {
     // 1. fetch report
     await this.props.getWeeklySummariesReport();
-    await this.props.fetchAllBadges();
+    // await this.props.fetchAllBadges();
 
     this.canPutUserProfileImportantInfo = this.props.hasPermission('putUserProfileImportantInfo');
     this.bioEditPermission = this.canPutUserProfileImportantInfo;
@@ -176,7 +176,7 @@ export class WeeklySummariesReport extends Component {
   };
 
   render() {
-    const { error, loading, summaries, activeTab, badges } = this.state;
+    const { error, loading, summaries, activeTab } = this.state;
 
     if (error) {
       return (


### PR DESCRIPTION
# Description
This is a hot fix for volunteer account couldn't fully load the WeeklySummariesReport page.

## Related PRS (if any):
This PR is related to the [#503](https://github.com/OneCommunityGlobal/HGNRest/pull/503#issue-1878400164) frontend PR.

## Main changes explained:
Two requests sent by this page would fail and prevent this page from fully loaded for volunteer users:
1. `getWeeklySummariesReport`: this is caused by permission issue and it will be fixed by the backend PR
2. `fetchAllBadges`: this is commented out, and one `badge` prop is removed since it is not used in `WeeklySummariesReport` component