### PR TITLE
Zijie fix Fix team page formatting of Active and Members

### DIFF
--- a/src/components/Teams/Team.css
+++ b/src/components/Teams/Team.css
@@ -68,12 +68,23 @@ thead {
   border: 1px solid #dee2e6;
 }
 
+.isActive {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
 .isActive i {
   color: lawngreen;
 }
 
 .isNotActive {
   color: #dee2e6;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
 }
 
 .isDisabled {

--- a/src/components/Teams/Team.css
+++ b/src/components/Teams/Team.css
@@ -14,6 +14,12 @@ thead {
   width: 10px;
 }
 
+.centered-cell {
+  text-align: center;
+  vertical-align: middle;
+}
+
+
 #teams__members {
   width: 15px;
 }

--- a/src/components/Teams/Team.jsx
+++ b/src/components/Teams/Team.jsx
@@ -36,7 +36,7 @@ export const Team = props => {
           </div>
         )}
       </td>
-      <td>
+      <td style={boxStyle}>
         <button
           type="button"
           className="btn btn-outline-info"

--- a/src/components/Teams/Team.jsx
+++ b/src/components/Teams/Team.jsx
@@ -36,8 +36,8 @@ export const Team = props => {
           </div>
         )}
       </td>
-      <td style={boxStyle} className="centered-cell">
-        <button
+      <td className="centered-cell">
+        <button style={boxStyle}
           type="button"
           className="btn btn-outline-info"
           onClick={e => {

--- a/src/components/Teams/Team.jsx
+++ b/src/components/Teams/Team.jsx
@@ -23,7 +23,7 @@ export const Team = props => {
             ? props.onStatusClick(props.name, props.teamId, props.active)
             : null;
         }}
-        style={boxStyle}
+        // style={boxStyle}
         data-testid='active-marker'
       >
         {props.active ? (

--- a/src/components/Teams/Team.jsx
+++ b/src/components/Teams/Team.jsx
@@ -36,7 +36,7 @@ export const Team = props => {
           </div>
         )}
       </td>
-      <td style={boxStyle}>
+      <td style={boxStyle} className="centered-cell">
         <button
           type="button"
           className="btn btn-outline-info"


### PR DESCRIPTION
# Description
<img width="697" alt="CleanShot 2023-09-05 at 12 23 39@2x" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/46791134/17d4265d-5260-4bc8-b337-c12c5ce94963">

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as admin or owner user
4. go to Other Links>Teams
5. check: Stuff below Active should be centered with no shadow. Stuff below Members should be centered with shadow.


Before:
<img width="371" alt="CleanShot 2023-09-05 at 12 26 50@2x" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/46791134/b3964c04-bf90-4d5e-86db-8edc7bdb292a">



After:
<img width="309" alt="CleanShot 2023-09-05 at 12 33 17@2x" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/46791134/639e5e40-8070-420c-b1e9-2e756ec4dba2">

## Update
Shadow small box instead of the big box.

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/46791134/b9aec51f-fbec-4484-a6cf-5dedf5f2427f)

