### PR TITLE
Tim: Fix Tool Detail Import Errors

### DIFF
--- a/src/actions/bmdashboard/toolActions.js
+++ b/src/actions/bmdashboard/toolActions.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { ENDPOINTS } from 'utils/URL';
-import { GET_TOOL_BY_ID } from 'constants/bmdashboard/toolsConstants';
+import GET_TOOL_BY_ID from 'constants/bmdashboard/toolsConstants';
 import { GET_ERRORS } from 'constants/errors';
 
 

--- a/src/reducers/bmdashboard/toolByIdReducer.js
+++ b/src/reducers/bmdashboard/toolByIdReducer.js
@@ -1,4 +1,4 @@
-import { GET_TOOL_BY_ID } from 'constants/bmdashboard/toolsConstants';
+import GET_TOOL_BY_ID from "constants/bmdashboard/toolsConstants";
 
 export const toolByIdReducer = (tool = null, action) => {
   if (action.type === GET_TOOL_BY_ID) {


### PR DESCRIPTION
# Description
Reopened PR for the Tool Details view created by @cvtqx

## Related PRS (if any):
[Backend PR 698](https://github.com/OneCommunityGlobal/HGNRest/pull/698)

## Main changes explained:
- created components: ToolModal.jsx, ToolDetailPage.jsx
- added ToolDetailPage.css for styling
- added tool actions, reducer and route
- added a new commit to fix import errors

## How to test:
- follow instructions to spin up backend branch
- `git checkout Olga_tool_equipment_details_page`
- `npm i`, then `npm run start:local`
- go to http://localhost:3000/bmdashboard/tools/659f72a1e49bf93bc79a1b2d to view a tool with 'Purchase' status
- go to http://localhost:3000/bmdashboard/tools/659f72c0e49bf93bc79a1b2e to view a tool with 'Rental' status
- Check that the links are working. Link to Buy/Rent takes you to a new page (HomeDepot website at the moment).
- Description link opens a modal with tool description.
- Check that if the tools Ownership is Purchase, Rental Duration line is not displayed.
- Check the page in different screen sizes.

## Screenshots or videos of changes:

## Note:
Please remember to leave reviews on both front and backend PRs!
