### PR TITLE
Aaron hotfix change console warns to errors and turn off warning for alert

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,8 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'import/no-duplicates': 'off',
     'import/no-named-as-default': 'off',
+    'no-alert': 'off',
+    'no-console': 'error',
   },
   overrides: [
     {


### PR DESCRIPTION
# Description
- fix to remove warnings from eslint, so they are either ignored or throw errors

## Related PRS (if any):
- there will be a future PR that changes `no-alert` to throw errors once the new "Alert" component is added

## Main changes explained:
- add a rule to treat `no-console` warnings as errors
- added a rule to turn off warnings for `no-alert` (will re-add this rule as an error once the new alert component is added)

## How to test:
1. check into current branch
2. add an alert to any js/jsx file (ex. `alert("hello world");` )
    a. run `npm run lint` and verify no warning/error is displayed
3. add a console statement (console.log, console.error) to any js/jsx file
    a. run `npm run lint` and verify that `no-console` shows up as an error instead of warning
