### PR TITLE
Yubo-Fix-Updating media folder links

### DIFF
--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -112,14 +112,9 @@ const EditLinkModal = props => {
   };
 
   const isDifferentMediaUrl = () => {
-    let mediaLink = null;
-    if (userProfile.adminLinks.length >= 2) {
-      mediaLink = userProfile.adminLinks[1].Link;
-    }
-    else if (userProfile.adminLinks.length === 1 && userProfile.adminLinks[0].Name === 'Media Folder') {
-      mediaLink = userProfile.adminLinks[0].Link;
-    } 
-    if (mediaLink && mediaLink !== mediaFolderLink.Link) {
+    //* This is to compare the mediaUrl with Media Folder link when editing in the input area.
+    //* Because mediaUrl is a differnt object, but the link should be the same as Media Folder's link.
+    if (userProfile.mediaUrl !== mediaFolderLink.Link  && userProfile.mediaUrl !== '') {
       setMediaFolderDiffWarning(true);
     } else {
       setMediaFolderDiffWarning(false);
@@ -150,8 +145,8 @@ const EditLinkModal = props => {
   };
 
   const handleUpdate = async () => {
-    const isGoogleDocsValid = isValidGoogleDocsUrl(googleLink.Link);
-    const isDropboxValid = isValidMediaUrl(mediaFolderLink.Link);
+    const isGoogleDocsValid = isValidUrl(googleLink.Link);
+    const isDropboxValid = isValidUrl(mediaFolderLink.Link);
     const updatable =
       (isGoogleDocsValid && isDropboxValid) ||
       (googleLink.Link === '' && mediaFolderLink.Link === '') ||


### PR DESCRIPTION
# Description
Now updating `Media Folder` link in Profile will sync it to `mediaUrl` in the user's profile, and will be reflected in Weekly Summaries Report.

## Related PRS (if any):
#1132 

## Main changes explained:
- Remove a mistakenly changed part that is suppose to compare `mediaUrl` and `Media Folder` link.
- Remove the method that fails RegEx with valid url, it makes the rules not so strict that sometimes preventing valid URLs.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin / Owner user -> go to the userProfile page -> Edit Link-> change `Media Folder` link to another valid link -> update 
4. verify the valid links can be updated properly and invalid links won't be updated right now.

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/57503876/d5c65b05-1217-484d-b087-ec0d2802d5c8


## Note:
# Remember to add links starting with protocols, such as HTTP.

