### PR TITLE
Aaron hotfix improve editing team code on Weekly Summaries page

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -285,14 +285,16 @@ function TeamCodeRow({ canEditTeamCode, summary }) {
   const handleCodeChange = e => {
     const { value } = e.target;
 
-    const regexTest = fullCodeRegex.test(value);
-    if (regexTest) {
-      setHasError(false);
-      setTeamCode(value);
-      handleOnChange(summary, value);
-    } else {
-      setTeamCode(value);
-      setHasError(true);
+    if (value.length <= 5) {
+      const regexTest = fullCodeRegex.test(value);
+      if (regexTest) {
+        setHasError(false);
+        setTeamCode(value);
+        handleOnChange(summary, value);
+      } else {
+        setTeamCode(value);
+        setHasError(true);
+      }
     }
   };
 
@@ -322,7 +324,7 @@ function TeamCodeRow({ canEditTeamCode, summary }) {
       </div>
       {hasError ? (
         <Alert className="code-alert" color="danger">
-          The code format should be A-AAA or AAAAA.
+          NOT SAVED! The code format must be A-AAA or AAAAA.
         </Alert>
       ) : null}
     </>


### PR DESCRIPTION
# Description

Currently, when owners go to /weeklysummariesreport and they edit someone's team code, they can add a ton of unnecessary letters and the message is not very descriptive. I have changed it so that the text cannot exceed 5 characters and edited the error message.

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/cb2c4b48-c11c-4e1f-b8fe-e1acbb79a764)


## Related PRS (if any):
N/A

## Main changes explained:
- added check to not add more than 5 characters to the team code
- invalid team code popup is more descriptive

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. login as owner user
4. go to dashboard→ Reports → Weekly Summary Reports 
5. go to any user and make sure you can't add more than 5 characters to their team code

## Screenshots or videos of changes:

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/9cd91f6f-9b41-4468-8412-32b13e5fc696)

<img width="955" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/3502c9d5-14ac-481e-8fdb-9801aa9bbf9b">


