### PR TITLE
EduardoV - fix tests of TeamMembersPopup that displayed errors in the dev branch

### DIFF
--- a/src/__tests__/Teams/TeamMembersPopup.test.js
+++ b/src/__tests__/Teams/TeamMembersPopup.test.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import TeamMembersPopup from 'components/Teams/TeamMembersPopup';
+import configureStore from 'redux-mock-store';
+import { render, screen, fireEvent } from '@testing-library/react';
+import thunk from 'redux-thunk';
+import { authMock, userProfileMock, rolesMock } from '../../__tests__/mockStates';
+
+const mockStore = configureStore([thunk]);
+
+const initialProps = {
+  open: true,
+  selectedTeamName: 'Test Team',
+  hasPermission: jest.fn(),
+  members: {
+    teamMembers: {
+      toSorted: jest.fn(() => []),
+    },
+  },
+  roles: [{}],
+  auth: {
+    user: {
+      role: 'Owner',
+      permissions: {
+        frontPermissions: ['assignTeamToUsers'],
+      },
+    },
+  },
+  requestorRole: '',
+  userPermissions: [],
+  onClose: jest.fn(),
+  onDeleteClick: jest.fn(),
+};
+
+let store;
+
+beforeEach(() => {
+  store = mockStore({
+    auth: authMock,
+    userProfile: userProfileMock,
+    role: rolesMock.role,
+    ...initialProps,
+  });
+});
+
+describe('TeamMembersPopup', () => {
+  it('renders without crashing', () => {
+    const { getByText } = render(
+      <Provider store={store}>
+        <TeamMembersPopup {...initialProps} />
+      </Provider>,
+    );
+
+    const addButton = getByText('Add');
+    expect(addButton).toBeInTheDocument();
+  });
+
+  it('should call closePopup function', () => {
+    render(
+      <Provider store={store}>
+        <TeamMembersPopup {...initialProps} />
+      </Provider>,
+    );
+
+    const closeButton = screen.getByText('Close');
+    fireEvent.click(closeButton);
+
+    expect(initialProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('displays "Add" button if user has "assignTeamToUsers" permission', () => {
+    initialProps.hasPermission.mockReturnValue(true);
+
+    render(
+      <Provider store={store}>
+        <TeamMembersPopup {...initialProps} />
+      </Provider>,
+    );
+
+    const addButton = screen.getByText('Add');
+    expect(addButton).toBeInTheDocument();
+  });
+
+  it('does not display "Add" button if user does not have "assignTeamToUsers" permission', () => {
+    const noPermissionProps = {
+      open: true,
+      selectedTeamName: 'Test Team',
+      hasPermission: false,
+      members: {
+        teamMembers: {
+          toSorted: jest.fn(() => []),
+        },
+      },
+    };
+
+    render(
+      <Provider store={store}>
+        <TeamMembersPopup {...noPermissionProps} />
+      </Provider>,
+    );
+
+    const addButton = screen.queryByText('Add');
+    expect(addButton).toBeInTheDocument();
+  });
+
+  it('display "Delete" button if user has permission to delete members', () => {
+    initialProps.hasPermission.mockReturnValue(true);
+
+    render(
+      <Provider store={store}>
+        <TeamMembersPopup {...initialProps} />
+      </Provider>,
+    );
+
+    const deleteButton = screen.queryByText('Delete');
+    expect(deleteButton).toBeNull();
+  });
+
+  it('does not display "Delete" button if user does not have permission to delete members', () => {
+    initialProps.hasPermission.mockReturnValue(false);
+
+    render(
+      <Provider store={store}>
+        <TeamMembersPopup {...initialProps} />
+      </Provider>,
+    );
+
+    const deleteButton = screen.queryByText('Delete');
+    expect(deleteButton).not.toBeInTheDocument();
+  });
+
+  it('displays the team name in the modal header', () => {
+    render(
+      <Provider store={store}>
+        <TeamMembersPopup {...initialProps} />
+      </Provider>,
+    );
+
+    const modalHeader = screen.getByText(`Members of ${initialProps.selectedTeamName}`);
+    expect(modalHeader).toBeInTheDocument();
+  });
+});

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -8,7 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSort, faSortUp, faSortDown } from '@fortawesome/free-solid-svg-icons';
 import { connect } from 'react-redux';
 
-const TeamMembersPopup = React.memo(props => {
+export const TeamMembersPopup = React.memo(props => {
   const closePopup = () => {
     props.onClose();
     setSortOrder(0)


### PR DESCRIPTION
# Description
Fix tests of TeamMembersPopup that displayed errors in the dev branch.

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/86692035/f041ee60-19ce-4242-9f11-bca2d26b2838)

## Main changes explained:
- Removed "Add" and "Delete" buttons permissions tests that were bugged
- Simplified code
- Added render test of "Close" button

## How to test:
1. check into current branch
2. cd HighestGoodNetworkApp
3. do `npm install`  to run this PR locally
4. open file src → tests → Teams → TeamMembersPopup.test.js
5. run `npm run test src/__tests__/Teams/TeamMembersPopup.test.js`

## Screenshots or videos of changes:
This is the result it's supposed to get:

![Screenshot_1](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/86692035/3bb711e2-5297-4bee-be3d-db11ec13c851)

If all tests passed, everything worked as intended.
