### PR TITLE
Roberto- Fixes Time Entry Log Modal Issues 

### DIFF
--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -122,7 +122,7 @@ const updateTimeEntries = (timeEntry, oldDateOfWork) => {
     const offset = Math.ceil(startOfWeek.diff(timeEntry.dateOfWork, 'week', true));
 
     if (offset <= 2 && offset >= 0) {
-      dispatch(getTimeEntriesForWeek(timeEntry.curruserId, offset));
+      dispatch(getTimeEntriesForWeek(timeEntry.personId, offset));
     }
   };
 };


### PR DESCRIPTION
# Description
When trying to delete a time entry log, the delete modal doesn't close by itself it requires you to click out and refresh the page manually instead of doing it on its own. On occasions when creating, editing, or deleting time entry logs sometimes you can observe errors thrown in your backend server.

## Related PRS (if any):
This frontend PR is related to the #[602](https://github.com/OneCommunityGlobal/HGNRest/pull/602) backend PR.


## Main changes explained:
- Fixes a typo in the timeEntries.js file, timeEntry.curruserId didn't exist causing issues so changed it to timeEntry.personId which fixes back to normal

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. log as any user
4. go to dashboard→ Tasks And Timelogs→ Add Intangible Time Entry → Fill out modal/add time entry with both project and task→  Current Week Timelog Tab→  Delete both time entries
5. verify that you don't receive any errors in your backend server while performing any of these issues
6. verify that when you delete a time entry the delete modal will close itself and refresh on its own

## Screenshots or videos of changes:
This Branch:


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/117053202/162eff47-c9e3-44c3-bf5f-7ade0b606f9a

Development:


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/117053202/b83abe46-d1d0-4f05-b64b-c46dd2a4a82c


