### PR TITLE
Jiangwei ceate unit test for selectors.js and taskstable.js

### DIFF
--- a/src/__tests__/TaskTable/Selectors.test.js
+++ b/src/__tests__/TaskTable/Selectors.test.js
@@ -1,0 +1,32 @@
+import { get_task_by_wbsId, getTasksTableData } from '../../components/Reports/TasksTable/selectors';
+
+describe('get_task_by_wbsId', () => {
+  it('returns the correct tasks based on WbsTasksID', () => {
+    const mockTasks = {
+      fetched: true,
+      taskItems: [
+        { id: 1, wbsId: 'A' },
+        { id: 2, wbsId: 'B' },
+        { id: 3, wbsId: 'A' }
+      ]
+    };
+    const WbsTasksID = ['A','B'];
+    const result = get_task_by_wbsId(WbsTasksID, mockTasks);
+    expect(result).toEqual([{ id: 2, wbsId: 'B' }]);
+  });
+
+  it('returns the correct tasks based on WbsTasksID', () => {
+    const mockTasks = {
+      fetched: true,
+      taskItems: [
+        { id: 1, wbsId: 'A' },
+        { id: 2, wbsId: 'B' },
+        { id: 3, wbsId: 'A' }
+      ]
+    };
+    const WbsTasksID = ['A'];
+    const result = get_task_by_wbsId(WbsTasksID, mockTasks);
+    expect(result).toEqual(undefined);
+  });
+});
+

--- a/src/__tests__/TaskTable/Selectors.test.js
+++ b/src/__tests__/TaskTable/Selectors.test.js
@@ -1,4 +1,4 @@
-import { get_task_by_wbsId, getTasksTableData } from '../../components/Reports/TasksTable/selectors';
+import { get_task_by_wbsId } from '../../components/Reports/TasksTable/selectors';
 
 describe('get_task_by_wbsId', () => {
   it('returns the correct tasks based on WbsTasksID', () => {

--- a/src/__tests__/TaskTable/TasksTable.test.js
+++ b/src/__tests__/TaskTable/TasksTable.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TasksTable } from '../../components/Reports/TasksTable';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+describe('TasksTable component', () => {
+  const mockStore = configureStore();
+  const mockState = {
+    tasks: {
+    }
+  };
+
+  const store = mockStore(mockState);
+
+  const renderComponent = () => render(
+    <Provider store={store}>
+      <TasksTable WbsTasksID={['someId']} />
+    </Provider>
+  );
+
+  it('renders the component', () => {
+    const { getByText } = renderComponent();
+    expect(getByText('Tasks')).toBeInTheDocument();
+  });
+
+  it('handles filter changes', () => {
+    renderComponent();
+    const classificationOption = screen.getByText('Any classification');
+    fireEvent.click(classificationOption);
+  });
+
+
+  it('handles checkbox changes', () => {
+    renderComponent();
+    const activeCheckbox = screen.getByLabelText('Active');
+    fireEvent.click(activeCheckbox);
+    expect(activeCheckbox).not.toBeChecked();
+  });
+
+
+  it('interacts with redux store', () => {
+    renderComponent();
+  });
+
+  it('passes correct props to TasksDetail', () => {
+    renderComponent();
+  });
+});

--- a/src/components/Reports/TasksTable/selectors.js
+++ b/src/components/Reports/TasksTable/selectors.js
@@ -1,9 +1,9 @@
-const get_task_by_wbsId = (WbsTasksID, tasks) => {
+export const get_task_by_wbsId = (WbsTasksID, tasks) => {
   const get_tasks = [];
   if (WbsTasksID.length > 0) {
     let i = 0;
     while (i < WbsTasksID.length && tasks.fetched) {
-      const result = tasks.taskItems.filter(task => task.wbsId == WbsTasksID[i]);
+      const result = tasks.taskItems.filter(task => task.wbsId === WbsTasksID[i]);
       get_tasks.push(result);
       i += 1;
     }


### PR DESCRIPTION
# Description
Create unit tests for the selectors component and taskstable component to confirm whether it working as intended.

## Main changes explained:
- Create file selectors.test.js to do the unit tests
-  Create file taskstable.test.js to do the unit tests

## How to test:
1. check into the current branch
2. do `npm install` and run this PR locally
3. open file `src → __tests__ → TaskTable → Selectors.test.js`
4. run `npm run test src/__tests__/TaskTable/Selectors.test.js`
5. open file `src → __tests__ → TaskTable → TasksTable.test.js`
6. run `npm run test src/__tests__/TaskTable/TasksTable.test.js`


## Screenshots or videos of changes:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/56906163/bf705072-1fa4-4436-9bf0-0ad71cb59da0)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/56906163/4a14a2b5-5ae5-488c-bc57-cddf10dcebe5)


## Note:
If all tests passed, everything worked as intended.
