### PR TITLE
Sucheta Replace the blue square self-scheduler for anyone with 5 or more blue squares (anyone other than Owner/Admin)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
   "eslint.alwaysShowStatus": true,
   "editor.tabSize": 2,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "files.exclude": {
     "**/.classpath": true,

--- a/src/actions/reasonsActions.js
+++ b/src/actions/reasonsActions.js
@@ -30,3 +30,14 @@ export async function patchReason(userId, reasonData) {
       return {message: error.response.data.message, errorCode: error.response.data.message, status: error.response.status}
     }
   }
+
+  // gets all scheduled reasons
+export async function getAllReasons(userId){
+  try{
+    const url = ENDPOINTS.GETALLUSERREASONS(userId);
+    const response = await axios.get(url);
+        return Promise.resolve(response)
+  }catch(error){
+    return {message: error.response.data.message, errorCode:error.response.data.message, status: error.repsonse.status}
+  }
+}

--- a/src/actions/reasonsActions.js
+++ b/src/actions/reasonsActions.js
@@ -31,7 +31,7 @@ export async function patchReason(userId, reasonData) {
     }
   }
 
-  // gets all scheduled reasons
+  // gets all scheduled reasons - Sucheta
 export async function getAllReasons(userId){
   try{
     const url = ENDPOINTS.GETALLUSERREASONS(userId);

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -166,7 +166,7 @@ export class Projects extends Component {
             <thead>
               <ProjectTableHeader />
             </thead>
-            <tbody>{ProjectsList}</tbody>
+              <tbody>{ProjectsList}</tbody>
           </table>
         </div>
 

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -14,6 +14,8 @@ import { addReason, patchReason } from 'actions/reasonsActions';
 import moment from 'moment-timezone';
 import { Modal } from 'react-bootstrap';
 import { boxStyle } from 'styles';
+import { color } from 'd3';
+import { fonts } from 'pdfmake/build/pdfmake';
 
 
 const BlueSquareLayout = props => {
@@ -173,19 +175,26 @@ const BlueSquareLayout = props => {
           {isInfringementMoreThanFive ? 
           <>
           <Button
-           variant='warning'
+          //  variant='warning'
            onClick={openInfoModal}
            className="w-100 text-success-emphasis"
             size="md"
             style={boxStyle}
+            id='stopSchedulerButton'
           >
             {fetchState.isFetching ? (
               <Spinner size="sm" animation="border" />
             ) : (
-              'Can\'t Schedule Time Off'
-            )}
+              <>
+              <span>Can't Schedule Time Off</span>
+              <br/>
+              <span style={{fontSize: ".8em", marginTop: "0"}}>
+                Click to learn why
+              </span>
+              </>
+              )}
           </Button> 
-            <p style={{cursor:"pointer"}} id='self-scheduler-off-info' onClick={openExplanationModal}>Click to learn why</p>
+            {/* <p style={{cursor:"pointer"}} id='self-scheduler-off-info' onClick={openExplanationModal}>Click to learn why</p> */}
           </>
           : <Button
             variant="primary"

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -93,12 +93,18 @@ const BlueSquareLayout = props => {
 //  This useEffect will check for any changes in the number of infringements
   useEffect(()=>{
     const checkInfringementCount = ()=>{
-      if(userProfile.infringements.length > 5){
-        setIsInfringementMoreThanFive(true)
+      if(userProfile.role === "Administrator" || userProfile.role === "Owner"){
+        setIsInfringementMoreThanFive(false);
+        return
+      }else{
+        if(userProfile.infringements.length > 5){
+          setIsInfringementMoreThanFive(true)
+        }
+        else{
+          setIsInfringementMoreThanFive(false)
+        }
       }
-      else{
-        setIsInfringementMoreThanFive(false)
-      }
+      
     }
     checkInfringementCount();
   },[]);
@@ -166,7 +172,7 @@ const BlueSquareLayout = props => {
               'Can\'t Schedule Time Off'
             )}
           </Button> 
-            <p id='self-scheduler-off-info'>(click to learn why)</p>
+            <p id='self-scheduler-off-info'><a href=''>Click to learn why</a></p>
           </>
           : <Button
             variant="primary"

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -6,6 +6,7 @@ import './UserProfileEdit/UserProfileEdit.scss';
 import { Button } from 'react-bootstrap';
 import ScheduleReasonModal from './ScheduleReasonModal/ScheduleReasonModal';
 import StopSelfSchedulerModal from './StopSelfSchedulerModal/StopSelfSchedulerModal.jsx';
+import SchedulerExplanationModal from './SchedulerExplanationModal/SchedulerExplanationModal';
 import { useState, useEffect } from 'react';
 import { useReducer } from 'react';
 import Spinner from 'react-bootstrap/Spinner';
@@ -57,6 +58,7 @@ const BlueSquareLayout = props => {
   const [isInfringementMoreThanFive, setIsInfringementMoreThanFive] = useState(false);
   const [show, setShow] = useState(false);
   const [showInfoModal, setShowInfoModal]= useState(false);
+  const [showExplanation, setShowExplanation]= useState(false);
   const [reason, setReason] = useState('');
   const [date, setDate] = useState(
     moment
@@ -74,7 +76,7 @@ const BlueSquareLayout = props => {
     errorCode: null,
     isSet: false,
   });
-
+  
   const handleOpen = useCallback(() => {
     setShow(true);
   }, []);
@@ -83,13 +85,24 @@ const BlueSquareLayout = props => {
     setShow(false);
   }, []);
 
-  const openInfoModal = useCallback(() => {
+  // This handler is used for Info Modal, that open when button "Can't Schedule Time Off" is clicked 
+  const openInfoModal = useCallback(() => { 
     setShowInfoModal(true);
   }, []);
-
+// This handler is used to close Info Modal, 
   const closeInfoModal = useCallback(() => {
     setShowInfoModal(false);
   }, []);
+  // This handler is used for Explanation Modal, that open when <a>Click to learn why </a> is clicked 
+  const openExplanationModal = useCallback(() => { 
+    setShowExplanation(true);
+  }, []);
+// This handler is used to close Info Modal, 
+  const closeExplanationModal  = useCallback(() => {
+    setShowExplanation(false);
+  }, []);
+
+
 //  This useEffect will check for any changes in the number of infringements
   useEffect(()=>{
     const checkInfringementCount = ()=>{
@@ -97,7 +110,7 @@ const BlueSquareLayout = props => {
         setIsInfringementMoreThanFive(false);
         return
       }else{
-        if(userProfile.infringements.length > 5){
+        if(userProfile.infringements.length >= 5){
           setIsInfringementMoreThanFive(true)
         }
         else{
@@ -172,7 +185,7 @@ const BlueSquareLayout = props => {
               'Can\'t Schedule Time Off'
             )}
           </Button> 
-            <p id='self-scheduler-off-info'><a href=''>Click to learn why</a></p>
+            <p style={{cursor:"pointer"}} id='self-scheduler-off-info' onClick={openExplanationModal}>Click to learn why</p>
           </>
           : <Button
             variant="primary"
@@ -191,10 +204,19 @@ const BlueSquareLayout = props => {
             )}
           </Button> }
         </div>
+        {isInfringementMoreThanFive && showExplanation && (
+          <Modal show={showExplanation} onHide={closeExplanationModal}>
+            <SchedulerExplanationModal
+              onHide={closeExplanationModal}
+              handleClose = {closeExplanationModal}
+              infringementsNum = {infringementsNum}
+              infringements = {userProfile.infringements}
+            />
+          </Modal>
+        )}
         {isInfringementMoreThanFive && showInfoModal && 
         (<Modal show={showInfoModal} onHide={closeInfoModal}>
           <StopSelfSchedulerModal
-            show = {showInfoModal}
             onHide={closeInfoModal}
             handleClose = {closeInfoModal}
             infringementsNum = {infringementsNum}

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -167,7 +167,7 @@ const BlueSquareLayout = props => {
           ) : null}
         </div>
 
-        <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} />
+        <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} isInfringementMoreThanFive={isInfringementMoreThanFive} userRole={userProfile.role}/>
          {/* Replaces Schedule Blue Square button when there are more than 5 blue squares -  by Sucheta */}
         <div className="mt-4 w-100">
           {isInfringementMoreThanFive ? 

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -14,8 +14,7 @@ import { addReason, patchReason } from 'actions/reasonsActions';
 import moment from 'moment-timezone';
 import { Modal } from 'react-bootstrap';
 import { boxStyle } from 'styles';
-import { color } from 'd3';
-import { fonts } from 'pdfmake/build/pdfmake';
+
 
 
 const BlueSquareLayout = props => {

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -14,7 +14,7 @@ import { addReason, patchReason } from 'actions/reasonsActions';
 import moment from 'moment-timezone';
 import { Modal } from 'react-bootstrap';
 import { boxStyle } from 'styles';
-import { color } from 'd3';
+
 
 const BlueSquareLayout = props => {
   const fetchingReducer = (state, action) => {

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -124,8 +124,22 @@ const BlueSquareLayout = props => {
         </div>
 
         <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} />
+         {/* This is just a test - by Sucheta */}
         <div className="mt-4 w-100">
+          {userProfile?.infringements.length > 5 ? 
+          <>
           <Button
+           variant='warning'
+          >
+            {fetchState.isFetching ? (
+              <Spinner size="sm" animation="border" />
+            ) : (
+              'Can’t Schedule Time Off'
+            )}
+          </Button> <p id='self-scheduler-off-info'>click to learn why</p>
+          {/* <i data-toggle="tooltip" data-placement="right" data-testid="info-name" id="info-name" aria-hidden="true" class="fa fa-info-circle" style="font-size: 15px; cursor: pointer; margin-left: 10px;"></i></> */}
+          </>
+          : <Button
             variant="primary"
             onClick={handleOpen}
             className="w-100"
@@ -140,7 +154,9 @@ const BlueSquareLayout = props => {
             ) : (
               'Schedule Blue Square Reason'
             )}
-          </Button>
+          </Button> }
+
+          
         </div>
         {show && (
           <Modal show={show} onHide={handleClose}>

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -86,14 +86,7 @@ const BlueSquareLayout = props => {
     setShow(false);
   }, []);
 
-  // This handler is used for Info Modal, that open when button "Can't Schedule Time Off" is clicked 
-  const openInfoModal = useCallback(() => { 
-    setShowInfoModal(true);
-  }, []);
-// This handler is used to close Info Modal, 
-  const closeInfoModal = useCallback(() => {
-    setShowInfoModal(false);
-  }, []);
+  
   // This handler is used for Explanation Modal, that open when <a>Click to learn why </a> is clicked 
   const openExplanationModal = useCallback(() => { 
     setShowExplanation(true);

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -5,7 +5,7 @@ import './UserProfile.scss';
 import './UserProfileEdit/UserProfileEdit.scss';
 import { Button } from 'react-bootstrap';
 import ScheduleReasonModal from './ScheduleReasonModal/ScheduleReasonModal';
-import StopSelfSchedulerModal from './StopSelfSchedulerModal/StopSelfSchedulerModal.jsx';
+// import StopSelfSchedulerModal from './StopSelfSchedulerModal/StopSelfSchedulerModal.jsx';
 import SchedulerExplanationModal from './SchedulerExplanationModal/SchedulerExplanationModal';
 import { useState, useEffect } from 'react';
 import { useReducer } from 'react';
@@ -58,7 +58,7 @@ const BlueSquareLayout = props => {
   const [infringementsNum, setInfringementsNum] = useState(userProfile.infringements.length)
   const [isInfringementMoreThanFive, setIsInfringementMoreThanFive] = useState(false);
   const [show, setShow] = useState(false);
-  const [showInfoModal, setShowInfoModal]= useState(false);
+  // const [showInfoModal, setShowInfoModal]= useState(false);
   const [showExplanation, setShowExplanation]= useState(false);
   const [reason, setReason] = useState('');
   const [date, setDate] = useState(
@@ -175,7 +175,7 @@ const BlueSquareLayout = props => {
           <>
           <Button
           //  variant='warning'
-           onClick={openInfoModal}
+           onClick={openExplanationModal}
            className="w-100 text-success-emphasis"
             size="md"
             style={boxStyle}
@@ -187,7 +187,9 @@ const BlueSquareLayout = props => {
               <>
               <span>Can't Schedule Time Off</span>
               <br/>
-              <span style={{fontSize: ".8em", marginTop: "0"}}>
+              <span 
+               className='mt-0'
+               style={{fontSize: ".8em"}}>
                 Click to learn why
               </span>
               </>
@@ -222,7 +224,7 @@ const BlueSquareLayout = props => {
             />
           </Modal>
         )}
-        {isInfringementMoreThanFive && showInfoModal && 
+        {/* {isInfringementMoreThanFive && showInfoModal && 
         (<Modal show={showInfoModal} onHide={closeInfoModal}>
           <StopSelfSchedulerModal
             onHide={closeInfoModal}
@@ -230,7 +232,7 @@ const BlueSquareLayout = props => {
             infringementsNum = {infringementsNum}
             user = {userProfile}
           />
-        </Modal>)}
+        </Modal>)} */}
         {show && (
           <Modal show={show} onHide={handleClose}>
             <ScheduleReasonModal

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -10,10 +10,16 @@ import SchedulerExplanationModal from './SchedulerExplanationModal/SchedulerExpl
 import { useState, useEffect } from 'react';
 import { useReducer } from 'react';
 import Spinner from 'react-bootstrap/Spinner';
-import { addReason, patchReason } from 'actions/reasonsActions';
+import { addReason, patchReason, getAllReasons } from 'actions/reasonsActions';
 import moment from 'moment-timezone';
 import { Modal } from 'react-bootstrap';
 import { boxStyle } from 'styles';
+import { ENDPOINTS } from 'utils/URL';
+import axios from 'axios';
+import { dispatch } from 'd3';
+import { set } from 'lodash';
+
+
 
 
 
@@ -58,8 +64,8 @@ const BlueSquareLayout = props => {
   const [infringementsNum, setInfringementsNum] = useState(userProfile.infringements.length)
   const [isInfringementMoreThanFive, setIsInfringementMoreThanFive] = useState(false);
   const [show, setShow] = useState(false);
-  // const [showInfoModal, setShowInfoModal]= useState(false);
   const [showExplanation, setShowExplanation]= useState(false);
+  const [allreasons, setAllReasons]= useState("");
   const [reason, setReason] = useState('');
   const [date, setDate] = useState(
     moment
@@ -95,8 +101,9 @@ const BlueSquareLayout = props => {
   const closeExplanationModal  = useCallback(() => {
     setShowExplanation(false);
   }, []);
-
-
+  
+  
+  
 //  This useEffect will check for any changes in the number of infringements
   useEffect(()=>{
     const checkInfringementCount = ()=>{
@@ -113,9 +120,28 @@ const BlueSquareLayout = props => {
       }
       
     }
+    // checks for blueSquare scheduled reasons 
+    const checkReasons = async ()=>{
+      fetchDispatch({type: 'FETCHING_STARTED'})
+      const response = await getAllReasons(userProfile._id);
+      if (response.status !== 200) {
+        fetchDispatch({
+          type: 'ERROR',
+          payload: { message: response.message, errorCode: response.errorCode },
+        });
+      } else {
+        // console.log(response.data)
+        fetchDispatch({ type: 'SUCCESS' });
+        setAllReasons(response.data)
+        }
+    }
+    checkReasons();
     checkInfringementCount();
   },[]);
-  
+  console.log("This is all reason", allreasons);
+  // console.log(infringementsNum);
+  // console.log(parseInt(userProfile.infringements.length) + parseInt(allreasons.reasons.length));
+
   const handleSubmit = async event => {
     event.preventDefault();
     if (fetchState.isSet && IsReasonUpdated) { //if reason already exists and if it is changed by the user

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -122,26 +122,25 @@ const BlueSquareLayout = props => {
     return () => isMounted = false;
 
   }, [addsReason])
-  
-//  This useEffect will check for any changes in the number of infringements
+
   useEffect(()=>{
     const checkInfringementCount = ()=>{
+      setInfringementsNum(userProfile.infringements.length)
       if(userProfile.role === "Administrator" || userProfile.role === "Owner"){
         setIsInfringementMoreThanFive(false);
         return
       }else{
-        if(userProfile.infringements.length >= 5){
+        if(infringementsNum >= 5){
           setIsInfringementMoreThanFive(true)
         }
         else{
           setIsInfringementMoreThanFive(false)
         }
       }
-      
     }
     checkInfringementCount();
-  },[]);
-
+  },[userProfile]);
+  
   const handleSubmit = async event => {
     event.preventDefault();
     if (fetchState.isSet && IsReasonUpdated) { //if reason already exists and if it is changed by the user
@@ -159,7 +158,7 @@ const BlueSquareLayout = props => {
     } else { //add/create reason
       fetchDispatch({ type: 'FETCHING_STARTED' });
       const response = await addReason(userProfile._id, { date: date, message: reason });
-      console.log(response);
+      // console.log(response);
       if (response.status !== 200) {
         fetchDispatch({
           type: 'ERROR',
@@ -193,7 +192,7 @@ const BlueSquareLayout = props => {
          {/* Replaces Schedule Blue Square button when there are more than 5 blue squares or scheduled reasons -  by Sucheta */}
         <div className="mt-4 w-100">
             {
-              isInfringementMoreThanFive || numberOfReasons >= 5 || (infringementsNum + numberOfReasons >= 5 ) ?  <>
+              ((isInfringementMoreThanFive || numberOfReasons >= 5 || (infringementsNum + numberOfReasons >= 5 )) && !(userProfile.role === "Administrator" || userProfile.role === "Owner") )?  <>
               <Button
               //  variant='warning'
                onClick={openExplanationModal}

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -13,6 +13,7 @@ import { addReason, patchReason } from 'actions/reasonsActions';
 import moment from 'moment-timezone';
 import { Modal } from 'react-bootstrap';
 import { boxStyle } from 'styles';
+import { color } from 'd3';
 
 const BlueSquareLayout = props => {
   const fetchingReducer = (state, action) => {
@@ -155,7 +156,7 @@ const BlueSquareLayout = props => {
           <Button
            variant='warning'
            onClick={openInfoModal}
-           className="w-100"
+           className="w-100 text-success-emphasis"
             size="md"
             style={boxStyle}
           >
@@ -164,7 +165,8 @@ const BlueSquareLayout = props => {
             ) : (
               'Can\'t Schedule Time Off'
             )}
-          </Button> <p id='self-scheduler-off-info'>click to learn why</p>
+          </Button> 
+            <p id='self-scheduler-off-info'>(click to learn why)</p>
           </>
           : <Button
             variant="primary"

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -188,7 +188,7 @@ const BlueSquareLayout = props => {
           ) : null}
         </div>
 
-        <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} isInfringementMoreThanFive={isInfringementMoreThanFive} userRole={userProfile.role}/>
+        <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} isInfringementMoreThanFive={isInfringementMoreThanFive} userRole={userProfile.role} numberOfReasons={numberOfReasons} infringementsNum={infringementsNum}/>
          {/* Replaces Schedule Blue Square button when there are more than 5 blue squares or scheduled reasons -  by Sucheta */}
         <div className="mt-4 w-100">
             {

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -8,7 +8,7 @@ import { formatDateFromDescriptionString } from 'utils/formatDateFromDescription
 const BlueSquare = (props) => {
   const isInfringementAuthorizer = props.hasPermission('infringementAuthorizer');
   const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
-  const { blueSquares, handleBlueSquare, isInfringementMoreThanFive } = props;
+  const { blueSquares, handleBlueSquare, isInfringementMoreThanFive, numberOfReasons, infringementsNum } = props;
 
   return (
     <div className="blueSquareContainer">
@@ -52,7 +52,7 @@ const BlueSquare = (props) => {
           : null}
       </div>
 
-      {isInfringementAuthorizer && !isInfringementMoreThanFive &&(
+      {isInfringementAuthorizer && (!(infringementsNum >= 5 || numberOfReasons >= 5 || (infringementsNum + numberOfReasons >= 5 ))) && (
         <div
           onClick={() => {
             handleBlueSquare(true, 'addBlueSquare', '');

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -8,7 +8,7 @@ import { formatDateFromDescriptionString } from 'utils/formatDateFromDescription
 const BlueSquare = (props) => {
   const isInfringementAuthorizer = props.hasPermission('infringementAuthorizer');
   const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
-  const { blueSquares, handleBlueSquare } = props;
+  const { blueSquares, handleBlueSquare, isInfringementMoreThanFive } = props;
 
   return (
     <div className="blueSquareContainer">
@@ -52,7 +52,7 @@ const BlueSquare = (props) => {
           : null}
       </div>
 
-      {isInfringementAuthorizer && (
+      {isInfringementAuthorizer && !isInfringementMoreThanFive &&(
         <div
           onClick={() => {
             handleBlueSquare(true, 'addBlueSquare', '');

--- a/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
+++ b/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
@@ -29,7 +29,7 @@ const ScheduleReasonModal = ({
     const initialFetching = async () => {
       fetchDispatch({ type: 'FETCHING_STARTED' });
       const response = await getReasonByDate(userId, date);
-      console.log(response);
+      console.log("This is the response from ScheduleReasonModal.jsx",response);
       if (response.status !== 200) {
         fetchDispatch({
           type: 'ERROR',

--- a/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
+++ b/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
@@ -29,7 +29,7 @@ const ScheduleReasonModal = ({
     const initialFetching = async () => {
       fetchDispatch({ type: 'FETCHING_STARTED' });
       const response = await getReasonByDate(userId, date);
-      console.log("This is the response from ScheduleReasonModal.jsx",response);
+      console.log(response);
       if (response.status !== 200) {
         fetchDispatch({
           type: 'ERROR',

--- a/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
+++ b/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
@@ -29,7 +29,7 @@ const ScheduleReasonModal = ({
     const initialFetching = async () => {
       fetchDispatch({ type: 'FETCHING_STARTED' });
       const response = await getReasonByDate(userId, date);
-      console.log(response);
+      // console.log(response);
       if (response.status !== 200) {
         fetchDispatch({
           type: 'ERROR',

--- a/src/components/UserProfile/SchedulerExplanationModal/SchedulerExplanationModal.jsx
+++ b/src/components/UserProfile/SchedulerExplanationModal/SchedulerExplanationModal.jsx
@@ -15,11 +15,11 @@ function SchedulerExplanationModal({infringementsNum,handleClose, infringements}
         </Modal.Header>
 
         <Modal.Body scrollable>
-         <p> Including your time already requested off, you have used the equivalent of <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares. <span style={{fontWeight:500, color:"green"}}>5</span> is the maximum allowed per year.</p>
-          <p>
-          Please remove a time-off request below or contact your Administrator if you need to request time off in addition to what is listed here:</p>
-          <ol>{infringements.map((el,index)=>{
-            return <li key={el._id}>{el.description}</li>
+         {/* <p> You have <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares already and <span style={{fontWeight:500, color:"green"}}>5</span> is the maximum allowed per year. Please contact your Administrator if you need to request time off</p> */}
+          <p>Including your time already requested off, you have used the equivalent of <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares. <span style={{fontWeight:500, color:"green"}}>5</span> is the maximum allowed per year. Please remove a time-off request below or contact your Administrator if you need to request time off in addition to what is listed here:
+</p>
+          <ol className='p-3 ml-2'>{infringements.map((el,index)=>{
+            return <li key={el._id} className='p-2'>{el.description}</li>
           })}</ol>
           
 

--- a/src/components/UserProfile/SchedulerExplanationModal/SchedulerExplanationModal.jsx
+++ b/src/components/UserProfile/SchedulerExplanationModal/SchedulerExplanationModal.jsx
@@ -18,10 +18,10 @@ function SchedulerExplanationModal({infringementsNum,handleClose, infringements,
           <p>Including your time already requested off, you have used the equivalent of <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares and <span style={{color:"red",fontWeight:500}}>{reasons.length}</span> schedule time offs. <span style={{fontWeight:500, color:"green"}}>5</span> is the maximum allowed per year. Please remove a time-off request below or contact your Administrator if you need to request time off in addition to what is listed here:
 </p>      
           
-          {infringements && <><h5>INFRINGEMENTS</h5><ol className='p-3 ml-2'>{infringements.map((el,index)=>{
+          {(infringements.length > 0) && <><h5>INFRINGEMENTS</h5><ol className='p-3 ml-2'>{infringements.map((el,index)=>{
             return <li key={el._id} className='p-2'>{el.description}</li>
           })}</ol></>}
-          {reasons && <>
+          {reasons.length > 0 && <>
           <h5>SCHEDULED REASONS</h5>
           <ul className='p-3 ml-2'>
           {reasons.map((el,index)=>{

--- a/src/components/UserProfile/SchedulerExplanationModal/SchedulerExplanationModal.jsx
+++ b/src/components/UserProfile/SchedulerExplanationModal/SchedulerExplanationModal.jsx
@@ -2,8 +2,7 @@ import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import { boxStyle } from 'styles';
 
-function SchedulerExplanationModal({infringementsNum,handleClose, infringements}) {
-  
+function SchedulerExplanationModal({infringementsNum,handleClose, infringements, reasons}) {
   return (
     <div
       className="modal show"
@@ -14,14 +13,21 @@ function SchedulerExplanationModal({infringementsNum,handleClose, infringements}
           <Modal.Title>Please Refer To The Explanation </Modal.Title>
         </Modal.Header>
 
-        <Modal.Body scrollable>
+        <Modal.Body scrollable="true">
          {/* <p> You have <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares already and <span style={{fontWeight:500, color:"green"}}>5</span> is the maximum allowed per year. Please contact your Administrator if you need to request time off</p> */}
-          <p>Including your time already requested off, you have used the equivalent of <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares. <span style={{fontWeight:500, color:"green"}}>5</span> is the maximum allowed per year. Please remove a time-off request below or contact your Administrator if you need to request time off in addition to what is listed here:
-</p>
-          <ol className='p-3 ml-2'>{infringements.map((el,index)=>{
-            return <li key={el._id} className='p-2'>{el.description}</li>
-          })}</ol>
+          <p>Including your time already requested off, you have used the equivalent of <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares and <span style={{color:"red",fontWeight:500}}>{reasons.length}</span> schedule time offs. <span style={{fontWeight:500, color:"green"}}>5</span> is the maximum allowed per year. Please remove a time-off request below or contact your Administrator if you need to request time off in addition to what is listed here:
+</p>      
           
+          {infringements && <><h5>INFRINGEMENTS</h5><ol className='p-3 ml-2'>{infringements.map((el,index)=>{
+            return <li key={el._id} className='p-2'>{el.description}</li>
+          })}</ol></>}
+          {reasons && <>
+          <h5>SCHEDULED REASONS</h5>
+          <ul className='p-3 ml-2'>
+          {reasons.map((el,index)=>{
+            return <li key={el._id} className='p-2'>{new Date(el.date).toLocaleDateString()} - {el.reason}</li>})}
+          </ul>
+          </>}
 
           <p><em>Note</em>: Blue squares expire after 1 calendar year from their issuance date.</p> 
 

--- a/src/components/UserProfile/SchedulerExplanationModal/SchedulerExplanationModal.jsx
+++ b/src/components/UserProfile/SchedulerExplanationModal/SchedulerExplanationModal.jsx
@@ -2,7 +2,8 @@ import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import { boxStyle } from 'styles';
 
-function SchedulerExplanationModal({infringementsNum,handleClose}) {
+function SchedulerExplanationModal({infringementsNum,handleClose, infringements}) {
+  
   return (
     <div
       className="modal show"
@@ -13,9 +14,17 @@ function SchedulerExplanationModal({infringementsNum,handleClose}) {
           <Modal.Title>Please Refer To The Explanation </Modal.Title>
         </Modal.Header>
 
-        <Modal.Body>
-          <p>You currently possess <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares, with an annual limit of <span style={{fontWeight:500, color:"green"}}>5</span>. If you require time off, kindly reach out to your Administrator. </p>
-          <p><em>Note</em>: Blue squares expire after 1 calendar year from their issuance date.</p>
+        <Modal.Body scrollable>
+         <p> Including your time already requested off, you have used the equivalent of <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares. <span style={{fontWeight:500, color:"green"}}>5</span> is the maximum allowed per year.</p>
+          <p>
+          Please remove a time-off request below or contact your Administrator if you need to request time off in addition to what is listed here:</p>
+          <ol>{infringements.map((el,index)=>{
+            return <li key={el._id}>{el.description}</li>
+          })}</ol>
+          
+
+          <p><em>Note</em>: Blue squares expire after 1 calendar year from their issuance date.</p> 
+
         </Modal.Body>
 
         <Modal.Footer>

--- a/src/components/UserProfile/SchedulerExplanationModal/SchedulerExplanationModal.jsx
+++ b/src/components/UserProfile/SchedulerExplanationModal/SchedulerExplanationModal.jsx
@@ -1,0 +1,29 @@
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+import { boxStyle } from 'styles';
+
+function SchedulerExplanationModal({infringementsNum,handleClose}) {
+  return (
+    <div
+      className="modal show"
+      style={{ display: 'block', position: 'initial' }}
+    >
+      <Modal.Dialog>
+        <Modal.Header closeButton>
+          <Modal.Title>Please Refer To The Explanation </Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          <p>You currently possess <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares, with an annual limit of <span style={{fontWeight:500, color:"green"}}>5</span>. If you require time off, kindly reach out to your Administrator. </p>
+          <p><em>Note</em>: Blue squares expire after 1 calendar year from their issuance date.</p>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleClose} style={boxStyle}>Close</Button>
+        </Modal.Footer>
+      </Modal.Dialog>
+    </div>
+  );
+}
+
+export default SchedulerExplanationModal;

--- a/src/components/UserProfile/StopSelfSchedulerModal/StopSelfSchedulerModal.jsx
+++ b/src/components/UserProfile/StopSelfSchedulerModal/StopSelfSchedulerModal.jsx
@@ -14,8 +14,8 @@ function StopSelfSchedulerModal({infringementsNum,handleClose}) {
         </Modal.Header>
 
         <Modal.Body>
-          <p>You currently possess <span style={{color:"red"}}>{infringementsNum}</span> blue squares, with an annual limit of 5. If you require time off, kindly reach out to your Administrator. </p>
-          <p>Note: Blue squares expire after 1 calendar year from their issuance date.</p>
+          <p>You currently possess <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares, with an annual limit of <span style={{fontWeight:500, color:"green"}}>5</span>. If you require time off, kindly reach out to your Administrator. </p>
+          <p><em>Note</em>: Blue squares expire after 1 calendar year from their issuance date.</p>
         </Modal.Body>
 
         <Modal.Footer>

--- a/src/components/UserProfile/StopSelfSchedulerModal/StopSelfSchedulerModal.jsx
+++ b/src/components/UserProfile/StopSelfSchedulerModal/StopSelfSchedulerModal.jsx
@@ -1,0 +1,29 @@
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+import { boxStyle } from 'styles';
+
+function StopSelfSchedulerModal({infringementsNum,handleClose}) {
+  return (
+    <div
+      className="modal show"
+      style={{ display: 'block', position: 'initial' }}
+    >
+      <Modal.Dialog>
+        <Modal.Header closeButton>
+          <Modal.Title>Can Not Schedule Time Off</Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          <p>You currently possess <span style={{color:"red"}}>{infringementsNum}</span> blue squares, with an annual limit of 5. If you require time off, kindly reach out to your Administrator. </p>
+          <p>Note: Blue squares expire after 1 calendar year from their issuance date.</p>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleClose} style={boxStyle}>Close</Button>
+        </Modal.Footer>
+      </Modal.Dialog>
+    </div>
+  );
+}
+
+export default StopSelfSchedulerModal;

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -56,6 +56,7 @@ import EditableInfoModal from './EditableModal/EditableInfoModal';
 import { fetchAllProjects } from '../../actions/projects';
 import { getAllUserTeams } from '../../actions/allTeamsAction';
 import { toast } from 'react-toastify';
+import { set } from 'lodash';
 
 function UserProfile(props) {
   /* Constant values */
@@ -99,6 +100,7 @@ function UserProfile(props) {
   const [showSummary, setShowSummary] = useState(false);
   const [saved, setSaved] = useState(false);
   const [summaryIntro, setSummaryIntro] = useState('');
+ 
 
   const userProfileRef = useRef();
 
@@ -126,6 +128,7 @@ function UserProfile(props) {
     setUserProfile({ ...userProfile, teams, projects });
     setOriginalUserProfile({ ...originalUserProfile, teams, projects });
   }, [teams, projects]);
+
 
   useEffect(() => {
     setShowLoading(true);
@@ -459,7 +462,9 @@ function UserProfile(props) {
    * @param {String} operation 'add' | 'update' | 'delete'
    */
   const modifyBlueSquares = (id, dateStamp, summary, operation) => {
+    
     if (operation === 'add') {
+    
       const newBlueSquare = { date: dateStamp, description: summary };
       setOriginalUserProfile({
         ...originalUserProfile,
@@ -470,23 +475,31 @@ function UserProfile(props) {
         infringements: userProfile.infringements?.concat(newBlueSquare),
       });
       setModalTitle('Blue Square');
+      
+      
     } else if (operation === 'update') {
+    
       const currentBlueSquares = [...userProfile?.infringements] || [];
-      if (dateStamp != null && currentBlueSquares !== []) {
+      if (dateStamp != null && currentBlueSquares.length !== 0) {
         currentBlueSquares.find(blueSquare => blueSquare._id === id).date = dateStamp;
+        
+        
       }
-      if (summary != null && currentBlueSquares !== []) {
+      if (summary != null && currentBlueSquares.length !== 0) {
         currentBlueSquares.find(blueSquare => blueSquare._id === id).description = summary;
+       
       }
 
       setUserProfile({ ...userProfile, infringements: currentBlueSquares });
       setOriginalUserProfile({ ...userProfile, infringements: currentBlueSquares });
     } else if (operation === 'delete') {
+      
       let newInfringements = [...userProfile?.infringements] || [];
-      if (newInfringements !== []) {
+      if (newInfringements.length !== 0) {
         newInfringements = newInfringements.filter(infringement => infringement._id !== id);
         setUserProfile({ ...userProfile, infringements: newInfringements });
         setOriginalUserProfile({ ...userProfile, infringements: newInfringements });
+       
       }
     }
     setShowModal(false);

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -260,7 +260,23 @@
     width: 250px;
   }
 }
+// Changed hover, focus and active class for the Stop Scheduler Button
+#stopSchedulerButton{
+  background-color:#ffc107;
+  border:#ffc107;
+ 
+  &:hover{
+    // background-color: #fff3cd;
+    // border: #fff3cd ;
+    background-color: #ffcd39;
+    border:  #ffcd39;
+  }
+  &:active, &:focus{
+    background-color: #997404;
+    border: #997404;
+  }
 
+}
 @media only screen and (max-width: 767px) {
   .emp-profile {
     margin-top: 0;


### PR DESCRIPTION
# Description
(PRIORITY HIGH) Jae: (WIP Sucheta ) Replace the blue square self-scheduler for anyone with 5 or more blue squares (**anyone other than Owner/Admin**)
- Related PRs [PR1542](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1542)+614, [PR1081](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1081) 
- Profile Page>Below Blue Squares 
- Replace with something that is a different color (not red) that says
Can’t Schedule Time Off
(click to learn why)
- This is needed because people with 5 or more blue squares should no longer be on the team and, if they still are, will need an Admin to enter their time off for them
- It should account for any future scheduled time off too (see above)
- When they click the new button, it should say this if 5 or more blue squares:

*You have X blue squares already and 5 are the maximum allowed per year. Please contact your Administrator if you need to request time off. 

Note: Blue squares drop off 1 calendar year after they are issued. *

- When they click the new button, it should say this if they have scheduled time off equaling 5 or more blue squares:

*Including your time already requested off, you have used the equivalent of X blue squares. 5 is the maximum allowed per year. Please remove a time-off request below or contact your Administrator if you need to request time off in addition to what is listed here:

Time off request 1 
Time off request 2
Etc.

Note: Blue squares drop off 1 calendar year after they are issued. *

## Related PRS (if any):
No backend PRs
…

## Main changes explained:

1. Created component: 
- components > UserProfile > SchedulerExplanationModal 

2. Adds new handler functions to BlueSquareLayout.jsx, that opens modals based on user roles and the number of BlueSquares assigned or scheduled.

3. The button `Schedule Blue Square Reason` changes to `Can't Schedule Time Off` if `((isInfringementMoreThanFive || numberOfReasons >= 5 || (infringementsNum + numberOfReasons >= 5 )) && !(userProfile.role === "Administrator" || userProfile.role === "Owner"))` 


…

## How to test:
1. check into the current branch
2. do `npm install` and `...` to run this PR locally
5. Clear site data/cache
6. log as (volunteer/ manager/ assistant manager) user
7. go to dashboard→ View Profile → BlueSquare section →…
8. If the numbers of BlueSquare are less than 5 the Users with permission to Schedule blueSquares, should see the `Schedule Blue Square` button. Otherwise, the button changes to `Can't Schedule Time Off Click to learn why`.
9. Click on the button to see a modal with an explanation of why scheduling has been disabled.

## Screenshots or videos of changes:
**Before Change**
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/159ce01e-da12-4b2a-ac37-86c47a8e26cb

**Updated Changes**



https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/7c12b59f-39d5-4bfa-a98e-446947cb3520



## Note:
Please note nothing has changed for the user role Admin/Owner. **Last updated 01/04/2024**
