### PR TITLE
Sucheta - Fix Task Name entry-box formatting (Add Task)

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -312,9 +312,11 @@ function AddTaskModal(props) {
               <tr>
                 <td scope="col">Task Name</td>
                 <td scope="col">
-                  <input
+                  {/* Fix Task-name formatting - by Sucheta */}
+                  <textarea
                     type="text"
-                    className="task-name"
+                    rows="2"
+                    className="task-name border border-dark rounded"
                     onChange={e => setTaskName(e.target.value)}
                     onKeyPress={e => setTaskName(e.target.value)}
                     value={taskName}


### PR DESCRIPTION
# Description
(PRIORITY URGENT) Jae: Fix Task Name entry-box formatting (WIP Sucheta)
This used to be an entry box that spanned the available width below. Not sure what broke it but what I’d like is for this to use the full 2 rows of text there so it is easier to read and edit.

## Related PRS (if any):
This frontend PR is related to the  [PR1742](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1724)

…

## Main changes explained:
- Changes made in `src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx`
- Changed `input` to `textarea`
- Added classNames= border border-dark rounded and rows = 2
…

## How to test:

1. check into current branch
2. do `npm install` and ... to run this PR locally
3. Clear site data/cache
4. log as Owner user
5. go to Other Links→ Projects → Click on the assigned task name→
6. In the task table → Click on Edit → Should open a Modal, the Task Name should have a textarea

## Screenshots or videos of changes:
Before the change:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/3425aca1-5159-47b7-9e3c-47179755f8a3

After the change:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/b0e4b58a-5b32-4e04-83c5-89afb390eaca


## Note:
These alterations were implemented because the prior pull request included modifications to a distinct component that had no impact on the present component.
