### PR TITLE
Navneeth Make adding a Project save the category selected

### DIFF
--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -86,7 +86,6 @@ export const deleteProject = projectId => {
 
 export const modifyProject = (type, projectId, projectName, category, isActive) => {
   const url = ENDPOINTS.PROJECT + projectId;
-
   if (type === 'setActive') {
     isActive = !isActive;
   }

--- a/src/components/Projects/Project/Project.jsx
+++ b/src/components/Projects/Project/Project.jsx
@@ -9,7 +9,7 @@ import { boxStyle } from 'styles';
 
 const Project = props => {
   const [originName] = useState(props.name);
-  const [originCategory] = useState(props.category);
+  const [originCategory, setOriginCategory] = useState(props.category);
   const [name, setName] = useState(props.name);
   const [category, setCategory] = useState(props.category);
   const [active, setActive] = useState(props.active);
@@ -35,6 +35,7 @@ const Project = props => {
       setName(originName);
     } else if (originName !== name || category != originCategory) {
       props.onUpdateProjectName(props.projectId, name, category, active);
+      setOriginCategory(category);
     }
   };
 


### PR DESCRIPTION
# Description
![bug I am working on](https://github.com/OneCommunityGlobal/HGNRest/assets/44264834/7206d7fa-d01d-4621-af80-5f787365aad6)

## Related PRS (if any):
This frontend PR is related to the [#490 backend PR](https://github.com/OneCommunityGlobal/HGNRest/pull/490).
To test this frontend PR, you need to checkout the above backend PR.

## Main changes explained:
- Fixed a bug in `Project.jsx` where a related state was not being updated after the project category was updated

## How to test:
1. check into the current branch (also in the [#490 backend PR](https://github.com/OneCommunityGlobal/HGNRest/pull/490)).
2. do `npm install` and `npm run start:local` to run this PR locally.
3. login as admin/owner user
4. go to Other Links -> Projects
5. Add a new project with an unique name and remember its category
6. Refresh the page or leave the Projects page and come back to it
7. Scroll down to your newly created project and check if its category is the same as the category set when it was created
8. Change the newly created project's category from the dropdown and see if the update works for all types of categories

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/44264834/f9ba417f-5939-4eca-906c-c241b8438563




