### PR TITLE
Nathan remove owner permission override

### DIFF
--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -6,11 +6,6 @@ const hasPermission = (action) => {
     const userRole = state.auth.user.role;
     const userPermissions = state.auth.user.permissions?.frontPermissions;
 
-    //Check user role
-    if (userRole === 'Owner') {
-      return true;
-    }
-
     if (userRole && rolePermissions && rolePermissions.length != 0) {
       const roleIndex = rolePermissions?.findIndex(({ roleName }) => roleName === userRole);
       let permissions = [];


### PR DESCRIPTION
# Description
This PR removes logic for Owners to bypass the permissions system to have every permission on frontend. 

## Main changes explained:
- removed `if(owner)return true` logic from `permissions.js`

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. login as an Owner user
5. remove a permission from Owner in permission management
6. log out and back in
7. check that you don't have permission to do the thing you removed the permission for
8. add the permission back
