### PR TITLE
Edwin - Add See User Management Tab (ONLY create users) permission

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -54,6 +54,7 @@ export const Header = props => {
   const canPostUserProfile = props.hasPermission('postUserProfile');
   const canDeleteUserProfile = props.hasPermission('deleteUserProfile');
   const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
+  const canSeeUserManagementTab = props.hasPermission('seeUserManagement') || props.hasPermission('seeUserManagementTab')
   // Badges
   const canCreateBadges = props.hasPermission('createBadges');
   // Projects
@@ -168,6 +169,7 @@ export const Header = props => {
                 </NavLink>
               </NavItem>
               {(canPostUserProfile ||
+                canSeeUserManagementTab || 
                 canDeleteUserProfile ||
                 canPutUserProfileImportantInfo ||
                 canCreateBadges ||
@@ -182,6 +184,7 @@ export const Header = props => {
                   </DropdownToggle>
                   <DropdownMenu>
                     {canPostUserProfile ||
+                    canSeeUserManagementTab ||
                     canDeleteUserProfile ||
                     canPutUserProfileImportantInfo ? (
                       <DropdownItem tag={Link} to="/usermanagement">

--- a/src/components/UserManagement/ResetPasswordButton.jsx
+++ b/src/components/UserManagement/ResetPasswordButton.jsx
@@ -28,6 +28,7 @@ class ResetPasswordButton extends React.PureComponent {
           className={'btn  btn-outline-success mr-1' + (this.props.isSmallButton ? ' btn-sm' : '')}
           style={{ ...boxStyle, minWidth: '115px' }}
           onClick={this.onResetClick}
+          disabled={this.props.hasPermission}
         >
           {'Reset Password'}
         </Button>

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -20,6 +20,7 @@ const UserTableData = React.memo(props => {
   const [isChanging, onReset] = useState(false);
   const history = useHistory();
   const canAddDeleteEditOwners = props.hasPermission('addDeleteEditOwners');
+  const canEditUserProfiles = !props.hasPermission('seeUserManagement')
 
   /**
    * reset the changing state upon rerender with new isActive status
@@ -74,6 +75,7 @@ const UserTableData = React.memo(props => {
             );
           }}
           style={boxStyle}
+          disabled={canEditUserProfiles}
         >
           {isChanging ? '...' : props.isActive ? PAUSE : RESUME}
         </button>
@@ -89,6 +91,7 @@ const UserTableData = React.memo(props => {
             );
           }}
           style={boxStyle}
+          disabled={canEditUserProfiles}
         >
           {props.isSet ? CANCEL : SET_FINAL_DAY}
         </button>
@@ -109,12 +112,13 @@ const UserTableData = React.memo(props => {
                 props.onDeleteClick(props.user, 'archive');
               }}
               style={boxStyle}
+              disabled={canEditUserProfiles}
             >
               {DELETE}
             </button>
           </span>
           <span className="usermanagement-actions-cell">
-            <ResetPasswordButton authEmail={props.authEmail} user={props.user} isSmallButton />
+            <ResetPasswordButton authEmail={props.authEmail} user={props.user} isSmallButton hasPermission={canEditUserProfiles}/>
           </span>
         </td>
       )}

--- a/src/routes.js
+++ b/src/routes.js
@@ -107,7 +107,7 @@ export default (
         path="/usermanagement"
         exact
         component={UserManagement}
-        routePermissions={RoutePermissions.userManagement}
+        routePermissions={[RoutePermissions.userManagement, RoutePermissions.userManagement_fullFunctionality, RoutePermissions.userManagement_onlyCreateUsers]}
       />
       <ProtectedRoute
         path="/badgemanagement"

--- a/src/utils/routePermissions.js
+++ b/src/utils/routePermissions.js
@@ -6,6 +6,8 @@ export const RoutePermissions = {
   weeklySummariesReport: 'getWeeklySummaries',
   projects: 'postProject',
   userManagement: 'postUserProfile',
+  userManagement_fullFunctionality: 'seeUserManagement',
+  userManagement_onlyCreateUsers: 'seeUserManagementTab',
   badgeManagement: 'createBadges',
   permissionsManagement: 'putRole',
   permissionsManagementRole: 'putRole',


### PR DESCRIPTION
# Description

<img width="1168" alt="Screen Shot 2023-09-07 at 4 45 07 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/fb58d3ec-3ed4-475b-be43-919c59e60063">

Make the "Other Links" -> "User Management" button appear/accessible and be able to ONLY create users. No editing or deleting access. 

## Main changes explained:

- Implemented the See User Management Tab (ONLY create users) permission
- Disabled buttons if the full functionality permission is not given
- Made changes to the protected route to include this new permission

## How to test:

1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Log in as Owner
4. Dashboard -> Other Links -> Permission Management -> Manage User Permissions -> Choose a volunteer account and give them "See User Management Tab (ONLY create Users)" permission 
5. Log into that account and you should be able to see the Other Links tab now -> User Management -> all buttons should be disabled except the create user button. Users should not be able to delete or edit user profiles.

## Videos/Screenshots of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/84d2864b-1010-41a3-8d19-5b3fa498fd32
