### PR TITLE
Hotfix: Carl-Suggestion-Modal-Improvement

### DIFF
--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -221,6 +221,9 @@ const SummaryBar = props => {
   const sendUserSuggestion = async event => {
     event.preventDefault();
     const data = readFormData('suggestionForm');
+    data['firstName'] = userProfile.firstName;
+    data['lastName'] = userProfile.lastName;
+    data['email'] = userProfile.email;
 
     if (data) {
       setShowSuggestionModal(prev => !prev);


### PR DESCRIPTION
# Description

When a suggestion is made, we want the body of the email received by One community to include the name and email of the user making the suggestion. We also want a reply button which makes it easy for One community to reply to the specific user

Fixes # (bug list priority medium)
Or Implements # (WBS) 

## Related PRS (if any):
This frontend PR is related to the [#609](https://github.com/OneCommunityGlobal/HGNRest/pull/609) backend PR.
To test this backend PR you need to checkout the [#609](https://github.com/OneCommunityGlobal/HGNRest/pull/609) frontend PR.
…

## Main changes explained:
- Added name and email data to the data object being sent to the backend
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin/volunteer/owner user
4. go to dashboard→ Suggestion→Make a suggestion…
5. verify function “A” (feel free to include screenshot here)

## Screenshots or videos of changes:

[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2023.11.13-11_12_13.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/68056104/c4c5d01a-c68f-47b1-a8d8-e36cb630133c)


### BEFORE

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/68056104/941c5de2-1ace-4c8a-8a53-9fa58b24755a)


### AFTER

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/68056104/0151971a-c3a3-47d7-b03b-b2fa1ccc4dc1)


