### PR TITLE
Remake Kaikanes Badge Key error

### DIFF
--- a/src/components/Reports/BadgeSummaryViz.jsx
+++ b/src/components/Reports/BadgeSummaryViz.jsx
@@ -78,13 +78,13 @@ function BadgeSummaryViz({ authId, userId, badges, dashboard }) {
                             {' '}
                             <img
                               src={value.badge.imageUrl}
-                              id={`popover_${value.badge.badgeId}`}
+                              id={`popover_${value.badge._id}`}
                               alt="badge"
                             />
                           </td>
                           <UncontrolledPopover
                             trigger="hover"
-                            target={`popover_${value.badge.badgeId}`}
+                            target={`popover_${value.badge._id}`}
                           >
                             <Card className="text-center">
                               <CardImg className="badge_image_lg" src={value?.badge?.imageUrl} />
@@ -116,9 +116,12 @@ function BadgeSummaryViz({ authId, userId, badges, dashboard }) {
                                 Dates
                               </DropdownToggle>
                               <DropdownMenu>
-                                {value.earnedDate.map(date => {
-                                  return <DropdownItem key={date}>{date}</DropdownItem>;
-                                })}
+                                {value.earnedDate.map((date, index) => (
+                                  // eslint-disable-next-line react/no-array-index-key
+                                  <DropdownItem key={`date-${value._id}-${index}`}>
+                                    {date}
+                                  </DropdownItem>
+                                ))}
                               </DropdownMenu>
                             </UncontrolledDropdown>
                           </td>
@@ -152,16 +155,16 @@ function BadgeSummaryViz({ authId, userId, badges, dashboard }) {
                     {badges && badges.length ? (
                       sortedBadges &&
                       sortedBadges.map(value => (
-                        <tr key={value.badge._id}>
+                        <tr key={value._id}>
                           <td className="badge_image_sm">
                             {' '}
                             <img
                               src={value.badge.imageUrl}
-                              id={`popover_${value.id}`}
+                              id={`popover_${value._id}`}
                               alt="badge"
                             />
                           </td>
-                          <UncontrolledPopover trigger="hover" target={`popover_${value.id}`}>
+                          <UncontrolledPopover trigger="hover" target={`popover_${value._id}`}>
                             <Card className="text-center">
                               <CardImg className="badge_image_lg" src={value?.badge?.imageUrl} />
                               <CardBody>


### PR DESCRIPTION
# Description
Remade old branch https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1461 because of gitattributes files changes
When loading the app there is a key prop warning and duplicate key warnings.
I noticed in the BadgeSummaryViz component we are assigning them keys but still causing errors
Also the hover was bugged out because of them having the same keys

[Untitled_ Oct 26, 2023 2_51 PM.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114305309/3db0fc63-eed2-4e7c-b5ad-fd9aa28f0ad3)


(bug list priority /low )
Gave the keys unique values by accessing the correct object ._id parameter instead of .id


## Related PRS (if any):
Front end only
…

## Main changes explained:
- Changed .id to ._id on multiple lines
- Updated the key attribute for the list of DropdownItem components inside the DropdownMenu on line 119. Instead of just using the date as the key, I have created a composite key that incorporates the value._id and an index. This change ensures that each DropdownItem component has a unique key,
- key changes also  fixes the bugged out badges
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as Admin who has badges 
4. go to dashboard check key warning is gone.  
5. /Reports/search a user/people/ click on user/ show badges 
6. Verify badges work properly when hovering/clicking on them in multiple view ports
7. verify key prop warning for BadgeSummaryViz Component is gone.

## Screenshots or videos of changes:
[Untitled_ Oct 26, 2023 4_03 PM.webm](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114305309/9c2a0fc0-9ee0-458e-a98c-b9b036e84578)


This error should be gone

![Badge key warning](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114305309/85467f9a-8b21-47b2-b443-1a5d0fe7b55a)

## Note:
There are still warnings for BadgeSummaryPreview component that will be a separate PR
