### PR TITLE
Nathan make editing roles permission-based

### DIFF
--- a/src/components/PermissionsManagement/RolePermissions.jsx
+++ b/src/components/PermissionsManagement/RolePermissions.jsx
@@ -15,6 +15,7 @@ import { boxStyle } from 'styles';
 import EditableInfoModal from 'components/UserProfile/EditableModal/EditableInfoModal';
 import PermissionsPresetsModal from './PermissionsPresetsModal.jsx';
 import { getPresetsByRole, createNewPreset } from 'actions/rolePermissionPresets';
+import hasPermission from '../../utils/permissions';
 
 
 function RolePermissions(props) {
@@ -26,6 +27,9 @@ function RolePermissions(props) {
   const [disabled, setDisabled] = useState(true);
   const history = useHistory();
   const [showPresetModal, setShowPresetModal] = useState(false);
+
+  const canEditRole = props.hasPermission('putRole');
+  const canDeleteRole = props.hasPermission('deleteRole');
 
   useEffect(() => {
     setRoleName(props.role);
@@ -109,7 +113,7 @@ function RolePermissions(props) {
         <div className="user-role-tab__name-container">
           <div className="name-container__role-name">
             <h1 className="user-role-tab__h1">Role Name: {roleName}</h1>
-            {props?.userRole === 'Owner' && (
+            {canEditRole && (
               <FontAwesomeIcon
                 icon={faEdit}
                 size="lg"
@@ -118,7 +122,7 @@ function RolePermissions(props) {
               />
             )}
           </div>
-          {props?.userRole === 'Owner' && (
+          {canEditRole && (
             <div style={{ flexDirection: 'row', display: 'flex' }}>
               <div className="name-container__btn_columns">
                 <div className="name-container__btns">
@@ -151,7 +155,7 @@ function RolePermissions(props) {
                   >
                     Save
                   </Button>
-                  <Button color="danger" onClick={toggleDeleteRoleModal} style={boxStyle}>
+                  <Button color="danger" onClick={toggleDeleteRoleModal} style={boxStyle} disabled={!canDeleteRole}>
                     Delete Role
                   </Button>
                 </div>
@@ -222,7 +226,7 @@ function RolePermissions(props) {
         <PermissionList
           rolePermissions={permissions}
           permissionsList={permissionLabel}
-          editable={true}
+          editable={canEditRole}
           setPermissions={setPermissions}
           onChange={()=>{setChanged(true)}}
         />
@@ -283,6 +287,7 @@ const mapDispatchToProps = dispatch => ({
   updateRole: (roleId, updatedRole) => dispatch(updateRole(roleId, updatedRole)),
   getPresets: role => dispatch(getPresetsByRole(role)),
   createNewPreset: newPreset => dispatch(createNewPreset(newPreset)),
+  hasPermission: permission => dispatch(hasPermission(permission)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(RolePermissions);

--- a/src/components/PermissionsManagement/RolePermissions.jsx
+++ b/src/components/PermissionsManagement/RolePermissions.jsx
@@ -28,8 +28,9 @@ function RolePermissions(props) {
   const history = useHistory();
   const [showPresetModal, setShowPresetModal] = useState(false);
 
-  const canEditRole = props.hasPermission('putRole');
-  const canDeleteRole = props.hasPermission('deleteRole');
+  const isEditableRole = props.role === 'Owner' ? props.hasPermission('addDeleteEditOwners') : props.auth.user.role !== props.role;
+  const canEditRole = isEditableRole && props.hasPermission('putRole');
+  const canDeleteRole = isEditableRole && props.hasPermission('deleteRole');
 
   useEffect(() => {
     setRoleName(props.role);
@@ -280,7 +281,7 @@ function RolePermissions(props) {
   );
 }
 
-const mapStateToProps = state => ({ roles: state.role.roles, presets: state.rolePreset.presets });
+const mapStateToProps = state => ({ roles: state.role.roles, presets: state.rolePreset.presets, auth: state.auth });
 
 const mapDispatchToProps = dispatch => ({
   getAllRoles: () => dispatch(getAllRoles()),


### PR DESCRIPTION
# Description
This PR replaces the role-based logic for determining front-end permission to edit roles to match the permission-based logic on the back end.

## Main changes explained:
- Use standardized `hasPermisison()` logic for checking if users can edit or delete roles
- Add a check to make sure nobody can edit their own or the Owner role except for Owners

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other LInks→ Permission Management→ any testing role
6. verify you can edit, save, and delete permissions and presets
7. verify you can create a new role and delete it as Owner
8. verify that you can't edit admin or owner as an admin, but can edit both as an owner
