### PR TITLE
Tzu Ning - Leo fix user id workaround bug for dashboard display

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -55,13 +55,18 @@ const Badge = props => {
       ? ` and a personal best of ${roundedHours} ${roundedHours === 1 ? 'hour' : 'hours'} in a week`
       : '';
 
-    return `Bravo! You have earned ${totalBadge} ${
-      totalBadge === 1 ? 'badge' : 'badges'
-    }${personalMaxText}! `;
+    return `Bravo! You have earned ${totalBadge} ${totalBadge === 1 ? 'badge' : 'badges'
+      }${personalMaxText}! `;
   };
 
   useEffect(() => {
-    const userId = props.userId;
+    if (props.userId) {
+      props.getUserProfile(props.userId);
+    }
+  }, [props.userId, props.getUserProfile]);
+
+  useEffect(() => {
+    // Assuming badgeCollection is part of the userProfile in Redux store
     let count = 0;
     if (props.userProfile.badgeCollection) {
       props.userProfile.badgeCollection.forEach(badge => {
@@ -73,7 +78,8 @@ const Badge = props => {
       });
       setTotalBadge(Math.round(count));
     }
-  }, [props.userProfile.badgeCollection, totalBadge]);
+  }, [props.userProfile.badgeCollection]);
+
 
   return (
     <>
@@ -187,4 +193,6 @@ const mapStateToProps = state => ({
   userProfile: state.userProfile,
 });
 
-export default connect(mapStateToProps)(Badge);
+export default connect(mapStateToProps, {
+  getUserProfile,
+})(Badge);

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -63,7 +63,7 @@ function LeaderBoard({
   useDeepEffect(() => {
     getLeaderboardData(userId);
     getOrgData();
-  }, [timeEntries]);
+  }, [userId, timeEntries]);
 
   useDeepEffect(() => {
     try {

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -33,7 +33,7 @@ import ActiveCell from 'components/UserManagement/ActiveCell';
 import { ProfileNavDot } from 'components/UserManagement/ProfileNavDot';
 import TeamMemberTasks from 'components/TeamMemberTasks';
 import { getTimeEntriesForWeek, getTimeEntriesForPeriod } from '../../actions/timeEntries';
-import { getUserProfile, updateUserProfile, getUserTask } from '../../actions/userProfile';
+import { getUserProfile, updateUserProfile, getUserTasks } from '../../actions/userProfile';
 import { getUserProjects } from '../../actions/userProjects';
 import { getAllRoles } from '../../actions/role';
 import TimeEntryForm from './TimeEntryForm';
@@ -147,7 +147,7 @@ const Timelog = props => {
         props.getTimeEntriesForPeriod(userId, state.fromDate, state.toDate),
         props.getUserProjects(userId),
         props.getAllRoles(),
-        props.getUserTask(userId),
+        props.getUserTasks(userId),
       ]);
     } catch (e) {
       setError(e);
@@ -805,7 +805,7 @@ export default connect(mapStateToProps, {
   getTimeEntriesForPeriod,
   getUserProjects,
   getUserProfile,
-  getUserTask,
+  getUserTasks,
   updateUserProfile,
   getAllRoles,
   hasPermission,

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -25,7 +25,7 @@ import {
 } from 'reactstrap';
 import './Timelog.css';
 import classnames from 'classnames';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import moment from 'moment';
 import { isEmpty, isEqual } from 'lodash';
 import ReactTooltip from 'react-tooltip';
@@ -33,10 +33,9 @@ import ActiveCell from 'components/UserManagement/ActiveCell';
 import { ProfileNavDot } from 'components/UserManagement/ProfileNavDot';
 import TeamMemberTasks from 'components/TeamMemberTasks';
 import { getTimeEntriesForWeek, getTimeEntriesForPeriod } from '../../actions/timeEntries';
-import { getUserProfile, updateUserProfile, getUserTasks } from '../../actions/userProfile';
-import { getUserProjects, getUserWBSs } from '../../actions/userProjects';
+import { getUserProfile, updateUserProfile, getUserTask } from '../../actions/userProfile';
+import { getUserProjects } from '../../actions/userProjects';
 import { getAllRoles } from '../../actions/role';
-import PopUpBar from '../PopUpBar';
 import TimeEntryForm from './TimeEntryForm';
 import TimeEntry from './TimeEntry';
 import EffortBar from './EffortBar';
@@ -48,7 +47,6 @@ import WeeklySummaries from './WeeklySummaries';
 import { boxStyle } from 'styles';
 import { formatDate } from 'utils/formatDate';
 import EditableInfoModal from 'components/UserProfile/EditableModal/EditableInfoModal';
-import { useParams } from 'react-router-dom';
 
 const doesUserHaveTaskWithWBS = (tasks = [], userId) => {
   if (!Array.isArray(tasks)) return false;
@@ -79,76 +77,30 @@ function useDeepEffect(effectFunc, deps) {
   }, deps);
 }
 
-// startOfWeek returns the date of the start of the week based on offset. Offset is the number of weeks before.
-// For example, if offset is 0, returns the start of this week. If offset is 1, returns the start of last week.
-const startOfWeek = offset => {
-  return moment()
-    .tz('America/Los_Angeles')
-    .startOf('week')
-    .subtract(offset, 'weeks')
-    .format('YYYY-MM-DD');
-};
-
-// endOfWeek returns the date of the end of the week based on offset. Offset is the number of weeks before.
-// For example, if offset is 0, returns the end of this week. If offset is 1, returns the end of last week.
-const endOfWeek = offset => {
-  return moment()
-    .tz('America/Los_Angeles')
-    .endOf('week')
-    .subtract(offset, 'weeks')
-    .format('YYYY-MM-DD');
-};
-
 const Timelog = props => {
-  // Main Function component
+  //Main Function component
   const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
   const canEditTimeEntry = props.hasPermission('editTimeEntry');
-  
-  // access the store states
-  const {
-    authUser,
-    displayUserProfile,
-    timeEntries,
-    roles,
-    displayUserProjects,
-    displayUserWBSs,
-    disPlayUserTask,
-  } = props;
- 
-  const initialState = {
-    timeEntryFormModal: false,
-    summary: false,
-    activeTab: 0,
-    projectsSelected: ['all'],
-    fromDate: startOfWeek(0),
-    toDate: endOfWeek(0),
-    infoModal: false,
-    information: '',
-    currentWeekEffort: 0,
-    isTimeEntriesLoading: true,
-  };
+  const userPermissions = props.auth.user?.permissions?.frontPermissions;
 
+  //access the store states
+  const auth = useSelector(state => state.auth);
+  const userProfile = useSelector(state => state.userProfile);
+  const timeEntries = useSelector(state => state.timeEntries);
+  const userProjects = useSelector(state => state.userProjects);
+  const role = useSelector(state => state.role);
+  const userTask = useSelector(state => state.userTask);
+  const userIdByState = useSelector(state => state.auth.user.userid);
   const [isTaskUpdated, setIsTaskUpdated] = useState(false);
-  const [initialTab, setInitialTab] = useState(null);
-  const [projectOrTaskOptions, setProjectOrTaskOptions] = useState(null);
-  const [currentWeekEntries, setCurrentWeekEntries] = useState(null);
-  const [lastWeekEntries, setLastWeekEntries] = useState(null);
-  const [beforeLastEntries, setBeforeLastEntries] = useState(null);
-  const [periodEntries, setPeriodEntries] = useState(null);
-  const [summaryBarData, setSummaryBarData] = useState(null);
-  const [data, setData] = useState({ isTangible: false });
-  const [timeLogState, setTimeLogState] = useState(initialState);
-  const { userId: paramsUserId } = useParams();
 
-  const displayUserId = paramsUserId || authUser.userid;
-  const isAuthUser = authUser.userid === displayUserId;
-  const fullName = `${displayUserProfile.firstName} ${displayUserProfile.lastName}`;
+  const LoggedInuserId = auth.user.userid;
+  const curruserId = props?.match?.params?.userId || props.asUser;
 
   const defaultTab = () => {
     //change default to time log tab(1) in the following cases:
-    const role = authUser.role;
+    const role = auth.user.role;
     let tab = 0;
-    const userHaveTask = doesUserHaveTaskWithWBS(disPlayUserTask, authUser.userid);
+    const UserHaveTask = doesUserHaveTaskWithWBS(userTask, userIdByState);
     /* To set the Task tab as defatult this.userTask is being watched.
     Accounts with no tasks assigned to it return an empty array.
     Accounts assigned with tasks with no wbs return and empty array.
@@ -157,7 +109,7 @@ const Timelog = props => {
     That breaks this feature. Necessary to check if this array should keep data or be reset when unassinging tasks.*/
 
     //if user role is volunteer or core team and they don't have tasks assigned, then default tab is timelog.
-    if (role === 'Volunteer' && !userHaveTask) {
+    if (role === 'Volunteer' && !UserHaveTask) {
       tab = 1;
     }
 
@@ -168,65 +120,49 @@ const Timelog = props => {
     return tab;
   };
 
-  /*---------------- methods -------------- */
-  const updateTimeEntryItems = () => {
-    const allTimeEntryItems = generateAllTimeEntryItems();
-    setCurrentWeekEntries(allTimeEntryItems[0]);
-    setLastWeekEntries(allTimeEntryItems[1]);
-    setBeforeLastEntries(allTimeEntryItems[2]);
-    setPeriodEntries(allTimeEntryItems[3]);
-  }
-
-  const generateAllTimeEntryItems = () => {
-    const currentWeekEntries = generateTimeEntries(timeEntries.weeks[0]);
-    const lastWeekEntries = generateTimeEntries(timeEntries.weeks[1]);
-    const beforeLastEntries = generateTimeEntries(timeEntries.weeks[2]);
-    const periodEntries = generateTimeEntries(timeEntries.period);
-    return [currentWeekEntries, lastWeekEntries, beforeLastEntries, periodEntries];
-  };
-
-  const generateTimeEntries = data => {
-    if (!timeLogState.projectsSelected.includes('all')) {
-      data = data.filter(entry => timeLogState.projectsSelected.includes(entry.projectId) || timeLogState.projectsSelected.includes(entry.taskId));
-    }
-    return data.map(entry => (
-      <TimeEntry
-        data={entry}
-        displayYear={false}
-        key={entry._id}
-        timeEntryUserProfile={displayUserProfile}
-      />
-    ));
+  const timeLogFunction = () => {
+    //build the time log component
+    buildOptions()
+      .then(response => {
+        setProjectOrTaskOptions(response);
+      })
+      .then(() => {
+        generateAllTimeEntries().then(response => {
+          setCurrentWeekEntries(response[0]);
+          setLastWeekEntries(response[1]);
+          setBeforeLastEntries(response[2]);
+          setPeriodEntries(response[3]);
+        });
+      });
   };
 
   const loadAsyncData = async userId => {
     //load the timelog data
-    setTimeLogState({ ...timeLogState, isTimeEntriesLoading: true });
+    setState({ ...state, isTimeEntriesLoading: true });
     try {
       await Promise.all([
-        props.getUserProfile(userId),
         props.getTimeEntriesForWeek(userId, 0),
         props.getTimeEntriesForWeek(userId, 1),
         props.getTimeEntriesForWeek(userId, 2),
-        props.getTimeEntriesForPeriod(userId, timeLogState.fromDate, timeLogState.toDate),
-        props.getAllRoles(),
+        props.getTimeEntriesForPeriod(userId, state.fromDate, state.toDate),
         props.getUserProjects(userId),
-        props.getUserWBSs(userId),
-        props.getUserTasks(userId),
+        props.getAllRoles(),
+        props.getUserTask(userId),
       ]);
-      setTimeLogState({ ...timeLogState, isTimeEntriesLoading: false });
     } catch (e) {
-      console.log(e);
+      setError(e);
     }
+
+    //setState({...state,activeTab:defaultTabValue});
   };
 
   const toggle = () => {
-    setTimeLogState({ ...timeLogState, timeEntryFormModal: !timeLogState.timeEntryFormModal });
+    setState({ ...state, modal: !state.modal });
   };
 
-  const showSummary = isAuthUser => {
-    if (isAuthUser) {
-      setTimeLogState({ ...timeLogState, summary: !timeLogState.summary });
+  const showSummary = isOwner => {
+    if (isOwner) {
+      setState({ ...state, summary: !state.summary });
       setTimeout(() => {
         const elem = document.getElementById('weeklySum');
         if (elem) {
@@ -235,10 +171,6 @@ const Timelog = props => {
       }, 150);
     }
   };
-
-  const toggleSummary = (summaryState) => {
-    setTimeLogState({ ...timeLogState, summary: summaryState })
-  }
 
   const openInfo = () => {
     const str = `This is the One Community time log! It is used to show a record of all the time you have volunteered with One Community, what you’ve done for each work session, etc.
@@ -249,27 +181,51 @@ const Timelog = props => {
     * Tangible Time: By default, the “Tangible” box is clicked. Tangible time is any time spent working on your Projects/Tasks and counts towards your committed time for the week and also the time allocated for your task.
     * Intangible Time: Clicking the Tangible box OFF will mean you are logging “Intangible Time.” This is for time not related to your tasks OR for time you need a manager to change to “Tangible” for you because you were working away from your computer or made a mistake and are trying to manually log time. Intangible time will not be counted towards your committed time for the week or your tasks. “Intangible” time changed by a manager to “Tangible” time WILL be counted towards your committed time for the week and whatever task it is logged towards. For Blue Square purposes, changing Intangible Time to Tangible Time for any reason other than work away from your computer will count and be recorded in the system the same as a time edit. `;
 
-    setTimeLogState({
-      ...timeLogState,
-      infoModal: !timeLogState.infoModal,
+    setState({
+      ...state,
+      in: !state.in,
       information: str.split('\n').map((item, i) => <p key={i}>{item}</p>),
     });
   };
 
   const changeTab = tab => {
-    setTimeLogState({
-      ...timeLogState,
+    setState({
+      ...state,
       activeTab: tab,
     });
   };
 
   const handleInputChange = e => {
-    setTimeLogState({ ...timeLogState, [e.target.name]: e.target.value });
+    setState({ ...state, [e.target.name]: e.target.value });
   };
 
   const handleSearch = e => {
     e.preventDefault();
-    props.getTimeEntriesForPeriod(displayUserId, timeLogState.fromDate, timeLogState.toDate);
+    const userId =
+      props.match && props.match.params.userId
+        ? props.match.params.userId
+        : props.asUser || auth.user.userid;
+    props.getTimeEntriesForPeriod(userId, state.fromDate, state.toDate);
+  };
+
+  // startOfWeek returns the date of the start of the week based on offset. Offset is the number of weeks before.
+  // For example, if offset is 0, returns the start of this week. If offset is 1, returns the start of last week.
+  const startOfWeek = offset => {
+    return moment()
+      .tz('America/Los_Angeles')
+      .startOf('week')
+      .subtract(offset, 'weeks')
+      .format('YYYY-MM-DD');
+  };
+
+  // endOfWeek returns the date of the end of the week based on offset. Offset is the number of weeks before.
+  // For example, if offset is 0, returns the end of this week. If offset is 1, returns the end of last week.
+  const endOfWeek = offset => {
+    return moment()
+      .tz('America/Los_Angeles')
+      .endOf('week')
+      .subtract(offset, 'weeks')
+      .format('YYYY-MM-DD');
   };
 
   const calculateTotalTime = (data, isTangible) => {
@@ -278,30 +234,54 @@ const Timelog = props => {
     return filteredData.reduce(reducer, 0);
   };
 
+  const generateTimeEntries = data => {
+    if (!state.projectsSelected.includes('all')) {
+      data = data.filter(entry => state.projectsSelected.includes(entry.projectId));
+    }
+    return data.map(entry => (
+      <TimeEntry
+        data={entry}
+        displayYear={false}
+        key={entry._id}
+        userProfile={userProfile}
+        LoggedInuserId={LoggedInuserId}
+        curruserId={curruserId}
+      />
+    ));
+  };
+
   const renderViewingTimeEntriesFrom = () => {
-    if (timeLogState.activeTab === 0 || timeLogState.activeTab === 5) {
+    if (state.activeTab === 0 || state.activeTab === 5) {
       return <></>;
-    } else if (timeLogState.activeTab === 4) {
+    } else if (state.activeTab === 4) {
       return (
         <p className="ml-1">
-          Viewing time Entries from <b>{formatDate(timeLogState.fromDate)}</b> to{' '}
-          <b>{formatDate(timeLogState.toDate)}</b>
+          Viewing time Entries from <b>{formatDate(state.fromDate)}</b> to{' '}
+          <b>{formatDate(state.toDate)}</b>
         </p>
       );
     } else {
       return (
         <p className="ml-1">
-          Viewing time Entries from <b>{formatDate(startOfWeek(timeLogState.activeTab - 1))}</b> to{' '}
-          <b>{formatDate(endOfWeek(timeLogState.activeTab - 1))}</b>
+          Viewing time Entries from <b>{formatDate(startOfWeek(state.activeTab - 1))}</b> to{' '}
+          <b>{formatDate(endOfWeek(state.activeTab - 1))}</b>
         </p>
       );
     }
   };
 
+  const generateAllTimeEntries = async () => {
+    const currentWeekEntries = generateTimeEntries(timeEntries.weeks[0]);
+    const lastWeekEntries = generateTimeEntries(timeEntries.weeks[1]);
+    const beforeLastEntries = generateTimeEntries(timeEntries.weeks[2]);
+    const periodEntries = generateTimeEntries(timeEntries.period);
+    return [currentWeekEntries, lastWeekEntries, beforeLastEntries, periodEntries];
+  };
+
   const makeBarData = userId => {
     //pass the data to summary bar
     const weekEffort = calculateTotalTime(timeEntries.weeks[0], true);
-    setTimeLogState({ ...timeLogState, currentWeekEffort: weekEffort });
+    setState({ ...state, currentWeekEffort: weekEffort });
     if (props.isDashboard) {
       props.passSummaryBarData({ personId: userId, tangibletime: weekEffort });
     } else {
@@ -309,128 +289,194 @@ const Timelog = props => {
     }
   };
 
-  const buildOptions = () => {
-    const projectsObject = {};
-    const options = [(
-      <option value="all" key="TimeLogDefaultProjectOrTask" >
-        Select Project/Task (all)
+  const buildOptions = async () => {
+    //build options for the project and task
+    let projects = [];
+    if (!isEmpty(userProjects.projects)) {
+      projects = userProjects.projects;
+    }
+    const options = projects.map(project => (
+      <option value={project.projectId} key={project.projectId}>
+        {' '}
+        {project.projectName}{' '}
       </option>
-    )];
-    displayUserProjects.forEach(project => {
-      const { projectId } = project;
-      project.WBSObject = {};
-      projectsObject[projectId] = project;
-    });
-    displayUserWBSs.forEach(WBS => {
-      const { projectId, _id: wbsId } = WBS;
-      WBS.taskObject = [];
-      projectsObject[projectId].WBSObject[wbsId] = WBS;
-    })
-    disPlayUserTask.forEach(task => {
-      const { projectId, wbsId, _id: taskId } = task;
-      projectsObject[projectId].WBSObject[wbsId].taskObject[taskId] = task;
-    });
-    for (const [projectId, project] of Object.entries(projectsObject)) {
-      const { projectName, WBSObject } = project;
-      options.push(
-        <option value={projectId} key={`TimeLog_${projectId}`} >
-          {projectName}
-        </option>
-      )
-      for (const [wbsId, WBS] of Object.entries(WBSObject)) {
-        const { wbsName, taskObject } = WBS;
-        options.push(
-          <option value={wbsId} key={`TimeLog_${wbsId}`} disabled>
-              {`\u2003WBS: ${wbsName}`}
-          </option>
-        )
-        for (const [taskId, task] of Object.entries(taskObject)) {
-          const { taskName } = task;
-          options.push(
-            <option value={taskId} key={`TimeLog_${taskId}`} >
-                {`\u2003\u2003 ↳ ${taskName}`}
-            </option>
-          )
-        }
-      }
-    };
-    return options
+    ));
+    options.unshift(
+      <option value="all" key="all">
+        All Projects and Tasks (Default)
+      </option>,
+    );
+
+    let tasks = [];
+    if (!isEmpty(userTask)) {
+      tasks = userTask;
+    }
+    const activeTasks = tasks.filter(task =>
+      task.resources.some(
+        resource => resource.userID === auth.user.userid && !resource.completedTask,
+      ),
+    );
+    const taskOptions = activeTasks.map(task => (
+      <option value={task._id} key={task._id}>
+        {task.taskName}
+      </option>
+    ));
+    const allOptions = options.concat(taskOptions);
+    return allOptions;
   };
 
-  const generateTimeLogItems = (userId) => {
-    //build the time log component
-    const options = buildOptions();
-    setProjectOrTaskOptions(options);
-    updateTimeEntryItems();
-    makeBarData(userId)
+  const [error, setError] = useState(null);
+  const [initialTab, setInitialTab] = useState(null);
+  const [projectOrTaskOptions, setProjectOrTaskOptions] = useState(null);
+  const [currentWeekEntries, setCurrentWeekEntries] = useState(null);
+  const [lastWeekEntries, setLastWeekEntries] = useState(null);
+  const [beforeLastEntries, setBeforeLastEntries] = useState(null);
+  const [periodEntries, setPeriodEntries] = useState(null);
+  const [userId, setUserId] = useState(null);
+  const [summaryBarData, setSummaryBarData] = useState(null);
+  const [data, setData] = useState({
+    disabled: !props.hasPermission('disabledDataTimelog') ? false : true,
+    isTangible: false,
+  });
+  const initialState = {
+    modal: false,
+    summary: false,
+    activeTab: 0,
+    projectsSelected: ['all'],
+    fromDate: startOfWeek(0),
+    toDate: endOfWeek(0),
+    in: false,
+    information: '',
+    currentWeekEffort: 0,
+    isTimeEntriesLoading: true,
   };
-  
+  const [state, setState] = useState(initialState);
+
   const handleUpdateTask = useCallback(() => {
     setIsTaskUpdated(!isTaskUpdated);
   }, []);
 
+  useEffect(() => {
+    // Does not run again (except once in development): load data
+    const userId = props?.match?.params?.userId || props.asUser; //Including fix for "undefined"
+    setUserId(userId);
+    if (userProfile._id !== userId) {
+      props.getUserProfile(userId);
+    }
+    loadAsyncData(userId).then(() => {
+      setState({ ...state, isTimeEntriesLoading: false });
+      const defaultTabValue = defaultTab();
+      setInitialTab(defaultTabValue);
+    });
+  }, []);
 
-  /*---------------- useEffects -------------- */
   useEffect(() => {
     changeTab(initialTab);
   }, [initialTab]);
 
-  useEffect(() => {
-    // Build the time log after new data is loaded
-    if (!timeLogState.isTimeEntriesLoading) {
-      generateTimeLogItems(displayUserId);
+  useDeepEffect(() => {
+    // Only re-render when time entries change
+    if (!state.isTimeEntriesLoading) {
+      makeBarData(userId);
+      timeLogFunction();
     }
-  }, [timeLogState.isTimeEntriesLoading, timeEntries]);
+  }, [timeEntries]);
 
   useEffect(() => {
-    loadAsyncData(displayUserId).then(() => {
-      const defaultTabValue = defaultTab();
-      setInitialTab(defaultTabValue);
-    });
-  }, [displayUserId, isTaskUpdated]);
+    // Build the time log after new data is loaded
+    if (!state.isTimeEntriesLoading) {
+      timeLogFunction();
+      makeBarData(userId);
+    }
+  }, [state.isTimeEntriesLoading]);
+
+  useEffect(() => {
+    // Only render (reload data) when asUser changes.
+    if (!userId && !state.isTimeEntriesLoading) {
+      // skip the first render.
+      setState(initialState);
+      const newId = props.match?.params?.userId || props.asUser;
+      if (userProfile._id !== newId) {
+        props.getUserProfile(newId);
+      }
+      loadAsyncData(newId).then(() => {
+        const defaultTabValue = defaultTab();
+        setInitialTab(defaultTabValue);
+        setState({ ...state, isTimeEntriesLoading: false });
+      });
+      setUserId(newId);
+    }
+  }, [props.asUser]);
 
   useEffect(() => {
     // Filter the time entries
-    updateTimeEntryItems();
-  }, [timeLogState.projectsSelected]);
-  
+    generateAllTimeEntries().then(response => {
+      setCurrentWeekEntries(response[0]);
+      setLastWeekEntries(response[1]);
+      setBeforeLastEntries(response[2]);
+      setPeriodEntries(response[3]);
+    });
+  }, [state.projectsSelected]);
+
+  useEffect(() => {
+    console.log('Auth User ID:', auth.user.userid);
+    console.log('Viewed User ID:', userId);
+    console.log('Is owner:', isOwner);
+    // Fetch user profile and update the state as necessary
+  }, [auth.user.userid, userId]);
+
+  useEffect(() => {
+    setUserId(props.match?.params?.userId || props.asUser || props.auth.user.userid);
+  }, [props.match?.params?.userId, props.asUser, props.auth.user.userid]);
+
+  const [isOwner, setIsOwner] = useState(false);
+
+  useEffect(() => {
+    const loggedInUserId = props.auth.user.userid;
+    const viewedUserId = props.match?.params?.userId || props.asUser || loggedInUserId;
+    setIsOwner(loggedInUserId === viewedUserId);
+  }, [props.auth.user.userid, props.match?.params?.userId, props.asUser]);
+
+
+  const fullName = `${userProfile.firstName} ${userProfile.lastName}`;
   return (
     <div>
       {!props.isDashboard ? (
         <Container fluid>
-          {!isAuthUser && <PopUpBar component="timelog" />}
           <SummaryBar
-            displayUserId={displayUserId}
-            toggleSubmitForm={() => showSummary(isAuthUser)}
-            role={authUser}
+            asUser={userId}
+            toggleSubmitForm={() => showSummary(isOwner)}
+            role={auth.user}
             summaryBarData={summaryBarData}
           />
           <br />
+
         </Container>
+
       ) : (
         <div className="text-center">
-        <EditableInfoModal
-          areaName="DashboardTimelog"
-          areaTitle="Timelog"
-          fontSize={30}
-          isPermissionPage={true}
-          role={authUser.role}
-        />
+          <EditableInfoModal
+            areaName="DashboardTimelog"
+            areaTitle="Timelog"
+            fontSize={30}
+            isPermissionPage={true}
+            role={auth.user.role}
+          />
         </div>
       )}
-      
-      {timeLogState.isTimeEntriesLoading ? (
+
+      {state.isTimeEntriesLoading ? (
         <LoadingSkeleton template="Timelog" />
       ) : (
         <Container fluid="md" className="right-padding-temp-fix">
-          {timeLogState.summary ? (
+          {state.summary ? (
             <div className="my-2">
               <div id="weeklySum">
-                <WeeklySummary displayUserId={displayUserId} setPopup={toggleSummary}/>
+                <WeeklySummary asUser={userId} />
               </div>
             </div>
           ) : null}
-          
+
           <Row>
             <Col md={12}>
               <Card>
@@ -438,109 +484,117 @@ const Timelog = props => {
                   <Row>
                     <Col md={11}>
                       <CardTitle tag="h4">
-                      <div className="d-flex align-items-center">
-                        <span className="mb-1 mr-2">Tasks and Timelogs</span>
-                        <EditableInfoModal
-                          areaName="TasksAndTimelogInfoPoint"
-                          areaTitle="Tasks and Timelogs"
-                          fontSize={22}
-                          isPermissionPage={true}
-                          role={authUser.role} // Pass the 'role' prop to EditableInfoModal
-                        />
-                      </div>
+                        <div className="d-flex align-items-center">
+                          <span className="mb-1 mr-2">Tasks and Timelogs</span>
+                          <EditableInfoModal
+                            areaName="TasksAndTimelogInfoPoint"
+                            areaTitle="Tasks and Timelogs"
+                            fontSize={22}
+                            isPermissionPage={true}
+                            role={auth.user.role} // Pass the 'role' prop to EditableInfoModal
+                          />
+                        </div>
                         <span style={{ padding: '0 5px' }}>
                           <ActiveCell
-                            isActive={displayUserProfile.isActive}
-                            user={displayUserProfile}
+                            isActive={userProfile.isActive}
+                            user={userProfile}
                             onClick={() => {
-                              props.updateUserProfile({
-                                ...displayUserProfile,
-                                isActive: !displayUserProfile.isActive,
+                              props.updateUserProfile(userId, {
+                                ...userProfile,
+                                isActive: !userProfile.isActive,
                                 endDate:
-                                  !displayUserProfile.isActive === false
+                                  !userProfile.isActive === false
                                     ? moment(new Date()).format('YYYY-MM-DD')
                                     : undefined,
                               });
                             }}
                           />
                         </span>
-                        <ProfileNavDot userId={displayUserId} />
+                        <ProfileNavDot
+                          userId={
+                            props.match?.params?.userId || props.asUser || props.auth.user.userid
+                          }
+                        />
                       </CardTitle>
                       <CardSubtitle tag="h6" className="text-muted">
                         Viewing time entries logged in the last 3 weeks
                       </CardSubtitle>
                     </Col>
                     <Col md={11}>
-                      {isAuthUser ? (
-                        <div className="float-right">
-                          <div>
-                            <Button color="success" onClick={toggle} style={boxStyle}>
-                              {'Add Intangible Time Entry '}
-                              <i
-                                className="fa fa-info-circle"
-                                data-tip
-                                data-for="timeEntryTip"
-                                data-delay-hide="1000"
-                                aria-hidden="true"
-                                title=""
-                              />
-                            </Button>
-                            <ReactTooltip id="timeEntryTip" place="bottom" effect="solid" delayShow={500}>
-                              Clicking this button only allows for “Intangible Time” to be added to
-                              your time log.{' '}
-                              <u>
-                                You can manually log Intangible Time but it doesn’t <br />
-                                count towards your weekly time commitment.
-                              </u>
-                              <br />
-                              <br />
-                              “Tangible Time” is the default for logging time using the timer at the
-                              top of the app. It represents all work done on assigned action items{' '}
-                              <br />
-                              and is what counts towards a person’s weekly volunteer time
-                              commitment. The only way for a volunteer to log Tangible Time is by
-                              using the clock
-                              <br />
-                              in/out timer. <br />
-                              <br />
-                              Intangible Time is almost always used only by the management team. It
-                              is used for weekly Monday night management team calls, monthly
-                              management
-                              <br />
-                              team reviews and Welcome Team Calls, and non-action-item related
-                              research, classes, and other learning, meetings, etc. that benefit or
-                              relate to <br />
-                              the project but aren’t related to a specific action item on the{' '}
-                              <a href="https://www.tinyurl.com/oc-os-wbs">
-                                One Community Work Breakdown Structure.
-                              </a>
-                              <br />
-                              <br />
-                              Intangible Time may also be logged by a volunteer when in the field or
-                              for other reasons when the timer wasn’t able to be used. In these
-                              cases, the <br />
-                              volunteer will use this button to log time as “intangible time” and
-                              then request that an Admin manually change the log from Intangible to
-                              Tangible.
-                              <br />
-                              <br />
-                            </ReactTooltip>
-                          </div>
-                        </div>
-                      ) : (
-                        canPutUserProfileImportantInfo && (
-                          <div className="float-right">
-                            <div>
-                              <Button color="warning" onClick={toggle} style={boxStyle}>
-                                Add Time Entry {!isAuthUser && `for ${fullName}`}
-                              </Button>
+                      <div key={userId}>
+                        <div>
+                          {isOwner ? (
+                            <div className="float-right">
+                              <div>
+                                <Button color="success" onClick={toggle} style={boxStyle}>
+                                  {'Add Intangible Time Entry '}
+                                  <i
+                                    className="fa fa-info-circle"
+                                    data-tip
+                                    data-for="timeEntryTip"
+                                    data-delay-hide="1000"
+                                    aria-hidden="true"
+                                    title=""
+                                  />
+                                </Button>
+                                <ReactTooltip id="timeEntryTip" place="bottom" effect="solid">
+                                  Clicking this button only allows for “Intangible Time” to be added to
+                                  your time log.{' '}
+                                  <u>
+                                    You can manually log Intangible Time but it doesn’t <br />
+                                    count towards your weekly time commitment.
+                                  </u>
+                                  <br />
+                                  <br />
+                                  “Tangible Time” is the default for logging time using the timer at the
+                                  top of the app. It represents all work done on assigned action items{' '}
+                                  <br />
+                                  and is what counts towards a person’s weekly volunteer time
+                                  commitment. The only way for a volunteer to log Tangible Time is by
+                                  using the clock
+                                  <br />
+                                  in/out timer. <br />
+                                  <br />
+                                  Intangible Time is almost always used only by the management team. It
+                                  is used for weekly Monday night management team calls, monthly
+                                  management
+                                  <br />
+                                  team reviews and Welcome Team Calls, and non-action-item related
+                                  research, classes, and other learning, meetings, etc. that benefit or
+                                  relate to <br />
+                                  the project but aren’t related to a specific action item on the{' '}
+                                  <a href="https://www.tinyurl.com/oc-os-wbs">
+                                    One Community Work Breakdown Structure.
+                                  </a>
+                                  <br />
+                                  <br />
+                                  Intangible Time may also be logged by a volunteer when in the field or
+                                  for other reasons when the timer wasn’t able to be used. In these
+                                  cases, the <br />
+                                  volunteer will use this button to log time as “intangible time” and
+                                  then request that an Admin manually change the log from Intangible to
+                                  Tangible.
+                                  <br />
+                                  <br />
+                                </ReactTooltip>
+                              </div>
                             </div>
-                          </div>
-                        )
-                      )}
-                      <Modal isOpen={timeLogState.infoModal} toggle={openInfo}>
+                          ) : (
+                            canPutUserProfileImportantInfo && (
+                              <div className="float-right">
+                                <div>
+                                  <Button color="warning" onClick={toggle} style={boxStyle}>
+                                    Add Time Entry {fullName}
+                                  </Button>
+                                </div>
+                              </div>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <Modal isOpen={state.in} toggle={openInfo}>
                         <ModalHeader>Info</ModalHeader>
-                        <ModalBody>{timeLogState.information}</ModalBody>
+                        <ModalBody>{state.information}</ModalBody>
                         <ModalFooter>
                           <Button onClick={openInfo} color="primary" style={boxStyle}>
                             Close
@@ -553,13 +607,16 @@ const Timelog = props => {
                         </ModalFooter>
                       </Modal>
                       <TimeEntryForm
+                        userId={userId}
+                        data={data}
                         edit={false}
                         toggle={toggle}
-                        isOpen={timeLogState.timeEntryFormModal}
-                        data={data}
-                        userProfile={displayUserProfile}
-                        roles={roles}
+                        isOpen={state.modal}
+                        userProfile={userProfile}
+                        roles={role.roles}
                         isTaskUpdated={isTaskUpdated}
+                        LoggedInuserId={LoggedInuserId}
+                        curruserId={curruserId}
                       />
                       <ReactTooltip id="registerTip" place="bottom" effect="solid">
                         Click this icon to learn about the timelog.
@@ -571,7 +628,7 @@ const Timelog = props => {
                   <Nav tabs className="mb-1">
                     <NavItem>
                       <NavLink
-                        className={classnames({ active: timeLogState.activeTab === 0 })}
+                        className={classnames({ active: state.activeTab === 0 })}
                         onClick={() => {
                           changeTab(0);
                         }}
@@ -582,7 +639,7 @@ const Timelog = props => {
                       </NavLink>
                     </NavItem>
                     <NavLink
-                      className={classnames({ active: timeLogState.activeTab === 1 })}
+                      className={classnames({ active: state.activeTab === 1 })}
                       onClick={() => {
                         changeTab(1);
                       }}
@@ -594,7 +651,7 @@ const Timelog = props => {
 
                     <NavItem>
                       <NavLink
-                        className={classnames({ active: timeLogState.activeTab === 2 })}
+                        className={classnames({ active: state.activeTab === 2 })}
                         onClick={() => {
                           changeTab(2);
                         }}
@@ -606,7 +663,7 @@ const Timelog = props => {
                     </NavItem>
                     <NavItem>
                       <NavLink
-                        className={classnames({ active: timeLogState.activeTab === 3 })}
+                        className={classnames({ active: state.activeTab === 3 })}
                         onClick={() => {
                           changeTab(3);
                         }}
@@ -618,7 +675,7 @@ const Timelog = props => {
                     </NavItem>
                     <NavItem>
                       <NavLink
-                        className={classnames({ active: timeLogState.activeTab === 4 })}
+                        className={classnames({ active: state.activeTab === 4 })}
                         onClick={() => {
                           changeTab(4);
                         }}
@@ -630,7 +687,7 @@ const Timelog = props => {
                     </NavItem>
                     <NavItem>
                       <NavLink
-                        className={classnames({ active: timeLogState.activeTab === 5 })}
+                        className={classnames({ active: state.activeTab === 5 })}
                         onClick={() => {
                           changeTab(5);
                         }}
@@ -642,9 +699,9 @@ const Timelog = props => {
                     </NavItem>
                   </Nav>
 
-                  <TabContent activeTab={timeLogState.activeTab}>
+                  <TabContent activeTab={state.activeTab}>
                     {renderViewingTimeEntriesFrom()}
-                    {timeLogState.activeTab === 4 && (
+                    {state.activeTab === 4 && (
                       <Form inline className="mb-2">
                         <FormGroup className="mr-2">
                           <Label for="fromDate" className="mr-2">
@@ -654,7 +711,7 @@ const Timelog = props => {
                             type="date"
                             name="fromDate"
                             id="fromDate"
-                            value={timeLogState.fromDate}
+                            value={state.fromDate}
                             onChange={handleInputChange}
                           />
                         </FormGroup>
@@ -666,7 +723,7 @@ const Timelog = props => {
                             type="date"
                             name="toDate"
                             id="toDate"
-                            value={timeLogState.toDate}
+                            value={state.toDate}
                             onChange={handleInputChange}
                           />
                         </FormGroup>
@@ -680,7 +737,7 @@ const Timelog = props => {
                         </Button>
                       </Form>
                     )}
-                    {timeLogState.activeTab === 0 || timeLogState.activeTab === 5 ? (
+                    {state.activeTab === 0 || state.activeTab === 5 ? (
                       <></>
                     ) : (
                       <Form className="mb-2">
@@ -692,11 +749,11 @@ const Timelog = props => {
                             type="select"
                             name="projectSelected"
                             id="projectSelected"
-                            value={timeLogState.projectsSelected}
+                            value={state.projectsSelected}
                             title="Ctrl + Click to select multiple projects and tasks to filter."
                             onChange={e => {
-                              setTimeLogState({
-                                ...timeLogState,
+                              setState({
+                                ...state,
                                 projectsSelected: Array.from(
                                   e.target.selectedOptions,
                                   option => option.value,
@@ -711,24 +768,24 @@ const Timelog = props => {
                       </Form>
                     )}
 
-                    {timeLogState.activeTab === 0 || timeLogState.activeTab === 5 ? (
+                    {state.activeTab === 0 || state.activeTab === 5 ? (
                       <></>
                     ) : (
                       <EffortBar
-                        activeTab={timeLogState.activeTab}
-                        projectsSelected={timeLogState.projectsSelected}
-                        roles={roles}
+                        activeTab={state.activeTab}
+                        projectsSelected={state.projectsSelected}
+                        roles={role.roles}
                       />
                     )}
                     <TabPane tabId={0}>
-                      <TeamMemberTasks handleUpdateTask={handleUpdateTask} />
+                      <TeamMemberTasks asUser={props.asUser} handleUpdateTask={handleUpdateTask} />
                     </TabPane>
                     <TabPane tabId={1}>{currentWeekEntries}</TabPane>
                     <TabPane tabId={2}>{lastWeekEntries}</TabPane>
                     <TabPane tabId={3}>{beforeLastEntries}</TabPane>
                     <TabPane tabId={4}>{periodEntries}</TabPane>
                     <TabPane tabId={5}>
-                      <WeeklySummaries userProfile={displayUserProfile} />
+                      <WeeklySummaries userProfile={userProfile} />
                     </TabPane>
                   </TabContent>
                 </CardBody>
@@ -741,24 +798,14 @@ const Timelog = props => {
   );
 };
 
-const mapStateToProps = state => ({
-  authUser: state.auth.user,
-  displayUserProfile: state.userProfile,
-  timeEntries: state.timeEntries,
-  displayUserProjects: state.userProjects.projects,
-  displayUserWBSs: state.userProjects.wbs,
-  disPlayUserTask: state.userTask,
-  roles: state.role.roles,
-});
-
+const mapStateToProps = state => state;
 
 export default connect(mapStateToProps, {
   getTimeEntriesForWeek,
   getTimeEntriesForPeriod,
-  getUserProfile,
   getUserProjects,
-  getUserWBSs,
-  getUserTasks,
+  getUserProfile,
+  getUserTask,
   updateUserProfile,
   getAllRoles,
   hasPermission,


### PR DESCRIPTION
# Description
![螢幕擷取畫面 2024-01-15 171036](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/341c9130-1538-4190-96a3-d4ee6ac84ba4)

## Related PRS (if any):
N/A
…

## Main changes explained:
- Fixed the Add Time Entry button on the Dashboard to display correct user id when clicked the dashboard button to navigate back to owners dashboard while viewing other users dashboard. Made adjustments in useEffect hooks and state management for accurate data loading.
- Corrected an issue where the wrong badges and leaderboard data were displayed for a user in dashboard. Modified useEffect dependencies for accurate badge updates based on user selection.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Leaderboard→ Select a user to view his/her dashboard…
6. click the dashboard button on the nav bar
7. check if the Add Time Entry button changes back to green with correct text
8. check if the badges and leaderboard are showing the correct user data

## Screenshots or videos of changes:


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/d6bb8f5e-cfb5-48d5-b9a8-fd1c6b18f609


