### PR TITLE
Add Fields to Purchase Record

### DIFF
--- a/src/components/BMDashboard/MaterialsList/RecordsModal.jsx
+++ b/src/components/BMDashboard/MaterialsList/RecordsModal.jsx
@@ -30,35 +30,6 @@ export default function RecordsModal({ modal, setModal, record, setRecord, recor
 }
 
 export function Record({ record, recordType }) {
-  // if (recordType === 'Usage') {
-  //   return (
-  //     <>
-  //       <thead>
-  //         <tr>
-  //           <th>Date</th>
-  //           <th>Qty</th>
-  //           <th>Creator</th>
-  //         </tr>
-  //       </thead>
-  //       <tbody>
-  //         {record.map(({ date, quantityUsed, createdBy }) => {
-  //           return (
-  //             <tr key={date + createdBy._id}>
-  //               <td>{moment(date).format('MM/DD/YY')}</td>
-  //               <td>{quantityUsed}</td>
-  //               <td>
-  //                 <a href={`/userprofile/${createdBy._id}`}>
-  //                   {`${createdBy.firstName} ${createdBy.lastName}`}
-  //                 </a>
-  //               </td>
-  //             </tr>
-  //           );
-  //         })}
-  //       </tbody>
-  //     </>
-  //   );
-  // }
-
   if (recordType === 'Update') {
     return (
       <>
@@ -94,24 +65,28 @@ export function Record({ record, recordType }) {
       <>
         <thead>
           <tr>
+            <th>Priority</th>
+            <th>Brand</th>
+            <th>Quantity</th>
+            <th>Requested By</th>
             <th>Date</th>
             <th>Status</th>
-            <th>Quantity</th>
-            <th>Creator</th>
           </tr>
         </thead>
         <tbody>
-          {record.map(({ date, status, quantity, requestedBy }) => {
+          {record.map(({ date, status, brand, priority, quantity, requestedBy }) => {
             return (
               <tr key={date + requestedBy._id}>
-                <td>{moment(date).format('MM/DD/YY')}</td>
-                <td>{status}</td>
+                <td>{priority}</td>
+                <td>{brand}</td>
                 <td>{quantity || '-'}</td>
                 <td>
                   <a href={`/userprofile/${requestedBy._id}`}>
                     {`${requestedBy.firstName} ${requestedBy.lastName}`}
                   </a>
                 </td>
+                <td>{moment(date).format('MM/DD/YY')}</td>
+                <td>{status}</td>
               </tr>
             );
           })}


### PR DESCRIPTION
# Description
Implements Phase 2 WBS 3.1.4: Adds new fields to purchase records modal.

## Related PRS (if any):
none

## Main changes explained:
- Deleted unused code
- Added new sections to purchase record (ie. brand and priority)
- Rearranged modal for clearer records display

## How to test:
1. git pull
2. check into current branch
3. do `npm install` and `npm run start:local` to run this PR locally
4. Clear site data/cache in local storage
5. log in as any user
6. go to http://localhost:3000/bmdashboard/login to confirm your login credentials
7. go to http://localhost:3000/bmdashboard/materials
8. select "View" under "Purchases"
9. Verify that "brand" and "priority" are now visible

## Screenshots or videos of changes:

<img width="1147" alt="Screenshot 2024-01-03 at 12 42 37 PM (2)" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/93569791/b000b2c3-8a46-4ff3-b86c-483ef444aa67">

## Note:
