### PR TITLE
Tim fix dashboard badge modal

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -8,7 +8,6 @@ import {
   CardText,
   CardBody,
   CardHeader,
-  Button,
   Modal,
   ModalBody,
   UncontrolledTooltip,
@@ -17,7 +16,7 @@ import {
 import './Badge.css';
 import NewBadges from './NewBadges';
 import OldBadges from './OldBadges';
-import BadgeReport from './BadgeReport';
+import BadgeSummaryViz from 'components/Reports/BadgeSummaryViz';
 import { getUserProfile } from '../../actions/userProfile';
 import { boxStyle } from 'styles';
 
@@ -89,25 +88,7 @@ const Badge = props => {
                     : 'You have no badges. '}
                   <i className="fa fa-info-circle" id="CountInfo" />
                 </CardText>
-                <Button
-                  className="btn--dark-sea-green float-right"
-                  onClick={toggle}
-                  style={boxStyle}
-                >
-                  Badge Report
-                </Button>
-                <Modal size={'lg'} isOpen={isOpen} toggle={toggle}>
-                  <ModalHeader toggle={toggle}>Full View of Badge History</ModalHeader>
-                  <ModalBody>
-                    <BadgeReport
-                      badges={props.userProfile.badgeCollection || []}
-                      userId={props.userId}
-                      firstName={props.userProfile.firstName}
-                      lastName={props.userProfile.lastName}
-                      close={toggle}
-                    />
-                  </ModalBody>
-                </Modal>
+                <BadgeSummaryViz badges={props.userProfile.badgeCollection} dashboard={true} />
               </CardBody>
             </Card>
           </Col>

--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -312,7 +312,7 @@ const BadgeReport = props => {
               </tr>
             </thead>
             <tbody>
-              {sortBadges &&
+              {sortBadges && sortBadges.length ?
                 sortBadges.map((value, index) => (
                   <tr key={index}>
                     <td className="badge_image_sm">
@@ -400,7 +400,13 @@ const BadgeReport = props => {
                       </FormGroup>
                     </td>
                   </tr>
-                ))}
+                )) : 
+                  <tr>
+                    <td colSpan={7} style={{ textAlign: "center" }}>
+                      {`${props.isUserSelf ? "You have" : "This person has"} no badges.`}
+                    </td>
+                  </tr>
+              }
             </tbody>
           </Table>
         </div>
@@ -458,7 +464,7 @@ const BadgeReport = props => {
               </tr>
             </thead>
             <tbody>
-              {sortBadges &&
+              {sortBadges && sortBadges.length ?
                 sortBadges.map((value, index) => (
                   <tr key={index}>
                     <td className="badge_image_sm">
@@ -584,7 +590,13 @@ const BadgeReport = props => {
                       </ButtonGroup>
                     </td>
                   </tr>
-                ))}
+                )) : 
+                  <tr>
+                    <td colSpan={7} style={{ textAlign: "center" }}>
+                      {`${props.isUserSelf ? "You have" : "This person has"} no badges.`}
+                    </td>
+                  </tr>
+              }
             </tbody>
           </Table>
         </div>

--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -350,8 +350,8 @@ const BadgeReport = props => {
                           Dates
                         </DropdownToggle>
                         <DropdownMenu>
-                          {value.earnedDate.map(date => {
-                            return <DropdownItem>{date}</DropdownItem>;
+                          {value.earnedDate.map((date, i) => {
+                            return <DropdownItem key={i}>{date}</DropdownItem>;
                           })}
                         </DropdownMenu>
                       </UncontrolledDropdown>
@@ -574,13 +574,12 @@ const BadgeReport = props => {
                               }}
                             >
                               {canDeleteBadges ? (
-                                <button
-                                  type="button"
+                                <div
                                   className="btn btn-danger"
                                   onClick={e => handleDeleteBadge(index)}
                                 >
                                   Delete
-                                </button>
+                                </div>
                               ) : (
                                 []
                               )}

--- a/src/components/Reports/BadgeSummaryViz.jsx
+++ b/src/components/Reports/BadgeSummaryViz.jsx
@@ -103,8 +103,8 @@ return (
                         Dates
                       </DropdownToggle>
                       <DropdownMenu>
-                        {value.earnedDate.map(date => {
-                          return <DropdownItem>{date}</DropdownItem>;
+                        {value.earnedDate.map((date, index) => {
+                          return <DropdownItem key={index}>{date}</DropdownItem>;
                         })}
                       </DropdownMenu>
                     </UncontrolledDropdown>

--- a/src/components/Reports/BadgeSummaryViz.jsx
+++ b/src/components/Reports/BadgeSummaryViz.jsx
@@ -22,7 +22,7 @@ import { boxStyle } from 'styles';
 import '../Badge/BadgeReport.css'
 import './BadgeSummaryViz.css'
 
-const BadgeSummaryViz = ({ badges, dashboard }) => {
+const BadgeSummaryViz = ({ authId, userId, badges, dashboard }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [sortedBadges, setSortedBadges] = useState([]);
 
@@ -42,6 +42,13 @@ const BadgeSummaryViz = ({ badges, dashboard }) => {
   }, [badges]);
   
 const toggle = () => setIsOpen(prev => !prev)
+
+// console.log('dashboard > badgesummaryviz > userId', userId)
+// console.log('dashboard > badgesummaryviz > badges', badges)
+// console.log('dashboard > badgesummaryviz > dashboard', dashboard)
+
+console.log('people report > badgesummaryviz > authId', authId)
+console.log('people report > badgesummaryviz > userId', userId)
 
 return (
   <div>
@@ -66,7 +73,7 @@ return (
                   </tr>
                 </thead>
                 <tbody>
-                { badges.length ? sortedBadges && sortedBadges.map((value, index) => (
+                { badges && badges.length ? sortedBadges && sortedBadges.map((value, index) => (
                 <tr key={index}>
                   <td className="badge_image_sm">
                     {' '}
@@ -111,7 +118,7 @@ return (
                   </td>
                   <td>{value.count}</td>
                 </tr>
-                )) : <tr><td colSpan={5} style={{ textAlign: "center" }}>This person has no badges.</td></tr>}
+                )) : <tr><td colSpan={5} style={{ textAlign: "center" }}>{`${dashboard || authId === userId ? "You have" : "This person has"} no badges.`}</td></tr>}
                 </tbody>
               </Table>
             </div>
@@ -129,7 +136,7 @@ return (
                   </tr>
                 </thead>
                 <tbody>
-                {badges.length ? sortedBadges && sortedBadges.map((value, index) => (
+                {badges && badges.length ? sortedBadges && sortedBadges.map((value, index) => (
                   <tr key={index}>
                     <td className="badge_image_sm">
                       {' '}
@@ -161,7 +168,7 @@ return (
                     </td>
                     <td>{value.count}</td>
                   </tr>
-                  )) : <tr><td colSpan={4} style={{ textAlign: "center" }}>This person has no badges.</td></tr>}
+                  )) : <tr><td colSpan={4} style={{ textAlign: "center" }}>{`${dashboard || authId === userId ? "You have" : "This person has"} no badges.`}</td></tr>}
                 </tbody>
               </Table>
             </div>

--- a/src/components/Reports/BadgeSummaryViz.jsx
+++ b/src/components/Reports/BadgeSummaryViz.jsx
@@ -43,13 +43,6 @@ const BadgeSummaryViz = ({ authId, userId, badges, dashboard }) => {
   
 const toggle = () => setIsOpen(prev => !prev)
 
-// console.log('dashboard > badgesummaryviz > userId', userId)
-// console.log('dashboard > badgesummaryviz > badges', badges)
-// console.log('dashboard > badgesummaryviz > dashboard', dashboard)
-
-console.log('people report > badgesummaryviz > authId', authId)
-console.log('people report > badgesummaryviz > userId', userId)
-
 return (
   <div>
     <Button onClick={toggle} style={boxStyle} className={`${dashboard && "btn--dark-sea-green float-right"}`}>

--- a/src/components/Reports/BadgeSummaryViz.jsx
+++ b/src/components/Reports/BadgeSummaryViz.jsx
@@ -22,7 +22,7 @@ import { boxStyle } from 'styles';
 import '../Badge/BadgeReport.css'
 import './BadgeSummaryViz.css'
 
-const BadgeSummaryViz = ({ badges }) => {
+const BadgeSummaryViz = ({ badges, dashboard }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [sortedBadges, setSortedBadges] = useState([]);
 
@@ -45,8 +45,8 @@ const toggle = () => setIsOpen(prev => !prev)
 
 return (
   <div>
-    <Button onClick={toggle} style={boxStyle}>
-      Show Badges
+    <Button onClick={toggle} style={boxStyle} className={`${dashboard && "btn--dark-sea-green float-right"}`}>
+      {dashboard ? "Badge Report" : "Show Badges"}
     </Button>
     <Modal size="lg" isOpen={isOpen} toggle={toggle}>
       <ModalHeader>Badge Summary</ModalHeader>

--- a/src/components/Reports/BadgeSummaryViz.jsx
+++ b/src/components/Reports/BadgeSummaryViz.jsx
@@ -66,7 +66,7 @@ return (
                   </tr>
                 </thead>
                 <tbody>
-                {sortedBadges && sortedBadges.map((value, index) => (
+                { badges.length ? sortedBadges && sortedBadges.map((value, index) => (
                 <tr key={index}>
                   <td className="badge_image_sm">
                     {' '}
@@ -111,7 +111,7 @@ return (
                   </td>
                   <td>{value.count}</td>
                 </tr>
-                ))}
+                )) : <tr><td colSpan={5} style={{ textAlign: "center" }}>This person has no badges.</td></tr>}
                 </tbody>
               </Table>
             </div>
@@ -129,7 +129,7 @@ return (
                   </tr>
                 </thead>
                 <tbody>
-                {sortedBadges && sortedBadges.map((value, index) => (
+                {badges.length ? sortedBadges && sortedBadges.map((value, index) => (
                   <tr key={index}>
                     <td className="badge_image_sm">
                       {' '}
@@ -161,7 +161,7 @@ return (
                     </td>
                     <td>{value.count}</td>
                   </tr>
-                  ))}
+                  )) : <tr><td colSpan={4} style={{ textAlign: "center" }}>This person has no badges.</td></tr>}
                 </tbody>
               </Table>
             </div>

--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -609,7 +609,7 @@ class PeopleReport extends Component {
                 <TimeEntriesViz timeEntries={timeEntries} fromDate={fromDate} toDate={toDate} />
               </div>
               <div className='visualizationDiv'>
-                <BadgeSummaryViz badges={userProfile.badgeCollection} />
+                <BadgeSummaryViz authId={this.props.auth.user.userid} userId={this.props.match.params.userId} badges={userProfile.badgeCollection} />
               </div>
             </table>
           </div>

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -73,6 +73,7 @@ export const Badges = props => {
                         setUserProfile={props.setUserProfile}
                         setOriginalUserProfile={props.setOriginalUserProfile}
                         handleSubmit={props.handleSubmit}
+                        isUserSelf={props.isUserSelf}
                       />
                     </ModalBody>
                   </Modal>


### PR DESCRIPTION
# Description
(PRIORITY MEDIUM) Fix View Full Badge History modal (Dashboard > Badges > Badge Report button) modal to not crash app. Attempting to edit values in the modal and clicking Save Changes results in an error that freezes the app and forces a page refresh.

<img width="396" alt="app-crash-error" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/98129080/f20e6a6d-2a5f-4e54-bc5b-c7b1ad7f8fb5">

## Related PRS (if any):
N/A

## Main changes explained:
- The Badge Summary modal accessible on the Dashboard (Dashboard > Badges > Badge Report) has been changed from editable to the same static modal that displays on the People Reports page.
   - The crashes were caused by unavailable (because the necessary prop drilling had not been set up) functions being called.
- All Badge Summary modals (Dashboard, People Reports, User Profile) have been updated to show text if the user has no badges.
   - “You have no badges” if it is the user’s own report.
   - “This person has no badges” if it is another user’s report.
- `key` prop errors in the badge summary modals have been fixed.
- A `button` element has been replaced by a `div` to fix a nested button error.

<img width="392" alt="nested-button-error" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/98129080/d1640f73-6cd3-4199-a04e-1f7482b3a983">

## How to test:
- `git checkout Tim_fix_dashboard_badge_modal` to check into current branch
- `npm install` to ensure your modules are up to date (no new modules are added in this PR)
- `npm run start:local` to run this PR locally
- Log in as an admin
- Navigate to Dashboard > Badges > Badge Report. The modal should not be editable and should not crash the app when closed. There should be no “key prop” or “nested button” errors in the console.
- In the User Profile > Select Featured modal you can temporarily delete your badges to check the text “You have no badges.” is displayed. You can test against various screen widths as well. Also check that this modal does not display “key prop” or “nested button” errors in your console.
- Lastly, use Other Links > User Management to navigate to a different user account who has no badges (you can delete the badges from one of your own test accounts, or use Tim Core). The text displayed should now be “This person has no badges.”
- You can run the same tests on the badge modal located at Reports > Reports > People > select a person > Show Badges.  

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/98129080/4cd85749-56f1-43ab-916c-9df33027ff44