### PR TITLE
keyun- fix blue square hover-box position

### DIFF
--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -1,8 +1,9 @@
 #wrapper .report {
   position: absolute;
-  left: 10px;
-  right: 10px;
-  top: 2vh;
+  left: -140px;
+  top: 0;
+  width: 200px;
+  overflow-y: auto;
   visibility: hidden;
 }
 

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -15,40 +15,40 @@ const BlueSquare = (props) => {
       <div className="blueSquares">
         {blueSquares
           ? blueSquares
-              .sort((a, b) => (a.date > b.date ? 1 : -1))
-              .map((blueSquare, index) => (
-                <div
-                  key={index}
-                  role="button"
-                  id="wrapper"
-                  data-testid="blueSquare"
-                  className="blueSquareButton"
-                  onClick={() => {
-                    if (!blueSquare._id) {
-                      handleBlueSquare(isInfringementAuthorizer, 'message', 'none');
-                    } else if (canPutUserProfileImportantInfo) {
-                      handleBlueSquare(
-                        canPutUserProfileImportantInfo,
-                        'modBlueSquare',
-                        blueSquare._id,
-                      );
-                    } else {
-                      handleBlueSquare(
-                        !canPutUserProfileImportantInfo,
-                        'viewBlueSquare',
-                        blueSquare._id,
-                      );
-                    }
-                  }}
-                >
-                  <div className="report" data-testid="report">
-                    <div className="title">{formatDate(blueSquare.date)}</div>
-                    {blueSquare.description !== undefined && 
-                      <div className="summary">{formatDateFromDescriptionString(blueSquare.description)}</div>
-                    }
-                  </div>
+            .sort((a, b) => (a.date > b.date ? 1 : -1))
+            .map((blueSquare, index) => (
+              <div
+                key={index}
+                role="button"
+                id="wrapper"
+                data-testid="blueSquare"
+                className="blueSquareButton"
+                onClick={() => {
+                  if (!blueSquare._id) {
+                    handleBlueSquare(isInfringementAuthorizer, 'message', 'none');
+                  } else if (canPutUserProfileImportantInfo) {
+                    handleBlueSquare(
+                      canPutUserProfileImportantInfo,
+                      'modBlueSquare',
+                      blueSquare._id,
+                    );
+                  } else {
+                    handleBlueSquare(
+                      !canPutUserProfileImportantInfo,
+                      'viewBlueSquare',
+                      blueSquare._id,
+                    );
+                  }
+                }}
+              >
+                <div className="report" data-testid="report">
+                  <div className="title">{formatDate(blueSquare.date)}</div>
+                  {blueSquare.description !== undefined &&
+                    <div className="summary">{formatDateFromDescriptionString(blueSquare.description)}</div>
+                  }
                 </div>
-              ))
+              </div>
+            ))
           : null}
       </div>
 


### PR DESCRIPTION
<img width="727" alt="Screenshot 2023-12-28 at 4 30 00 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/124097392/c21c9201-d541-46e7-b8a9-4bfdd70c8504">

## Related PRS (if any):
None

## Main changes explained:
- move .report to the left 
- make the a fix width

## How to test:
1. Checkout this branch
2. Run npm start in BE
3. Clear site data/cache
4. Run npm run start:local in FE
6. Logged in as any user
7. Go to  Profile Page>Blue Squares Component, and check hover box does not cover any text on the page

## Screenshots or videos of changes:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/124097392/056edbef-8a65-4e78-bbcf-9dbd5b15301f
