### PR TITLE
Shrey create a toggle switch to have active and all users

### DIFF
--- a/src/components/Projects/Members/Members.jsx
+++ b/src/components/Projects/Members/Members.jsx
@@ -18,9 +18,12 @@ import FoundUser from './FoundUser';
 import './members.css';
 import hasPermission from '../../../utils/permissions';
 import { boxStyle } from 'styles';
+import ToggleSwitch from 'components/UserProfile/UserProfileEdit/ToggleSwitch';
 
 const Members = props => {
   const projectId = props.match.params.projectId;
+  const [showFindUserList, setShowFindUserList] = useState(false);
+  const [membersList, setMembersList] = useState(props.state.projectMembers.members);
 
   const canGetProjectMembers = props.hasPermission('getProjectMembers') || props.hasPermission('seeProjectManagement') || props.hasPermission('seeProjectManagementTab');
   const canAssignProjectToUsers = props.hasPermission('assignProjectToUsers') || props.hasPermission('seeProjectManagement') || props.hasPermission('seeProjectManagementTab');
@@ -30,11 +33,32 @@ const Members = props => {
     props.fetchAllMembers(projectId);
   }, [projectId]);
 
-  const assignAll = () => {
+  const assignAll = async () => {
     const allUsers = props.state.projectMembers.foundUsers.filter(user => user.assigned === false);
-    allUsers.forEach(user => {
-      props.assignProject(projectId, user._id, 'Assign', user.firstName, user.lastName);
-    });
+    
+    // Wait for all members to be assigned
+    await Promise.all(allUsers.map(user => 
+      props.assignProject(projectId, user._id, 'Assign', user.firstName, user.lastName)
+    ));
+  
+    props.fetchAllMembers(projectId);
+  };
+
+  useEffect(() => {
+    setMembersList(props.state.projectMembers.members);
+  }, [props.state.projectMembers.members]);
+
+  // ADDED: State for toggling display of active members only
+  const [showActiveMembersOnly, setShowActiveMembersOnly] = useState(false);
+
+  const displayedMembers = showActiveMembersOnly 
+  ? membersList.filter(member => member.isActive)
+  : membersList;
+
+  const handleToggle = async () => {
+    setShowActiveMembersOnly(prevState => !prevState);
+    await props.fetchAllMembers(projectId);
+    setMembersList(props.state.projectMembers.members);
   };
 
   return (
@@ -65,21 +89,33 @@ const Members = props => {
               placeholder="Name"
               onChange={e => {
                 props.findUserProfiles(e.target.value);
+                setShowFindUserList(true);
               }}
+              disabled={showActiveMembersOnly}
             />
             <div className="input-group-append">
               <button
                 className="btn btn-outline-primary"
                 type="button"
-                onClick={e => props.getAllUserProfiles()}
+                onClick={e => {props.getAllUserProfiles();
+                  setShowFindUserList(true);
+                }}
+                disabled={showActiveMembersOnly}
               >
                 All
+              </button>
+              <button
+                className="btn btn-outline-danger"
+                type="button"
+                onClick={() => setShowFindUserList(false)} // Hide the find user list
+              >
+                Cancel
               </button>
             </div>
           </div>
         ) : null}
 
-        {props.state.projectMembers.foundUsers.length === 0 ? null : (
+        {showFindUserList && props.state.projectMembers.foundUsers.length > 0 ? (
           <table className="table table-bordered table-responsive-sm">
             <thead>
               <tr>
@@ -118,7 +154,13 @@ const Members = props => {
               ))}
             </tbody>
           </table>
-        )}
+        ) : null}
+
+          <ToggleSwitch 
+            switchType="active_members"
+            state={showActiveMembersOnly}
+            handleUserProfile={handleToggle}
+          />
 
         <table className="table table-bordered table-responsive-sm">
           <thead>
@@ -131,7 +173,7 @@ const Members = props => {
             </tr>
           </thead>
           <tbody>
-            {props.state.projectMembers.members.map((member, i) => (
+            {displayedMembers.map((member, i) => (
               <Member
                 index={i}
                 key={member._id}

--- a/src/components/UserProfile/UserProfileEdit/ToggleSwitch/ToggleSwitch.jsx
+++ b/src/components/UserProfile/UserProfileEdit/ToggleSwitch/ToggleSwitch.jsx
@@ -185,6 +185,44 @@ const ToggleSwitch = ({ switchType, state, handleUserProfile, fontSize }) => {
           </div>
         </div>
       );
+      case 'active_members':
+      if (state) {
+        return (
+          <div className="blueSqare">
+            <div className={style.switchSection}>
+              <div className={style.switchContainer}>
+                Active
+                <input
+                  data-testid="active-switch"
+                  id="showActiveMembersOnly"
+                  type="checkbox"
+                  className={style.toggle}
+                  onChange={handleUserProfile}
+                />
+                All
+              </div>
+            </div>
+          </div>
+        );
+      }
+      return (
+        <div className="blueSqare">
+          <div className={style.switchSection}>
+            <div className={style.switchContainer}>
+              Active
+              <input
+                data-testid="active-switch"
+                id="showActiveMembersOnly"
+                type="checkbox"
+                className={style.toggle}
+                defaultChecked
+                onChange={handleUserProfile}
+              />
+              All
+            </div>
+          </div>
+        </div>
+      );
     default:
       break;
   }


### PR DESCRIPTION
# Description
Create Projects “active” and “all” option.
Other links>Projects>click people icon
Right now it shows ever person in that project and I’d like it to only show active people but have a button or other way to show “all” people

## Main changes explained:
Created a toggle switch for active and all user.
Added a cancel button to close the found user list which was not there before
Disabled the functionality to add members from the active side to avoid extra re rendering.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to dashboard→ Other Links→ Projects→click People Icon
5. verify that the toggle switch is working and only the active users are shown the toggle side.(go to user management and pause users to check the functionality)
6. The active side doesnt support to add user, because it makes multiple re rendering.

## Screenshots or videos of changes:
Before:
<img width="1285" alt="Screenshot 2023-10-21 at 3 45 05 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/ed0435bb-441c-44ce-a44c-cea05f4d8b5a">


After:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118795427/b0191fda-7204-452a-b9b4-1b8d56f347f6

