### PR TITLE
Shihao - Hotfix Weekly Summary Not Be Updated After Submission

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-# * text eol=lf
+* text eol=lf

--- a/src/actions/weeklySummariesReport.js
+++ b/src/actions/weeklySummariesReport.js
@@ -31,8 +31,8 @@ export const fetchWeeklySummariesReportError = error => ({
 
 /**
  * Update one summary report
- * 
- * @param {Object} updatedField the updated field object, dynamic 
+ *
+ * @param {Object} updatedField the updated field object, dynamic
  */
 export const updateSummaryReport = ({ _id, updatedField }) => ({
   type: actions.UPDATE_SUMMARY_REPORT,
@@ -50,7 +50,7 @@ export const getWeeklySummariesReport = () => {
     try {
       const response = await axios.get(url);
       dispatch(fetchWeeklySummariesReportSuccess(response.data));
-      return response.status;
+      return {status: response.status, data: response.data};
     } catch (error) {
       dispatch(fetchWeeklySummariesReportError(error));
       return error.response.status;

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -13,7 +13,6 @@ import axios from 'axios';
 import { assignStarDotColors, showStar } from 'utils/leaderboardPermissions';
 import { updateOneSummaryReport } from 'actions/weeklySummariesReport';
 import RoleInfoModal from 'components/UserProfile/EditableModal/roleInfoModal';
-import useIsInViewPort from 'utils/useIsInViewPort';
 import {
   Input,
   ListGroup,
@@ -74,17 +73,17 @@ function FormattedReport({
   const handleEmailButtonClick = () => {
     const batchSize = 90;
     const emailChunks = [];
-      
+
     for (let i = 0; i < emails.length; i += batchSize) {
-      emailChunks.push(emails.slice(i, i + batchSize));      
-    }  
-  
+      emailChunks.push(emails.slice(i, i + batchSize));
+    }
+
     const openEmailClientWithBatchInNewTab = (batch) => {
       const emailAddresses = batch.join(', ');
       const mailtoLink = `mailto:${emailAddresses}`;
       window.open(mailtoLink, '_blank');
-    };  
-    
+    };
+
     emailChunks.forEach((batch, index) => {
       setTimeout(() => {
         openEmailClientWithBatchInNewTab(batch);
@@ -151,7 +150,6 @@ function ReportDetails({
   canEditTeamCode,
 }) {
   const ref = useRef(null);
-  const isInViewPort = useIsInViewPort(ref);
 
   const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
 
@@ -161,8 +159,6 @@ function ReportDetails({
         <ListGroupItem>
           <Index summary={summary} weekIndex={weekIndex} allRoleInfo={allRoleInfo} />
         </ListGroupItem>
-        {isInViewPort && (
-          <>
             <Row className="flex-nowrap">
               <Col className="flex-grow-0">
                 <ListGroupItem>
@@ -222,8 +218,6 @@ function ReportDetails({
             <ListGroupItem>
               <WeeklySummaryMessage summary={summary} weekIndex={weekIndex} />
             </ListGroupItem>
-          </>
-        )}
       </ListGroup>
     </li>
   );
@@ -335,7 +329,7 @@ const TeamCodeRow = ({canEditTeamCode, summary}) => {
               placeholder="X-XXX"
             />
           </div>
-          : 
+          :
           <div style={{paddingLeft: "5px"}}>
             {teamCode == ''? "No assigned team code!": teamCode}
           </div>

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -67,7 +67,8 @@ export class WeeklySummariesReport extends Component {
     } = this.props;
 
     // 1. fetch report
-    const { data: summaries } = await getWeeklySummariesReport();
+    const res = await getWeeklySummariesReport();
+    const summaries = res?.data ?? this.props.summaries
     const badgeStatusCode = await fetchAllBadges();
 
     this.canPutUserProfileImportantInfo = hasPermission('putUserProfileImportantInfo');

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -55,7 +55,6 @@ export class WeeklySummariesReport extends Component {
 
   async componentDidMount() {
     const {
-      summaries,
       error,
       loading,
       allBadgeData,
@@ -68,7 +67,7 @@ export class WeeklySummariesReport extends Component {
     } = this.props;
 
     // 1. fetch report
-    await getWeeklySummariesReport();
+    const { data: summaries } = await getWeeklySummariesReport();
     const badgeStatusCode = await fetchAllBadges();
 
     this.canPutUserProfileImportantInfo = hasPermission('putUserProfileImportantInfo');
@@ -148,6 +147,26 @@ export class WeeklySummariesReport extends Component {
     }
     this.setState({ allRoleInfo });
   }
+
+  // componentDidUpdate(preProps) {
+  //   const {summaries} = preProps
+
+  //   if (this.props.summaries !== summaries) {
+  //     let summariesCopy = [...summaries];
+  //     summariesCopy = this.alphabetize(summariesCopy);
+
+  //     // 3. add new key of promised hours by week
+  //     summariesCopy = summariesCopy.map(summary => {
+  //       // append the promised hours starting from the latest week (this week)
+  //       const promisedHoursByWeek = this.weekDates.map(weekDate =>
+  //         this.getPromisedHours(weekDate.toDate, summary.weeklycommittedHoursHistory),
+  //       );
+  //       return { ...summary, promisedHoursByWeek };
+  //     });
+
+  //     this.setState({filteredSummaries: summariesCopy, summaries: summariesCopy})
+  //   }
+  // }
 
   componentWillUnmount() {
     sessionStorage.removeItem('tabSelection');
@@ -262,7 +281,7 @@ export class WeeklySummariesReport extends Component {
       loadBadges,
       hasSeeBadgePermission,
       selectedCodes,
-      selectedColors, 
+      selectedColors,
       filteredSummaries,
     } = this.state;
 
@@ -297,17 +316,17 @@ export class WeeklySummariesReport extends Component {
         </Row>
         <Row style={{ marginBottom: '10px' }}>
           <Col lg={{ size: 5, offset:1 }} xs={{size: 5, offset: 1}}>
-            Select Team Code 
+            Select Team Code
             <MultiSelect
-              options={this.teamCodes} 
-              value={selectedCodes} 
+              options={this.teamCodes}
+              value={selectedCodes}
               onChange={(e) => {this.handleSelectCodeChange(e)}}/>
           </Col>
           <Col lg={{ size: 5 }} xs={{size: 5}}>
-            Select Color 
-            <MultiSelect 
-              options={this.colorOptions} 
-              value={selectedColors} 
+            Select Color
+            <MultiSelect
+              options={this.colorOptions}
+              value={selectedColors}
               onChange={(e) => {this.handleSelectColorChange(e)}}/>
           </Col>
         </Row>


### PR DESCRIPTION
# Description
The summaries cannot be updated for the first open page after they are submitted.

https://www.loom.com/embed/7932d4687fb142d0b24af01dc971919a?unfurl=blocks

## Main changes explained:
- Return the newest data from `getWeeklySummariesReport` and use it instead of using the data in redux

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin/owner user
4. change the summary in the dashboard
5. go to dashboard → Reports → Weekly Summaries Reports
6. check the summary to see whether keeps up to date

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/62367016/5699d9f5-6846-4b84-8324-cfab5a75e3a5
