### PR TITLE
Roberto-hotfix adds Ethiopia timezone to constants file

### DIFF
--- a/src/constants/timeZones.js
+++ b/src/constants/timeZones.js
@@ -12,6 +12,12 @@ export const timeZones = [
     utcDstOffset: '+00:00',
   },
   {
+    countryCode: 'ET',
+    name: 'Africa/Addis_Ababa',
+    utcOffset: '+03:00',
+    utcDstOffset: '+00:00',
+  },
+  {
     countryCode: 'DZ',
     name: 'Africa/Algiers',
     utcOffset: '+01:00',


### PR DESCRIPTION
# Description
When trying to get timezone of Ethiopia in the userprofile section the page would crash.

## Related PRS (if any):
Any backend

## Main changes explained:
- Adds Ethiopia's timezone information to the Timezones.js file
## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to user profile→ Location→ Timezone input
6. verify that when you put Ethiopia into the get timezone input the page doesn't crash and returns the correct timezone.

