### PR TITLE
Leo_fix_issue_update_with_updating_existing_password

### DIFF
--- a/src/__tests__/UpdatePassword/UpdatePassword.test.js
+++ b/src/__tests__/UpdatePassword/UpdatePassword.test.js
@@ -155,13 +155,13 @@ describe('Update Password Page', () => {
     });
 
     it('should show error if new and confirm passwords are not same', async () => {
-      await userEvent.type(screen.getByLabelText(/current password:/i), 'abced@12', {
+      await userEvent.type(screen.getByLabelText(/current password:/i), 'Abced@12', {
         allAtOnce: false,
       });
-      await userEvent.type(screen.getByLabelText(/new password:/i), 'ABCDabc123', {
+      await userEvent.type(screen.getByLabelText(/new password:/i), 'Abcdef@123', {
         allAtOnce: false,
       });
-      await userEvent.type(screen.getByLabelText(/confirm password:/i), 'ABCDabc1234', {
+      await userEvent.type(screen.getByLabelText(/confirm password:/i), 'Abcdef@124', {
         allAtOnce: false,
       });
       expect(screen.getByText(errorMessages.confirmpasswordMismatch)).toBeInTheDocument();

--- a/src/__tests__/UpdatePassword/UpdatePassword.test.js
+++ b/src/__tests__/UpdatePassword/UpdatePassword.test.js
@@ -155,7 +155,7 @@ describe('Update Password Page', () => {
     });
 
     it('should show error if new and confirm passwords are not same', async () => {
-      await userEvent.type(screen.getByLabelText(/current password:/i), 'abced', {
+      await userEvent.type(screen.getByLabelText(/current password:/i), 'abced@12', {
         allAtOnce: false,
       });
       await userEvent.type(screen.getByLabelText(/new password:/i), 'ABCDabc123', {

--- a/src/components/UpdatePassword/UpdatePassword.jsx
+++ b/src/components/UpdatePassword/UpdatePassword.jsx
@@ -8,11 +8,23 @@ import { updatePassword } from '../../actions/updatePassword';
 import { logoutUser } from '../../actions/authActions';
 import { clearErrors } from '../../actions/errorsActions';
 
+
 class UpdatePassword extends Form {
   state = {
     data: { currentpassword: '', newpassword: '', confirmnewpassword: '' },
     errors: {},
+    showPassword: { currentpassword: false, newpassword: false, confirmnewpassword: false }
   };
+  
+  togglePasswordVisibility = (field) => {
+    this.setState(prevState => ({
+      showPassword: {
+        ...prevState.showPassword,
+        [field]: !prevState.showPassword[field]
+      }
+    }));
+  }
+  
 
   componentDidMount() {}
 
@@ -84,31 +96,39 @@ class UpdatePassword extends Form {
 
   render() {
     return (
-      <div className="container mt-5">
-        <h2>Change Password</h2>
+        <div className="container mt-5">
+            <h2 className="text-2xl font-bold mb-5">Change Password</h2>
+            <form className="col-md-6 xs-12" onSubmit={e => this.handleSubmit(e)}>
+                <div className="mb-4">
+                    <div className="flex justify-between items-center">
+                        <label htmlFor="currentpassword" className="text-sm font-medium text-gray-700 mr-2">Current Password:</label>
+                        <i className={`fa ${this.state.showPassword.currentpassword ? 'fa-eye-slash' : 'fa-eye'} cursor-pointer`} onClick={() => this.togglePasswordVisibility('currentpassword')}></i>
+                    </div>
+                    {this.renderInput({ name: 'currentpassword', type: this.state.showPassword.currentpassword ? 'text' : 'password' })}
+                </div>
 
-        <form className="col-md-6 xs-12" onSubmit={e => this.handleSubmit(e)}>
-          {this.renderInput({
-            name: 'currentpassword',
-            label: 'Current Password:',
-            type: 'password',
-          })}
-          {this.renderInput({
-            name: 'newpassword',
-            label: 'New Password:',
-            type: 'password',
-          })}
-          {this.renderInput({
-            name: 'confirmnewpassword',
-            label: 'Confirm Password:',
-            type: 'password',
-            'data-refers': 'newpassword',
-          })}
-          {this.renderButton('Submit')}
-        </form>
-      </div>
+                <div className="mb-4">
+                    <div className="flex justify-between items-center">
+                        <label htmlFor="newpassword" className="text-sm font-medium text-gray-700 mr-2">New Password:</label>
+                        <i className={`fa ${this.state.showPassword.newpassword ? 'fa-eye-slash' : 'fa-eye'} cursor-pointer`} onClick={() => this.togglePasswordVisibility('newpassword')}></i>
+                    </div>
+                    {this.renderInput({ name: 'newpassword', type: this.state.showPassword.newpassword ? 'text' : 'password' })}
+                </div>
+
+                <div className="mb-4">
+                    <div className="flex justify-between items-center">
+                        <label htmlFor="confirmnewpassword" className="text-sm font-medium text-gray-700 mr-2">Confirm Password:</label>
+                        <i className={`fa ${this.state.showPassword.confirmnewpassword ? 'fa-eye-slash' : 'fa-eye'} cursor-pointer`} onClick={() => this.togglePasswordVisibility('confirmnewpassword')}></i>
+                    </div>
+                    {this.renderInput({ name: 'confirmnewpassword', type: this.state.showPassword.confirmnewpassword ? 'text' : 'password' })}
+                </div>
+
+                {this.renderButton('Submit')}
+            </form>
+        </div>
     );
-  }
+}
+
 }
 
 const mapStateToProps = state => ({

--- a/src/components/UpdatePassword/UpdatePassword.jsx
+++ b/src/components/UpdatePassword/UpdatePassword.jsx
@@ -43,7 +43,7 @@ class UpdatePassword extends Form {
       .required()
       .label('Current Password'),
     newpassword: Joi.string()
-      .regex(/(?=^.{8,}$)((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/)
+      .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[\W_]).{8,}$/)
       .required()
       .disallow(Joi.ref('currentpassword'))
       .label('New Password')

--- a/src/components/UpdatePassword/UpdatePassword.jsx
+++ b/src/components/UpdatePassword/UpdatePassword.jsx
@@ -43,7 +43,7 @@ class UpdatePassword extends Form {
       .required()
       .label('Current Password'),
     newpassword: Joi.string()
-      .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*-])(?=.{8,})/)
+      .regex(/(?=^.{8,}$)((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/)
       .required()
       .disallow(Joi.ref('currentpassword'))
       .label('New Password')

--- a/src/components/UpdatePassword/UpdatePassword.jsx
+++ b/src/components/UpdatePassword/UpdatePassword.jsx
@@ -43,7 +43,7 @@ class UpdatePassword extends Form {
       .required()
       .label('Current Password'),
     newpassword: Joi.string()
-      .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[\W_]).{8,}$/)
+      .regex(/(?=^.{8,}$)(?=.*\d)(?=.*\W)(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/)
       .required()
       .disallow(Joi.ref('currentpassword'))
       .label('New Password')

--- a/src/components/UpdatePassword/UpdatePassword.jsx
+++ b/src/components/UpdatePassword/UpdatePassword.jsx
@@ -43,7 +43,7 @@ class UpdatePassword extends Form {
       .required()
       .label('Current Password'),
     newpassword: Joi.string()
-      .regex(/(?=^.{8,}$)((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/)
+      .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*-]).{8,}$/)
       .required()
       .disallow(Joi.ref('currentpassword'))
       .label('New Password')

--- a/src/components/UpdatePassword/UpdatePassword.jsx
+++ b/src/components/UpdatePassword/UpdatePassword.jsx
@@ -43,7 +43,7 @@ class UpdatePassword extends Form {
       .required()
       .label('Current Password'),
     newpassword: Joi.string()
-      .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*-]).{8,}$/)
+      .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*-])(?=.{8,})/)
       .required()
       .disallow(Joi.ref('currentpassword'))
       .label('New Password')

--- a/src/components/UserManagement/ResetPasswordPopup.jsx
+++ b/src/components/UserManagement/ResetPasswordPopup.jsx
@@ -18,6 +18,10 @@ const ResetPasswordPopup = React.memo(props => {
   const [newPassword, onNewPasswordChange] = useState({ password: '', isValid: false });
   const [confirmPassword, onConfirmPasswordChange] = useState({ password: '', isValid: false });
   const [errorMessage, setError] = useState('');
+  const [showPassword, setShowPassword] = useState({
+    newPassword: false,
+    confirmPassword: false
+  });
   const closePopup = e => {
     props.onClose();
   };
@@ -28,6 +32,13 @@ const ResetPasswordPopup = React.memo(props => {
     onConfirmPasswordChange({ password: '', isValid: false });
     setError('');
   }, [props.open]);
+
+    const togglePasswordVisibility = (field) => {
+    setShowPassword(prevState => ({
+      ...prevState,
+      [field]: !prevState[field]
+    }));
+  };
 
   const resetPassword = () => {
     if (!newPassword.isValid) {
@@ -42,7 +53,7 @@ const ResetPasswordPopup = React.memo(props => {
   };
 
   const isValidPassword = password => {
-    const regex = new RegExp('^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*])(?=.{8,})');
+    const regex = new RegExp('^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*\\-])(?=.{8,})');
     return regex.test(password);
   };
 
@@ -51,24 +62,42 @@ const ResetPasswordPopup = React.memo(props => {
       <ModalHeader toggle={closePopup}>Reset Password</ModalHeader>
       <ModalBody>
         <Form>
-          <Label for="newpassword">New Password</Label>
+          <div className="flex justify-between items-center mb-2">
+              <Label className="mr-2" for="newpassword">New Password</Label>
+              <span 
+                className={`fa ${showPassword.newPassword ? 'fa-eye-slash' : 'fa-eye'} cursor-pointer`} 
+                onClick={() => togglePasswordVisibility('newPassword')} 
+              ></span>
+          </div>
           <Input
             autoFocus
-            type="password"
+            type={showPassword.newPassword ? 'text' : 'password'}
             name="newpassword"
             id="newpassword"
             value={newPassword.password}
             onChange={event => {
+              const value = event.target.value;
               onNewPasswordChange({
-                password: event.target.value,
-                isValid: isValidPassword(event.target.value),
+                password: value,
+                isValid: isValidPassword(value),
               });
-              setError('');
+              if (!isValidPassword(value)) {
+                setError('Please choose a strong password which is at least 8 characters long and should contains a digit, a capital letter, and a special character.');
+              } else {
+                setError('');
+              }
             }}
           />
-          <Label for="confirmpassword">Confirm Password</Label>
+          
+          <div className="flex justify-between items-center mt-4 mb-2">
+              <Label className="mr-2" for="confirmpassword">Confirm Password</Label>
+              <span 
+                className={`fa ${showPassword.confirmPassword ? 'fa-eye-slash' : 'fa-eye'} cursor-pointer`} 
+                onClick={() => togglePasswordVisibility('confirmPassword')} 
+              ></span>
+          </div>
           <Input
-            type="password"
+            type={showPassword.confirmPassword ? 'text' : 'password'}
             name="confirmpassword"
             id="confirmpassword"
             value={confirmPassword.password}
@@ -77,7 +106,11 @@ const ResetPasswordPopup = React.memo(props => {
                 password: event.target.value,
                 isValid: isValidPassword(event.target.value),
               });
-              setError('');
+              if (newPassword.password !== event.target.value) {
+                setError('Your password and confirmation password do not match.');
+              } else {
+                setError('');
+              }
             }}
           />
         </Form>
@@ -92,7 +125,7 @@ const ResetPasswordPopup = React.memo(props => {
         </Button>
       </ModalFooter>
     </Modal>
-  );
+);
 });
 
 export default ResetPasswordPopup;


### PR DESCRIPTION
# Description
![Screenshot 2023-10-13 151833](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/5d4db37c-04aa-492a-942b-13b004012a02)


## Related PRS (if any):
This frontend PR is related to the [#571](https://github.com/OneCommunityGlobal/HGNRest/pull/571)  backend PR.
To test this frontend PR you need to checkout the [#571](https://github.com/OneCommunityGlobal/HGNRest/pull/571) backend PR.
…

## Main changes explained:
- Update UpdatePassword.jsx for including an eye icon for users to select the visibility of their password …
- Create a showPassword state to manage the visibility
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin or Owner user
4. go to dashboard→View Profile→Update password
5. check if you can change your own password successfully and see if the eye icon allows to hide or show the password
6. login with the new password
7. find an volunteer user you have access to and click on the profile→ Reset Password→…
8. change the password and login as the volunteer user with the new password
9. find a user and click on their profile, see if there is no buttons for the volunteer user to reset others password
10. go to dashboard→View Profile→Update password
11. check if you can change your own password successfully and see if the eye icon allows to hide or show the password

## Screenshots or videos of changes:
Login as volunteer:
![Screenshot 2023-10-13 153550](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/1618791b-5c45-45d4-a627-df7d0c22ddef)
Login as admin/Owner:
![Screenshot 2023-10-13 153629](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/66f27028-cddd-41ca-b831-9ee376462a60)

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/c2adce2c-954b-470a-9220-b5c9754d4e6d



## Note:
Include the information the reviewers need to know.
