### PR TITLE
Eduardo Add button to copy all emails to clipboard

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -34,6 +34,7 @@ import { ENDPOINTS } from '../../utils/URL';
 import ToggleSwitch from '../UserProfile/UserProfileEdit/ToggleSwitch';
 import googleDocIconGray from './google_doc_icon_gray.png';
 import googleDocIconPng from './google_doc_icon.png';
+import CopyToClipboard from 'components/common/Clipboard/CopyToClipboard';
 
 const textColors = {
   Default: '#000000',
@@ -120,13 +121,14 @@ function FormattedReport({
           containing a maximum of 90 addresses.
         </Tooltip>
         <FontAwesomeIcon
-          className="ml-2"
+          className="mx-2"
           onClick={handleEmailButtonClick}
           icon={faMailBulk}
           size="lg"
           style={{ color: '#0f8aa9', cursor: 'pointer' }}
           id="emailIcon"
         />
+        <CopyToClipboard writeText={emails.join(', ')} message="Emails Copied!"/>
       </div>
       <p>{emails.join(', ')}</p>
     </>


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105796041/b68fe9ce-eb31-4362-9a0a-ca776f2fe84d)

Hot fix to Add a button to copy all emails to clipboard on the Weekly Summaries Page.
