### PR TITLE
Ziming - fix Add New Project functionality. 

### DIFF
--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -61,7 +61,6 @@ export class Projects extends Component {
   };
 
   onUpdateProjectName = (projectId, projectName, category, isActive) => {
-    console.log('updateName', projectId, projectName, category, isActive);
     this.props.modifyProject('updateName', projectId, projectName, category, isActive);
   };
 

--- a/src/reducers/allProjectsReducer.js
+++ b/src/reducers/allProjectsReducer.js
@@ -28,8 +28,9 @@ export const allProjectsReducer = (allProjects = allProjectsInital, action) => {
         status: '200',
       });
     case types.ADD_NEW_PROJECT:
+      allProjects.status = action.status;
       if (action.status === 201) {
-        return { ...allProjects, projects: [action.payload, ...allProjects.projects] };
+        return { ...allProjects, projects: [action.payload, ...allProjects.projects], status: action.status };
       } 
         return { ...allProjects, status: action.status };
       


### PR DESCRIPTION
# Description
PRIORITY MEDIUM) Obeda: Fix Add New Project functionality. (WIP Ziming)
Modal message keeps showing even after successfully adding a new unique project name
Other Links -> Projects
Add a project name that already exists, and then add a new unique project name. The project gets added but the modal message (“This project name is already taken”) keeps showing.

## Related PRS (if any):
no

## Main changes explained:
change src/reducers/allProjectsReducer.js
change src/components/Projects/Projects.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
5. go to dashboard→ Other Links -> Project
6. Add a project name that already exists, and then add a new unique project name. check whether the later new unique project name can be added successfully.

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/58033867/61253ded-0084-497d-ad7b-4f72247a6ca8

