### PR TITLE
XiaoW_ hot fix of weeklysummariesreport page not showing up.

### DIFF
--- a/src/actions/badgeManagement.js
+++ b/src/actions/badgeManagement.js
@@ -18,9 +18,17 @@ const getAllBadges = allBadges => ({
   allBadges,
 });
 
-export const fetchAllBadges = () => async dispatch => {
-  const { data } = await axios.get(ENDPOINTS.BADGE());
-  dispatch(getAllBadges(data));
+export const fetchAllBadges = () => {
+  const url = ENDPOINTS.BADGE();
+  return async (dispatch) => {
+    try {
+      const response = await axios.get(ENDPOINTS.BADGE());
+      dispatch(getAllBadges(response.data));
+      return response.status;
+    } catch(err) {
+      return err.response.status;
+    }
+  }
 };
 
 export const closeAlert = () => {

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -41,6 +41,7 @@ export class WeeklySummariesReport extends Component {
       activeTab: navItems[1],
       badges: [],
       loadBadges: false,
+      hasSeeBadgePermission: false,
     };
 
     this.weekDates = Array(4)
@@ -64,7 +65,7 @@ export class WeeklySummariesReport extends Component {
 
     // 1. fetch report
     await getWeeklySummariesReport();
-    await fetchAllBadges();
+    const badgeStatusCode = await fetchAllBadges();
 
     this.canPutUserProfileImportantInfo = hasPermission('putUserProfileImportantInfo');
     this.bioEditPermission = this.canPutUserProfileImportantInfo;
@@ -93,6 +94,7 @@ export class WeeklySummariesReport extends Component {
           ? navItems[1]
           : sessionStorage.getItem('tabSelection'),
       badges: allBadgeData,
+      hasSeeBadgePermission: badgeStatusCode === 200,
     });
     await getInfoCollections();
     const role = authUser?.role;
@@ -202,7 +204,16 @@ export class WeeklySummariesReport extends Component {
   };
 
   render() {
-    const { error, loading, summaries, activeTab, allRoleInfo, badges, loadBadges } = this.state;
+    const {
+      error,
+      loading,
+      summaries,
+      activeTab,
+      allRoleInfo,
+      badges,
+      loadBadges,
+      hasSeeBadgePermission,
+    } = this.state;
 
     if (error) {
       return (
@@ -263,13 +274,15 @@ export class WeeklySummariesReport extends Component {
                         weekIndex={index}
                         weekDates={this.weekDates[index]}
                       />
-                      <Button
-                        className="btn--dark-sea-green"
-                        style={boxStyle}
-                        onClick={() => this.setState({ loadBadges: !loadBadges })}
-                      >
-                        {loadBadges ? 'Hide Badges' : 'Load Badges'}
-                      </Button>
+                      {hasSeeBadgePermission && (
+                        <Button
+                          className="btn--dark-sea-green"
+                          style={boxStyle}
+                          onClick={() => this.setState({ loadBadges: !loadBadges })}
+                        >
+                          {loadBadges ? 'Hide Badges' : 'Load Badges'}
+                        </Button>
+                      )}
                       <Button className="btn--dark-sea-green" style={boxStyle}>
                         Load Trophies
                       </Button>


### PR DESCRIPTION
# Description
hotfix of weeklysummariesreport page not showing up correctly for volunteer users.

## Related PRS (if any):
This frontend PR is related to the #[541](https://github.com/OneCommunityGlobal/HGNRest/pull/541#issue-1903926835) backend PR.

## Main changes explained:
- Add try catch block in fetchAllBadges
- check the status code of fetchAllBadges, hide buttons for loading badge if not receive 200 status code
