### PR TITLE
Jerry - Hotfix Reports page view person shows wrong person

### DIFF
--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -91,11 +91,13 @@ class PeopleReport extends Component {
 
     if (match) {
       const { userId } = match.params;
-      await getUserProfile(userId);
-      await getUserTask(userId);
-      await getUserProjects(userId);
-      await getWeeklySummaries(userId);
-      await getTimeEntriesForPeriod(userId, fromDate, toDate);
+      await this.props.getUserProfile(userId);
+      await this.props.getUserTask(userId);
+      await this.props.getUserProjects(userId);
+      await this.props.getWeeklySummaries(userId);
+      await this.props.getTimeEntriesForPeriod(userId, fromDate, toDate);
+
+      const { userProfile, userTask, userProjects, timeEntries, auth } = this.props;
 
       this.setState({
         // eslint-disable-next-line react/no-unused-state


### PR DESCRIPTION
# Description
https://www.loom.com/share/ee28af8cb6334345b747d2bff49d42ef?sid=39150c94-3a31-48ab-89b9-ad28fe64050d

Clicking on a Person Name on the Reports Page does not show the correct person’s report. The motivation of this PR is to correct this bug so that the correct person's report is shown.

## Related PRS (if any):
N/A

## Main changes explained:
- Added the leading `this.props` on functions that dispatch actions.
- After awaiting those functions, destructure variables from `this.props` and those variables contain the updated state values.


## How to test:
1. Check into `development` branch of back end code and run the server.
2. check into current branch
3. do `npm install` and `...` to run this PR locally
4. Log in as Owner or Administrator account
4. Reports -> Reports -> People -> click on a Person Name
5. verify that the correct person's report appears

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/55968519/05d0a973-3b31-42f3-a97f-c58a7c246573

## Note:

Special thanks to Xiao W for coming up with this solution to the bug!