### PR TITLE
Xiao F Hot fix personal max badge 'x hours' label position

### DIFF
--- a/src/components/UserProfile/Badge.css
+++ b/src/components/UserProfile/Badge.css
@@ -50,14 +50,14 @@
   padding-top: 7px;
   border-radius: 55%;
   width: 38px;
-  height: 27px;
+  height: 26px;
   background: #800080;
   color: #fff;
   text-align: center;
   font: 11px Arial, sans-serif;
   position: absolute;
-  right: 40px;
-  bottom: 12px;
+  right: 34px;
+  bottom: 26px;
   z-index: 0;
 }
 


### PR DESCRIPTION
# Description
Move personal max badge 'x hours' label to a proper position

## Related PRS (if any):
PR #1300 

## Main changes explained:
Changed styling of `.badge_featured_count_personalmax` in `src/components/UserProfile/Badge.css`

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. Go to User -> View Profile -> Badges -> Assign Badges -> Check 'New Max - Personal Record Award' badge -> Confirm
5. Check if the badge label's background color is purple and has 'x hr(s)' label on it with the proper position

## Screenshots or videos of changes:
dev branch:
![CleanShot 2023-09-19 at 20 13 58](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/43768723/41f1cf43-637b-4bb7-9b24-1a7d6ec97732)


After:
![CleanShot 2023-09-19 at 20 13 21](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/43768723/0464eefd-1b89-41c9-b5cb-8a9e95d13b34)

