### PR TITLE
Vishala_Timelog_React_warning_key_prop

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -277,10 +277,11 @@ const Timelog = props => {
     }
   };
 
+
   const buildOptions = async () => {
     //build options for the project and task
     let projects = [];
-    if (!isEmpty(userProjects.projects)) {
+    if (!isEmpty(userProjects.projects) && !((userProjects?.projects?.length == 1 && userProjects?.projects[0]?.projectId == undefined))) {
       projects = userProjects.projects;
     }
     const options = projects.map(project => (

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -281,10 +281,11 @@ const Timelog = props => {
   const buildOptions = async () => {
     //build options for the project and task
     let projects = [];
-    if (!isEmpty(userProjects.projects) && !((userProjects?.projects?.length == 1 && userProjects?.projects[0]?.projectId == undefined))) {
+    if (!isEmpty(userProjects.projects)) {
       projects = userProjects.projects;
     }
     const options = projects.map(project => (
+      (project?.projectId != undefined) &&
       <option value={project.projectId} key={project.projectId}>
         {' '}
         {project.projectName}{' '}


### PR DESCRIPTION
**# Description**
<img width="547" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/65274029/ac12e0bd-1cd1-44b8-8a39-0f66c4146e30">
Fixes # Removed the unique key warning that has been displaying in the console.
Changes # Timelog.jsx

**## Screenshots or videos of changes:**

**-----------------------------------------------------BEFORE-----------------------------------------------------**





https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/65274029/a440c302-4b58-452e-b496-a82eca847f2b


**-----------------------------------------------------AFTER-----------------------------------------------------**





https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/65274029/d306ad15-c994-49e1-b45e-db7857edbe55



…

**## Main changes explained:**
- The user's related projects response from backend has empty object {} in the array (like [{}]) when the user actually had no projects
- Hence , the empty object was mapped to empty `"<option></option>"` tag in jsx
- Added checks , so that only if the object had a valid projectId , it would be added to the project select list
…

**## How to test:**
1. check into current branch
2. do `npm run start:local` to run this PR locally
3. log in as admin/volunteer/any user
4. go to Dashboard→ Tasks and Timelogs→ Current Week Timelog
5. Test if the "Each child in a list should have a unique "key" prop" warning is coming in the console as a part of Timelog component
6. Test first with no projects and then after adding projects  

