### PR TITLE
Jerry - Hotfix Tangible Time Bug

### DIFF
--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -48,8 +48,7 @@ const TimeEntry = ({ data, displayYear, userProfile }) => {
     //permission to edit any time entry on their own time logs tab
     dispatch(hasPermission('editTimeEntry')) ||
     //default permission: edit own sameday timelog entry
-    (isOwner && isSameDay);
-
+    (isOwner && isSameDay && (role === "Owner" || role === "Administrator"));
   const projectCategory = data.category?.toLowerCase() || '';
   const taskClassification = data.classification?.toLowerCase() || '';
 


### PR DESCRIPTION
# Description
https://www.loom.com/share/a366803737ae48d49cb97a607dea7283?sid=28dfe140-8ad7-4aaf-b31f-08bd9591ebba

Accounts that are not Owner or Administrator are currently able to click on the 'Tangible' checkbox on their own Intangible Time Entry. Accounts that are not Owner or Administrator SHOULD NOT be able to do this.

## Related PRS (if any):
N/A

## Main changes explained:
- `canEdit` checks if `role` is equal to "Owner" or "Administrator"

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as Admin or Owner user. If there are no Intangible Time Entry, create one. Then try to click on the time entry's 'Tangible' checkbox. Admin and Owner accounts are the only roles allowed to do this. 
4. log as a user that is not Admin or Owner (e.g., Volunteer). If there are no Intangible Time Entry, create one. Then try to click on the time entry's 'Tangible' checkbox. Accounts that are not Admin and Owner will have the 'Tangible' checkout disabled. 

## Screenshots or videos of changes:


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/55968519/63440b8c-62fe-4d21-963c-a3d1e9116147
