### PR TITLE
Shrey fix changes for team member list which showed already added member in the list and limit set to 10

### DIFF
--- a/src/__tests__/Teams/MembersAutoComplete.test.js
+++ b/src/__tests__/Teams/MembersAutoComplete.test.js
@@ -12,6 +12,7 @@ const defaultProps = {
     userProfiles: [],
   },
   onAddUser: mock,
+  existingMembers: [],
 };
 
 const dropdownProps = {
@@ -27,6 +28,7 @@ const dropdownProps = {
     ],
   },
   onAddUser: mock,
+  existingMembers: [],
 };
 
 describe('MembersAutoComplete', () => {

--- a/src/components/Teams/MembersAutoComplete.jsx
+++ b/src/components/Teams/MembersAutoComplete.jsx
@@ -4,6 +4,13 @@ import { Dropdown, Input } from 'reactstrap';
 export const MemberAutoComplete = props => {
   const [isOpen, toggle] = useState(false);
 
+  const dropdownStyle = {
+    marginTop: '0px',
+    width: '100%',
+    maxHeight: '350px',  // Adjust this value as needed
+    overflowY: 'auto'
+  };
+
   return (
     <Dropdown
       isOpen={isOpen}
@@ -32,19 +39,20 @@ export const MemberAutoComplete = props => {
           role="menu"
           aria-hidden="false"
           className={`dropdown-menu${isOpen ? ' show' : ''}`}
-          style={{ marginTop: '0px', width: '100%' }}
+          style={ dropdownStyle}
         >
           {props.userProfileData.userProfiles
             .filter(user => {
               if (
                 user.isActive &&
-                (user.firstName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1 ||
-                user.lastName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1)
+                (user.firstName.toLowerCase().includes(props.searchText.toLowerCase()) ||
+                user.lastName.toLowerCase().includes(props.searchText.toLowerCase())) &&
+                !props.existingMembers.some(member => member._id === user._id)
               ) {
-                return user;
+                return true;
               }
+              return false;
             })
-            .slice(0, 10)
             .map(item => (
               <div
                 className="user-auto-cpmplete"

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -132,6 +132,7 @@ const TeamMembersPopup = React.memo(props => {
             <div className="input-group-prepend" style={{ marginBottom: '10px' }}>
               <MembersAutoComplete
                 userProfileData={props.usersdata}
+                existingMembers={props.members.teamMembers}
                 onAddUser={selectUser}
                 searchText={searchText}
                 setSearchText={setSearchText}


### PR DESCRIPTION
# Description
Fix Teams showing members already there and limited view issue
i) Login as admin/Owner-> Other Links-> Teams-> In an existing team or create a new team -> Click on Add members icon
When the user searches for a team member to add, the search list should not show already added team members. It should only show active members not already on the team. 
ii) There should not be a limit on the number of  items that are displayed. Currently only 10 items are getting displayed

## Main changes explained:
Changed the filter in MemberAutoComplete.jsx file to add the existing member condition.
Also changed the dropdown style to fit the add team member modal, and removed the limit 10.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to Other Links→ Teams→ Select Members for a team→ Add Team member
5. verify function that if a member is already in the team, he is not visible in the add list.
6. verify that add team member list doen not have a hard limit of 10, but is scrollable if there are more users.
7. The pop up message for addition is not a scope for this PR

## Screenshots or videos of changes:
Before Change

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/3b6b22f4-cc3d-4d23-b3a0-cb6bfbf45572

After Change

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/209447ef-b624-42ef-af61-45e6a6c3ed99


