### PR TITLE
Jay - Ready for Review Button Permission

### DIFF
--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -158,6 +158,11 @@ export const permissionLabels = [
                 key: 'suggestTask',
                 description: 'Gives the user permission to suggest changes on a task. "Dashboard" -> "Tasks tab" -> "Click on any task" -> "Suggest button"',
               },
+              {
+                label: 'Interact with Task "Ready for Review"',
+                key: 'putReviewStatus',
+                description: 'Give the user permission to interact with any "Ready for Review" task button to either mark it as complete or reset it with "More work needed, reset this button" ',
+              }
             ],
           },
         ],

--- a/src/components/TeamMemberTasks/ReviewButton.jsx
+++ b/src/components/TeamMemberTasks/ReviewButton.jsx
@@ -12,7 +12,8 @@ import { ApiEndpoint } from 'utils/URL';
 const ReviewButton = ({
   user,
   task,
-  updateTask
+  updateTask,
+  userPermission
 }) => {
   const myUserId = useSelector(state => state.auth.user.userid);
   const myRole = useSelector(state => state.auth.user.role);
@@ -51,7 +52,7 @@ const ReviewButton = ({
         Submit for Review
       </Button>;
      } else if (reviewStatus == "Submitted")  {
-      if (myRole == "Owner" ||myRole == "Administrator" || myRole == "Mentor" || myRole == "Manager") {
+      if (myRole == "Owner" ||myRole == "Administrator" || myRole == "Mentor" || myRole == "Manager" || userPermission) {
         return (
           <UncontrolledDropdown>
             <DropdownToggle className="btn--dark-sea-green reviewBtn" caret style={boxStyle}>

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -26,6 +26,7 @@ const TeamMemberTask = React.memo(
     userRole,
     userId,
     updateTaskStatus,
+    userPermission
   }) => {
     const ref = useRef(null);
     const currentDate = moment.tz('America/Los_Angeles').startOf('day');
@@ -205,6 +206,7 @@ const TeamMemberTask = React.memo(
                           <div>
                             <ReviewButton
                               user={user}
+                              userPermission={userPermission}
                               userId={userId}
                               task={task}
                               updateTask={updateTaskStatus}

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -447,6 +447,7 @@ const TeamMemberTasks = React.memo(props => {
                   return (
                     <TeamMemberTask
                       user={user}
+                      userPermission={props?.auth?.user?.permissions?.frontPermissions?.includes('putReviewStatus')}
                       key={user.personId}
                       handleOpenTaskNotificationModal={handleOpenTaskNotificationModal}
                       handleMarkAsDoneModal={handleMarkAsDoneModal}


### PR DESCRIPTION
# Description
This PR enables the user with the Ready for Review button permission to be able to view and manipulate the button.

## Related PRS (if any):
N/A

…

## Main changes explained:
- Added a new permission label called "Interact with Interact with Task "Ready for Review".
- Added conditional logic so that the user with the permission can view and manipulate the button.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to Other Links -> Permissions Management -> Manage User Permissions -> Choose a user without Interact with Task "Ready for Review" permission -> click on Add  -> Scroll down then submit
6. verify that the user who was given the permission is now able to see Ready for Review button on users whose tasks are ready for review (not everyone will have the button).

## Screenshots or videos of changes:



https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/118868270/0b590957-a743-4bc1-91c0-9b77fd75f117




## Note:
**Unmute the video**

