### PR TITLE
Xiao F hotfix update teams page sorting

### DIFF
--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -66,7 +66,6 @@ class Teams extends React.PureComponent {
       // Teams have changed, update or re-fetch them
       this.props.getAllUserTeams();
       this.props.getAllUserProfile();
-      this.sortTeamsByModifiedDate();
     }
   }
 


### PR DESCRIPTION
# Description
![CleanShot 2024-01-07 at 23 23 54@2x](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/43768723/959d7fc4-a2d5-4825-9e50-2c7e3eb9dbc4)


## Related PRS (if any):
[PR 1757](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1757)
[Hot fix 1788](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1788)

## Main changes explained:
- Update file `src/components/Teams/Teams.jsx` for removing extra call on sorting function

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner/admin user (Right now, you need an owner account to toggle 'Active' status for a team)
5. go to Other Links-> Teams->  Click 'Team Names' to cycle through sorting methods: default(by modified date), ascending, descending
6. go to Other Links-> Teams->  Click 'Active' to cycle through sorting methods: default(by modified date), ascending(inactive teams on top), descending
7. When 'Team Names' is not in default sorting, clicking on 'Active' will reset 'Team Names' icon to default

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/43768723/8da74c09-bbcf-4cd4-b404-e68258cbb6ba



## Note:
N/A
