### PR TITLE
Shihao - Change the Layout of The Badge in Weekly Summary Report Page

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -22,6 +22,8 @@ import {
   CardImg,
   CardText,
   UncontrolledPopover,
+  Row,
+  Col,
 } from 'reactstrap';
 import { ENDPOINTS } from '../../utils/URL';
 import ToggleSwitch from '../UserProfile/UserProfileEdit/ToggleSwitch';
@@ -106,56 +108,62 @@ function ReportDetails({
         </ListGroupItem>
         {isInViewPort && (
           <>
-            <ListGroupItem>
-              <b>Media URL:</b> <MediaUrlLink summary={summary} />
-            </ListGroupItem>
-            <ListGroupItem>
-              <Bio
-                bioCanEdit={bioCanEdit}
-                userId={summary._id}
-                bioPosted={summary.bioPosted}
-                summary={summary}
-                totalTangibleHrs={summary.totalTangibleHrs}
-                daysInTeam={summary.daysInTeam}
-              />
-            </ListGroupItem>
-            <ListGroupItem>
-              <TotalValidWeeklySummaries
-                summary={summary}
-                canEditSummaryCount={canEditSummaryCount}
-              />
-            </ListGroupItem>
-            {hoursLogged >= summary.promisedHoursByWeek[weekIndex] && (
-              <ListGroupItem>
-                <p>
-                  <b
-                    style={{
-                      color: textColors[summary?.weeklySummaryOption] || textColors.Default,
-                    }}
-                  >
-                    Hours logged:{' '}
-                  </b>
-                  {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
-                </p>
-              </ListGroupItem>
-            )}
-            {hoursLogged < summary.promisedHoursByWeek[weekIndex] && (
-              <ListGroupItem>
-                <b
-                  style={{
-                    color: textColors[summary?.weeklySummaryOption] || textColors.Default,
-                  }}
-                >
-                  Hours logged:
-                </b>
-                <span className="ml-2">
-                  {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
-                </span>
-              </ListGroupItem>
-            )}
-            {loadBadges && summary.badgeCollection?.length > 0 && (
-              <WeeklyBadge summary={summary} weekIndex={weekIndex} badges={badges} />
-            )}
+            <Row>
+              <Col className="flex-grow-0">
+                <ListGroupItem>
+                  <b>Media URL:</b> <MediaUrlLink summary={summary} />
+                </ListGroupItem>
+                <ListGroupItem>
+                  <Bio
+                    bioCanEdit={bioCanEdit}
+                    userId={summary._id}
+                    bioPosted={summary.bioPosted}
+                    summary={summary}
+                    totalTangibleHrs={summary.totalTangibleHrs}
+                    daysInTeam={summary.daysInTeam}
+                  />
+                </ListGroupItem>
+                <ListGroupItem>
+                  <TotalValidWeeklySummaries
+                    summary={summary}
+                    canEditSummaryCount={canEditSummaryCount}
+                  />
+                </ListGroupItem>
+                {hoursLogged >= summary.promisedHoursByWeek[weekIndex] && (
+                  <ListGroupItem>
+                    <p>
+                      <b
+                        style={{
+                          color: textColors[summary?.weeklySummaryOption] || textColors.Default,
+                        }}
+                      >
+                        Hours logged:{' '}
+                      </b>
+                      {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
+                    </p>
+                  </ListGroupItem>
+                )}
+                {hoursLogged < summary.promisedHoursByWeek[weekIndex] && (
+                  <ListGroupItem>
+                    <b
+                      style={{
+                        color: textColors[summary?.weeklySummaryOption] || textColors.Default,
+                      }}
+                    >
+                      Hours logged:
+                    </b>
+                    <span className="ml-2">
+                      {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
+                    </span>
+                  </ListGroupItem>
+                )}
+              </Col>
+              <Col>
+                {loadBadges && summary.badgeCollection?.length > 0 && (
+                  <WeeklyBadge summary={summary} weekIndex={weekIndex} badges={badges} />
+                )}
+              </Col>
+            </Row>
             <ListGroupItem>
               <WeeklySummaryMessage summary={summary} weekIndex={weekIndex} />
             </ListGroupItem>


### PR DESCRIPTION
# Description
<img width="743" alt="Screenshot 2023-09-19 at 15 41 23" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/62367016/9a3ef1d1-b9f6-4277-8b9b-c22c7c6d89bf">

## Related PR
This PR is to restore the layout of badges in #1116 

## Main changes explained:
- Adjusted the layout of the DOM

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to dashboard→ Reports→ Weekly Summaries Report
5. Click the button "Load Badge" to display the badges
6. Check the badge is on the right of the info card

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/62367016/79dfda2e-86b5-4058-87c7-7a4afc7fd22b
