### PR TITLE
Carl_fix_suggestion_icon_modal

### DIFF
--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -239,12 +239,19 @@ const SummaryBar = props => {
 
   const openSuggestionModal = async () => {
     if (!showSuggestionModal) {
-      let res = await httpService
-        .get(`${ApiEndpoint}/dashboard/suggestionoption/${userProfile._id}`)
-        .catch(e => {});
-      if (res.status == 200) {
-        setSuggestionCategory(res.data.suggestion);
-        setInputField(res.data.field);
+      try {
+        let res = await httpService.get(`${ApiEndpoint}/dashboard/suggestionoption/${userProfile._id}`);
+        
+        if (res && res.status === 200) {
+          setSuggestionCategory(res.data.suggestion);
+          setInputField(res.data.field);
+        } else {
+          console.error(res.status);
+          // Handle the error as needed
+        }
+      } catch (error) {
+        console.error('Error:', error);
+        // Handle the error
       }
     }
     setShowSuggestionModal(prev => !prev);


### PR DESCRIPTION
# Description
The "Suggestion Icon Modal" stopped over a week ago. Initially, when the Suggestion Icon is clicked a modal appears on the screen allowing suggestions to be made.

## Related PRS (if any):
This frontend PR is related to the [#537](https://github.com/OneCommunityGlobal/HGNRest/pull/537) backend PR.
To test this frontend PR you need to checkout the[#537](https://github.com/OneCommunityGlobal/HGNRest/pull/537) backend PR.
…

## Main changes explained:

-  Added a try-catch block to catch any uncaught errors sent by the showSuggestionModal function.

-  Added an extra check to see if data is being returned before checking the status of the data.


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as owner/admin user
4. go to dashboard→ Suggestion Icon
5. verify if the Suggestion Icon modal works (feel free to include screenshot/video here)

## Screenshots or videos of changes:

### Suggestion Icon Before

[Suggestion-icon-before.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/68056104/8df4e5c4-543b-4b2b-a2d0-ef40e338fda8)

### Suggestion Icon After

[Suggestion-Icon-After.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/68056104/800815bf-be35-4dc0-ad7f-9fe3d97b807f)

