### PR TITLE
Jay - Edit Header Message Permission

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -73,6 +73,7 @@ export const Header = props => {
   const canPutRole = props.hasPermission('putRole');
   // Permissions
   const canManageUser = props.hasPermission('putUserProfilePermissions');
+  const canEditHeaderMessage = props.hasPermission('editHeaderMessage');
 
   const dispatch = useDispatch();
 
@@ -109,7 +110,7 @@ export const Header = props => {
           style={user.role == 'Owner' ? { marginRight: '6rem' } : { marginRight: '10rem' }}
         >
           {isAuthenticated && <Timer />}
-          {isAuthenticated && (
+          {(isAuthenticated || canEditHeaderMessage) &&(
             <div className="owner-message">
               <OwnerMessage />
             </div>

--- a/src/components/OwnerMessage/OwnerMessage.jsx
+++ b/src/components/OwnerMessage/OwnerMessage.jsx
@@ -127,7 +127,8 @@ function OwnerMessage({
     <div className="message-container">
       {ownerMessage ? getContent(ownerMessage) : getContent(ownerStandardMessage)}
 
-      {user.role === 'Owner' && (
+      {(user.role === 'Owner' ||
+        user.permissions.frontPermissions.includes('editHeaderMessage')) && (
         <div className="icon-wrapper">
           <button type="submit" onClick={toggle}>
             <img src={editIcon} alt="edit icon" title="Edit this header" />

--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -18,6 +18,11 @@ export const permissionLabels = [
         key: 'highlightEligibleBios',
         description: 'Under "Reports" -> "Weekly Summaries Reports", make the "Bio announcement" row highlighted yellow if that user is eligible for their bio to be posted (they have at least 80 tangible hours, 60 days on the team, and still don\'t have their bio posted)',
       },
+      {
+        label: 'Edit Header Message',
+        key: 'editHeaderMessage',
+        description: 'Gives the user permission to edit the message displayed in the header.',
+      }
     ]
   },
   {


### PR DESCRIPTION
# Description
This PR enables the user with the Edit Header Message Permission to be able to edit the header message.

## Related PRS (if any):
This frontend PR is related to the [#]() backend PR.

…

## Main changes explained:
- Added a new permission lable for Edit Header Message.
- Added conditional logic so that user with the permission or 'Owner' role have access to the edit button.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to Other Links -> Permissions Management -> Manage User Permissions -> Choose a user without Edit Header Message under Reports -> add Edit Header Message
6. verify that user is now able to see the edit button in the header and is able to edit it.

## Screenshots or videos of changes:



https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118868270/0ff2f93f-4214-4396-9b40-22b4ca1ea64a


## Note:
**Unmute the video**

