### PR TITLE
Changhao - added new unit tests for NewUserPopup

### DIFF
--- a/src/__tests__/UserManagement/NewUserPopup.test.js
+++ b/src/__tests__/UserManagement/NewUserPopup.test.js
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import configureStore from 'redux-mock-store';
 import { renderWithProvider } from '../utils';
 import thunk from 'redux-thunk';
-
 import NewUserPopup from '../../components/UserManagement/NewUserPopup';
 
 jest.mock('../../components/UserProfile/AddNewUserProfile', () => {
@@ -38,6 +37,9 @@ describe('new user popup', () => {
     it('should render two close buttons', () => {
       expect(screen.getAllByRole('button', { name: /close/i })).toHaveLength(2);
     });
+    it('should render create new user heading', () => {
+      expect(screen.getByText('Create New User')).toBeInTheDocument();
+    });
   });
   describe('behavior', () => {
     it('should fire onUserPopupClose() when the user clicks close buttons', () => {
@@ -46,5 +48,19 @@ describe('new user popup', () => {
       });
       expect(onUserPopupClose).toHaveBeenCalledTimes(2);
     });
+  });
+});
+
+describe('new user popup close test', () => {
+  const onUserPopupClose = jest.fn();
+  let store;
+  it('should not render new user popup when closed', () => {
+  store = mockStore({
+    userProfile: {
+      role: 'userRole', // Provide the role here in the initial state
+    },
+  });
+  const {testid} = renderWithProvider(<NewUserPopup close onUserPopupClose={onUserPopupClose} />, { store });
+  expect(testid).toBeFalsy();
   });
 });


### PR DESCRIPTION
# Description
new unit tests for NewUserPopup.jsx

## How to test:
1. check into current branch
2. do `npm install` and `npm test NewUserPopup.test.js` to run this PR locally
3. verify all 8 tests are passed

## Screenshots:
<img width="681" alt="Screenshot 2023-12-20 at 12 36 28 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/104778270/112a8b79-5f34-4906-9cb0-bb845a6437ef">


## Note:
please ignore the error caused by `EditableInfoModal`
