### PR TITLE
added route to LessonForm /lessonform and simple jsx

### DIFF
--- a/src/components/Lesson/LessonForm.jsx
+++ b/src/components/Lesson/LessonForm.jsx
@@ -1,9 +1,8 @@
 function LessonForm() {
-    return (
-      <div>
-        <h2>Hi kai</h2>
-      </div>
-    );
-  }
-  export default LessonForm;
-  
+  return (
+    <div>
+      <h2>Hi kai</h2>
+    </div>
+  );
+}
+export default LessonForm;

--- a/src/components/Lesson/LessonForm.jsx
+++ b/src/components/Lesson/LessonForm.jsx
@@ -1,8 +1,8 @@
-const LessonForm = () => {
-    return(
-        <div>
-            <h2>Hi kai</h2>
-        </div>
-    )
+function LessonForm() {
+  return (
+    <div>
+      <h2>Hi kai</h2>
+    </div>
+  );
 }
-export default LessonForm
+export default LessonForm;

--- a/src/components/Lesson/LessonForm.jsx
+++ b/src/components/Lesson/LessonForm.jsx
@@ -1,0 +1,8 @@
+const LessonForm = () => {
+    return(
+        <div>
+            <h2>Hi kai</h2>
+        </div>
+    )
+}
+export default LessonForm

--- a/src/components/Lesson/LessonForm.jsx
+++ b/src/components/Lesson/LessonForm.jsx
@@ -1,8 +1,9 @@
 function LessonForm() {
-  return (
-    <div>
-      <h2>Hi kai</h2>
-    </div>
-  );
-}
-export default LessonForm;
+    return (
+      <div>
+        <h2>Hi kai</h2>
+      </div>
+    );
+  }
+  export default LessonForm;
+  

--- a/src/routes.js
+++ b/src/routes.js
@@ -47,6 +47,8 @@ import BMLogin from 'components/BMDashboard/Login';
 import MaterialsList from 'components/BMDashboard/MaterialsList';
 
 import ProjectDetails from 'components/BMDashboard/Projects/ProjectDetails/ProjectDetails';
+// Lesson
+import LessonForm from 'components/Lesson/LessonForm';
 
 
 export default (
@@ -171,7 +173,14 @@ export default (
   
       
       {/* ----- END BM Dashboard Routing ----- */}
-
+  {/* ----- BEGIN Lesson Routing ----- */}
+  <ProtectedRoute
+            path="/lessonform"
+            exact
+            component={LessonForm}
+            
+          />
+  {/* ----- END Lesson Routing ----- */}
       <Route path="/login" component={Login} />
       <Route path="/forgotpassword" component={ForgotPassword} />
       <ProtectedRoute path="/infoCollections" component={EditableInfoModal} />


### PR DESCRIPTION
# Description
Added a route to simple LessonForm.jsx
If user is no loged in and trys to access route they are redirected to login page.

## Related PRS (if any):
n/a
…

## Main changes explained:
- Needed a route to display new LessonForm.jsx
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as anyone
4. type http://localhost:3000/lessonform in path
5. new LessonForm.jsx is displayed only when logged in

## Screenshots or videos of changes:
<img width="944" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114305309/bfaf893d-37c1-4900-9d65-38394f9317c1">

## Note:

