### PR TITLE
XiaoW_Make timer buttons responsive to screen size

### DIFF
--- a/src/components/Timer/Timer.module.css
+++ b/src/components/Timer/Timer.module.css
@@ -31,12 +31,6 @@
   color: white;
 }
 
-/* @media (max-width: 768px) {
-  .timer-container .add-btn span {
-    display: none;
-  }
-} */
-
 .timer {
   position: absolute;
   width: 280px;
@@ -103,4 +97,26 @@
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 300ms;
+}
+
+@media (max-width: 576px) {
+  .btns {
+    display: grid;
+    grid-template-columns: auto auto auto auto;
+  }
+
+  .btns button {
+    padding: 1px 5px;
+  }
+}
+
+@media (max-width: 410px) {
+  .btns {
+    display: grid;
+    grid-template-columns: auto auto auto;
+  }
+
+  .btns button {
+    padding: 1px 3px;
+  }
 }

--- a/src/components/Timer/Timer.module.css
+++ b/src/components/Timer/Timer.module.css
@@ -99,7 +99,7 @@
   transition-duration: 300ms;
 }
 
-@media (max-width: 576px) {
+@media (max-width: 460px) {
   .btns {
     display: grid;
     grid-template-columns: auto auto auto auto;


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/77769556/39732ed5-ae24-44ba-80ac-f1793228f294)

## Main changes explained:
- add media queries to make the timer buttons responsive to screen sizes

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as any user
5. go to dashboard
6. verify function buttons are responsive to different screen sizes

## Screenshots or videos of changes:
![responsive timer buttons example 2](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/77769556/e689a147-fe99-4cd9-a51d-99309b60d8b0)
![responsive timer buttons example 3](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/77769556/15d4c171-9288-4847-ad5d-b0eaa824682e)
![responsive timer buttons example 1](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/77769556/8299bf23-0dfd-4deb-ade6-580248e03944)
