### PR TITLE
resolved a bug which adding the manager to the generated list and fix…

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -57,7 +57,6 @@ import { fetchAllProjects } from '../../actions/projects';
 import { getAllUserTeams } from '../../actions/allTeamsAction';
 import { toast } from 'react-toastify';
 
-
 function UserProfile(props) {
   /* Constant values */
   const initialFormValid = {
@@ -207,7 +206,8 @@ function UserProfile(props) {
   };
 
   const loadSummaryIntroDetails = async (teamId, user) => {
-    const { firstName, lastName } = user;
+    const currentManager = user;
+
     const res = await axios.get(ENDPOINTS.TEAM_USERS(teamId));
     const { data } = res;
 
@@ -215,20 +215,25 @@ function UserProfile(props) {
     const memberNotSubmitted = [];
 
     data.forEach(member => {
-      member.weeklySummaries[0].summary !== ''
-        ? memberSubmitted.push(`${member.firstName} ${member.lastName}`)
-        : memberNotSubmitted.push(`${member.firstName} ${member.lastName}`);
+      if (member._id !== currentManager._id) {
+        if (member.weeklySummaries[0].summary !== '') {
+          memberSubmitted.push(`${member.firstName} ${member.lastName}`);
+        } else {
+          memberNotSubmitted.push(`${member.firstName} ${member.lastName}`);
+        }
+      }
     });
+
     const memberSubmittedString =
       memberSubmitted.length !== 0
         ? memberSubmitted.join(', ')
-        : '<list all team members names included in the summary>.';
+        : '<list all team members names included in the summary>';
     const memberDidntSubmitString =
       memberNotSubmitted.length !== 0
-        ? memberSubmitted.join(', ')
+        ? memberNotSubmitted.join(', ')
         : '<list all team members names NOT included in the summary>';
 
-    const summaryIntroString = `This week’s summary was managed by ${firstName} ${lastName} and includes ${memberSubmittedString} These people did NOT provide a summary ${memberDidntSubmitString}. <Insert the proofread and single-paragraph summary created by ChatGPT>`;
+    const summaryIntroString = `This week’s summary was managed by ${currentManager.firstName} ${currentManager.lastName} and includes ${memberSubmittedString}. These people did NOT provide a summary ${memberDidntSubmitString}. <Insert the proofread and single-paragraph summary created by ChatGPT>`;
 
     setSummaryIntro(summaryIntroString);
   };


### PR DESCRIPTION

# Description
The current implementation of the generate summary intro button has a bug , 
The string doesn't generate those who haven't submitted their weekly summaries, the wrong array was used. 

Lastly, the user who generates the text is also added to the list, instead of being the sole manager. 
This PR resolves this issue 

The generated text is show below 
<img width="376" alt="Screenshot 2023-11-12 at 8 23 47 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/22454953/0bb7824d-dde1-430a-82e7-0536922aaafc">


## Main changes explained:
-- Added a check so see if the current user isn't the manger if so the filtering will occur. 
-- fixed the join method by adding the correct array of members who didn't submit their weekly summary 


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. Make sure you are on a team otherwise the button will be hidden
5. Make sure a team member has submitted a summary and you may test that all members haven't 
6. go to dashboard→ user profile → click generate summary intro button
7. paste the text in a document.
8. make sure the text appears like so 
The manager is listed first, followed by those who have submitted lastly, by those who haven't. 
If user's haven't submitted the following filer text appears


This week’s summary was managed by luisAd Admin and includes <list all team members names included in the summary>. These people did NOT provide a summary luisOwner Owner, luisVolunteer Volunteer, luisManager Manager. <Insert the proofread and single-paragraph summary created by ChatGPT>

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/22454953/a20b1008-a3c0-4934-baa1-e6b98e6cf737



## Note:
Note the video for the following errors, that are not related to the PR
