### PR TITLE
Leo Move "Back to Top" button in front of People Reports page background 

### DIFF
--- a/src/components/Reports/PeopleReport/PeopleReport.css
+++ b/src/components/Reports/PeopleReport/PeopleReport.css
@@ -205,7 +205,7 @@ body {
 }
 
 .container-people-wrapper {
-  max-height: 100%;
+  min-height: 100%;
   max-width: 100vw;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
# Description
<img width="1000" alt="PR" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/5b670b15-5d68-4625-9bd2-971312d3d7db">


## Related PRS (if any):
…

## Main changes explained:
- Changed max-height to min-height in the .container-people-wrapper class to fix the "Back to Top" button issue.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. go to dashboard→ Reports→ People→tap any user…
5. see if the "Back to Top" button is in front of People Reports page background 

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/5b714e77-c4b1-4571-b592-ea78befa1c37



