### PR TITLE
Ramya  Lint fix:  Userprofile -> Blue Square 

### DIFF
--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -77,4 +77,3 @@ function BlueSquare(props) {
 }
 
 export default connect(null, { hasPermission })(BlueSquare);
-

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -1,12 +1,17 @@
-import React from 'react';
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/interactive-supports-focus */
+/* eslint-disable react/no-array-index-key */
 import './BlueSquare.css';
-import hasPermission from 'utils/permissions';
 import { connect } from 'react-redux';
-import { formatDate } from 'utils/formatDate';
-import { formatDateFromDescriptionString } from 'utils/formatDateFromDescriptionString';
+import hasPermission from '../../../utils/permissions';
+import { formatDate } from '../../../utils/formatDate';
+import { formatDateFromDescriptionString } from '../../../utils/formatDateFromDescriptionString';
 
-const BlueSquare = (props) => {
+function BlueSquare(props) {
+  // eslint-disable-next-line react/destructuring-assignment
   const isInfringementAuthorizer = props.hasPermission('infringementAuthorizer');
+  // eslint-disable-next-line react/destructuring-assignment
   const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
   const { blueSquares, handleBlueSquare } = props;
 
@@ -43,9 +48,11 @@ const BlueSquare = (props) => {
                 >
                   <div className="report" data-testid="report">
                     <div className="title">{formatDate(blueSquare.date)}</div>
-                    {blueSquare.description !== undefined && 
-                      <div className="summary">{formatDateFromDescriptionString(blueSquare.description)}</div>
-                    }
+                    {blueSquare.description !== undefined && (
+                      <div className="summary">
+                        {formatDateFromDescriptionString(blueSquare.description)}
+                      </div>
+                    )}
                   </div>
                 </div>
               ))
@@ -67,6 +74,7 @@ const BlueSquare = (props) => {
       <br />
     </div>
   );
-};
+}
 
 export default connect(null, { hasPermission })(BlueSquare);
+


### PR DESCRIPTION
![200w](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/89441435/9e6e5487-f69c-4093-a894-301eda0797ff)


# Description

- Lint fix for the Blue Square (sub module) of the UserProfile Component

## Main changes explained:

- Commented out print statements ( Will remove it once the PR is ready to merge )
- Enforced a function type for function components
- Enforced a convention in module import order
- Reordered the function definitions order
- Disabled esLint rules  for the component related to the usage of non-interactive objects . The team has decided to keep the current code as it is, but we plan to enforce this behavior in future code revisions.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3.  Verify if the application works as expected with respect to BlueSquare in UserProfile 


## Note:
- Thoroughly test the functionality  , ensure it  works as before . Report any error you see so that I can go ahead make similar changes in the  other modules of UserProfile component 
-  A kind request to focus on testing the frontend over the eslint test . 