### PR TITLE
Aaron new scripts for lint and lint:fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "test:coverage": "cross-env CI=true react-scripts test --env=jest-environment-jsdom-sixteen --coverage",
     "eject": "react-scripts eject",
     "start:local": "react-scripts start",
-    "lint": "eslint . --ext .jsx --ext .js",
-    "lint:fix": "eslint --fix .",
+    "lint": "eslint . --ext .jsx,.js",
+    "lint:fix": "eslint --fix . --ext .jsx,.js",
     "prepare": "husky install"
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "test:coverage": "cross-env CI=true react-scripts test --env=jest-environment-jsdom-sixteen --coverage",
     "eject": "react-scripts eject",
     "start:local": "react-scripts start",
-    "lint": "eslint .",
+    "lint": "eslint . --ext .jsx --ext .js",
     "lint:fix": "eslint --fix .",
     "prepare": "husky install"
   },


### PR DESCRIPTION
# Description
Currently our linting command `npm run lint` does not check all of the files. I have added some flags that make sure all necessary files are checked so any files with linting errors will not pass the checks to merge.

## Related PRS (if any):
N/A

## Main changes explained:
- added flags that make sure eslint checks both `.js` and `.jsx` files
- also added these flags to lint:fix command

## How to test:
1. check into current branch
2. do `npm install` 
3. run `npm run lint` and make sure it passes (nothing should happen)
4. remove one of the component folders from `.eslintignore` (ex. `src/components/SetupProfile/**`)
5. run `npm run lint` again and verify the lint errors show up
6. run `npm run lint:fix` and make sure the number of lint errors go down
7. revert the changes (can be done manually or using `git reset --hard`)

## Screenshots or videos of changes:

Running `npm run lint`

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/b7668a1e-05e3-42f6-8710-cd52839d6b2f)

Running `npm run lint:fix`

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/c5729d3c-0194-4770-b447-c09b121a2538)
