### PR TITLE
Nathan format user permissions popup

### DIFF
--- a/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
+++ b/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
@@ -12,6 +12,7 @@ import { ENDPOINTS } from 'utils/URL';
 import { boxStyle } from 'styles';
 
 const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles }) => {
+  const mainPermissions = ['See All the Reports Tab (DNE)', 'See User Management Tab (Full Functionality) (DNE)', 'See Badge Management Tab (Full Functionality) (DNE)', 'See Project Management Tab (Full Functionality) (DNE)', 'Edit Task', 'See Teams Management Tab (Full Functionality) (DNE)', 'Edit Timelog Information (DNE)', 'Edit User Profile', 'See Popup Management Tab (create and update popups) (DNE - separate)', 'See Permissions Management Tab (DNE - postRole/putRole)', 'See Summary Indicator (DNE)', 'See Visibility Icon (DNE)'  ]
   const [searchText, onInputChange] = useState('');
   const [actualUserProfile, setActualUserProfile] = useState();
   const [isOpen, setIsOpen] = useState(false);
@@ -169,10 +170,15 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles }) =
             return (
               <li key={key} className="user-role-tab__permission">
                 <div
-                  style={{
-                    color: isPermissionChecked(key) || isPermissionDefault(key) ? 'green' : 'red',
-                    padding: '14px',
-                  }}
+                  style = { mainPermissions.includes(value) ? {
+                            color: isPermissionChecked(key) || isPermissionDefault(key) ? 'green' : 'red',
+                            fontSize: '20px',
+                            padding: '14px',
+                          } : {
+                            color: isPermissionChecked(key) || isPermissionDefault(key) ? 'green' : 'red',
+                            padding: '14px',
+                            paddingLeft: '50px',
+                          }}
                 >
                   {value}
                 </div>


### PR DESCRIPTION
# Description
Adds header styling to user permissions popup.

## Related PRS (if any):
This is a continuation of PRs#1227 and #1220.

## Main changes explained:
- Copied list of headers from `RolePermissions.jsx` to `UserPermissionsPopUp.jsx`.
- Added conditional styling for headers/subheaders.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. login as owner user
4. go to dashboard→ Other Links→ Permisison Management→Manage User Permissions
5. Check styling indentation and font conforms with screenshots and Google Sheets doc.
https://docs.google.com/spreadsheets/d/1TfiJY9OLDZuyP2UgF0C1wI9tOSLKbS9MiJFH6n1Dsao/edit#gid=0

## Screenshots or videos of changes:
Before:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/5f4d5124-8266-4341-b8f3-c423fcc15dca)

After:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/28d88ece-19ed-499b-bbb5-bcb02bfb30ad)
