### PR TITLE
Anny_fix_alginment_of_text_in_Permission_Management_buttons

### DIFF
--- a/src/components/PermissionsManagement/UserRoleTab.css
+++ b/src/components/PermissionsManagement/UserRoleTab.css
@@ -115,8 +115,5 @@
 
 .info-button {
   height: 40px;
-  line-height: 40px;
   width: 80px;
-  padding-left: 20px;
-  padding-right: 20px;
 }


### PR DESCRIPTION
# Description
![Screen Shot 2023-11-08 at 8 50 42 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/98345990/21c6cb33-1367-42dc-945e-d6c84a8271c2)


## Related PRS (if any):
No

## Main changes explained:
- Delete the styling of info-button to prevent the alignment issue on the deployed code

## How to test:
1. check into current branch
2. do npm install and npm run start:local to run this PR locally
3. log as owner user
4. go to Other Links → Permissions Management → Manage User Permissions 
5. check if both "Add" and "Delete" button is aligned

## Screenshots or vide
<img width="2240" alt="Screen Shot 2023-11-08 at 2 05 21 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/98345990/77c994f0-66b3-4141-a6b1-f9ea8080f97a">
os of changes:


## Note:
The code is the same however it displays differently on local devices and when deployed.