### PR TITLE
Text alignment on Permissions page

### DIFF
--- a/src/components/PermissionsManagement/UserRoleTab.css
+++ b/src/components/PermissionsManagement/UserRoleTab.css
@@ -111,6 +111,7 @@
   height: 40px; /* You can adjust this value */
   line-height: 40px; /* This should be the same as the height */
   min-width: 80px; /* Optional: Sets a minimum width for the button */
+  padding: 0px 10px; /* Optional: Adds some padding inside the button */
 }
 
 .info-button {


### PR DESCRIPTION
# Description
![Screenshot 2024-01-07 at 9 47 15 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/0cce9b17-5496-4574-9e91-b62823695188)

## Main changes explained:
- Aligned text to the center

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
5. go to dashboard→ Other Links → Permissions Management → Click on Any Role
6. **Check if the text is in the center of these buttons**.
<img width="450" alt="Screenshot 2024-01-07 at 9 50 11 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/c4718173-85bd-4a0c-8d2d-5a96a7da03e4">

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/27c8f8fc-9309-45ef-97f4-e22a24c9eee6

## Note:
Include the information the reviewers need to know.
