### PR TITLE
Make 'Save' button visible to users who have permission 'Edit User Profile'

### DIFF
--- a/src/components/UserProfile/UserLinkLayout.jsx
+++ b/src/components/UserProfile/UserLinkLayout.jsx
@@ -10,8 +10,8 @@ const UserLinkLayout = props => {
   return (
     <div data-testid="user-link">
       <p style={{ display: 'inline-block', marginRight: 10 }}>LINKS </p>
-      {props.canEdit ? (
-        <LinkModButton userProfile={userProfile} updateLink={updateLink} role={props.role} handleSubmit={handleSubmit}/>
+      {props.canEdit || props.canEditAdminLinks ? (
+        <LinkModButton userProfile={userProfile} updateLink={updateLink} role={props.role} handleSubmit={handleSubmit} isUpdated={props.isUpdated}/>
       ) : null}
       <UserLinks linkSection="user" links={personalLinks} handleLinkModel={handleLinkModel} />
       <UserLinks linkSection="user" links={adminLinks} handleLinkModel={handleLinkModel} />

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -622,7 +622,7 @@ function UserProfile(props) {
 
   const canChangeUserStatus = props.hasPermission('changeUserStatus');
   const canAddDeleteEditOwners = props.hasPermission('addDeleteEditOwners');
-  const canPutUserProfile = props.hasPermission('putUserProfile');
+  const canPutUserProfile = props.hasPermission('editUserProfile');
   const canUpdatePassword = props.hasPermission('updatePassword');
   const canGetProjectMembers = props.hasPermission('getProjectMembers');
 

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -99,6 +99,7 @@ function UserProfile(props) {
   const [showSummary, setShowSummary] = useState(false);
   const [saved, setSaved] = useState(false);
   const [summaryIntro, setSummaryIntro] = useState('');
+  const [isUpdated, setIsUpdated] = useState(false);
 
   const userProfileRef = useRef();
 
@@ -495,7 +496,7 @@ function UserProfile(props) {
     }
     try {
       await props.updateUserProfile(props.match.params.userId, userProfileRef.current);
-
+  
       if (userProfile._id === props.auth.user.userid && props.auth.user.role !== userProfile.role) {
         await props.refreshToken(userProfile._id);
       }
@@ -625,6 +626,7 @@ function UserProfile(props) {
   const canPutUserProfile = props.hasPermission('editUserProfile');
   const canUpdatePassword = props.hasPermission('updatePassword');
   const canGetProjectMembers = props.hasPermission('getProjectMembers');
+  const canManageAdminLinks = props.hasPermission('adminLinks');
 
   const targetIsDevAdminUneditable = cantUpdateDevAdminDetails(userProfile.email, authEmail);
   const selfIsDevAdminUneditable = cantUpdateDevAdminDetails(authEmail, authEmail);
@@ -663,6 +665,10 @@ function UserProfile(props) {
   const handleEndDate = async endDate => {
     setUserEndDate(endDate);
   };
+
+  const handleOnUpdate = () => {
+    setIsUpdated(true);
+  }
 
   return (
     <div>
@@ -852,6 +858,8 @@ function UserProfile(props) {
                 handleSubmit={handleSubmit}
                 role={requestorRole}
                 canEdit={canEdit}
+                canEditAdminLinks={canManageAdminLinks}
+                isUpdated={handleOnUpdate}
               />
               <BlueSquareLayout
                 userProfile={userProfile}
@@ -1061,7 +1069,7 @@ function UserProfile(props) {
                           </Button>
                         </Link>
                       )}
-                      {canEdit && (activeTab == '1' || canPutUserProfile) && (
+                      {canEdit || canManageAdminLinks && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
                             className="mr-1 btn-bottom"
@@ -1071,6 +1079,7 @@ function UserProfile(props) {
                               !formValid.lastName ||
                               !formValid.email ||
                               !codeValid ||
+                              !isUpdated ||
                               (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                             }
                             userProfile={userProfile}
@@ -1117,7 +1126,7 @@ function UserProfile(props) {
                 <ModalFooter>
                   <Row>
                     <div className="profileEditButtonContainer">
-                      {canEdit && (activeTab == '1' || canPutUserProfile) && (
+                      {canEdit || canManageAdminLinks && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
                             className="mr-1 btn-bottom"
@@ -1127,6 +1136,7 @@ function UserProfile(props) {
                               !formValid.lastName ||
                               !formValid.email ||
                               !codeValid ||
+                              !isUpdated ||
                               (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                             }
                             userProfile={userProfile}
@@ -1185,7 +1195,7 @@ function UserProfile(props) {
                 <ModalFooter>
                   <Row>
                     <div className="profileEditButtonContainer">
-                      {canEdit && (activeTab == '1' || canPutUserProfile) && (
+                      {canEdit || canManageAdminLinks && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
                             className="mr-1 btn-bottom"
@@ -1195,6 +1205,7 @@ function UserProfile(props) {
                               !formValid.lastName ||
                               !formValid.email ||
                               !codeValid ||
+                              !isUpdated ||
                               (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                             }
                             userProfile={userProfile}
@@ -1246,7 +1257,7 @@ function UserProfile(props) {
                 <ModalFooter>
                   <Row>
                     <div className="profileEditButtonContainer">
-                      {canEdit && (activeTab == '1' || canPutUserProfile) && (
+                      {canEdit || canManageAdminLinks && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
                             className="mr-1 btn-bottom"
@@ -1256,6 +1267,7 @@ function UserProfile(props) {
                               !formValid.lastName ||
                               !formValid.email ||
                               !codeValid ||
+                              !isUpdated ||
                               (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                             }
                             userProfile={userProfile}
@@ -1294,7 +1306,7 @@ function UserProfile(props) {
                 <ModalFooter>
                   <Row>
                     <div className="profileEditButtonContainer">
-                      {canEdit && (activeTab == '1' || canPutUserProfile) && (
+                      {canEdit || canManageAdminLinks && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
                             className="mr-1 btn-bottom"
@@ -1304,6 +1316,7 @@ function UserProfile(props) {
                               !formValid.lastName ||
                               !formValid.email ||
                               !codeValid ||
+                              !isUpdated ||
                               (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                             }
                             userProfile={userProfile}
@@ -1361,7 +1374,7 @@ function UserProfile(props) {
                   </Button>
                 </Link>
               )}
-              {canEdit && (activeTab === '1' || activeTab === '3' || canPutUserProfile) && (
+              {canEdit || canManageAdminLinks && (activeTab === '1' || activeTab === '3' || canPutUserProfile) && (
                 <>
                   <SaveButton
                     className="mr-1 btn-bottom"
@@ -1371,6 +1384,7 @@ function UserProfile(props) {
                       !formValid.lastName ||
                       !formValid.email ||
                       !codeValid ||
+                      !isUpdated ||
                       (userStartDate > userEndDate && userEndDate !== '') ||
                       (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                     }

--- a/src/components/UserProfile/UserProfileEdit/LinkModButton.jsx
+++ b/src/components/UserProfile/UserProfileEdit/LinkModButton.jsx
@@ -18,6 +18,7 @@ const LinkModButton = props => {
         handleSubmit={handleSubmit}
         setChanged={setChanged}
         role={props.role}
+        isUpdated={props.isUpdated}
       />
       <span
         style={{

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -17,9 +17,10 @@ import { connect } from 'react-redux';
 import { isValidGoogleDocsUrl, isValidMediaUrl } from 'utils/checkValidURL';
 
 const EditLinkModal = props => {
-  const { isOpen, closeModal, updateLink, userProfile, handleSubmit } = props;
+  const { isOpen, closeModal, updateLink, userProfile, handleSubmit, isUpdated } = props;
 
   const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
+  const canManageAdminLinks = props.hasPermission('adminLinks');
 
   const initialAdminLinkState = [
     { Name: 'Google Doc', Link: '' },
@@ -150,6 +151,7 @@ const EditLinkModal = props => {
   };
 
   const handleUpdate = async () => {
+    isUpdated();
     const isGoogleDocsValid = isValidGoogleDocsUrl(googleLink.Link);
     const isDropboxValid = isValidMediaUrl(mediaFolderLink.Link);
     const updatable =
@@ -191,7 +193,7 @@ const EditLinkModal = props => {
         <ModalHeader toggle={closeModal}>Edit Links</ModalHeader>
         <ModalBody>
           <div>
-            {canPutUserProfileImportantInfo && (
+            {canPutUserProfileImportantInfo || canManageAdminLinks && (
               <CardBody>
                 <Card style={{ padding: '16px' }}>
                   <Label style={{ display: 'flex', margin: '5px' }}>Admin Links:</Label>


### PR DESCRIPTION
# Description


<img width="594" alt="Screen Shot 2023-08-24 at 9 55 57 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/197f5ad4-7bb7-41b5-aac5-1bf2f23081b4">

## Main changes explained:

- Made code changes for save button to be visible when updating admin links when having the 'Manage Admin Links' permission
- Made code changes for save button to be visible when updating admin links when having 'Edit User Profile' permission

## How to test:

1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as Owner user
4.  Other Links -> Permissions Management -> Manage User Permissions -> Give "Manage Admin Links" permission to a non Admin/Owner user
5. Log into that user -> Click into any user -> Change the Edit button besides links in the bottom left -> Change admin links -> Update -> Save Changes button should appear and you should be able to click, refresh and changes should remain
6. Other Links -> Permissions Management -> Manage User Permissions -> Remove "Manage Admin Links" Permission and give "Edit User Profile" permissions to a non Admin/Owner user and repeat step 5. 

## Videos/Screenshots of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/42288987/e4b88f01-9c72-468c-98bf-2e2c515ad2de
