### PR TITLE
Aaron hotfix remove "Popup Management" option 

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -203,18 +203,13 @@ export const Header = props => {
                         {TEAMS}
                       </DropdownItem>
                     )}
-                    {canCreatePopup || canUpdatePopup ? (
-                      <>
-                        <DropdownItem divider />
-                        <DropdownItem tag={Link} to={`/popupmanagement`}>
-                          {POPUP_MANAGEMENT}
-                        </DropdownItem>
-                      </>
-                    ) : null}
                     {(canPutRole || canManageUser) && (
+                      <>
+                      <DropdownItem divider />
                       <DropdownItem tag={Link} to="/permissionsmanagement">
                         {PERMISSIONS_MANAGEMENT}
                       </DropdownItem>
+                      </>
                     )}
                   </DropdownMenu>
                 </UncontrolledDropdown>


### PR DESCRIPTION
# Description
Removed "Popup Management" from Other Links in the dashboard

## Related PRS (if any):
N/A

## Main changes explained:
- removed "Popup Management" dropdown item option in `Header.jsx`

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local`
3. log as admin/owner 
4. go to dashboard→ Other Links 
5. verify "Popup Management" is not there anymore

## Screenshots or videos of changes:

<img width="968" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/10265513/95cb0b6c-f7f6-4e16-82d5-4f74bb676e9f">