### PR TITLE
Shrey fix castError issue and stop unecessary api call when task id is undefined

### DIFF
--- a/src/components/Projects/WBS/SingleTask/SingleTask.js
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.js
@@ -33,6 +33,7 @@ function SingleTask(props) {
   const history = useHistory();
   useEffect(() => {
     const fetchTaskData = async () => {
+      if (!taskId) return;
       try {
         const res = await axios.get(ENDPOINTS.GET_TASK(taskId));
         setTask(res?.data || {});
@@ -41,7 +42,7 @@ function SingleTask(props) {
       }
     };
     fetchTaskData();
-  }, []);
+  }, [taskId]);
 
   const deleteTask = (taskId, taskMother) => {
     props.deleteTask(taskId, taskMother);

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -203,6 +203,9 @@ const EditTaskModal = props => {
   */
   useEffect(() => {
     const fetchTaskData = async () => {
+      if (!props.taskId) {
+        return;
+      }
       try {
         const res = await axios.get(ENDPOINTS.GET_TASK(props.taskId));
         setThisTask(res?.data || {});


### PR DESCRIPTION
# Description
Fix sentry logging issue when accessing a task from dashboard page logged in as any type of user.
Log in to HGN app in development branch for frontend and backend under any type of user i.e. Admin, Manager, Volunteer, etc.
On the Dashboard page select a task by clicking the name of the task.
You will be redirected to the task page but you will notice the CastError that gets logged to the console on the server side.

## Related PRS (if any):
This frontend PR is related to the [#531](https://github.com/OneCommunityGlobal/HGNRest/pull/531) backend PR.
To test this backend PR you need to checkout the [#531](https://github.com/OneCommunityGlobal/HGNRest/pull/531) frontend PR.
…

## Main changes explained:
updated fetchTaskData function in singleTask.js file to handle undefined taskId
updated fetchTaskData function in editTaskModal.js file to handle undefined taskId
…

## How to test:
1. check into current branch and [531](https://github.com/OneCommunityGlobal/HGNRest/pull/531) in the backend
2. do `npm install` and `...` to run this PR locally
3. log as admin/owner/volunteer all of the users or any user 
4. go to dashboard→ Tasks→ eam Member Tasks→ Click on task name
5. verify on the backend console that you do not see castError. 
6. Verify on the console that you do not see 500 or 400 for undefined taskId

## Screenshots or videos of changes:
Before:
<img width="1476" alt="Screenshot 2023-09-07 at 5 57 40 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/cecc251a-79b1-4341-a5f8-7c42749ae7cb">

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/997209ce-e235-45cf-b072-c70ec7ff5374


After:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/378479f1-1578-439c-8fb2-1b309f81ad7f


