### PR TITLE
fixes api key not being defined

### DIFF
--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -28,7 +28,8 @@ export function Dashboard(props) {
   };
 
   useEffect(() => {
-    getTimeZoneAPIKey();
+    // eslint-disable-next-line react/destructuring-assignment
+    props.getTimeZoneAPIKey();
   }, []);
 
   useEffect(() => {

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -524,6 +524,8 @@ class AddUserProfile extends Component {
             response.data.results.length
           ) {
             let timezone = response.data.results[0].annotations.timezone.name;
+            if (timezone === 'Europe/Kyiv') timezone = 'Europe/Kiev';
+            
             this.setState({
               ...this.state,
               timeZoneFilter: timezone,


### PR DESCRIPTION
# Description
<img width="819" alt="Screenshot 2023-11-03 at 6 27 36 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/117053202/8ea5e45a-251b-459a-92c4-2f3e1593088b">
Ukraine was previously not an optional location to choose when editing a user's profile information. Selecting Ukraine would crash the page.

## Related PRS (if any):
Test with backend development

## Main changes explained:
- Adds if statement if Ukraine is selected, the api timezone gives you `Europe/Kyiv` which is the correct timezone name but built in javascript function spells it wrong. They spell it `Europe/Kiev`. So if statement just fixes the typo which prevents future functions from not crashing.
- Fixes getTImeZoneAPIKey function in Dashboard to perform function correctly and retrieve api key.


## Sign up for API KEY
1. Go to `https://opencagedata.com/users/sign_up` and sign up for an account its free
2. Once in dashboard press on geocoding API or `https://opencagedata.com/dashboard#geocoding`
3. Scroll down to api keys and press create another api key. You will see a error warning saying ‘Error adding API key’ above but it’s wrong, return to geocoding API.



## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. **Add TIMEZONE_PREMIUM_KEY='your api key' to your backend .env**
4. **Add TIMEZONE_COMMON_KEY='your api key' to your backend .env** - yes it will be the same as above
5. **Make sure to compile your backend by running `npm run build && npm start`**
6. Log into any account that has permission to edit user's account information. Suggested: Admin
7. Select any User's profile in user management and edit their location with Ukraine or any city in Ukraine, then press the get time zone button
8. Confirm that the page doesn't crash and that the timezone does change to `Europe/Kiev`

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/117053202/ea9c13c9-9eb4-4d38-9eaf-8397c721c6eb



