### PR TITLE
XiaoW_Hot fix of resources dropdown not showing up

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/components/TagsSearch.jsx
+++ b/src/components/Projects/WBS/WBSDetail/components/TagsSearch.jsx
@@ -60,8 +60,8 @@ function TagsSearch({ placeholder, members, addResources, removeResource, resour
   };
 
   return (
-    <div className="container-fluid d-flex flex-column px-0">
-      <div className="d-flex flex-column container-fluid mb-1 px-0">
+    <div className="d-flex flex-column px-0">
+      <div className="d-flex flex-column mb-1 px-0">
         <div className="align-items-start justify-content-start w-100 px-0 position-relative">
           <input
             type="text"


### PR DESCRIPTION
# Description
This is a hot fix that when adding task, resources dropdown not showing up. 

## Main changes explained:
remove `container-fluid` class from resources containers since the styling it takes is changed from Bootstrap to `public/index.css` by [#PR1224](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1224#issue-1878531104), which leads to the `overflow-y` value changed from default `visible` to `auto`.
