### PR TITLE
Tim: Fix BM Dashboard Server Errors

### DIFF
--- a/src/components/BMDashboard/Consumables/ConsumablesList/ConsumablesInputs.jsx
+++ b/src/components/BMDashboard/Consumables/ConsumablesList/ConsumablesInputs.jsx
@@ -31,13 +31,13 @@ function ConsumablesInputs({ consumable, setConsumable, project, setProject }) {
 
     if (consumables.length) {
       if (project.value === '0')
-        consumablesSet = [...new Set(consumables.map(rec => rec.itemType.name))];
+        consumablesSet = [...new Set(consumables.map(rec => rec.itemType?.name))];
       else
         consumablesSet = [
           ...new Set(
             consumables
               .filter(rec => rec.project?.name === project.label)
-              .map(rec => rec.itemType.name),
+              .map(rec => rec.itemType?.name),
           ),
         ];
     }

--- a/src/components/BMDashboard/MaterialsList/RecordsModal.jsx
+++ b/src/components/BMDashboard/MaterialsList/RecordsModal.jsx
@@ -74,11 +74,11 @@ export function Record({ record, recordType }) {
           </tr>
         </thead>
         <tbody>
-          {record.map(({ date, status, brand, priority, quantity, requestedBy }) => {
+          {record.map(({ date, status, brandPref, priority, quantity, requestedBy }) => {
             return (
               <tr key={date + requestedBy._id}>
                 <td>{priority}</td>
-                <td>{brand}</td>
+                <td>{brandPref}</td>
                 <td>{quantity || '-'}</td>
                 <td>
                   <a href={`/userprofile/${requestedBy._id}`}>


### PR DESCRIPTION
# Description
Hotfix for various server errors and crashes in the BM Dashboard. Changes to database models are causing these errors in the current dev branch. This PR and accompanying backend PR should fix these issues!

## Related PRS (if any):
[689](https://github.com/OneCommunityGlobal/HGNRest/pull/689)

## Main changes explained:
- adds optional chaining to invType objects in Consumables List page to prevent crashes
- updates `brand` field to `brandPref` in Records modals
- use this branch to test various pages after API updates

## How to test:
1. follow instructions to spin up backend branch
2. `git checkout Tim_fix_mat_view_crash`
3. `npm i`
4. `npm run start:local`
5. Clear site data/cache (`localStorage.clear()` in browser console will dump all persisted state)
6. log in as volunteer user
7. navigate to "/bmdashboard/login" and confirm credentials to log in to BM Dashboard
8. Test the following pages to ensure they do not crash when loaded:
   - /bmdashboard - check that data displays correctly
   - /bmdashboard/materials -- also check modals for proper data display
   - /bmdashboard/materials/purchase
   - /bmdashboard/materials/update
   - /bmdashboard/consumables -- also test filters

## Notes
Please also leave a review of the backend PR.