### PR TITLE
Roberto-fixes add team not working

### DIFF
--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -49,7 +49,6 @@ class Teams extends React.PureComponent {
     // Initiating the teams fetch action.
     this.props.getAllUserTeams();
     this.props.getAllUserProfile();
-    // console.log('teams: props', this.props);
     this.sortTeamsByModifiedDate();
   }
 
@@ -59,8 +58,15 @@ class Teams extends React.PureComponent {
       const teamsTable = this.state.sortedTeams.map(team => {
         return team;
       });
-
+  
       this.setState({ teamsTable });
+    }
+  
+    if (prevProps.state.allTeamsData.allTeams !== this.props.state.allTeamsData.allTeams) {
+      // Teams have changed, update or re-fetch them
+      this.props.getAllUserTeams();
+      this.props.getAllUserProfile();
+      this.sortTeamsByModifiedDate();
     }
   }
 
@@ -71,7 +77,6 @@ class Teams extends React.PureComponent {
     this.state.teams = this.teamTableElements(allTeams);
     const numberOfTeams = allTeams.length;
     const numberOfActiveTeams = numberOfTeams ? allTeams.filter(team => team.isActive).length : 0;
-    // console.log(this.state.teams[0].props.index);
 
     return (
       <Container fluid>
@@ -352,7 +357,7 @@ class Teams extends React.PureComponent {
         toast.error(updateTeamResponse)
       }
     } else {
-      const postResponse = await this.props.postNewTeam(name);
+      const postResponse = await this.props.postNewTeam(name, true);
       if (postResponse.status === 200) {
         toast.success('Team added successfully');
       } else {


### PR DESCRIPTION
# Description
When visiting team management the function to create a new team did not actually result in expected behavior.

## Related PRS (if any):
-Try with latest backend

## Main changes explained:
- Passed down a true boolean to the postNewTeam function, boolean was required but originally not given. Caused the backend to send a bad request
- Updates the component did update to trigger re-render of the team list when a change is made


## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to team management→ add new team→ 
6. verify function creating new team works as expected

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
