### PR TITLE
Add curruserId into data

### DIFF
--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -55,6 +55,7 @@ const TimeEntry = ({ data, displayYear, userProfile, LoggedInuserId, curruserId 
     const newData = {
       ...data,
       isTangible: !data.isTangible,
+      curruserId: curruserId,
       timeSpent: `${data.hours}:${data.minutes}:00`,
     };
     dispatch(editTimeEntry(data._id, newData));


### PR DESCRIPTION
# Description
 Improve efficiency of time log page - esp converting intangible time to tangible and vice versa  

1. Leaderboard → Click a person’s time bar → Create intangible time entry for that person → save → refresh → click the “tangible” box to make that time entry tangible and you’ll see the process takes way longer than it should. It should instantly make it tangible
2. Refresh and confirm it saved 

## Related PRS (if any):
N/A

## Main changes explained:
- Fix bug in timeEntries.js


## How to test:
1. check into current branch
4. do **npm run install** and then **npm run start** run this PR locally
5. log as admin user
6. go to dashboard→ Leaderboard → Click a person’s time bar → Create intangible time entry for that person → save
7. repeat step 6 for multiple users. Open 5-10 tabs for each person's time entry.
8. click on the checkbox of tangible for each tab and test if they function correctly and evaluate the component's efficiency.

## Screenshots or videos of changes:
Before:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/65985986/5f8f2007-aa40-4698-8f3f-62a4e273e1ee

After:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/65985986/53397a3b-97aa-4586-9471-73c79aa92f4e
