### PR TITLE
Jiyuan - Fixed Assign Badges permission function

### DIFF
--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -22,7 +22,7 @@ import { boxStyle } from 'styles';
 export const Badges = props => {
   const [isOpen, setOpen] = useState(false);
   const [isAssignOpen, setAssignOpen] = useState(false);
-  const canAssignBadges = props.hasPermission('assignBadges');
+  const canAssignBadges = props.hasPermission('assignBadges') || props.hasPermission('assignBadgeOthers');
 
   const toggle = () => setOpen(!isOpen);
 


### PR DESCRIPTION
# Description
![Screenshot 2023-10-06 162922](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/92963742/c5563db0-ed3c-4c5e-89c3-c1f9e6632457)

## Related PRS (if any):
This frontend PR is related to the [#547](https://github.com/OneCommunityGlobal/HGNRest/pull/547) backend PR.

## Main changes explained:
- Add a new check condition when assign a badge
## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as owner user
4. go to dashboard→ Other Links→ Permissions Management→ Manage User Permissions
5. type in another account name of yours which is not owner nor admin in User name→ find Assign Badges and click the Add button→ scroll down and click Submit
6. use the account you gave badge assignment permission to log in
7. click anyone's name to see if you can see the Assign Badges button on his profile page

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/92963742/7ccd6df7-5e70-4307-86f6-b0c4a62db85b


## Note:
If you click the Assign Badges button and see 403 error and there is nothing on Assign Badges page, it is ok because it is caused by lack of seeBadges permission.
