### PR TITLE
Fix icons next to "Tasks and Timelogs" not aligned

### DIFF
--- a/src/components/Timelog/Timelog.css
+++ b/src/components/Timelog/Timelog.css
@@ -69,3 +69,11 @@
 .right-padding-temp-fix {
   padding-right: 0px !important;
 }
+
+.activeUser {
+  color: lawngreen;
+}
+
+.notActiveUser {
+  color: #dee2e6;
+}

--- a/src/components/UserManagement/ActiveCell.jsx
+++ b/src/components/UserManagement/ActiveCell.jsx
@@ -9,7 +9,7 @@ const ActiveCell = props => {
   return (
     <span
       style={{ fontSize: '1.5rem', cursor: props.canChange ? 'pointer' : 'default' }}
-      className={props.isActive ? 'isActive' : 'isNotActive'}
+      className={props.isActive ? 'activeUser' : 'notActiveUser'}
       id={props.index === undefined ? undefined : `active_cell_${props.index}`}
       title={
         props.canChange


### PR DESCRIPTION
# Description

The three icons in the "Tasks and Timelogs" box are supposed to be in the same line next to the text
<img width="952" alt="image" 
src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/424c23b7-1774-4b71-bf1e-417b46d2c392">


## Related PRS (if any):
N/A

## Main changes explained:
- put the styling for the ActiveCell component into Timelog.css and renamed the active/inactive classes

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as admin/owner user
4. make sure your "Tasks and Timelogs" box matches the image below
5. go to the Welcome tab ->View Profile and make sure the icons next to the name look the same as normal
6. go to Other Links -> User Management and make sure the circles next to the users look the same as normal
7. redo steps 4 and 5 as other user roles

## Screenshots or videos of changes:

![after](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/f17fcb58-7945-4ee6-aa9a-a5baa588e160)
