### PR TITLE
Ruike fix permission toaster

### DIFF
--- a/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
+++ b/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
@@ -96,17 +96,24 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles }) =
       .put(url, newUserInfo)
       .then(res => {
         res.data;
-      })
-      .catch(err => console.log(err));
-    getAllUsers();
-
-    const SUCCESS_MESSAGE = `
+        const SUCCESS_MESSAGE = `
         Permission has been updated successfully. Be sure to tell them that you are changing these
         permissions and for that they need to log out and log back in for their new permissions to take
         place.`;
-    toast.success(SUCCESS_MESSAGE, {
-      autoClose: 10000,
-    });
+        toast.success(SUCCESS_MESSAGE, {
+          autoClose: 10000,
+        });
+      })
+      .catch(err => {
+        console.log(err);
+        const ERROR_MESSAGE = `
+        Permission updated failed. ${err}
+        `
+        toast.error(ERROR_MESSAGE, {
+          autoClose: 10000,
+        })
+      });
+    getAllUsers();
   };
   const mainPermissions = ['See All the Reports Tab', 'See User Management Tab (Full Functionality)', 'See Badge Management Tab (Full Functionality)', 'See Project Management Tab (Full Functionality)', 'Edit Project', 'See Teams Management Tab (Full Functionality)', 'Edit Timelog Information', 'Edit User Profile', 'See Permissions Management Tab' ]
   return (

--- a/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
+++ b/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
@@ -95,7 +95,6 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles }) =
     await axios
       .put(url, newUserInfo)
       .then(res => {
-        res.data;
         const SUCCESS_MESSAGE = `
         Permission has been updated successfully. Be sure to tell them that you are changing these
         permissions and for that they need to log out and log back in for their new permissions to take


### PR DESCRIPTION
# Description
<img width="741" alt="Screenshot 2023-12-02 at 2 24 06 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114443664/043d5592-74ce-4af0-8b2b-6b52849d23cd">


## Related PRS (if any):
N/A

## Main changes explained:
- Added logic to check for http response and then display related messages

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to other links/permission management/manage user permission
6. edit any user's permission and save
7. make sure the green toaster pop up
8. go to HighestGoodNetworkApp/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
9. at line 96 modify the url so it will receive a 404 from server
10. refresh the page and do step 6 again
11. make sure the red toaster and error pop up
## Screenshots or videos of changes:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114443664/58226b50-025c-4b83-81d4-87e1ecacf388

