### PR TITLE
Shiwani add leaderboard indicator for additional weeks off

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -301,6 +301,22 @@ function LeaderBoard({
                     }}
                   >
                     {item.name}
+                    {currentDate.isSameOrAfter(
+                      moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'),
+                    ) &&
+                    currentDate.isBefore(moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ')) ? (
+                      <sup>
+                        {' '}
+                        +
+                        {Math.floor(
+                          1 +
+                            moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ').diff(
+                              moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'),
+                              'weeks',
+                            ),
+                        )}
+                      </sup>
+                    ) : null}
                   </Link>
                   &nbsp;&nbsp;&nbsp;
                   {hasVisibilityIconPermission && !item.isVisible && (

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -309,12 +309,11 @@ function LeaderBoard({
                         {' '}
                         +
                         {Math.floor(
-                          1 +
-                            moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ').diff(
-                              moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'),
-                              'weeks',
-                            ),
-                        )}
+                          moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ').diff(
+                            moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'),
+                            'weeks',
+                          ),
+                        ) + 1}
                       </sup>
                     ) : null}
                   </Link>


### PR DESCRIPTION
# Description
<img width="1104" alt="Screenshot 2024-01-10 at 6 13 35 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/78906820/8d74d5fb-9bdc-4c01-8cb1-82f25a7c179b">


## Related PRS (if any):
This PR is a follow up PR to [PR#1722](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1722)

## Main changes explained:
- Added a superscript to name in leaderboard.jsx which would calculate the number of weeks between timeOffFrom and timeOffTill dates and would only get displayed if the user is currently on a time off.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in as any user
5. go to View Profile→ click on schedule blue square → fill in the details → click submit → click on dashboard → check if the name of the user in grey has a superscript which shows the number of weeks the user will be off. 

## Screenshots or videos of changes:
<img width="1431" alt="Screenshot 2024-01-10 at 6 10 37 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/78906820/6fc355bd-f79b-4358-adbd-a5ab89c7714f">

