### PR TITLE
Make managers, mentors, and assistant manager obvious on teams

### DIFF
--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -21,6 +21,8 @@ const TeamMembersPopup = React.memo(props => {
 
   const canAssignTeamToUsers = props.hasPermission('assignTeamToUsers');
 
+
+
   const onAddUser = () => {
     if (selectedUser && !props.members.teamMembers.some(x => x._id === selectedUser._id)) {
       props.onAddUser(selectedUser);
@@ -41,12 +43,33 @@ const TeamMembersPopup = React.memo(props => {
    * 0: alphabetized order by name
    * 1: descending order by date
   */
-
   const sortList = (sort = 0) => {
     let sortedList = []
+    let newList = []
 
     if (sort === 0) {
-      sortedList = sortByRole(props?.members?.teamMembers)
+
+      let roleArr = [{ priority: 1, role: "owner" }, { priority: 2, role: "administrator" },
+      { priority: 3, role: "core team" }, { priority: 4, role: "manager" }, { priority: 5, role: 'mentor' },
+      { priority: 6, role: "assistant manager" }, { priority: 7, role: "volunteer" }]
+ 
+      props.usersdata.userProfiles.map(elem => {
+        props.members.teamMembers.map(team => {
+          if (elem._id == team._id) {
+            sortedList.push(elem)
+          }
+        })
+      })
+      sortedList.map((elem, i) => {
+        roleArr.map(role => {
+          if (elem.role.toLowerCase() == role["role"]) {
+            let o = Object.assign({}, elem)
+            o.priority = role['priority']
+            newList.push(o)
+          }
+        })
+      })
+      sortedList = newList.sort((a, b) => a.priority - b.priority)
     } else {
       const sortByDateList = props.members.teamMembers.toSorted((a, b) => {
         return moment(a.addDateTime).diff(moment(b.addDateTime)) * -sort;
@@ -66,24 +89,9 @@ const TeamMembersPopup = React.memo(props => {
     setMemberList(sortedList);
   }
 
-  const sortByRole = (args) => {
-    let roleArr = [{ priority: 1, role: "owner" }, { priority: 2, role: "administrator" },
-    { priority: 3, role: "core team" }, { priority: 4, role: "manager" },
-    { priority: 5, role: "assistant manager" }, { priority: 6, role: "volunteer" }]
-
-    let newArr = [];
-    args.length > 0 && args.map((elem, i) => {
-      roleArr.map(role => {
-        if (elem.role && elem.role.toLowerCase() == role.role) {
-          let mergedOptions = {
-            ...elem, ...{ priority: role?.priority }
-          };
-          newArr.push(mergedOptions)
-        }
-      })
-    });
-    newArr.sort((a, b) => a.priority - b.priority)
-    return newArr
+  let returnUserRole = (user) => {
+    let rolesArr = ["Manager", "Mentor", "Assistant Manager"]
+    if (rolesArr.includes(user.role)) return true
   }
 
   const sortByAlpha = useCallback((a, b) => {
@@ -114,11 +122,6 @@ const TeamMembersPopup = React.memo(props => {
   useEffect(() => {
     onValidation(true);
   }, [props.open]);
-
-  let returnUserRole = (user) => {
-    let rolesArr = ["Manager", "Mentor", "Assistant Manager"]
-    if (rolesArr.includes(user.role)) return true
-  }
 
   return (
     <Container fluid>
@@ -153,7 +156,7 @@ const TeamMembersPopup = React.memo(props => {
                 memberList.toSorted().map((user, index) => (
                   <tr key={`team_member_${index}`}>
                     <td>{index + 1}</td>
-                    <td>{returnUserRole(user)? <b>{user.firstName} {user.lastName} ({user.role})</b>: <span>{user.firstName} {user.lastName} ({user.role})</span>} </td>
+                    <td>{returnUserRole(user) ? <b>{user.firstName} {user.lastName} ({user.role})</b> : <span>{user.firstName} {user.lastName} ({user.role})</span>} </td>
                     <td>{moment(user.addDateTime).format('MMM-DD-YY')}</td>
                     {canAssignTeamToUsers && (
                       <td>


### PR DESCRIPTION
# Description
Make managers, mentors, and assistant manager obvious on teams

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to Other Links→ Teams

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/49270410/b2fd2204-371b-4442-b99c-392af0734d11




## Note:
Include the information the reviewers need to know.
