### PR TITLE
Shihao - FIxed the refresh efficiency when resolving tasks

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -113,7 +113,7 @@ const TeamMemberTasks = React.memo(props => {
       taskId,
     };
     submitTasks(newTask);
-    dispatch(fetchTeamMembersTask(userId, props.auth.user.userid, true));
+    dispatch(fetchTeamMembersTask(userId, props.auth.user.userid, false));
     props.handleUpdateTask();
   }, []);
 


### PR DESCRIPTION
# Description
![Screenshot 2023-12-07 at 16 15 35](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/62367016/3a5941ac-e838-4974-afd8-ee9a2a4e5e27)
[video](https://www.loom.com/share/a9d336faf8a84a1f9d0014c1c51210cc?sid=b417d677-f9a3-4f6e-80e9-d3c9fcfb82fc)

## Main changes explained:
- do not allow reload after marking the task resolved

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to the dashboard
6. Click the "check" icon and then click the "Mark as Done" button
7. To see if the page is reloaded

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/62367016/14b607f2-e9ed-423e-8a37-fa913ecd43c6


## Known Bug (Needs to be fixed first)
The API of `teams/tasks` failed, causing the app cannot get the updated data.