### PR TITLE
Kurtis ~ re-implement 'add start date to user management table' with my fix from pr1278

### DIFF
--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -98,6 +98,7 @@ const UserTableData = React.memo(props => {
           ? formatDate(props.user.reactivationDate)
           : ''}
       </td>
+      <td>{props.user.createdDate ? formatDate(props.user.createdDate) : 'N/A'}</td>
       <td>{props.user.endDate ? formatDate(props.user.endDate) : 'N/A'}</td>
       {checkPermissionsOnOwner() ? null : (
         <td>

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -2,10 +2,8 @@ import React, { useState, useEffect } from 'react';
 import ResetPasswordButton from './ResetPasswordButton';
 import { DELETE, PAUSE, RESUME, SET_FINAL_DAY, CANCEL } from '../../languages/en/ui';
 import { UserStatus, FinalDay } from '../../utils/enums';
-import { useHistory } from 'react-router-dom';
 import ActiveCell from './ActiveCell';
 import hasPermission from 'utils/permissions';
-import Table from 'react-bootstrap/Table';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { toast } from 'react-toastify';
@@ -18,7 +16,6 @@ import { formatDate } from 'utils/formatDate';
  */
 const UserTableData = React.memo(props => {
   const [isChanging, onReset] = useState(false);
-  const history = useHistory();
   const canAddDeleteEditOwners = props.hasPermission('addDeleteEditOwners');
 
   /**

--- a/src/components/UserManagement/UserTableHeader.jsx
+++ b/src/components/UserManagement/UserTableHeader.jsx
@@ -9,6 +9,8 @@ import {
   PAUSE,
   USER_RESUME_DATE,
   MANAGE_FINAL_DAY,
+  USER_START_DATE,
+  USER_END_DATE
 } from '../../languages/en/ui';
 import userTableDataPermissions from 'utils/userTableDataPermissions';
 
@@ -46,7 +48,10 @@ const UserTableHeader = React.memo(props => {
         {USER_RESUME_DATE}
       </th>
       <th scope="col" id="usermanagement_resume_date">
-        End Date
+        {USER_START_DATE}
+      </th>
+      <th scope="col" id="usermanagement_resume_date">
+        {USER_END_DATE}
       </th>
       {userTableDataPermissions(props.authRole, props.roleSearchText) && (
         <th scope="col" id="usermanagement_delete"></th>

--- a/src/components/UserManagement/UserTableSearchHeader.jsx
+++ b/src/components/UserManagement/UserTableSearchHeader.jsx
@@ -52,6 +52,7 @@ const UserTableSearchHeader = React.memo(props => {
       <td id="user_pause"></td>
       <td id="user_finalDay"></td>
       <td id="user_resume_date"></td>
+      <td id="user_start_date"></td>
       <td id="user_end_date"></td>
       {userTableDataPermissions(props.authRole, props.roleSearchText) && (
         <td id="user__delete"></td>

--- a/src/languages/en/ui.js
+++ b/src/languages/en/ui.js
@@ -51,3 +51,5 @@ export const CANCEL = 'Delete Final Day';
 export const SET_FINAL_DAY = 'Set Final Day';
 export const MANAGE_FINAL_DAY = 'Manage Final Day';
 export const SEND_SETUP_LINK = 'Send Setup Link';
+export const USER_START_DATE = 'Start Date';
+export const USER_END_DATE = 'End Date';


### PR DESCRIPTION
<h1 align="center">Adding Start Date to the user management table</h1>

## Description
This pull request is a continuation of pr1278 due to it going stale despite the fix being 100% available. Therefore, I went ahead and implemented the fix, so this small feature could be added. This fix was the proper handling of the props.user object. All these changes were implemented off of the current frontend dev branch from 10/02/2023


## Related PRS (if any):
This frontend PR is a continuation of [pr1278](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1278) as it has gone stale


## Main changes explained:
- Implementation of start date in the user management table
- Implementation of my fix to show the start date through proper props usage



## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin/owner user
4. go to dashboard→ other links→ user management -> pause any user and verify start date shows
5. verify functionality through pausing volunteer (feel free to include screenshot here)

## Screenshots or videos of changes:

<h4>Before without start date column:</h4>

![Start date before](https://user-images.githubusercontent.com/65274029/272408522-a9dbab0c-a2a0-45ca-9f8f-c55989ce0422.png)

<h4>After with the start date column changes:</h4>

![Start date in usermanagement table](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/19482363/1384c509-cde6-48b1-9f4d-ffb3714dd4be)


