### PR TITLE
Unit test for LinkModButton

### DIFF
--- a/src/components/UserProfile/UserProfileEdit/__test__/LinkModButton.test.js
+++ b/src/components/UserProfile/UserProfileEdit/__test__/LinkModButton.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { authMock, userProfileMock } from '__tests__/mockStates';
+import LinkModButton from '../LinkModButton';
+
+// Mock child component
+jest.mock('components/UserProfile/UserProfileModal/EditLinkModal', () => {
+  return function(props) {
+    return (
+      <div data-testid="edit-modal">
+        {props.isOpen ? <div data-testid="modal">mocked EditLinkModal</div> : null}
+      </div>
+    );
+  };
+});
+
+describe('LinkModButton Component', () => {
+  const mockProps = {
+    updateLink: jest.fn(),
+    userProfile: userProfileMock,
+    setChanged: jest.fn(),
+    handleSubmit: jest.fn(),
+    role: authMock.user.role,
+  };
+
+  it('should render LinkModButton with closed eidt modal', () => {
+    render(<LinkModButton {...mockProps} />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(() => screen.getByText('mocked EditLinkModal')).toThrow();
+  });
+
+  it('should open Modal after "Edit" button is Clicked', () => {
+    render(<LinkModButton {...mockProps} />);
+    fireEvent.click(screen.getByTestId('edit-link'));
+    expect(screen.getByText('mocked EditLinkModal')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Description
This is a unit test for `LinkModButton` at `src/components/UserProfile/UserProfileEdit/__test__/LinkModButton.test.js`


## Main changes explained:

- Add the unit test cases for `LinkModButton` component.


## How to test:
1. check into current branch
2. do `npm install` and `npm test src/components/UserProfile/UserProfileEdit/__test__/LinkModButton.test.js`
3. verify that all tests pass.

## Screenshots or videos of changes:
<img width="1085" alt="UnitTest_LinkModButton_Result" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/57503876/381368ca-1c7d-4e84-bb36-1f1d8f16612e">

## Note
### the mocked component is a customized component, because the modal inside `EditLinkModal` is controlled by the state in `LinkModButton` .


