### PR TITLE
Jay - Reset Password Permission

### DIFF
--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -54,6 +54,11 @@ export const permissionLabels = [
         key: 'putUserProfileImportantInfo',
         description: 'Gives the user the ability to modify several protected parts of users profiles. This includes changing admin links,  weekly summary options, committed hours, role, isRehireable, email, date created, bio status, and more. It also allows to circumvent permissions related to assigning teams or projects and changing active status.',
       },
+      {
+        label: 'Reset / Change Password (Others)',
+        key: 'resetPassword',
+        description: 'Gives the user permission to Reset and/or Change the password of any user but Owner/Admin classes. ',
+      }
     ]
   },
   {

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -622,7 +622,7 @@ function UserProfile(props) {
 
   const { userId: targetUserId } = props.match ? props.match.params : { userId: undefined };
   const { userid: requestorId, role: requestorRole } = props.auth.user;
-
+  const {role: userRole} = userProfile;
   const authEmail = props.userProfile?.email;
   const isUserSelf = targetUserId === requestorId;
 
@@ -631,7 +631,8 @@ function UserProfile(props) {
   const canPutUserProfile = props.hasPermission('putUserProfile');
   const canUpdatePassword = props.hasPermission('updatePassword');
   const canGetProjectMembers = props.hasPermission('getProjectMembers');
-
+  const canResetPassword = props.hasPermission('resetPassword') && !(userRole === "Administrator" || userRole === "Owner") ;
+ 
   const targetIsDevAdminUneditable = cantUpdateDevAdminDetails(userProfile.email, authEmail);
   const selfIsDevAdminUneditable = cantUpdateDevAdminDetails(authEmail, authEmail);
 
@@ -1344,7 +1345,7 @@ function UserProfile(props) {
           <Col md="4"></Col>
           <Col md="8" className="desktop-panel">
             <div className="profileEditButtonContainer">
-              {canUpdatePassword && canEdit && !isUserSelf && (
+              {(canUpdatePassword && canEdit && !isUserSelf) || (canResetPassword) && (
                 <ResetPasswordButton
                   className="mr-1 btn-bottom"
                   user={userProfile}


### PR DESCRIPTION
# Description
This PR enables the user with the Reset Password Permission to be able to reset other users' passwords.

## Related PRS (if any):
This frontend PR is related to the [#692](https://github.com/OneCommunityGlobal/HGNRest/pull/692) backend PR.

…

## Main changes explained:
- Added a new permission label for Reset Password.
- Added conditional logic so that the user with the permission can have access to the reset password button.
- Added conditional logic so that the user with the permission is not able to reset the password of Owner or Administrator.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to Other Links -> Permissions Management -> Manage User Permissions -> Choose a user without Edit Header Message under Reports -> add Reset / Change Password (Others) -> Scroll down then submit
6. verify that the user who was given the permission is now able to see the reset password button and reset another user's (make sure to reset your own account for testing) password.

## Screenshots or videos of changes:


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118868270/af17fc24-0a33-4ace-ac3e-b241dd9a2edc



## Note:
**Unmute the video**

