### PR TITLE
Aaron add message to popup management when there are no popups

### DIFF
--- a/src/components/Admin/Admin.jsx
+++ b/src/components/Admin/Admin.jsx
@@ -13,7 +13,10 @@ function Admin(props) {
   return (
     <div className="container mt-3">
       {popupEditor.popupItems.length === 0 ? (
-        <p style={{ textAlign: 'center' }}>You have not created any popup messages!</p>
+        <p style={{ textAlign: 'center' }}>
+          A popup is needed for this. Help us make the app better by sharing with the Admin what you
+          did to get this screen.
+        </p>
       ) : (
         popupEditor.popupItems.map(item => (
           <PopupText

--- a/src/components/Admin/Admin.jsx
+++ b/src/components/Admin/Admin.jsx
@@ -12,14 +12,18 @@ function Admin(props) {
 
   return (
     <div className="container mt-3">
-      {popupEditor.popupItems.map(item => (
-        <PopupText
-          key={item._id}
-          title={item.popupName}
-          content={item.popupContent}
-          id={item._id}
-        />
-      ))}
+      {popupEditor.popupItems.length === 0 ? (
+        <p style={{ textAlign: 'center' }}>You have not created any popup messages!</p>
+      ) : (
+        popupEditor.popupItems.map(item => (
+          <PopupText
+            key={item._id}
+            title={item.popupName}
+            content={item.popupContent}
+            id={item._id}
+          />
+        ))
+      )}
     </div>
   );
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -208,7 +208,7 @@ export const Header = props => {
                     {canCreatePopup || canUpdatePopup ? (
                       <>
                         <DropdownItem divider />
-                        <DropdownItem tag={Link} to={`/admin/`}>
+                        <DropdownItem tag={Link} to={`/popupmanagement`}>
                           {POPUP_MANAGEMENT}
                         </DropdownItem>
                       </>

--- a/src/routes.js
+++ b/src/routes.js
@@ -59,7 +59,7 @@ export default (
           <ProtectedRoute path="/dashboard/:userId" exact component={Dashboard} />
           <ProtectedRoute path="/wbs/tasks/:wbsId/:projectId/:wbsName" component={WBSDetail} />
           <ProtectedRoute path="/project/members/:projectId" component={Members} />
-          <ProtectedRoute path="/admin" component={Admin} />
+          <ProtectedRoute path="/popupmanagement" component={Admin} />
           <ProtectedRoute path="/timelog/" exact component={Timelog} />
           <ProtectedRoute path="/timelog/:userId" exact component={Timelog} />
           <ProtectedRoute path="/peoplereport/:userId" component={PeopleReport} />


### PR DESCRIPTION
# Description
Currently, whenever an admin/owner goes to the Popup Management page, no content is loaded if there aren't any popups. I've added a message that appears when no popups exist. I've also renamed the route to /popupmanagement, since the link currently reroutes to /admin which is confusing.

## Related PRS (if any):
N/A

## Main changes explained:
- added text to the Popup Management page when no popups exist
- renamed route for Popup Management for /admin to /popupmanagement

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as admin/owner user
4. go to dashboard→ Other Links → Popup Management
5. verify you are taken to /popupmanagement instead of /admin
6. if there are no popups, verify that you can see the message below 

## Screenshots or videos of changes:

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/8653e09a-a3d4-4afb-a131-b602f9d0bfdd)
