### PR TITLE
add profilePic select modal to user management page

### DIFF
--- a/src/actions/userManagement.js
+++ b/src/actions/userManagement.js
@@ -34,7 +34,7 @@ export const getAllUserProfile = () => {
  * @param {*} status  - Active/InActive
  */
 export const updateUserStatus = (user, status, reactivationDate) => {
-  const userProfile = { ...user};
+  const userProfile = { ...user };
   userProfile.isActive = status === UserStatus.Active;
   userProfile.reactivationDate = reactivationDate;
   const patchData = { status, reactivationDate };
@@ -46,6 +46,26 @@ export const updateUserStatus = (user, status, reactivationDate) => {
     userProfile.endDate = undefined;
   }
 
+  const updateProfilePromise = axios.patch(ENDPOINTS.USER_PROFILE(user._id), patchData);
+  return async dispatch => {
+    updateProfilePromise.then(res => {
+      dispatch(userProfileUpdateAction(userProfile));
+    });
+  };
+};
+
+/**
+ * update the user profile picture
+ * @param {*} user - the user to be updated
+ * @param {*} pic  - profile picture url
+ */
+export const updateUserProfilePic = (user, pic, status) => {
+  const userProfile = { ...user };
+  const patchData = { status, profilePic: pic };
+  if (pic) {
+    patchData.profilePic = pic;
+    userProfile.profilePic = pic;
+  }
   const updateProfilePromise = axios.patch(ENDPOINTS.USER_PROFILE(user._id), patchData);
   return async dispatch => {
     updateProfilePromise.then(res => {
@@ -134,7 +154,7 @@ export const userProfileDeleteAction = user => {
  * @param {*} finalDate  - the date to be inactive
  */
 export const updateUserFinalDayStatus = (user, status, finalDayDate) => {
-  const userProfile = { ...user};
+  const userProfile = { ...user };
   userProfile.endDate = finalDayDate;
   userProfile.isActive = status === 'Active';
   const patchData = { status, endDate: finalDayDate };
@@ -155,7 +175,7 @@ export const updateUserFinalDayStatus = (user, status, finalDayDate) => {
 };
 
 export const updateUserFinalDayStatusIsSet = (user, status, finalDayDate, isSet) => {
-  const userProfile = { ...user};
+  const userProfile = { ...user };
   userProfile.endDate = finalDayDate;
   userProfile.isActive = status === 'Active';
   userProfile.isSet = isSet === 'FinalDay';

--- a/src/components/UserManagement/SelectProfilePicPopUp.jsx
+++ b/src/components/UserManagement/SelectProfilePicPopUp.jsx
@@ -1,0 +1,119 @@
+import moment from 'moment';
+import React, { useEffect, useState } from 'react';
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Input, Alert } from 'reactstrap';
+import { boxStyle } from 'styles';
+import { toast } from 'react-toastify';
+import { getUserProfile, updateUserProfile } from '../../actions/userProfile';
+import { connect, useDispatch, useSelector } from 'react-redux';
+
+/**
+ * Modal popup to show the user profile picture
+ */
+const SelectProfilePicPopUp = React.memo(props => {
+  const [selectedPic, setSelectedPic] = useState();
+  const [newPic, setNewPic] = useState();
+  const storedPic = [props.user?.profilePic].flat();
+  const userProfile = useSelector(state => state.userProfile);
+
+  const closePopup = e => {
+    props.onClose();
+  };
+
+  /****
+   * Remaining Problem: cannot selct the added url because it does not pass the
+   * validateProfilePic function in the userHelper.js, which should be further
+   * modified for the new feature.
+   *  ****/
+  const saveChange = async e => {
+    try {
+      await props.getUserProfile(props.user._id);
+      const updatedProfile = {
+        ...userProfile,
+        profilePic: selectedPic[0],
+      };
+      await props.updateUserProfile(userProfile._id, updatedProfile);
+      toast.success('Picture selected has been saved as profile photo.');
+    } catch (err) {
+      console.log(err);
+      toast.error('Failed to update the profile picture.');
+    }
+  };
+
+  const addPic = e => {
+    const newURL = [document.getElementById('newProfilePicURL').value];
+    setNewPic(newURL);
+  };
+
+  const selectPic = (pic, id) => {
+    const selected = [pic].flat();
+    setSelectedPic(selected);
+    document.querySelectorAll('.dashboardimg').forEach(element => {
+      element.style.border = '';
+    });
+    document.getElementById(id).style.border = '3px solid red';
+  };
+
+  return (
+    <Modal isOpen={props.open} toggle={closePopup} autoFocus={false}>
+      <ModalHeader toggle={closePopup}>Select Your Profile Picture</ModalHeader>
+      <ModalBody>
+        <b>Please choose the profile picture:</b>
+        <div>
+          {storedPic.map((pic, index) => {
+            return (
+              <img
+                src={`${pic || '/pfp-default-header.png'}`}
+                alt=""
+                style={{ maxWidth: '60px', maxHeight: '60px' }}
+                className="dashboardimg"
+                key={`pic_fetched_'+${index}`}
+                id={`pic_fetched_'+${index}`}
+                onClick={e => selectPic(pic, `pic_fetched_'+${index}`)}
+              />
+            );
+          })}
+          {newPic && (
+            <img
+              src={`${newPic || '/pfp-default-header.png'}`}
+              alt=""
+              style={{ maxWidth: '60px', maxHeight: '60px' }}
+              className="dashboardimg"
+              key={`pic_added`}
+              id={`pic_added`}
+              onClick={e => selectPic(newPic, `pic_added`)}
+            />
+          )}
+        </div>
+        <p>Cannot find any? Add an image:</p>
+
+        <input
+          type="url"
+          name="url"
+          id="newProfilePicURL"
+          placeholder="https://example.com"
+          pattern="https://.*"
+          size="30"
+          required
+        />
+        <Button color="primary" onClick={addPic} style={boxStyle} id="add_url">
+          Add
+        </Button>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="primary" onClick={saveChange} style={boxStyle}>
+          Save
+        </Button>
+        <Button color="secondary" onClick={closePopup} style={boxStyle}>
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+});
+
+const mapStateToProps = state => state;
+
+export default connect(mapStateToProps, {
+  getUserProfile,
+  updateUserProfile,
+})(SelectProfilePicPopUp);

--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -29,6 +29,7 @@ import ActiveInactiveConfirmationPopup from './ActiveInactiveConfirmationPopup';
 import { Container } from 'reactstrap';
 import SetUpFinalDayPopUp from './SetUpFinalDayPopUp';
 import { Table } from 'react-bootstrap';
+import SelectProfilePicPopUp from './SelectProfilePicPopUp';
 
 class UserManagement extends React.PureComponent {
   filteredUserDataCount = 0;
@@ -50,6 +51,7 @@ class UserManagement extends React.PureComponent {
       deletePopupOpen: false,
       isPaused: false,
       finalDayDateOpen: false,
+      profilePicOpen: false,
     };
   }
 
@@ -117,6 +119,7 @@ class UserManagement extends React.PureComponent {
    * 3. Popup to choose the delete option upon clicking delete button.
    * 4. Popup to confirm the action of setting a user active or inactive upon the status column click.
    * 5. Popup to show the last day selection
+   * 6. Popup to show and select the profile pictures matched
    */
   popupElements = () => {
     return (
@@ -152,6 +155,11 @@ class UserManagement extends React.PureComponent {
           open={this.state.finalDayDateOpen}
           onClose={this.setUpFinalDayPopupClose}
           onSave={this.deactiveUser}
+        />
+        <SelectProfilePicPopUp
+          open={this.state.profilePicOpen}
+          onClose={this.profilePicPopupClose}
+          user={this.state.selectedUser}
         />
       </React.Fragment>
     );
@@ -201,6 +209,8 @@ class UserManagement extends React.PureComponent {
               user={user}
               role={this.props.state.auth.user.role}
               roles={rolesPermissions}
+              hasProfilePic={user.profilePic ? [user.profilePic].flat().length : 0}
+              onSelectProfilePicClick={that.onSelectProfilePicClick}
             />
           );
         });
@@ -260,6 +270,16 @@ class UserManagement extends React.PureComponent {
         selectedUser: user,
       });
     }
+  };
+
+  /**
+   * Call back on Select or Show button click to trigger the action to update user profile picture
+   */
+  onSelectProfilePicClick = user => {
+    this.setState({
+      profilePicOpen: true,
+      selectedUser: user,
+    });
   };
 
   /**
@@ -326,7 +346,7 @@ class UserManagement extends React.PureComponent {
    * Callback to trigger on the status (active/inactive) column click to show the confirmaton change the status
    */
   onActiveInactiveClick = user => {
-    const authRole = this?.props?.state?.auth?.user.role||user.role
+    const authRole = this?.props?.state?.auth?.user.role || user.role;
     const canChangeUserStatus = hasPermission('changeUserStatus');
     if (!canChangeUserStatus) {
       //permission to change the status of any user on the user profile page or User Management Page.
@@ -366,6 +386,15 @@ class UserManagement extends React.PureComponent {
   activeInactivePopupClose = () => {
     this.setState({
       activeInactivePopupOpen: false,
+    });
+  };
+
+  /**
+   * Callback to close the profile picture popup on close button click.
+   */
+  profilePicPopupClose = () => {
+    this.setState({
+      profilePicOpen: false,
     });
   };
 

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -1,6 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import ResetPasswordButton from './ResetPasswordButton';
-import { DELETE, PAUSE, RESUME, SET_FINAL_DAY, CANCEL } from '../../languages/en/ui';
+import {
+  DELETE,
+  PAUSE,
+  RESUME,
+  SET_FINAL_DAY,
+  CANCEL,
+  SELECT,
+  SHOW,
+  ADD,
+} from '../../languages/en/ui';
 import { UserStatus, FinalDay } from '../../utils/enums';
 import { useHistory } from 'react-router-dom';
 import ActiveCell from './ActiveCell';
@@ -59,6 +68,24 @@ const UserTableData = React.memo(props => {
             toast.success('Email Copied!');
           }}
         />
+      </td>
+      <td className="image_cell">
+        <button
+          type="button"
+          className={`btn btn-outline-${props.hasProfilePic === 1 ? 'success' : 'warning'} btn-sm`}
+          style={boxStyle}
+          onClick={e => {
+            props.onSelectProfilePicClick(props.user, null);
+          }}
+        >
+          {isChanging
+            ? '...'
+            : props.hasProfilePic > 0
+            ? props.hasProfilePic > 1
+              ? SELECT
+              : SHOW
+            : ADD}
+        </button>
       </td>
       <td>{props.user.weeklycommittedHours}</td>
       <td>

--- a/src/components/UserManagement/UserTableHeader.jsx
+++ b/src/components/UserManagement/UserTableHeader.jsx
@@ -5,6 +5,7 @@ import {
   LAST_NAME,
   ROLE,
   EMAIL,
+  IMAGE,
   WKLY_COMMITTED_HRS,
   PAUSE,
   USER_RESUME_DATE,
@@ -32,6 +33,9 @@ const UserTableHeader = React.memo(props => {
       </th>
       <th scope="col" id="usermanagement_email">
         {EMAIL}
+      </th>
+      <th scope="col" id="usermanagement_image">
+        {IMAGE}
       </th>
       <th scope="col" id="usermanagement_hrs">
         {WKLY_COMMITTED_HRS}

--- a/src/components/UserManagement/UserTableSearchHeader.jsx
+++ b/src/components/UserManagement/UserTableSearchHeader.jsx
@@ -42,6 +42,7 @@ const UserTableSearchHeader = React.memo(props => {
       <td id="user_email">
         <TextSearchBox id={'email_search'} searchCallback={onEmailSearch} />
       </td>
+      <td id="user_image"></td>
       <td id="user_hrs">
         <TextSearchBox
           id={'hrs_search'}

--- a/src/languages/en/ui.js
+++ b/src/languages/en/ui.js
@@ -50,3 +50,6 @@ export const POPUP_MANAGEMENT = 'Popup Management';
 export const CANCEL = 'Delete Final Day';
 export const SET_FINAL_DAY = 'Set Final Day';
 export const MANAGE_FINAL_DAY = 'Manage Final Day';
+export const IMAGE = 'Profile Image';
+export const SELECT = 'Select';
+export const ADD = 'Add';


### PR DESCRIPTION
# Description
### This branch is part of the work towards the following task. Although it didn't solve the problem, it may served as reference and provide a little help for the developer who is going to take this task.

3. (PRIORITY High) Jae: Make App Get Profile Images from Website
Suggested approach:
1. Create a cron job that would run to scan the website and get the image location and save it into a user profile.  
I. Check if profile already has assigned image, if no
II. Check for matching first and last name
III. If no match, then check for last name only
**IV. If multiple matches in i or ii, present popup requiring Admin to choose**
1. If step ii and iii are done, it should always find a picture to match for anyone who has been with the team for 2 months or more (that’s when we add people to the site) UNLESS there is a spelling error in the file name. The common problem could be multiple images to choose from, that’s why I was thinking of listing them so a person could choose. They’ve got dates on them too, so it could also just check the dates and choose the most recent one. 
    1. This is the page of the site that the app should search: https://www.onecommunityglobal.org/team/ 
    2. This is the format of the images: https://www.onecommunityglobal.org/wp-content/uploads/2022/05/Adolph-Karubanga-127x127-1.jpg?x13107

## Related PRS (if any):
To test this frontend PR you need to checkout the [536 backend PR](https://github.com/OneCommunityGlobal/HGNRest/pull/536).

## Main changes explained:
- Depending on the number of images stored under one user, the user management table will have Add/Show/Select button for the 0/1/more than 1 .
- After clicking the button, there is a pop up modal. It will show the profilePic (images) saved for the user currently, admin can also use the input box to add one temporary image to the window. The admin can select any one image from the images shown in the modal and save it as the (the only one) profile picture of the user.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
4. log as admin user
5. go to dashboard→ other links: user management
6. check the profile image column

## Screenshots or videos of changes:
<img width="144" alt="1" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/03c47d26-0742-4ec4-84c9-aed8fbdf30db">
<img width="503" alt="2" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/6b39ba29-7ea1-4d96-bd12-25e9c51004ef">

## Note:
Now if we add a url as the temporary picture and want to save it as the profilePic, the change wil be rejected by the server (error 400) and returning the error from this validation function in the userHelper.js
To enable the feature as well as to move forward for the whole task, the profile pic validation process may require some update.
<img width="230" alt="3" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/9314962/74573487-dcbc-4dd0-80d8-a8fe6a4feca4">

