### PR TITLE
Gary fix reports page state

### DIFF
--- a/src/components/Reports/PeopleTable.js
+++ b/src/components/Reports/PeopleTable.js
@@ -15,7 +15,7 @@ function PeopleTable(props) {
             <div>{index + 1}</div>
           </th>
           <td>
-            <Link to={`/peoplereport/${person._id}`} personId={person._id}>
+            <Link to={`/peoplereport/${person._id}`}>
               {person.firstName}{' '}
               {person.lastName.length > 15 ? person.lastName.slice(0, 15) + '...' : person.lastName}
             </Link>

--- a/src/components/Reports/ProjectTable.jsx
+++ b/src/components/Reports/ProjectTable.jsx
@@ -7,12 +7,12 @@ const ProjectTable = props => {
   let ProjectsList = [];
   if (props.projects.length > 0) {
     ProjectsList = props.projects.map((project, index) => (
-      <tr id={'tr_' + project._id}>
+      <tr id={'tr_' + project._id} key={project._id}>
         <th scope="row">
           <div>{index + 1}</div>
         </th>
         <td>
-          <Link to={`/projectreport/${project._id}`} projectId={project._id}>
+          <Link to={`/projectreport/${project._id}`}>
             {project.projectName}
           </Link>
         </td>

--- a/src/components/Reports/Reports.jsx
+++ b/src/components/Reports/Reports.jsx
@@ -91,12 +91,12 @@ class ReportsPage extends Component {
   async componentDidMount() {
     this.props.fetchAllProjects(); // Fetch to get all projects
     this.props.getAllUserTeams();
-    this.state = {
+    this.setState({
       showProjects: false,
       showPeople: false,
       showTeams: false,
       checkActive: '',
-    };
+    });
     this.props.getAllUserProfile();
   }
 

--- a/src/components/Reports/TeamTable.jsx
+++ b/src/components/Reports/TeamTable.jsx
@@ -7,12 +7,12 @@ function TeamTable(props) {
   let TeamsList = [];
   if (props.allTeams.length > 0) {
     TeamsList = props.allTeams.map((team, index) => (
-      <tr id={`tr_${team._id}`}>
+      <tr id={`tr_${team._id}`} key={team._id}>
         <th scope="row">
           <div>{index + 1}</div>
         </th>
         <td>
-          <Link to={`/teamreport/${team._id}`} teamId={team._id} teamName={team.teamName}>
+          <Link to={`/teamreport/${team._id}`}>
             {team.teamName}
           </Link>
         </td>


### PR DESCRIPTION
# Description
Fix console errors that occur upon visiting the Reports page. These include the state of the ReportsPage not matching memoized state, React not recognizing certain props, and suggesting that children in a list should have a 'key' property.

## Related PRS (if any):
None

## Main changes explained:
- Update Reports.jsx to not mutate state directly on componentDidMount().
- Update PeopleTable.js by providing 'tr' children with a key property.
- Update ProjectTable.jsx by removing unnecessary props given to Link component and providing 'tr' children with a key property.
- Update TeamTable.jsx by removing unnecessary props given to Link component and providing 'tr' children with a key property.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. open dev tools and open the console
5. go to dashboard→ Reports→ Reports
6. verify functionality of page and that the console errors displayed below are not logged
7. click on the Projects, People, and Teams buttons to cycle through the tables
8. verify functionality of the tables and that the console errors displayed below are not logged

## Screenshots or videos of changes:
![Screenshot 2023-09-06 at 2 51 24 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/108501006/1c59648d-0802-4af5-81ce-4821ee7056d9)
![Screenshot 2023-09-06 at 2 52 01 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/108501006/0f9371b4-5b51-4010-ab2a-0df2d102b862)