### PR TITLE
Yufu - fix reset password popup in usermanagement page

### DIFF
--- a/src/components/UserManagement/ResetPasswordPopup.jsx
+++ b/src/components/UserManagement/ResetPasswordPopup.jsx
@@ -8,7 +8,7 @@ import {
   Input,
   Label,
   Alert,
-  FormGroup,
+  Form,
 } from 'reactstrap';
 import { boxStyle } from 'styles';
 /**
@@ -50,7 +50,7 @@ const ResetPasswordPopup = React.memo(props => {
     <Modal isOpen={props.open} toggle={closePopup} autoFocus={false}>
       <ModalHeader toggle={closePopup}>Reset Password</ModalHeader>
       <ModalBody>
-        <FormGroup>
+        <Form>
           <Label for="newpassword">New Password</Label>
           <Input
             autoFocus
@@ -66,8 +66,6 @@ const ResetPasswordPopup = React.memo(props => {
               setError('');
             }}
           />
-        </FormGroup>
-        <FormGroup>
           <Label for="confirmpassword">Confirm Password</Label>
           <Input
             type="password"
@@ -82,7 +80,7 @@ const ResetPasswordPopup = React.memo(props => {
               setError('');
             }}
           />
-        </FormGroup>
+        </Form>
       </ModalBody>
       <ModalFooter>
         {errorMessage === '' ? <React.Fragment /> : <Alert color="danger">{errorMessage}</Alert>}


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23627067/57b6b826-e0fc-41f3-8078-1aacaac32e4c)

## Main changes explained:
- Delete two \<FormGroup\> in the ResetPasswordPopup.jsx into only one \<Form\>

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to dashboard→ Other Links→ User Management  
5. Don't input the search fields and then choose any user by pagination or other ways, then reset the password and check whether the user list is cleared. If nothing happens, it's okay.

## Screenshots or videos of changes:
 https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23627067/86b8b199-f80c-41ba-8742-ceb981b74de4

## Note:
This bug is wired. The reason is the browser's auto-fill. When we use autofill to input in the popup. Then the browser will input our email into "wkly Committed Hrs". Then the search will return no result, so that the user table is cleared. LOL  

I changed the two \<FormGroup\> into one \<Form\>, so this problem will not show up.
