### PR TITLE
Xiao F Make map add new user fields edit more easily

### DIFF
--- a/src/components/TeamLocations/AddOrEditPopup.jsx
+++ b/src/components/TeamLocations/AddOrEditPopup.jsx
@@ -9,9 +9,9 @@ import { createLocation, editLocation } from 'services/mapLocationsService';
 import { useEffect } from 'react';
 
 const initialLocationData = {
-  firstName: 'Prior to HGN Data Collection',
-  lastName: 'Prior to HGN Data Collection',
-  jobTitle: 'Prior to HGN Data Collection',
+  firstName: '',
+  lastName: '',
+  jobTitle: '',
   location: {
     userProvided: '',
     coords: {

--- a/src/components/TeamLocations/AddOrEditPopup.jsx
+++ b/src/components/TeamLocations/AddOrEditPopup.jsx
@@ -31,7 +31,7 @@ function AddOrEditPopup({
   isEdit,
   editProfile,
   submitText,
-  apiKey
+  apiKey,
 }) {
   const [locationData, setLocationData] = useState(initialLocationData);
   const [timeZone, setTimeZone] = useState('');
@@ -172,7 +172,6 @@ function AddOrEditPopup({
         }
         toast.success('A person successfully added to a map!');
         setManuallyUserProfiles(prev => [...prev, { ...res.data, type: 'm_user' }]);
-        setLocationData(newLocationObject);
         setLocationData(initialLocationData);
         setFormSubmitted(true);
       } else if (isEdit) {
@@ -226,7 +225,7 @@ function AddOrEditPopup({
         if (firstNameRef.current) {
           firstNameRef.current.focus();
         }
-      }, 100); // Adjust the delay time if necessary
+      }, 100);
       setFormSubmitted(false);
     }
   }, [open, formSubmitted]);

--- a/src/components/TeamLocations/AddOrEditPopup.jsx
+++ b/src/components/TeamLocations/AddOrEditPopup.jsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Form } from 'reactstrap';
 import Input from 'components/common/Input';
+import CustomInput from './CustomInput.jsx';
 import getUserTimeZone from 'services/timezoneApiService';
 import { useSelector } from 'react-redux';
 import { boxStyle } from 'styles';
 import { toast } from 'react-toastify';
 import { createLocation, editLocation } from 'services/mapLocationsService';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 const initialLocationData = {
   firstName: '',
@@ -215,6 +216,18 @@ function AddOrEditPopup({
     }
   }
 
+  const firstNameRef = useRef(null);
+
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => {
+        if (firstNameRef.current) {
+          firstNameRef.current.focus();
+        }
+      }, 100); // Adjust the delay time if necessary
+    }
+  }, [open]);
+
   return (
     <Modal isOpen={open} toggle={onClose} className="modal-dialog modal-lg">
       <ModalHeader toggle={onClose} cssModule={{ 'modal-title': 'w-100 text-center my-auto pl-2' }}>
@@ -222,7 +235,7 @@ function AddOrEditPopup({
       </ModalHeader>
       <ModalBody>
         <Form onSubmit={onSubmitHandler}>
-          <Input
+          <CustomInput
             type="text"
             name="firstName"
             value={locationData.firstName}
@@ -231,6 +244,7 @@ function AddOrEditPopup({
             onChange={locationDataHandler}
             required
             error={errors.firstName}
+            ref={firstNameRef}
           />
           <Input
             type="text"

--- a/src/components/TeamLocations/AddOrEditPopup.jsx
+++ b/src/components/TeamLocations/AddOrEditPopup.jsx
@@ -170,10 +170,11 @@ function AddOrEditPopup({
         if (!res) {
           throw new Error();
         }
-        onClose();
         toast.success('A person successfully added to a map!');
         setManuallyUserProfiles(prev => [...prev, { ...res.data, type: 'm_user' }]);
         setLocationData(newLocationObject);
+        setLocationData(initialLocationData);
+        setFormSubmitted(true);
       } else if (isEdit) {
         const res = await editLocation(newLocationObject);
         if (!res || res.status !== 200) {
@@ -217,6 +218,7 @@ function AddOrEditPopup({
   }
 
   const firstNameRef = useRef(null);
+  const [formSubmitted, setFormSubmitted] = useState(false);
 
   useEffect(() => {
     if (open) {
@@ -225,8 +227,9 @@ function AddOrEditPopup({
           firstNameRef.current.focus();
         }
       }, 100); // Adjust the delay time if necessary
+      setFormSubmitted(false);
     }
-  }, [open]);
+  }, [open, formSubmitted]);
 
   return (
     <Modal isOpen={open} toggle={onClose} className="modal-dialog modal-lg">

--- a/src/components/TeamLocations/CustomInput.jsx
+++ b/src/components/TeamLocations/CustomInput.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Wrap the component with React.forwardRef
+const CustomInput = React.forwardRef(({ label, name, error, className, ...rest }, ref) => {
+  return (
+    <div className={`form-group ${className ? className : ''}`}>
+      <label htmlFor={name}>{label}</label>
+      <input {...rest} ref={ref} id={name} name={name} className={`form-control`} />
+
+      {error && <div className="alert alert-danger mt-1">{error}</div>}
+    </div>
+  );
+});
+
+CustomInput.propTypes = {
+  label: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  error: PropTypes.string,
+};
+
+export default CustomInput;

--- a/src/components/TeamLocations/CustomInput.jsx
+++ b/src/components/TeamLocations/CustomInput.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-// Wrap the component with React.forwardRef
 const CustomInput = React.forwardRef(({ label, name, error, className, ...rest }, ref) => {
   return (
     <div className={`form-group ${className ? className : ''}`}>


### PR DESCRIPTION
# Description
![CleanShot 2023-12-14 at 18 13 26](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/43768723/a45ff47f-a4f0-4a28-b2be-a9697bcced24)


## Related PRS (if any):
See https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1549 for instructions on setting up geocoding API

## Main changes explained:
- Update file `src/components/TeamLocations/AddOrEditPopup.jsx` for setting up placeholder text correctly
- Create file `src/components/TeamLocations/CustomInput.jsx` for custom input component that can be focused when modal opens
## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as Owner user
5. go to dashboard->Report->Team Locations->Add person->Check if cursor starts at first name->Check if placeholder text works
6. go to dashboard->Report->Team Locations->Add person->Type in valid first name, last name, job title, and location->Click on 'Get location'->Click on 'Save to map'->Upon successful submission, the modal will refresh and the cursor will be placed on first name again

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/43768723/34078d92-e927-4b6d-b9d9-e7361eb93aed


