### PR TITLE
vishala_hotfix_team&projects_userprofile

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -50,8 +50,10 @@ import { UserStatus } from '../../utils/enums';
 import BlueSquareLayout from './BlueSquareLayout';
 import TeamWeeklySummaries from './TeamWeeklySummaries/TeamWeeklySummaries';
 import { boxStyle } from 'styles';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import { formatDate } from 'utils/formatDate';
+import { fetchAllProjects } from '../../actions/projects';
+import { getAllUserTeams } from '../../actions/allTeamsAction';
 
 function UserProfile(props) {
   /* Constant values */
@@ -61,6 +63,7 @@ function UserProfile(props) {
     email: true,
   };
   const roles = props?.role.roles;
+  const dispatch = useDispatch();
 
   /* Hooks */
   const [showLoading, setShowLoading] = useState(true);
@@ -103,9 +106,10 @@ function UserProfile(props) {
   const [userEndDate, setUserEndDate] = useState('');
 
   /* useEffect functions */
-
   useEffect(() => {
     loadUserProfile();
+    dispatch(fetchAllProjects());
+    dispatch(getAllUserTeams());
   }, []);
 
   useEffect(() => {
@@ -446,7 +450,7 @@ function UserProfile(props) {
     setShowModal(false);
     setUserProfile({
       ...userProfile,
-      mediaUrl:mediaUrlUpdate !== undefined ? mediaUrlUpdate : userProfile.mediaUrl,
+      mediaUrl: mediaUrlUpdate !== undefined ? mediaUrlUpdate : userProfile.mediaUrl,
       personalLinks: personalLinksUpdate,
       adminLinks: adminLinksUpdate,
     });
@@ -556,8 +560,8 @@ function UserProfile(props) {
   const canEditUserProfile = targetIsDevAdminUneditable
     ? false
     : userProfile.role === 'Owner'
-    ? canAddDeleteEditOwners
-    : canPutUserProfile;
+      ? canAddDeleteEditOwners
+      : canPutUserProfile;
 
   const canEdit = canEditUserProfile || isUserSelf;
 
@@ -646,7 +650,7 @@ function UserProfile(props) {
                 Please click on &quot;Save changes&quot; to save the changes you have made.{' '}
               </Alert>
             ) : null}
-              {!codeValid ? (
+            {!codeValid ? (
               <Alert color="danger">
                 The code format should be A-AAA or AAAAA.
               </Alert>
@@ -954,8 +958,8 @@ function UserProfile(props) {
                             if (selfIsDevAdminUneditable) {
                               alert(
                                 'STOP! YOU SHOULDN’T BE TRYING TO CHANGE THIS PASSWORD. ' +
-                                  'You shouldn’t even be using this account except to create your own accounts to use. ' +
-                                  'Please re-read the Local Setup Doc to understand why and what you should be doing instead of what you are trying to do now.',
+                                'You shouldn’t even be using this account except to create your own accounts to use. ' +
+                                'Please re-read the Local Setup Doc to understand why and what you should be doing instead of what you are trying to do now.',
                               );
                               return `#`;
                             }
@@ -1247,8 +1251,8 @@ function UserProfile(props) {
                     if (selfIsDevAdminUneditable) {
                       alert(
                         'STOP! YOU SHOULDN’T BE TRYING TO CHANGE THIS PASSWORD. ' +
-                          'You shouldn’t even be using this account except to create your own accounts to use. ' +
-                          'Please re-read the Local Setup Doc to understand why and what you should be doing instead of what you are trying to do now.',
+                        'You shouldn’t even be using this account except to create your own accounts to use. ' +
+                        'Please re-read the Local Setup Doc to understand why and what you should be doing instead of what you are trying to do now.',
                       );
                       return `#`;
                     }


### PR DESCRIPTION
**# Description**
In user's profile page , when a user tries to assign team/project , the select list is not populating data. 
Note : It might populate the data due to some cached loads. Please test this in a new chrome profile or clear browser cookies and cached files. https://support.google.com/accounts/answer/32050?hl=en&co=GENIE.Platform%3DDesktop
Fixes # Fetch call for 2 apis

**## Screenshots or videos of changes:**
**------------------------------------------------------------BEFORE------------------------------------------------**




[hotfix_teamProj_before.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/65274029/8b894cf4-5c9f-44f5-aeab-fd3961d12916)



**------------------------------------------------------------AFTER--------------------------------------------------------**

[hotfix_teamProj_after.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/65274029/fb046b4f-9740-4929-b140-6271e132f105)


…

**## Main changes explained:**
- Fetched Projects in UserProfile Comp
- Fetched Teams in UserProfile Comp
…

**## How to test:**
1. check into current branch
2. do `npm run start:local`  to run this PR locally
3. log as admin/owner user
4. go to dashboard→ Other Links -> UserManagement→ Select a user→… 
5. go to Teams Tab and click Assign Team. The pop up should open and when you type in words , it should populate appropriate Teams
6. go to Projects Tab and click Assign Project. The pop up should open and when you type in words , it should populate appropriate Projects
7. Please check if the details are not being populated as a part of before changes and being populated as a part of after changes. If it loads before changes , please clear cache. 


