### PR TITLE
Aaron hotfix new popup message for invalid team code when updating User Profile

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -292,8 +292,6 @@ function UserProfile(props) {
     setProjects(prevProjects => [...prevProjects, assignedProject]);
   };
 
-  console.log(userProfile);
-
   const onUpdateTask = (taskId, updatedTask) => {
     const newTask = {
       updatedTask,

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -292,6 +292,8 @@ function UserProfile(props) {
     setProjects(prevProjects => [...prevProjects, assignedProject]);
   };
 
+  console.log(userProfile);
+
   const onUpdateTask = (taskId, updatedTask) => {
     const newTask = {
       updatedTask,

--- a/src/components/UserProfile/UserProfileEdit/SaveButton.jsx
+++ b/src/components/UserProfile/UserProfileEdit/SaveButton.jsx
@@ -19,6 +19,7 @@ const getRandomMessage = () => {
 };
 
 const invalidCodemessage = 'Nice save! It seems you do not have a valid team code. It would be a lot cooler if you did. You can add one in the teams tab';
+const validTeamCodeRegex = /^([a-zA-Z]-[a-zA-Z]{3}|[a-zA-Z]{5})$/;
 
 /**
  *
@@ -28,7 +29,7 @@ const invalidCodemessage = 'Nice save! It seems you do not have a valid team cod
  * @returns
  */
 const SaveButton = props => {
-  const { handleSubmit, disabled, userProfile, isValidTeamCode } = props;
+  const { handleSubmit, disabled, userProfile } = props;
   const [modal, setModal] = useState(false);
   const [randomMessage, setRandomMessage] = useState(getRandomMessage());
 
@@ -43,7 +44,8 @@ const SaveButton = props => {
 
   useEffect(() => {
     if (modal === true) {
-      if (!isValidTeamCode) {
+      const regexTest = validTeamCodeRegex.test(userProfile.teamCode);
+      if (!regexTest) {
         setRandomMessage(invalidCodemessage);
       }
       else {

--- a/src/components/UserProfile/UserProfileEdit/SaveButton.jsx
+++ b/src/components/UserProfile/UserProfileEdit/SaveButton.jsx
@@ -18,6 +18,8 @@ const getRandomMessage = () => {
   return messages[Math.floor(Math.random() * messages.length)];
 };
 
+const invalidCodemessage = 'Nice save! It seems you do not have a valid team code. It would be a lot cooler if you did. You can add one in the teams tab';
+
 /**
  *
  * @param {func} props.handleSubmit
@@ -26,7 +28,7 @@ const getRandomMessage = () => {
  * @returns
  */
 const SaveButton = props => {
-  const { handleSubmit, disabled, userProfile } = props;
+  const { handleSubmit, disabled, userProfile, isValidTeamCode } = props;
   const [modal, setModal] = useState(false);
   const [randomMessage, setRandomMessage] = useState(getRandomMessage());
 
@@ -41,7 +43,12 @@ const SaveButton = props => {
 
   useEffect(() => {
     if (modal === true) {
-      setRandomMessage(getRandomMessage());
+      if (!isValidTeamCode) {
+        setRandomMessage(invalidCodemessage);
+      }
+      else {
+        setRandomMessage(getRandomMessage());
+      }
     }
   }, [modal]);
 


### PR DESCRIPTION
# Description
- added a new popup message when a user's profile information is updated and their team code is invalid

## Related PRS (if any):
- this PR adds a warning that was removed in the backend [PR563](https://github.com/OneCommunityGlobal/HGNRest/pull/563)

## Main changes explained:
- when clicking "Save" to update a user's profile, a regex check is now made to see if the user's team code is invalid/nonexistent and if so a different message is displayed
- if the team code is valid, the message is one of the normal messages

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as admin/owner user
4. go to dashboard→ Go to a user profile with a valid team code
   a. Edit profile info and click save
   b. Verify the behaviour is normal
5. go to dashboard→ Go to a user profile with an invalid/nonexistent team code
   a. Edit profile info and click save
   b. Verify the message is the new message (see below)

## Screenshots or videos of changes:

<b>Valid Team Code</b>

![image (8)](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/5349ca55-4cc2-4706-920b-69e75e490749)

<b>Invalid Team Code</b>

![image (7)](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/676aa2d5-a47e-46e6-8449-f56b86ec7a25)
