### PR TITLE
Ilya fix blue square hover box on phones

### DIFF
--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -72,7 +72,6 @@
 
   #wrapper .report { 
      left: 60px;
-     /* left: 25%; */
      top: -280px; 
      z-index: 1;
      overflow: visible;
@@ -82,10 +81,19 @@
    }
  }
 
+ @media (max-width: 768px) {
+  #wrapper .report { 
+    position: fixed;
+    left: 50%;
+    top: 60%;
+    transform: translate(-50%, -50%);
+  }
+ }
 
-@media screen and (max-width: 450px) and (max-height: 850px) {
+
+@media (max-height: 850px) {
   #wrapper .report {
     position: fixed;
-      top:10%;
+      top:35%;
   }
 }

--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -90,8 +90,14 @@
   }
  }
 
+ @media (max-height: 850px) {
+  #wrapper .report {
+    position: fixed;
+      top:5%;
+  }
+}
 
-@media (max-height: 850px) {
+@media (max-width: 768px) and (max-height: 850px) {
   #wrapper .report {
     position: fixed;
       top:35%;

--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -67,3 +67,17 @@
   background: linear-gradient(to bottom, #0061a7 5%, #007dc1 100%);
   background-color: #0061a7;
 }
+
+
+@media (max-width: 1420px) {
+  
+ #wrapper .report { 
+    left: 60px;
+    top: -280px; 
+    z-index: 1;
+    overflow: visible;
+  }
+
+}
+
+

--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -68,18 +68,24 @@
   background-color: #0061a7;
 }
 
-
 @media (max-width: 1420px) {
-  
- #wrapper .report { 
-    left: 60px;
-    top: -280px; 
-    z-index: 1;
-    overflow: visible;
-  }
-  .summary {
-    min-height: 300px;
+
+  #wrapper .report { 
+     left: 60px;
+     /* left: 25%; */
+     top: -280px; 
+     z-index: 1;
+     overflow: visible;
+   }
+   .summary {
+     min-height: 300px;
+   }
+ }
+
+
+@media screen and (max-width: 450px) and (max-height: 850px) {
+  #wrapper .report {
+    position: fixed;
+      top:10%;
   }
 }
-
-

--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -77,7 +77,9 @@
     z-index: 1;
     overflow: visible;
   }
-
+  .summary {
+    min-height: 300px;
+  }
 }
 
 

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import './BlueSquare.css';
 import hasPermission from 'utils/permissions';
 import { connect } from 'react-redux';

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import './BlueSquare.css';
 import hasPermission from 'utils/permissions';
 import { connect } from 'react-redux';


### PR DESCRIPTION
<img width="905" alt="blue-sq-hover-tooltip" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105448137/74f6917f-9139-4706-a2c2-3fb69d7be6f2">


# Description
The hover box (aka Tooltip) appears when the blue square is hovered over and displays the date the blue square was assigned and the reasoning behind it. On screens sized 1420px wide and larger it occupies the white space to the left of the blue square. On smaller screens it gets cut off.   

Fixes # 21 (UserProfile component)

## Related PRS (if any):
This frontend PR is related to the [#1751 ](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1751)frontend PR.
To test this PR checkout the current branch on the front end and the "development" branch on the backend
…

## Main changes explained:
- Added a media query in BlueSquares.css to match screens narrower than 1420px
- Added min-height to the "summary" for edge cases when the summary is really short and appears too far removed from the square itself.  
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ Other Links → User Management → search → select any user with at least one blue square assigned
6. Open the Developer Tools on your browser (cmd + option + i on Mac) and expand the side panel so that the main page is narrower than 1420px. Alternatively you can exit the full screen mode on your browser and drag one of the vertical borders to make the window narrower. 
7. Note that using the "device toolbar" feature of your dev tools will not help one test the PR because smart phones don't have cursors and do not need hover effects.
8. Verify that the hover box is covering the less crucial information above the blue squares. 
9. Reduce the browser window to about 350-450px to simulate a smart phone and test again

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/105448137/c49b4e0c-d979-42ac-9c53-890684e95aa2


## Note:
I'm open to any suggestions on how this UI could be improved. 