### PR TITLE
Nathan preset info points

### DIFF
--- a/src/components/PermissionsManagement/RolePermissions.jsx
+++ b/src/components/PermissionsManagement/RolePermissions.jsx
@@ -125,9 +125,9 @@ export const  modalInfo = {
   'Edit Team 4-Digit Codes' :
     'Gives the user permission to edit 4-digit team codes on profile page and weekly summaries report page.',
   'Create New Preset' :
-    'Saves current permissions into a new preset named \'New Preset #\' with the lowest number not already taken.',
+    '\'Create New Preset\' saves current permissions into a new preset named \'New Preset #\' with the lowest number not already taken.',
   'Load Presets' :
-    'Opens list of presets saved for this role where they can be renamed, applied, or deleted.'
+    '\'Load Presets\' opens a list of presets saved for this role where they can be renamed, applied, or deleted.'
 };
 
 function RolePermissions(props) {

--- a/src/components/PermissionsManagement/RolePermissions.jsx
+++ b/src/components/PermissionsManagement/RolePermissions.jsx
@@ -124,7 +124,10 @@ export const  modalInfo = {
     'Give the ability to see on the dashboard the eye indicator for when a person is invisible. ',
   'Edit Team 4-Digit Codes' :
     'Gives the user permission to edit 4-digit team codes on profile page and weekly summaries report page.',
-
+  'Create New Preset' :
+    'Saves current permissions into a new preset named \'New Preset #\' with the lowest number not already taken.',
+  'Load Presets' :
+    'Opens list of presets saved for this role where they can be renamed, applied, or deleted.'
 };
 
 function RolePermissions(props) {
@@ -254,22 +257,48 @@ function RolePermissions(props) {
             )}
           </div>
           {props?.userRole === 'Owner' && (
-            <div className="name-container__btn_columns">
-              <div className="name-container__btns">
-                <Button className="btn_save" color="success" onClick={()=>{ saveNewPreset()}} style={boxStyle}>
+            <div style={{flexDirection:'row', display:'flex'}}>
+              <div className="name-container__btn_columns">
+                <div className="name-container__btns">
+                  <Button className="btn_save" color="success" onClick={()=>{ saveNewPreset()}} style={boxStyle}>
                     Create New Preset
                   </Button>
                   <Button color="primary" onClick={()=>{setShowPresetModal(!showPresetModal);}} style={boxStyle}>
                     Load Presets
                   </Button>
+                </div>
+                <div className="name-container__btns">
+                  <Button className="btn_save" color="success" onClick={() => updateInfo()} style={boxStyle}>
+                    Save
+                  </Button>
+                  <Button color="danger" onClick={toggleDeleteRoleModal} style={boxStyle}>
+                    Delete Role
+                  </Button>
+                </div>
               </div>
-              <div className="name-container__btns">
-                <Button className="btn_save" color="success" onClick={() => updateInfo()} style={boxStyle}>
-                  Save
-                </Button>
-                <Button color="danger" onClick={toggleDeleteRoleModal} style={boxStyle}>
-                  Delete Role
-                </Button>
+              <div className="icon-button-container" style={{position: 'relative', width:'0', height:'0'}}>
+                <div className='name-container__btns' style={{position: 'absolute', left: '10px', top: '20px'}}>
+                  <i
+                    data-toggle="tooltip"
+                    data-placement="center"
+                    title="Click for more information"
+                    aria-hidden="true"
+                    className="fa fa-info-circle"
+                    onClick={() => {
+                      handleModalOpen('Create New Preset');
+                    }}
+                  />
+                  <i
+                    data-toggle="tooltip"
+                    data-placement="center"
+                    title="Click for more information"
+                    aria-hidden="true"
+                    className="fa fa-info-circle"
+                    onClick={() => {
+                      handleModalOpen('Load Presets');
+                    }}
+                  />
+                </div>
               </div>
             </div>
           )}
@@ -326,7 +355,7 @@ function RolePermissions(props) {
                   handleModalOpen(permission);
                 }}
               />
-              </div>
+            </div>
               <Button
                 className="icon-button"
                 color={permissions.includes(permission) ? 'danger' : 'success'}


### PR DESCRIPTION
# Description
Adds info points for the `Load Presets` and `Create New Preset` buttons.

## Main changes explained:
- add info points with wrapper divs for styling

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin/owner user
4. go to Other Links → Permission Management → some role
5. verify that info points appear and work when clicked on

## Screenshots or videos of changes:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/856c0d53-a595-41a9-8c56-ef4075d8ade2)

