### PR TITLE
shiwani hotfix for weeks update

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -304,16 +304,20 @@ function LeaderBoard({
                     {currentDate.isSameOrAfter(
                       moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'),
                     ) &&
-                    currentDate.isBefore(moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ')) ? (
+                    currentDate.isBefore(moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ')) &&
+                    Math.floor(
+                      moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ')
+                        .subtract(1, 'day')
+                        .diff(moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'), 'weeks'),
+                    ) > 0 ? (
                       <sup>
                         {' '}
                         +
                         {Math.floor(
-                          moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ').diff(
-                            moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'),
-                            'weeks',
-                          ),
-                        ) + 1}
+                          moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ')
+                            .subtract(1, 'day')
+                            .diff(moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'), 'weeks'),
+                        )}
                       </sup>
                     ) : null}
                   </Link>


### PR DESCRIPTION
# Description
modified weeks calculation in leaderboard to only include additional weeks when the user is off and not include the current week.

## Main changes explained:
- subtracted 1 day from timeOffTill date to calculate weeks

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in as any user
5. go to view profile -> click on schedule blue square
6. enter the details and click save
7. go to dashboard and check if a superscript is not added to name when the user takes off for only one week and a superscript should be added to the name if the user is taking off for more than one week indicating the additional weeks the user is off without considering the current week.

## Screenshots or videos of changes:
For only one week off, there would be no superscript:

<img width="1304" alt="Screenshot 2024-01-22 at 12 18 22 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/78906820/9261dbcb-ffc2-4503-a60a-f5b49df7f38a">

<img width="1143" alt="Screenshot 2024-01-22 at 12 18 35 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/78906820/1b2a54e4-5193-458d-b14b-ff3aea00aa60">

for more than one week off, there would be a superscript indicating the additional weeks off not including the current week:

<img width="1337" alt="Screenshot 2024-01-22 at 12 19 16 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/78906820/1fc9e947-3c8c-4223-801b-e6c4073fc5cf">

<img width="1163" alt="Screenshot 2024-01-22 at 12 19 05 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/78906820/2765a763-0d84-43aa-ab6e-9f8205710d13">

