### PR TITLE
Ruike_filter_active_user

### DIFF
--- a/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
+++ b/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
@@ -12,6 +12,7 @@ import { ENDPOINTS } from 'utils/URL';
 import { boxStyle } from 'styles';
 
 const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles }) => {
+
   const [searchText, onInputChange] = useState('');
   const [actualUserProfile, setActualUserProfile] = useState();
   const [isOpen, setIsOpen] = useState(false);
@@ -109,6 +110,9 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles }) =
     });
   };
   const mainPermissions = ['See All the Reports Tab', 'See User Management Tab (Full Functionality)', 'See Badge Management Tab (Full Functionality)', 'See Project Management Tab (Full Functionality)', 'Edit Project', 'See Teams Management Tab (Full Functionality)', 'Edit Timelog Information', 'Edit User Profile', 'See Permissions Management Tab' ]
+  useEffect(() => {
+    refInput.current.focus();
+  }, []);
   return (
     <>
     <Form
@@ -142,7 +146,7 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles }) =
         <Input
           type="text"
           value={searchText}
-          ref={refInput}
+          innerRef={refInput}
           onFocus={e => {
             setIsInputFocus(true);
             setIsOpen(true);
@@ -151,6 +155,7 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles }) =
             onInputChange(e.target.value);
             setIsOpen(true);
           }}
+          placeholder="Shows only ACTIVE users"
         />
         {isInputFocus || (searchText !== '' && allUserProfiles && allUserProfiles.length > 0) ? (
           <div
@@ -169,7 +174,9 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles }) =
                     .toLowerCase()
                     .includes(searchText.toLowerCase())
                 ) {
-                  return user;
+                  if (user.isActive) {
+                    return user;
+                  }
                 }
               })
               .map(user => (


### PR DESCRIPTION
# Description
<img width="678" alt="Screenshot 2023-11-25 at 8 26 33 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114443664/4cf790da-b5c9-43e3-829e-e6a8ce353898">

## Related PRS (if any):
N/A

## Main changes explained:
- Update inputref to autofocus when user enter this page
- filter the user array to ignore inactive user

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as owner user who has permission management permission
4. set an existing user(or create a new one) to be inactive
5. go to permission management 
6. make sure when you enter, the cursor is auto focus on the input field
7. and there's a placeholder to indicate only shows active user unless you type in characters
8. search for the user that you set inactive and make sure can't find it

## Screenshots or videos of changes:
<img width="693" alt="Screenshot 2023-11-25 at 8 32 40 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114443664/69186ea2-9bc7-4eda-a6ad-a079899be4f1">
