### PR TITLE
Jiyuan added scheduled-on date to scheduled blue square reason

### DIFF
--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import './BlueSquare.css';
 import hasPermission from 'utils/permissions';
 import { connect } from 'react-redux';
-import { formatDate } from 'utils/formatDate';
+import { formatCreatedDate, formatDate } from 'utils/formatDate';
 import { formatDateFromDescriptionString,formatTimeOffRequests } from 'utils/formatDateFromDescriptionString';
 
 const BlueSquare = (props) => {
@@ -50,15 +50,18 @@ const BlueSquare = (props) => {
                 
                         if (formattedDescription.length > 0) {
                           return (
+                            <>
+                            <span>{blueSquare.createdDate !== undefined ? formatCreatedDate(BlueSquare.createdDate)+":"  : null}</span>
                             <span>
                               {formattedDescription[0]}
                               <br />
                               <span style={{ fontWeight: 'bold' }}>Notice :</span>
                               <span style={{ fontStyle: "italic", textDecoration: "underline" }}>{`${formattedDescription[1]}`}</span>
                             </span>
+                            </>
                           );
                         } else {
-                          return dateFormattedDescription;
+                          return blueSquare.createdDate !== undefined ? formatCreatedDate(BlueSquare.createdDate)+": "+dateFormattedDescription  : dateFormattedDescription
                         }
                       })()}</div>
                     }

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -460,7 +460,7 @@ function UserProfile(props) {
    */
   const modifyBlueSquares = (id, dateStamp, summary, operation) => {
     if (operation === 'add') {
-      const newBlueSquare = { date: dateStamp, description: summary };
+      const newBlueSquare = { date: dateStamp, description: summary , createdDate: moment.tz('America/Los_Angeles').toISOString().split('T')[0]};
       setOriginalUserProfile({
         ...originalUserProfile,
         infringements: userProfile.infringements?.concat(newBlueSquare),

--- a/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
@@ -320,7 +320,12 @@ const UserProfileModal = props => {
               <Label for="date">Date</Label>
               <Input type="date" onChange={e => setDateStamp(e.target.value)} value={dateStamp} />
             </FormGroup>
-
+            <FormGroup>
+              <Label for="createdDate">
+                Created Date:
+                {blueSquare[0]?.createdDate}
+              </Label>
+            </FormGroup>
             <FormGroup>
               <Label for="report">Summary</Label>
               <Input type="textarea" onChange={e => setSummary(e.target.value)} value={summary} />
@@ -334,6 +339,12 @@ const UserProfileModal = props => {
               <Label for="date">
                 Date:
                 {blueSquare[0]?.date}
+              </Label>
+            </FormGroup>
+            <FormGroup>
+              <Label for="createdDate">
+                Created Date:
+                {blueSquare[0]?.createdDate}
               </Label>
             </FormGroup>
             <FormGroup>

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -4,3 +4,4 @@ import moment from "moment-timezone";
 export const formatDate = (date) => moment(date).tz('America/Los_Angeles').format('MMM-DD-YY');
 // converts time to AM/PM format. E.g., '2023-09-21T07:08:09-07:00' becomes '7:08:09 AM'.
 export const formatted_AM_PM_Time = (date) => moment(date).format('h:mm:ss A');
+export const formatCreatedDate = (date) => moment(date).format("MM/DD");


### PR DESCRIPTION
# Description
![Screenshot 2023-11-29 153713](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/92963742/37306e7b-3789-44df-8aba-9eff76cba0e4)
![Screenshot 2023-11-29 153739](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/92963742/dc81fac0-c8b9-48bd-b171-1c90ad644498)

## Related PRS (if any):
This frontend PR is related to the [#640](https://github.com/OneCommunityGlobal/HGNRest/pull/640) backend PR.
To test this backend PR you need to checkout the [#640](https://github.com/OneCommunityGlobal/HGNRest/pull/640) backend PR.


## How to test:
1. check into current branch
2. `npm install`
3. `npm run start:local`
4. log in as admin
5. go to anyone's profile page
6. add a blue square to this person by clicking `+`
7. check if the new blue square contains the created date before the summary with right format(month/day) by hovering it
8. click this new blue square
9. check if  **created date** appears 

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/92963742/2ead345b-2013-4f42-aeef-d8dbf69ca07b


## Note:
Old blue squares do not have **created date**
