### PR TITLE
ruike_avoid_overlap

### DIFF
--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -90,13 +90,13 @@
   text-align: center;
   vertical-align: middle;
   background: #ff4d4f;
-  border-radius: 40px;
+  border-radius: 50%;
   color: #fff;
   height: 25px;
   font-size: 15px;
   width: 25px;
   top: 3px;
-  right: 0;
+  right: -10px;
 }
 
 .team-clocks {


### PR DESCRIPTION
# Description
<img width="704" alt="Screenshot 2023-11-25 at 12 56 53 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114443664/32602607-505d-4e9d-92f3-42d69de682a5">

## Related PRS (if any):
N/A

## Main changes explained:
- Update css file to move the circle to right enough

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log in as any volunteer user(with existing tasks)
4. if needed, generate some intangible time and convert it to tangible time by admin/owner account.
5. check even if the total digits are 5, the circle will not overlap
6. if there are more digits, it will be separated into two lines

## Screenshots or videos of changes:
Before
<img width="256" alt="Screenshot 2023-11-25 at 1 01 04 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114443664/5c72a4b1-6284-4afc-bac3-249570fbf1cf">


After
<img width="140" alt="Screenshot 2023-11-25 at 12 58 01 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114443664/25d54049-dd44-45c8-afdd-3c1d03600a7d">
