### PR TITLE
Xiao F hotfix personal max badge label position

### DIFF
--- a/src/components/UserProfile/Badge.css
+++ b/src/components/UserProfile/Badge.css
@@ -63,7 +63,7 @@
 }
 
 .badge_featured_count_3_digit {
-  padding-top: 3px;
+  padding-top: 6px;
   border-radius: 50%;
   width: 40px;
   height: 30px;

--- a/src/components/UserProfile/Badge.css
+++ b/src/components/UserProfile/Badge.css
@@ -14,8 +14,8 @@
 }
 
 .badge_image_md > img {
-  height: 100px;
-  width: 100px;
+  height: 115px;
+  width: 115px;
   margin: 2px;
 }
 
@@ -56,7 +56,7 @@
   text-align: center;
   font: 11px Arial, sans-serif;
   position: absolute;
-  transform: translate(-50%, 25%);
+  transform: translate(-50%, 75%);
   top: 50%;
   left: 50%;
   z-index: 0;

--- a/src/components/UserProfile/Badge.css
+++ b/src/components/UserProfile/Badge.css
@@ -56,8 +56,8 @@
   text-align: center;
   font: 11px Arial, sans-serif;
   position: absolute;
-  right: 34px;
-  bottom: 26px;
+  right: 40px;
+  bottom: 13px;
   z-index: 0;
 }
 

--- a/src/components/UserProfile/Badge.css
+++ b/src/components/UserProfile/Badge.css
@@ -56,7 +56,9 @@
   text-align: center;
   font: 11px Arial, sans-serif;
   position: absolute;
-  transform: translate(85%, -150%);
+  transform: translate(-50%, 25%);
+  top: 50%;
+  left: 50%;
   z-index: 0;
 }
 

--- a/src/components/UserProfile/Badge.css
+++ b/src/components/UserProfile/Badge.css
@@ -56,8 +56,7 @@
   text-align: center;
   font: 11px Arial, sans-serif;
   position: absolute;
-  right: 40px;
-  bottom: 13px;
+  transform: translate(85%, -150%);
   z-index: 0;
 }
 

--- a/src/components/UserProfile/BadgeImage.jsx
+++ b/src/components/UserProfile/BadgeImage.jsx
@@ -15,17 +15,17 @@ const BadgeImage = props => {
             id={'popover_' + props.time + props.index.toString()}
             alt=""
           />
+        
+          {props.badgeData.type == 'Personal Max' ? (
+            <span className={'badge_featured_count_personalmax'}>
+              {`${Math.floor(props.personalBestMaxHrs)} ${Math.floor(props.personalBestMaxHrs) <= 1 ? ' hr' : ' hrs'}`}
+            </span>
+          ) : props.count < 100 ? (
+            <span data-testid="badge_featured_count" className={'badge_featured_count'}>{Math.round(props.count)}</span>
+          ) : (
+            <span className="badge_featured_count_3_digit">{Math.round(props.count)}</span>
+          )}
         </div>
-
-        {props.badgeData.type == 'Personal Max' ? (
-          <span className={'badge_featured_count_personalmax'}>
-            {`${Math.floor(props.personalBestMaxHrs)} ${Math.floor(props.personalBestMaxHrs) <= 1 ? ' hr' : ' hrs'}`}
-          </span>
-        ) : props.count < 100 ? (
-          <span data-testid="badge_featured_count" className={'badge_featured_count'}>{Math.round(props.count)}</span>
-        ) : (
-          <span className="badge_featured_count_3_digit">{Math.round(props.count)}</span>
-        )}
       </div>
       <Popover
         trigger="hover"


### PR DESCRIPTION
# Description
![CleanShot 2024-01-01 at 11 01 19](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/43768723/cf36adb8-40f6-49b3-b07c-a5b11b9fece2)

## Related PRS (if any):
N/A

## Main changes explained:
- Update file `src/components/UserProfile/Badge.css` for new CSS pattern
- Revert image size in `src/components/UserProfile/Badge.css` from 100px to 115px
- Update file `src/components/UserProfile/BadgeImage.jsx` to put the label inside the image container

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to profile -> featured badges -> Personal max badge's label should be in the correct position

## Screenshots or videos of changes:
![CleanShot 2024-01-01 at 12 51 38](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/43768723/2621e825-d06e-40a3-ac28-1f826cd4d840)


