### PR TITLE
Aaron change no-alert to error and remove unused alert

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'import/no-duplicates': 'off',
     'import/no-named-as-default': 'off',
-    'no-alert': 'off',
+    'no-alert': 'error',
     'no-console': 'error',
   },
   overrides: [

--- a/src/components/ForcePasswordUpdate/ForcePasswordUpdate.jsx
+++ b/src/components/ForcePasswordUpdate/ForcePasswordUpdate.jsx
@@ -49,14 +49,9 @@ export class ForcePasswordUpdate extends Form {
   };
 
   doSubmit = async () => {
-    const { newpassword, confirmnewpassword } = {
+    const { newpassword } = {
       ...this.state.data,
     };
-
-    if (newpassword !== confirmnewpassword) {
-      alert('Confirm Password must match New Password');
-      return;
-    }
 
     const { userId } = this.props.match.params;
     const data = { userId, newpassword };


### PR DESCRIPTION
# Description
In a previous PR, I turned off the lint warning for `no-alert`, which doesn't allow the use of the JavaScript "alert" function. I am now changing the rule so that it treats `no-alert` as an error,  and moving forward we will not be using the "alert" function when developing.

## Related PRS (if any):
[PR1415](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1415)

## Main changes explained:
- change `no-alert` in lint rules from "off" to "error"
- remove alert function in `ForcePasswordUpdate.jsx` that was not being used.

## How to test:
1. check into current branch
2. run `npm run lint` to make sure there are no errors/warnings
3. do `npm install` and `npm run start:local` to run this PR locally
4. log as admin/owner user
5. go to dashboard→ User Management → create new account
6. log into the new account so you get to the /forcePasswordUpdate page
7. make sure everything on this page works as normal when updating your password

## Note:
I will be adding some notes to the linting document to help with dealing with the `no-alert` error in the future