### PR TITLE
Shengwei fix badge date scroll down issue

### DIFF
--- a/src/components/Badge/BadgeReport.css
+++ b/src/components/Badge/BadgeReport.css
@@ -11,3 +11,8 @@
     display: block;
   }
 }
+
+.dropdown-menu {
+  height: 15vh;
+  overflow-y: scroll;
+}

--- a/src/components/Badge/BadgeReport.css
+++ b/src/components/Badge/BadgeReport.css
@@ -15,4 +15,5 @@
 .dropdown-menu {
   height: 15vh;
   overflow-y: scroll;
+  overflow: auto;
 }

--- a/src/components/UserProfile/EditableModal/EditableInfoModal.jsx
+++ b/src/components/UserProfile/EditableModal/EditableInfoModal.jsx
@@ -252,32 +252,33 @@ export class EditableInfoModal extends Component {
           }
           </ModalBody>
           <ModalFooter>
-          <Row>
-            <Col md={{ size: 5, offset:4}}>
-            {(this.state.editing)&&
+          <Row className='no-gutters'>
+          {(this.state.editing)&&
             (
-                <Select 
+              <Col md={6} style={{paddingRight: '2px'}}>
+               <Select 
                   options={options} 
                   onChange={this.handleSelectChange}
                   value={options.find(option => option.value === this.state.visibility)} 
                   />
-            )
+              </Col>)
             }
-             </Col>
+
             {(CanEdit&&this.state.editing)&&
             (
-              <Col md={{ size: 1}} style={{paddingLeft:'5px'}}>
+              <Col md={3} style={{paddingLeft: '4px'}}
+              >
                 <Button
                   className='saveBtn' 
                   onClick={this.handleSave}
                   style={boxStyle}>Save</Button>
               </Col>)
             }
-          <Col 
-            md={{ size: 1}}
-            >
-            <Button onClick={this.handleClose} style={boxStyle}>Close</Button>
-          </Col>
+            <Col 
+              md={3}
+              >
+              <Button onClick={this.handleClose} style={boxStyle}>Close</Button>
+            </Col>
           </Row>
           </ModalFooter>
           </Modal>


### PR DESCRIPTION

# Description
- Earned date scroll-down issue.
 ![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69882989/5b8bc5f7-1d6e-473d-b0fa-89d7bb639c74)
- Fix the bug that was identified while fixing the scroll-down issue. Popup modal CSS.
 ![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69882989/9443cc55-80cf-40f1-bba2-c1bfdb6ab7a8)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69882989/1b3ebfd7-fb7b-4408-a6b6-0a1bfc1ff9b1)

## Main changes explained:
- Update CSS file for dropdown-menu to enable scrolling
- Update style file for 


## How to test:
1. check into the current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in as any user that has a badge with a badge count over 40
5. go to view profile → Select Feature
6. verify the scroll bar is hidden for fewer item list
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69882989/6ebd5ccc-e1a2-4497-9b97-4265b3c6c02d)
7. verify the scroll bar is enabled for larger item list
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69882989/1f9346bc-4b26-4526-87da-c290ea3fffe0)
8. click on the info icon
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69882989/fedf5ddb-cca9-4842-b761-ad86f4599fd2)
9. verify modal close button align correctly
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69882989/2d6fac20-ea67-4735-b4bd-e4d9c64be655)
10. click on the content body and verify the buttons in editor footer are correctly aligned
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69882989/fd46b787-cca5-4b9b-9196-3f9428b2e2da)



## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
