### PR TITLE
Kaikanes infringe bugfix

### DIFF
--- a/src/components/Reports/InfringementsViz.jsx
+++ b/src/components/Reports/InfringementsViz.jsx
@@ -26,8 +26,13 @@ function InfringementsViz({ infringements, fromDate, toDate }) {
       d3.selectAll('#infplot > *').remove();
     } else {
       d3.selectAll('#infplot > *').remove();
-      const margin = { top: 10, right: 30, bottom: 30, left: 60 };
-      const width = 1000 - margin.left - margin.right;
+      const margin = { top: 30, right: 20, bottom: 30, left: 20 };
+      const containerWidth =
+        window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
+
+      // Adjusted width based on the available space
+      const width = Math.min(containerWidth - margin.left - margin.right, 1000);
+
       const height = 400 - margin.top - margin.bottom;
 
       const tooltipEl = function(d) {
@@ -275,7 +280,7 @@ function InfringementsViz({ infringements, fromDate, toDate }) {
       <Button onClick={handleModalShow} aria-expanded={graphVisible} style={boxStyle}>
         Show Infringements Graph
       </Button>
-      <div id="infplot" />
+      <div className="kaitest" id="infplot" />
 
       <Modal size="lg" show={modalVisible} onHide={handleModalClose}>
         <Modal.Header closeButton>

--- a/src/components/Reports/InfringementsViz.jsx
+++ b/src/components/Reports/InfringementsViz.jsx
@@ -273,7 +273,7 @@ function InfringementsViz({ infringements, fromDate, toDate }) {
   return (
     <div>
       <Button onClick={handleModalShow} aria-expanded={graphVisible} style={boxStyle}>
-        Show Infringements Graph
+        {graphVisible ? 'Hide Infringements Graph' : 'Show Infringements Graph'}
       </Button>
       <div className="kaitest" id="infplot" />
 

--- a/src/components/Reports/InfringementsViz.jsx
+++ b/src/components/Reports/InfringementsViz.jsx
@@ -27,9 +27,7 @@ function InfringementsViz({ infringements, fromDate, toDate }) {
     } else {
       d3.selectAll('#infplot > *').remove();
       const margin = { top: 30, right: 20, bottom: 30, left: 20 };
-      const containerWidth =
-        window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
-
+      const containerWidth = '1000';
       // Adjusted width based on the available space
       const width = Math.min(containerWidth - margin.left - margin.right, 1000);
 
@@ -70,8 +68,9 @@ function InfringementsViz({ infringements, fromDate, toDate }) {
       const svg = d3
         .select('#infplot')
         .append('svg')
-        .attr('width', width + margin.left + margin.right)
+        .attr('width', '100%')
         .attr('height', height + margin.top + margin.bottom)
+        .attr('viewBox', `0 0 ${containerWidth} ${height + margin.top + margin.bottom}`)
         .append('g')
         .attr('transform', `translate(${margin.left},${margin.top})`);
 
@@ -184,11 +183,7 @@ function InfringementsViz({ infringements, fromDate, toDate }) {
       const legend = d3
         .select('#infplot')
         .append('div')
-        .attr('class', 'legendContainer')
-        .style('position', 'relative')
-        .style('top', `-450px`)
-        .style('left', `980px`);
-
+        .attr('class', 'legendContainer');
       legend.html(legendEl());
 
       legend.select('.infLabelsOff').on('click', function() {
@@ -287,7 +282,7 @@ function InfringementsViz({ infringements, fromDate, toDate }) {
           <Modal.Title>{focusedInf.date ? focusedInf.date.toString() : 'Infringement'}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <table id="inf">
+          <div id="inf">
             <thead>
               <tr>
                 <th>Descriptions</th>
@@ -304,7 +299,7 @@ function InfringementsViz({ infringements, fromDate, toDate }) {
                   })
                 : null}
             </tbody>
-          </table>
+          </div>
         </Modal.Body>
         <Modal.Footer>
           <Button variant="secondary" onClick={handleModalClose}>

--- a/src/components/Reports/InfringementsViz.jsx
+++ b/src/components/Reports/InfringementsViz.jsx
@@ -5,20 +5,24 @@ import './PeopleReport/PeopleReport.css';
 import { boxStyle } from '../../styles';
 
 function InfringementsViz({ infringements, fromDate, toDate }) {
-  const [show, setShow] = React.useState(false);
-  const [modalShow, setModalShow] = React.useState(false);
+  const [graphVisible, setGraphVisible] = React.useState(false);
+  const [modalVisible, setModalVisible] = React.useState(false);
   const [focusedInf, setFocusedInf] = React.useState({});
 
   const handleModalClose = () => {
-    setModalShow(false);
+    setModalVisible(false);
     setFocusedInf({});
   };
+
   const handleModalShow = d => {
     setFocusedInf(d);
-    setModalShow(true);
+    if (graphVisible === false) {
+      setModalVisible(!modalVisible);
+    }
+    setGraphVisible(!graphVisible); // Open the graph when opening the modal
   };
   function displayGraph(bsCount, maxSquareCount) {
-    if (!show) {
+    if (!graphVisible) {
       d3.selectAll('#infplot > *').remove();
     } else {
       d3.selectAll('#infplot > *').remove();
@@ -198,7 +202,6 @@ function InfringementsViz({ infringements, fromDate, toDate }) {
       });
     }
   }
-
   const generateGraph = () => {
     const dict = {};
     const value = [];
@@ -258,23 +261,23 @@ function InfringementsViz({ infringements, fromDate, toDate }) {
     }
 
     // eslint-disable-next-line no-console
-    console.log('INFvalues', value);
+    // console.log('INFvalues', value);
 
     displayGraph(value, maxSquareCount);
   };
 
   React.useEffect(() => {
     generateGraph();
-  }, [show, fromDate, toDate]);
+  }, [graphVisible, fromDate, toDate, focusedInf]);
 
   return (
     <div>
-      <Button onClick={() => setShow(!show)} aria-expanded={show} style={boxStyle}>
+      <Button onClick={handleModalShow} aria-expanded={graphVisible} style={boxStyle}>
         Show Infringements Graph
       </Button>
       <div id="infplot" />
 
-      <Modal size="lg" show={show} onHide={handleModalClose}>
+      <Modal size="lg" show={modalVisible} onHide={handleModalClose}>
         <Modal.Header closeButton>
           <Modal.Title>{focusedInf.date ? focusedInf.date.toString() : 'Infringement'}</Modal.Title>
         </Modal.Header>
@@ -284,16 +287,18 @@ function InfringementsViz({ infringements, fromDate, toDate }) {
               <tr>
                 <th>Descriptions</th>
               </tr>
-              <tbody>
-                {focusedInf.des
-                  ? focusedInf.des.map(desc => (
+            </thead>
+            <tbody>
+              {focusedInf.des
+                ? focusedInf.des.map(desc => {
+                    return (
                       <tr>
                         <td>{desc}</td>
                       </tr>
-                    ))
-                  : focusedInf.des}
-              </tbody>
-            </thead>
+                    );
+                  })
+                : null}
+            </tbody>
           </table>
         </Modal.Body>
         <Modal.Footer>

--- a/src/components/Reports/PeopleReport/PeopleReport.css
+++ b/src/components/Reports/PeopleReport/PeopleReport.css
@@ -229,7 +229,5 @@ body {
     flex-direction: column;
     justify-content: flex-start;
     align-items: flex-start;    
-    width: 1000px;
-    margin-left: 732px;
   }
 }

--- a/src/components/Reports/PeopleReport/PeopleReport.css
+++ b/src/components/Reports/PeopleReport/PeopleReport.css
@@ -149,13 +149,14 @@ body {
 /*Badge changes ends here*/
 
 .visualizationDiv {
-  display: inline-flex;
   /* margin-bottom: 10px; */
   margin-top: 20px;
 }
-
-.visualizationDiv > * {
-  margin-left: 10px;
+.BadgeSummaryPreviewDiv{
+  padding-left: 1%;
+}
+.BadgeSummaryDiv{
+  padding-right: 1%;
 }
 
 #inf td,
@@ -213,7 +214,21 @@ body {
     color: white;
   }
 }
-
+.Infringementcontainer{
+  display: flex;
+  justify-content: center;
+}
+.InfringementcontainerInner{
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+.visualizationDivRow{
+  padding-top: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
 .container-people-wrapper {
   min-height: 100%;
   max-width: 100vw;

--- a/src/components/Reports/PeopleReport/PeopleReport.css
+++ b/src/components/Reports/PeopleReport/PeopleReport.css
@@ -174,7 +174,17 @@ body {
   margin: 16px 0px 16px 0px;
   display: flex;
 }
-
+.kaitest{
+  width: 100%;
+}
+@media (max-width: 850px) {
+  .intro_date {
+    margin: 16px 0px 16px 0px;
+    display: flex;
+    justify-content: center;
+  }
+  
+}
 .intro_date div {
   display: inline-flex;
   vertical-align: top;

--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -2,12 +2,12 @@
 import React, { Component, useState } from 'react';
 import '../../Teams/Team.css';
 import './PeopleReport.css';
-import { formatDate } from 'utils/formatDate';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { FiUser } from 'react-icons/fi';
 import moment from 'moment';
 import { toast } from 'react-toastify';
+import { formatDate } from '../../../utils/formatDate';
 import {
   updateUserProfileProperty,
   getUserProfile,
@@ -549,8 +549,8 @@ class PeopleReport extends Component {
 
               <PeopleDataTable />
 
-              <div className="container">
-                <table>
+              <div className="Infringementcontainer">
+                <div className="InfringementcontainerInner">
                   <UserProject userProjects={userProjects} />
                   <Infringements
                     infringements={infringements}
@@ -568,17 +568,19 @@ class PeopleReport extends Component {
                   <div className="visualizationDiv">
                     <TimeEntriesViz timeEntries={timeEntries} fromDate={fromDate} toDate={toDate} />
                   </div>
-                  <div className="visualizationDiv">
-                    <BadgeSummaryViz
-                      authId={auth.user.userid}
-                      userId={match.params.userId}
-                      badges={userProfile.badgeCollection}
-                    />
+                  <div className="visualizationDivRow">
+                    <div className="BadgeSummaryDiv">
+                      <BadgeSummaryViz
+                        authId={auth.user.userid}
+                        userId={match.params.userId}
+                        badges={userProfile.badgeCollection}
+                      />
+                    </div>
+                    <div className="BadgeSummaryPreviewDiv">
+                      <BadgeSummaryPreview badges={userProfile.badgeCollection} />
+                    </div>
                   </div>
-                  <div className="visualizationDiv">
-                    <BadgeSummaryPreview badges={userProfile.badgeCollection} />
-                  </div>
-                </table>
+                </div>
               </div>
             </ReportPage.ReportBlock>
           </div>

--- a/src/components/Reports/PeopleTableDetails.css
+++ b/src/components/Reports/PeopleTableDetails.css
@@ -13,6 +13,7 @@
 .people-table-row {
   display: flex;
   flex-wrap: wrap;
+  flex-direction: row;
   justify-content: space-between;
   align-items: center;
   min-height: 42px;
@@ -22,22 +23,13 @@
 }
 
 .people-table-row > div {
-  flex: 1;
-  max-width: calc((100% - 42px) / 9); 
-  padding: 4px;
+  padding: 1%;
   text-align: center;
+  margin:1%;
 }
 
 .people-table-row:hover {
   background-color: #fafafa;
-}
-
-.people-table-center-cell {
-  margin: auto;
-}
-
-.people-table-end-cell {
-  margin-left: auto;
 }
 
 .people-table-body-row:hover {

--- a/src/components/Reports/TableFilter/TableFilter.css
+++ b/src/components/Reports/TableFilter/TableFilter.css
@@ -5,6 +5,7 @@ select {
 
 .table-filter-wrapper {
   display: flex;
+  justify-content: center;
   flex-wrap: wrap;
   margin-bottom: 24px;
 }

--- a/src/components/Reports/TimeEntriesViz.jsx
+++ b/src/components/Reports/TimeEntriesViz.jsx
@@ -16,8 +16,11 @@ function TimeEntriesViz({ timeEntries, fromDate, toDate }) {
       d3.selectAll('#tlplot > *').remove();
     } else {
       d3.selectAll('#tlplot > *').remove();
-      const margin = { top: 10, right: 30, bottom: 30, left: 60 };
-      const width = 1000 - margin.left - margin.right;
+      const margin = { top: 30, right: 20, bottom: 30, left: 20 };
+      const containerWidth = '1000';
+      // Adjusted width based on the available space
+      const width = Math.min(containerWidth - margin.left - margin.right, 1000);
+
       const height = 400 - margin.top - margin.bottom;
 
       const tooltipEl = function generateTooltipElement(d) {
@@ -54,8 +57,9 @@ function TimeEntriesViz({ timeEntries, fromDate, toDate }) {
       const svg = d3
         .select('#tlplot')
         .append('svg')
-        .attr('width', width + margin.left + margin.right)
+        .attr('width', '100%')
         .attr('height', height + margin.top + margin.bottom)
+        .attr('viewBox', `0 0 ${containerWidth} ${height + margin.top + margin.bottom}`)
         .append('g')
         .attr('transform', `translate(${margin.left},${margin.top})`);
 
@@ -158,11 +162,7 @@ function TimeEntriesViz({ timeEntries, fromDate, toDate }) {
       const legend = d3
         .select('#tlplot')
         .append('div')
-        .attr('class', 'legendContainer')
-        .style('position', 'relative')
-        .style('top', `-450px`)
-        .style('left', `980px`);
-
+        .attr('class', 'legendContainer');
       legend.html(legendEl(totalHours));
 
       legend.select('.entLabelsOff').on('click', function handleEntLabelsOffClick() {

--- a/src/components/Reports/TimeEntriesViz.jsx
+++ b/src/components/Reports/TimeEntriesViz.jsx
@@ -258,7 +258,7 @@ function TimeEntriesViz({ timeEntries, fromDate, toDate }) {
   return (
     <div>
       <Button onClick={() => setShow(!show)} aria-expanded={show} style={boxStyle}>
-        Show Time Entries Graph
+        {show ? 'Hide Time Entries Graph' : 'Show Time Entries Graph'}
       </Button>
       <div id="tlplot" />
     </div>


### PR DESCRIPTION
# Description
The people report page was not mobile responsive and the infringement button was bugged/ would not close when opened.

## Related PRS (if any):
This frontend PR only


## Main changes explained:
- renamed and created another state variable for modal close/open
- css/jsx changes for a more mobile friendly design


## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin 
5. go to dashboard→ reports→ people→ choose a user
6. verify `show infringements graph` button modal closes properly
7. verify page is mobile responsive

## Screenshots or videos of changes:


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114305309/2544444b-1382-4705-8403-f90050e10fa5


## Note:
I still don't know the purpose of the modal

While making these changes I discovered other functionalitys hidden off to the side.
now in view and works when clicked
<img width="473" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114305309/794c7c1f-06a7-40eb-8c00-64550ebf9a6b">
(note the show dates/ other fuctionality of the graph can look cluttered and over lap other dates and should be addressed in another PR.) 
<img width="286" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114305309/924249bf-aa11-4c9f-b91a-f31c8f819f53">


Note when viewing in small view ports like iphone it seems really small on pc but you will be able to use fingers to zoom in while on mobile.

ScreenShot below
![moble infringement copy](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114305309/632d8cfe-6387-411a-82da-b26681592622)

