### PR TITLE
Anny fix alginment of text in permissions management buttons

### DIFF
--- a/src/components/PermissionsManagement/UserRoleTab.css
+++ b/src/components/PermissionsManagement/UserRoleTab.css
@@ -112,8 +112,3 @@
   line-height: 40px; /* This should be the same as the height */
   min-width: 80px; /* Optional: Sets a minimum width for the button */
 }
-
-.info-button {
-  height: 40px;
-  width: 80px;
-}

--- a/src/components/PermissionsManagement/UserRoleTab.css
+++ b/src/components/PermissionsManagement/UserRoleTab.css
@@ -112,7 +112,9 @@
   line-height: 40px; /* This should be the same as the height */
   min-width: 80px; /* Optional: Sets a minimum width for the button */
 }
+
 .info-button {
   height: 40px;
   width: 80px;
+  padding: 0px;
 }

--- a/src/components/PermissionsManagement/UserRoleTab.css
+++ b/src/components/PermissionsManagement/UserRoleTab.css
@@ -112,3 +112,7 @@
   line-height: 40px; /* This should be the same as the height */
   min-width: 80px; /* Optional: Sets a minimum width for the button */
 }
+.info-button {
+  height: 40px;
+  width: 80px;
+}


### PR DESCRIPTION
# Description
Fix the remove button in Permission Management modal

## Related PRS (if any):
#1505 


## Main changes explained:
- Remove the padding of the button to make it align 

## How to test:
1. check into current branch
2. do npm install and npm run start:local to run this PR locally
log as owner user
3. go to Other Links → Permissions Management → Manage User Permissions
4. check if both "Add" and "Delete" button is aligned

## Screenshots or videos of changes:
<img width="712" alt="Screenshot 2023-11-11 at 3 52 59 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/98345990/c1f4e5ab-a0e0-4fce-9b80-8d7763915110">


## Note:
Include the information the reviewers need to know.
