### PR TITLE
EduardoV - fix tests of TeamMembersPopup that displayed errors in the dev branch

### DIFF
--- a/src/__tests__/Teams/TeamMembersPopup.test.js
+++ b/src/__tests__/Teams/TeamMembersPopup.test.js
@@ -61,4 +61,9 @@ describe('TeamMembersPopup', () => {
     renderComponent({ ...initialState, usersdata });
     expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
   });
+
+  it('should render "Close" button', () => {
+    renderComponent({ ...initialState, usersdata });
+    expect(screen.getByText('Close')).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/Teams/TeamMembersPopup.test.js
+++ b/src/__tests__/Teams/TeamMembersPopup.test.js
@@ -1,0 +1,38 @@
+import configureStore from 'redux-mock-store';
+import TeamMembersPopup from 'components/Teams/TeamMembersPopup';
+import thunk from 'redux-thunk';
+import { authMock, userProfileMock, rolesMock } from '../../__tests__/mockStates';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+
+const mockStore = configureStore([thunk]);
+
+const mockProps = {
+  members: {
+    teamMembers: [],
+  },
+  usersdata: {
+    userProfiles: [],
+  },
+};
+
+const renderComponent = props => {
+  const store = mockStore({
+    auth: authMock,
+    userProfile: userProfileMock,
+    role: rolesMock.role,
+    ...props,
+  });
+
+  render(
+    <Provider store={store}>
+      <TeamMembersPopup {...props} />
+    </Provider>,
+  );
+};
+
+describe('TeamMembersPopup', () => {
+  it('should render correctly', () => {
+    renderComponent(mockProps);
+  });
+});

--- a/src/__tests__/Teams/TeamMembersPopup.test.js
+++ b/src/__tests__/Teams/TeamMembersPopup.test.js
@@ -2,18 +2,14 @@ import configureStore from 'redux-mock-store';
 import TeamMembersPopup from 'components/Teams/TeamMembersPopup';
 import thunk from 'redux-thunk';
 import { authMock, userProfileMock, rolesMock } from '../../__tests__/mockStates';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
 const mockStore = configureStore([thunk]);
 
 const mockProps = {
-  members: {
-    teamMembers: [],
-  },
-  usersdata: {
-    userProfiles: [],
-  },
+  members: { teamMembers: [] },
+  usersdata: { userProfiles: [] },
 };
 
 const renderComponent = props => {
@@ -31,8 +27,38 @@ const renderComponent = props => {
   );
 };
 
+const initialState = {
+  open: true,
+  selectedTeamName: 'Test Team',
+  hasPermission: jest.fn(),
+  members: {
+    teamMembers: { toSorted: jest.fn(() => []) },
+  },
+  roles: [{}],
+  auth: {
+    user: {
+      role: 'Owner',
+      permissions: {
+        frontPermissions: ['assignTeamToUsers'],
+      },
+    },
+  },
+  userProfile: { userProfiles: [] },
+  requestorRole: '',
+  userPermissions: [],
+  onClose: jest.fn(),
+  onDeleteClick: jest.fn(),
+};
+
+const usersdata = { userProfiles: [] };
+
 describe('TeamMembersPopup', () => {
   it('should render correctly', () => {
     renderComponent(mockProps);
+  });
+
+  it('should render "Add" button', () => {
+    renderComponent({ ...initialState, usersdata });
+    expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
   });
 });

--- a/src/__tests__/Teams/TeamMembersPopup.test.js
+++ b/src/__tests__/Teams/TeamMembersPopup.test.js
@@ -2,7 +2,7 @@ import configureStore from 'redux-mock-store';
 import TeamMembersPopup from 'components/Teams/TeamMembersPopup';
 import thunk from 'redux-thunk';
 import { authMock, userProfileMock, rolesMock } from '../../__tests__/mockStates';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
 const mockStore = configureStore([thunk]);
@@ -65,5 +65,11 @@ describe('TeamMembersPopup', () => {
   it('should render "Close" button', () => {
     renderComponent({ ...initialState, usersdata });
     expect(screen.getByText('Close')).toBeInTheDocument();
+  });
+
+  it('should call closePopup function', () => {
+    renderComponent({ ...initialState, usersdata });
+    fireEvent.click(screen.getByText('Close'));
+    expect(initialState.onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/Teams/TeamMembersPopup.test.js
+++ b/src/__tests__/Teams/TeamMembersPopup.test.js
@@ -72,4 +72,9 @@ describe('TeamMembersPopup', () => {
     fireEvent.click(screen.getByText('Close'));
     expect(initialState.onClose).toHaveBeenCalledTimes(1);
   });
+
+  it('displays the team name in the modal header', () => {
+    renderComponent({ ...initialState, usersdata });
+    expect(screen.getByText(`Members of ${initialState.selectedTeamName}`)).toBeInTheDocument();
+  });
 });

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -8,7 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSort, faSortUp, faSortDown } from '@fortawesome/free-solid-svg-icons';
 import { connect } from 'react-redux';
 
-const TeamMembersPopup = React.memo(props => {
+export const TeamMembersPopup = React.memo(props => {
   const closePopup = () => {
     props.onClose();
     setSortOrder(0)


### PR DESCRIPTION
# Description
Fix tests of TeamMembersPopup that displayed errors in the dev branch.

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/86692035/f041ee60-19ce-4242-9f11-bca2d26b2838)

## Main changes explained:
- Removed "Add" and "Delete" buttons permissions tests that were bugged
- Simplified code
- Added render test of "Close" button

## How to test:
1. check into current branch
2. cd HighestGoodNetworkApp
3. do `npm install`  to run this PR locally
4. open file src → tests → Teams → TeamMembersPopup.test.js
5. run `npm run test src/__tests__/Teams/TeamMembersPopup.test.js`

## Screenshots or videos of changes:
This is the result it's supposed to get:

![Screenshot_2](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/86692035/09185581-6c10-49e5-b1f9-e3d1c12c3137)

If all tests passed, everything worked as intended.
