### PR TITLE
Sucheta - Fix Task Name entry-box formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
   "eslint.alwaysShowStatus": true,
   "editor.tabSize": 2,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "files.exclude": {
     "**/.classpath": true,

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -264,13 +264,16 @@ const EditTaskModal = props => {
               <tr>
                 <td scope="col">Task Name</td>
                 <td scope="col">
-                  <input
+                  {/* change by Sucheta */}
+                  <textarea
+                    rows="2"
                     type="text"
-                    className="task-name"
+                    className="task-name border border-dark rounded"
                     onChange={e => setTaskName(e.target.value)}
                     onKeyPress={e => setTaskName(e.target.value)}
                     value={taskName}
                   />
+                 
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
# Description
(PRIORITY URGENT) Jae: Fix Task Name entry-box formatting (WIP Sucheta)
This used to be an entry box that spanned the available width below. Not sure what broke it but what I’d like is for this to use the full 2 rows of text there so it is easier to read and edit. 

## Related PRS (if any):
None
…

## Main changes explained:
- Changes made in components > Projects > WBS > WBSDetail > EditTask > EditTaskModal.jsx
- Changed `input` to `textarea`
- Added `classNames= border border-dark rounded` and `rows = 2`
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ Click on the assigned task name→ 
6. In the task table → Click on `Edit` → Should open a Modal, the `Task Name` should have a `textarea`

## Screenshots or videos of changes:
Before Change:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/c610629b-aa8c-4dcb-95a9-bea28bd02384

After Change:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/c4743ebf-833a-4e5a-a4cd-c99f2c5eb62e

