### PR TITLE
Xiao F Hotfix Differentiate Personal Max Badge Part C Number of Hours

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -47,6 +47,20 @@ const Badge = props => {
     setOpenTypes(isOpenTypes => !isOpenTypes);
   };
 
+  const generateBadgeText = (totalBadge, badgeCollection, personalBestMaxHrs) => {
+    if (!totalBadge) return 'You have no badges. ';
+
+    const personalMaxText = badgeCollection.find(badgeObj => badgeObj.badge.type === 'Personal Max')
+      ? ` and a personal best of ${parseFloat(personalBestMaxHrs).toFixed(1)} ${
+          parseFloat(personalBestMaxHrs) === 1.0 ? 'hour' : 'hours'
+        } in a week`
+      : '';
+
+    return `Bravo! You have earned ${totalBadge} ${
+      totalBadge === 1 ? 'badge' : 'badges'
+    }${personalMaxText}! `;
+  };
+
   useEffect(() => {
     const userId = props.userId;
     let count = 0;
@@ -87,23 +101,11 @@ const Badge = props => {
                     color: '#285739',
                   }}
                 >
-                  {totalBadge
-                    ? `Bravo! You have earned ${totalBadge} ${
-                        totalBadge === 1 ? 'badge' : 'badges'
-                      }${
-                        props.userProfile.badgeCollection.find(
-                          badgeObj => badgeObj.badge.type === 'Personal Max',
-                        )
-                          ? ` and a personal best of ${parseFloat(
-                              props.userProfile.personalBestMaxHrs,
-                            ).toFixed(1)} ${
-                              parseFloat(props.userProfile.personalBestMaxHrs) === 1.0
-                                ? 'hour'
-                                : 'hours'
-                            } in a week`
-                          : ''
-                      }! `
-                    : 'You have no badges. '}
+                  {generateBadgeText(
+                    totalBadge,
+                    props.userProfile.badgeCollection,
+                    props.userProfile.personalBestMaxHrs,
+                  )}
                   <i className="fa fa-info-circle" id="CountInfo" />
                 </CardText>
                 <BadgeSummaryViz badges={props.userProfile.badgeCollection} dashboard={true} />

--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -50,7 +50,7 @@ const Badge = props => {
   const generateBadgeText = (totalBadge, badgeCollection, personalBestMaxHrs) => {
     if (!totalBadge) return 'You have no badges. ';
 
-    const roundedHours = Math.round(personalBestMaxHrs);
+    const roundedHours = Math.floor(personalBestMaxHrs);
     const personalMaxText = badgeCollection.find(badgeObj => badgeObj.badge.type === 'Personal Max')
       ? ` and a personal best of ${roundedHours} ${roundedHours === 1 ? 'hour' : 'hours'} in a week`
       : '';

--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -94,8 +94,12 @@ const Badge = props => {
                         props.userProfile.badgeCollection.find(
                           badgeObj => badgeObj.badge.type === 'Personal Max',
                         )
-                          ? ` and a personal best of ${props.userProfile.personalBestMaxHrs} ${
-                              props.userProfile.personalBestMaxHrs === 1 ? 'hour' : 'hours'
+                          ? ` and a personal best of ${parseFloat(
+                              props.userProfile.personalBestMaxHrs,
+                            ).toFixed(1)} ${
+                              parseFloat(props.userProfile.personalBestMaxHrs) === 1.0
+                                ? 'hour'
+                                : 'hours'
                             } in a week`
                           : ''
                       }! `

--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -50,10 +50,9 @@ const Badge = props => {
   const generateBadgeText = (totalBadge, badgeCollection, personalBestMaxHrs) => {
     if (!totalBadge) return 'You have no badges. ';
 
+    const roundedHours = Math.round(personalBestMaxHrs);
     const personalMaxText = badgeCollection.find(badgeObj => badgeObj.badge.type === 'Personal Max')
-      ? ` and a personal best of ${parseFloat(personalBestMaxHrs).toFixed(1)} ${
-          parseFloat(personalBestMaxHrs) === 1.0 ? 'hour' : 'hours'
-        } in a week`
+      ? ` and a personal best of ${roundedHours} ${roundedHours === 1 ? 'hour' : 'hours'} in a week`
       : '';
 
     return `Bravo! You have earned ${totalBadge} ${

--- a/src/components/Badge/BadgeImage.jsx
+++ b/src/components/Badge/BadgeImage.jsx
@@ -19,7 +19,7 @@ const BadgeImage = props => {
         </div>
 
         {props.badgeData.type == 'Personal Max' ? (
-          <span className={'badge_count_personalmax'}>{Math.round(props.personalBestMaxHrs)}</span>
+          <span className={'badge_count_personalmax'}>{Math.floor(props.personalBestMaxHrs)}</span>
         ) : props.count < 100 ? (
           <span className={'badge_count'}>{Math.round(props.count)}</span>
         ) : (

--- a/src/components/UserProfile/BadgeImage.jsx
+++ b/src/components/UserProfile/BadgeImage.jsx
@@ -19,7 +19,7 @@ const BadgeImage = props => {
 
         {props.badgeData.type == 'Personal Max' ? (
           <span className={'badge_featured_count_personalmax'}>
-            {`${Math.round(props.personalBestMaxHrs)} ${Math.round(props.personalBestMaxHrs) <= 1 ? ' hr' : ' hrs'}`}
+            {`${Math.floor(props.personalBestMaxHrs)} ${Math.floor(props.personalBestMaxHrs) <= 1 ? ' hr' : ' hrs'}`}
           </span>
         ) : props.count < 100 ? (
           <span className={'badge_featured_count'}>{Math.round(props.count)}</span>


### PR DESCRIPTION
# Description
Round down personal best hours to the whole number. So 21.99 hours should still log as a personal best of only 21. Although dev database shows `personalBestMaxHrs` as type `Int32`, I found in deployed HGN that it will show '24.133333 hours' as float.

## Related PRS (if any):
PR #1300 

## Main changes explained:
- Update file `src/components/Badge/Badge.jsx` to approximate personal best hours to whole number

## How to test:
See test intructions of PR #1300 part c

## Screenshots or videos of changes:
Before:
![CleanShot 2023-10-01 at 09 50 18](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/43768723/4ac818d2-1ea2-4702-946d-f58e8f3a3400)

After:
![CleanShot 2023-10-01 at 12 51 24](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/43768723/211809c0-8e3b-403d-b68d-1a0a68418c8f)


