### PR TITLE
Yubo- unit test for Edit Link Modal

### DIFF
--- a/src/__tests__/UserProfile/EditLinkModal.test.js
+++ b/src/__tests__/UserProfile/EditLinkModal.test.js
@@ -1,0 +1,178 @@
+import React from "react";
+import { fireEvent, getByPlaceholderText, render, component, waitFor, within } from "@testing-library/react";
+import EditLinkModal from "components/UserProfile/UserProfileModal/EditLinkModal";
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { rolesMock, authMock, userProfileMock, userProjectMock } from "__tests__/mockStates";
+import { Provider } from "react-redux";
+import hasPermission from "utils/permissions";
+
+
+const VALID_URL = 'https://valid.url';
+const VALID_URL2 = 'https://valid.url.again';
+const INVALID_URL = 'invalid.';
+
+const EmptyLinkUserProfile= {
+  role: "Owner",
+  adminLinks:[],
+  personlLinks:[],
+  mediaUrl: undefined,
+}
+const filledUserProfile = {
+  role: "Owner",
+  adminLinks:
+  [
+    { Name: 'Google Doc', Link: VALID_URL },
+    { Name: 'Media Folder', Link: VALID_URL },
+    { Name: 'New admin link', Link: 'https://admin.com' },
+  ],
+  personalLinks:[
+    { Name: 'New personal link', Link: 'https://personal.com' }
+  ],
+  mediaUrl:VALID_URL
+}
+
+describe('EditLinkModal with admin links and personal links', () => {
+
+  const mockStore = configureStore([thunk]);
+  let store;
+  let component;
+  const props = {
+    isOpen: true,
+    closeModal: jest.fn(),
+    updateLink: jest.fn(),
+    userProfile:filledUserProfile,
+  };
+
+  beforeEach(() => {
+    store = mockStore({
+      auth: authMock,
+      userProjects: userProjectMock,
+      userProfile: userProfileMock,
+      role: rolesMock.role
+    });
+
+    component = render(
+      <Provider store={store}>
+        <EditLinkModal {...props} />
+      </Provider>
+    );
+  });
+  
+  it('test hasPermission()', () =>{
+    store.dispatch(hasPermission('putUserProfileImportantInfo'))
+    const actions = store.getActions();
+    expect(actions).toBeDefined;
+  })
+
+  it('should not display input for admin links without permission', () =>{
+    // TODO
+  })
+
+  it('should add new admin link when add button is clicked', () => {
+    const newAdminLinkContainer = document.querySelector('.new-admin-links')
+    const nameInput = within(newAdminLinkContainer).getByPlaceholderText('enter name');
+    const linkInput = within(newAdminLinkContainer).getByPlaceholderText('enter link');
+    const adminAddButton = component.getAllByLabelText('add-admin-link-button')
+    
+    fireEvent.change(nameInput, { target: { value: 'New Admin Link' } });
+    fireEvent.change(linkInput, { target: { value: 'https://example.com/newadminlink' } });
+    fireEvent.click(adminAddButton[0]);
+    
+    const delButton = component.getByRole('button', { name: 'x' });;
+    const newAdminLinkName = component.getByPlaceholderText('Link Name')
+    const newAdminLinkURL = component.getByDisplayValue('https://example.com/newadminlink');
+    expect(delButton).toBeInTheDocument();
+    expect(newAdminLinkName).toBeInTheDocument();
+    expect(newAdminLinkURL).toBeInTheDocument();
+
+  })
+
+  it('should popup warning when media url is changed',() => {
+    const mediaFolderLink = component.getByPlaceholderText('Enter Dropbox link');
+    fireEvent.change(mediaFolderLink, {target: {value: 'INVALID_URL'}});
+    expect(component.getByTestId('popup-warning')).toBeInTheDocument();
+  });
+  
+  it('should display diff warning when editing media url', ()=> {
+    const mediaFolderLink = component.getByPlaceholderText('Enter Dropbox link');
+    fireEvent.change(mediaFolderLink, {target: {value: 'changed url'}});
+    expect(component.getByTestId('diff-media-url-warning')).toBeInTheDocument();
+    // * display original link
+    expect(component.getByText(VALID_URL)).toBeInTheDocument();
+  })
+  
+  it('should restore media url after "Cancel" button is clicked', () =>{
+    const mediaFolderLink = component.getByPlaceholderText('Enter Dropbox link');
+    const cancelButton = component.getByText('Cancel');
+    // Edit existing media url
+    fireEvent.change(mediaFolderLink, {target: {value: 'changed url'}});
+    fireEvent.click(cancelButton);
+    expect(mediaFolderLink.value).toBe(VALID_URL);
+  })
+  
+  it('should remove existing links after delete button is clicked', () =>{
+    const delButtons = component.getAllByText('x');
+    const addedAdminLink = component.getByDisplayValue('New admin link')
+    const addedPersonalLink = component.getByDisplayValue('New personal link')
+    delButtons.forEach(button => {
+      fireEvent.click(button);
+    })
+    expect(addedAdminLink).not.toBeInTheDocument();
+    expect(addedPersonalLink).not.toBeInTheDocument();
+  })
+
+  it('should display warning when invalid ulr is typed', () =>{
+    const googleInput = component.getByPlaceholderText('Enter Google Doc link');
+    const updateButton = component.getByText('Update');
+    fireEvent.change(googleInput,{ target: {value: INVALID_URL}});
+    fireEvent.click(updateButton);
+    expect(component.getByTestId('invalid-url-warning')).toBeInTheDocument();
+  })
+});
+
+
+describe('Edit Link Modal with empty admin links', () =>{
+  const mockStore = configureStore([thunk]);
+  let store;
+  let component;
+  const props = {
+    isOpen: true,
+    closeModal: jest.fn(),
+    updateLink: jest.fn(),
+    userProfile:EmptyLinkUserProfile,
+  };
+
+  beforeEach(() => {
+    store = mockStore({
+      auth: authMock,
+      userProjects: userProjectMock,
+      userProfile: userProfileMock,
+      role: rolesMock.role
+    });
+
+    component = render(
+      <Provider store={store}>
+        <EditLinkModal {...props} />
+      </Provider>
+    );
+  });
+
+  it('should render special admin link labels when empty admin links', () =>{
+    const googleDocLabel = component.getByLabelText('Google Doc')
+    const mediaFolderLink = component.getByPlaceholderText('Enter Dropbox link');
+    const updateButton =  component.getByText('Update')
+    expect(googleDocLabel).toBeEmptyDOMElement;
+    expect(mediaFolderLink).toBeEmptyDOMElement;
+    expect(updateButton).toBeDisabled();
+  })
+
+  it('should not popup warning when empty media url is changed',() =>{
+    // const mediaFolderLink = component.getByPlaceholderText('Enter Dropbox link');
+    // fireEvent.change(mediaFolderLink, {target: {value: 'INVALID_URL'}});
+    // expect(component.getByTestId('popup-warning')).not.toBeInTheDocument();
+  })
+})
+
+
+

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -196,7 +196,7 @@ const EditLinkModal = props => {
                 <Card style={{ padding: '16px' }}>
                   <Label style={{ display: 'flex', margin: '5px' }}>Admin Links:</Label>
                   {mediaFolderDiffWarning && (
-                    <span className="warning-help-context">
+                    <span className="warning-help-context" data-testid="diff-media-url-warning" >
                       <strong>Media Folder link must be a working DropBox link</strong>
                       <p>
                         Current Media URL: <a href={userProfile.mediaUrl}>{userProfile.mediaUrl}</a>
@@ -205,8 +205,9 @@ const EditLinkModal = props => {
                   )}
                   <div>
                     <div style={{ display: 'flex', margin: '5px' }} className="link-fields">
-                      <label className='custom-label'>Google Doc</label>
+                      <label className='custom-label' htmlFor='google-doc-link' >Google Doc</label>
                       <input
+                        id='google-doc-link'
                         className="customEdit"
                         placeholder="Enter Google Doc link"
                         value={googleLink.Link}
@@ -218,10 +219,10 @@ const EditLinkModal = props => {
                     </div>
                     <div style={{ display: 'flex', margin: '5px' }} className="link-fields">
 
-                      <label className='custom-label'>Media Folder</label>
+                      <label className='custom-label' htmlFor='media-folder-link' >Media Folder</label>
                       <input
                         className="customEdit"
-                        id="linkURL2"
+                        id="media-folder-link"
                         placeholder="Enter Dropbox link"
                         value={mediaFolderLink.Link}
                         onChange={e => {handleMediaFolderLinkChanges(e)}}
@@ -266,7 +267,7 @@ const EditLinkModal = props => {
                       <div className="customTitle">+ ADD LINK:</div>
                     </div>
 
-                    <div style={{ display: 'flex', margin: '5px' }} className="link-fields">
+                    <div style={{ display: 'flex', margin: '5px' }} className="link-fields new-admin-links">
                       <input
                         className="customEdit"
                         id="linkName"
@@ -291,6 +292,7 @@ const EditLinkModal = props => {
                       <button
                         type="button"
                         className="addButton"
+                        aria-label='add-admin-link-button'
                         onClick={() => {
                           addNewLink(adminLinks, setAdminLinks, newAdminLink, () =>
                             setNewAdminLink(emptyLink),
@@ -328,6 +330,7 @@ const EditLinkModal = props => {
                         type="button"
                         className="closeButton"
                         color="danger"
+                        aria-label='add-personal-link-button'
                         onClick={() =>
                           removeLink(personalLinks, setPersonalLinks, {
                             name: link.Name,
@@ -380,7 +383,7 @@ const EditLinkModal = props => {
                 </div>
               </Card>
               {!isValidLink && (
-                <p className="invalid-help-context">
+                <p className='invalid-help-context' data-testid='invalid-url-warning' >
                   Please ensure each link has a unique and not empty, and enter valid URLs.
                 </p>
               )}
@@ -411,7 +414,7 @@ const EditLinkModal = props => {
           </Button>
         </ModalFooter>
 
-        <Modal isOpen={isWarningPopupOpen} toggle={()=> setIsWarningPopupOpen(!isWarningPopupOpen)}  >
+        <Modal data-testid='popup-warning' isOpen={isWarningPopupOpen} toggle={()=> setIsWarningPopupOpen(!isWarningPopupOpen)}  >
           <ModalHeader>Warning!</ModalHeader>
           <ModalBody>
             Whoa Tiger, don’t do this! This link was added by an Admin when you were set up in the system. It is used by the Admin Team and your Manager(s) for reviewing your work. You should only change it if you are ABSOLUTELY SURE the one you are changing it to is more correct than the one here already.


### PR DESCRIPTION
# Description
This is a unit test for Edit Link Modal
Or Implements # (WBS) 

## Main changes explained:
- add some `id` and `data-testid` in `EditLinkModal.jsx` for better testing experience.
- test some logic when editing EditLInkModal, especially **Media Folder LInk** (some times it's used **media Url**)


## How to test:
1. check into current branch
2. do `npm install` and `npm test src/components/UserProfile/UserProfileModal/EditLinkModal.test.js`
3. verify that all tests pass.

## Screenshots or videos of changes:
<img width="903" alt="Screenshot 2023-11-12 at 00 50 00" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/57503876/f2d38a39-2777-40a1-92d5-8779e3b8d812">


