### PR TITLE
fix private public setup user toggle

### DIFF
--- a/src/components/SetupProfile/SetupProfileUserEntry.jsx
+++ b/src/components/SetupProfile/SetupProfileUserEntry.jsx
@@ -317,8 +317,8 @@ const SetupProfileUserEntry = ({ token, userEmail }) => {
         weeklycommittedHours: Number(userProfile.weeklyCommittedHours.trim()),
         collaborationPreference: userProfile.collaborationPreference.trim(),
         privacySettings: {
-          email: false,
-          phoneNumber: false,
+          email: true,
+          phoneNumber: true,
         },
         jobTitle: userProfile.jobTitle.trim(),
         timeZone: userProfile.timeZone.trim(),


### PR DESCRIPTION
Fix default values for the public/private toggle options (phone number and email) for users who are created using setup links.
