### PR TITLE
XiaoW_Hot fix of auto-clear resources input 

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/components/TagsSearch.jsx
+++ b/src/components/Projects/WBS/WBSDetail/components/TagsSearch.jsx
@@ -10,7 +10,7 @@ function TagsSearch({ placeholder, members, addResources, removeResource, resour
   const handleClick = (event, member) => {
     addResources(member._id, member.firstName, member.lastName);
     setIsHidden(!isHidden);
-    event.target.closest('.container-fluid').querySelector('input').value = '';
+    event.target.closest(".my-element").previousElementSibling.value = '';
   };
 
   // sorting using the input letter, giving highest priority to first name starting with that letter,


### PR DESCRIPTION
# Description
This is a hot fix of making resources input auto-clear itself when a member is selected. 

## Related PRS (if any):
This is a follow-up patch for [PR#1238](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1238#issue-1879208999)

## Main changes explained:
Make `handleClick` logic not depend on class `.container-fluid`