### PR TITLE
Roberto-hotfix for viewing others dashboard

### DIFF
--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -93,7 +93,7 @@ export function Dashboard(props) {
             </div>
           ) : null}
           <div className="my-2" id="wsummary">
-            <Timelog isDashboard passSummaryBarData={setSummaryBarData} />
+            <Timelog isDashboard passSummaryBarData={setSummaryBarData} match={match} />
           </div>
           <Badge userId={displayUserId} role={auth.user.role} />
         </Col>

--- a/src/components/TeamMemberTasks/ReviewButton.jsx
+++ b/src/components/TeamMemberTasks/ReviewButton.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter, DropdownToggle, DropdownMenu, DropdownItem, UncontrolledDropdown } from 'reactstrap';
 import './style.css';
 import './reviewButton.css';
@@ -10,12 +11,11 @@ import { ApiEndpoint } from 'utils/URL';
 
 const ReviewButton = ({
   user,
-  myUserId,
-  myRole,
   task,
   updateTask
 }) => {
-
+  const myUserId = useSelector(state => state.auth.user.userid);
+  const myRole = useSelector(state => state.auth.user.role);
   const [modal, setModal] = useState(false);
 
   const toggleModal = () => {

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -10,7 +10,7 @@ import hasPermission from 'utils/permissions';
 import './style.css';
 import { boxStyle } from 'styles';
 import ReviewButton from './ReviewButton';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import TeamMemberTaskIconsInfo from './TeamMemberTaskIconsInfo';
 
 const NUM_TASKS_SHOW_TRUNCATE = 6;
@@ -192,8 +192,7 @@ const TeamMemberTask = React.memo(
                           <div>
                             <ReviewButton
                               user={user}
-                              myUserId={userId}
-                              myRole={userRole}
+                              userId={userId}
                               task={task}
                               updateTask={updateTaskStatus}
                               style={boxStyle}


### PR DESCRIPTION
# Description
Currently when trying to view another person's dashboard the data present is still your own information when the new window pops open not the expected behavior.
[https://drive.google.com/file/d/1wHyFgrequgWJCvZIyJ-xN8h6hK98i9TB/view?usp=sharing](https://drive.google.com/file/d/1wHyFgrequgWJCvZIyJ-xN8h6hK98i9TB/view?usp=sharing)

## Related PRS (if any):
Test with latest Backend

## Main changes explained:
- In dashboard, passes down props to the timelog so the logic knows how to handle it.
- Removes the myUserId and myRole variables from props in the reviewbutton file, this was necessary so if a volunteer wanted to view admin or owner they don't have permission to edit people's tasks.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as any user
5. go to dashboard→ Leaderboard→ any user→ click on their red/green dot
6. verify that when the new window pops up, you are able to view that person's dashboard just fine. Should not be storing your own information like before. 


