### PR TITLE
Sucheta Replace the blue square self-scheduler for anyone with 5 or more blue squares (anyone other than Owner/Admin)- updated

### DIFF
--- a/src/actions/reasonsActions.js
+++ b/src/actions/reasonsActions.js
@@ -30,3 +30,14 @@ export async function patchReason(userId, reasonData) {
       return {message: error.response.data.message, errorCode: error.response.data.message, status: error.response.status}
     }
   }
+
+// gets all scheduled reasons - Sucheta
+export async function getAllReasons(userId){
+  try{
+    const url = ENDPOINTS.GETALLUSERREASONS(userId);
+    const response = await axios.get(url);
+        return Promise.resolve(response)
+  }catch(error){
+    return {message: error.response.data.message, errorCode:error.response.data.message, status: error.repsonse.status}
+  }
+}

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -5,12 +5,12 @@ import ReactTooltip from 'react-tooltip';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
 import { Editor } from '@tinymce/tinymce-react';
 import dateFnsFormat from 'date-fns/format';
+import { boxStyle } from 'styles';
+import { useMemo } from 'react';
 import { addNewTask } from '../../../../../actions/task';
 import { DUE_DATE_MUST_GREATER_THAN_START_DATE } from '../../../../../languages/en/messages';
 import 'react-day-picker/lib/style.css';
 import TagsSearch from '../components/TagsSearch';
-import { boxStyle } from 'styles';
-import { useMemo } from 'react';
 
 function AddTaskModal(props) {
   /*
@@ -23,9 +23,9 @@ function AddTaskModal(props) {
   const defaultCategory = useMemo(() => {
     if (props.taskId) {
       return tasks.find(({ _id }) => _id === props.taskId).category;
-    } else {
+    } 
       return allProjects.projects.find(({ _id }) => _id === props.projectId).category;
-    }  
+      
   }, []);
   const [taskName, setTaskName] = useState('');
   const [priority, setPriority] = useState('Primary');
@@ -343,6 +343,7 @@ function AddTaskModal(props) {
                       addResources={addResources}
                       removeResource={removeResource}
                       resourceItems={resourceItems}
+                      disableInput={false}
                     />
                   </div>
                 </td>
@@ -357,7 +358,7 @@ function AddTaskModal(props) {
                         type="radio"
                         id="true"
                         name="Assigned"
-                        value={true}
+                        value
                         checked={assigned}
                         onChange={() => setAssigned(true)}
                       />
@@ -549,7 +550,7 @@ function AddTaskModal(props) {
                     {links.map((link, i) =>
                       link.length > 1 ? (
                         <div key={i}>
-                          <i className="fa fa-trash-o remove-link" aria-hidden="true" data-tip='delete' onClick={() => removeLink(i)} ></i>
+                          <i className="fa fa-trash-o remove-link" aria-hidden="true" data-tip='delete' onClick={() => removeLink(i)}  />
                           <a href={link} className="task-link" target="_blank" rel="noreferrer">
                             {link}
                           </a>

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -358,7 +358,7 @@ function AddTaskModal(props) {
                         type="radio"
                         id="true"
                         name="Assigned"
-                        value
+                        value={true}
                         checked={assigned}
                         onChange={() => setAssigned(true)}
                       />

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -437,17 +437,21 @@ function EditTaskModal(props) {
                     <label htmlFor="bestCase" className="text-nowrap mr-2 w-25 mr-4">
                       Best-case
                     </label>
-                    <input
-                      type="number"
-                      min="0"
-                      max="500"
-                      value={hoursBest}
-                      onChange={e => setHoursBest(e.target.value)}
-                      onBlur={() => calHoursEstimate()}
-                      id="bestCase"
-                      className="w-25"
-                      disabled={!editable}
-                    />
+                    {ReadOnlySectionWrapper(
+                      <input
+                        type="number"
+                        min="0"
+                        max="500"
+                        value={hoursBest}
+                        onChange={e => setHoursBest(e.target.value)}
+                        onBlur={() => calHoursEstimate()}
+                        id="bestCase"
+                        className="w-25"
+                      />,
+                      editable,
+                      hoursBest,
+                      {componentOnly:true}
+                    )}
                     <div className="warning">
                       {hoursWarning
                         ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
@@ -458,16 +462,20 @@ function EditTaskModal(props) {
                     <label htmlFor="worstCase" className="text-nowrap mr-2  w-25 mr-4">
                       Worst-case
                     </label>
-                    <input
-                      type="number"
-                      min={hoursBest}
-                      max="500"
-                      value={hoursWorst}
-                      onChange={e => setHoursWorst(e.target.value)}
-                      onBlur={() => calHoursEstimate('hoursWorst')}
-                      className="w-25"
-                      disabled={!editable}
-                    />
+                    {ReadOnlySectionWrapper(
+                      <input
+                        type="number"
+                        min={hoursBest}
+                        max="500"
+                        value={hoursWorst}
+                        onChange={e => setHoursWorst(e.target.value)}
+                        onBlur={() => calHoursEstimate('hoursWorst')}
+                        className="w-25"
+                      />,
+                      editable,
+                      hoursWorst,
+                      {componentOnly:true}
+                    )}
                     <div className="warning">
                       {hoursWarning
                         ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
@@ -478,16 +486,20 @@ function EditTaskModal(props) {
                     <label htmlFor="mostCase" className="text-nowrap mr-2 w-25 mr-4">
                       Most-case
                     </label>
-                    <input
-                      type="number"
-                      min="0"
-                      max="500"
-                      value={hoursMost}
-                      onChange={e => setHoursMost(e.target.value)}
-                      onBlur={() => calHoursEstimate('hoursMost')}
-                      className="w-25"
-                      disabled={!editable}
-                    />
+                    {ReadOnlySectionWrapper(
+                      <input
+                        type="number"
+                        min="0"
+                        max="500"
+                        value={hoursMost}
+                        onChange={e => setHoursMost(e.target.value)}
+                        onBlur={() => calHoursEstimate('hoursMost')}
+                        className="w-25"
+                      />,
+                      editable,
+                      hoursMost,
+                      {componentOnly:true}
+                    )}
                     <div className="warning">
                       {hoursWarning
                         ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
@@ -498,15 +510,19 @@ function EditTaskModal(props) {
                     <label htmlFor="Estimated" className="text-nowrap mr-2  w-25 mr-4">
                       Estimated
                     </label>
-                    <input
-                      type="number"
-                      min="0"
-                      max="500"
-                      value={hoursEstimate}
-                      onChange={e => setHoursEstimate(e.target.value)}
-                      className="w-25"
-                      disabled={!editable}
-                    />
+                    {ReadOnlySectionWrapper(
+                      <input
+                        type="number"
+                        min="0"
+                        max="500"
+                        value={hoursEstimate}
+                        onChange={e => setHoursEstimate(e.target.value)}
+                        className="w-25"
+                      />,
+                      editable,
+                      hoursEstimate,
+                      {componentOnly:true}
+                    )}
                   </div>
                 </td>
               </tr>

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -585,7 +585,8 @@ function EditTaskModal(props) {
 
               <tr>
                 <td scope="col" colSpan="2">
-                  Why this Task is Important
+                  Why this Task is Important:
+                  {ReadOnlySectionWrapper (
                   <Editor
                     disabled={!editable}
                     init={EditorInit}
@@ -593,12 +594,17 @@ function EditTaskModal(props) {
                     className="why-info form-control"
                     value={whyInfo}
                     onEditorChange={content => setWhyInfo(content)}
-                  />
+                  />,
+                  editable,
+                  whyInfo,
+                  {componentOnly: true}
+                  )}
                 </td>
               </tr>
               <tr>
                 <td scope="col" colSpan="2">
-                  Design Intent
+                  Design Intent:
+                  {ReadOnlySectionWrapper (
                   <Editor
                     disabled={!editable}
                     init={EditorInit}
@@ -606,12 +612,17 @@ function EditTaskModal(props) {
                     className="intent-info form-control"
                     value={intentInfo}
                     onEditorChange={content => setIntentInfo(content)}
-                  />
+                  />,
+                  editable,
+                  intentInfo,
+                  {componentOnly: true}
+                  )}
                 </td>
               </tr>
               <tr>
                 <td scope="col" colSpan="2">
-                  Endstate
+                  Endstate:
+                  {ReadOnlySectionWrapper (
                   <Editor
                     disabled={!editable}
                     init={EditorInit}
@@ -619,7 +630,11 @@ function EditTaskModal(props) {
                     className="endstate-info form-control"
                     value={endstateInfo}
                     onEditorChange={content => setEndstateInfo(content)}
-                  />
+                  />,
+                  editable,
+                  endstateInfo,
+                  {componentOnly: true}
+                  )}
                 </td>
               </tr>
               <tr>

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -585,7 +585,7 @@ function EditTaskModal(props) {
 
               <tr>
                 <td scope="col" colSpan="2">
-                  Why this Task is Important:
+                  <div>Why this Task is Important:</div>
                   {ReadOnlySectionWrapper (
                   <Editor
                     disabled={!editable}
@@ -603,7 +603,7 @@ function EditTaskModal(props) {
               </tr>
               <tr>
                 <td scope="col" colSpan="2">
-                  Design Intent:
+                  <div>Design Intent:</div>
                   {ReadOnlySectionWrapper (
                   <Editor
                     disabled={!editable}
@@ -621,7 +621,7 @@ function EditTaskModal(props) {
               </tr>
               <tr>
                 <td scope="col" colSpan="2">
-                  Endstate:
+                  <div>Endstate:</div>
                   {ReadOnlySectionWrapper (
                   <Editor
                     disabled={!editable}

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -18,7 +18,6 @@ import { toast } from 'react-toastify';
 import TagsSearch from '../components/TagsSearch';
 import ReadOnlySectionWrapper from './ReadOnlySectionWrapper';
 
-// const EditTaskModal = props => {
 function EditTaskModal(props) {
   /*
   * -------------------------------- variable declarations --------------------------------

--- a/src/components/Projects/WBS/WBSDetail/EditTask/ReadOnlySectionWrapper.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/ReadOnlySectionWrapper.jsx
@@ -1,0 +1,25 @@
+/** 
+ * Returns either editable or non-editable section in Task view with background color.
+ * @param {ReactNode} WrappedComponent - React component to render when editable.
+ * @param {Boolean} editable - Indicates permission to edit. Will render the default editable element (e.g., textarea) if true.
+ * @param {*} value - component should display for non-editable component
+ * @param {Object | undefined} option: Additional options for customization.
+ * @param {boolean} [option.componentOnly] - If true, only the component (value) will be rendered, ignoring other styling.
+ * 
+ * @returns {ReactNode}
+*/
+export default function ReadOnlySectionWrapper(WrappedComponent, editable, value, option) {
+  if (editable){
+    return WrappedComponent
+  } 
+  if(option){
+    if (option.componentOnly){
+      return value
+    }
+  }
+  return (
+    <td style={{backgroundColor: '#e9ecef'}}>
+      <span>{value}</span>
+    </td>
+  )
+}

--- a/src/components/Projects/WBS/WBSDetail/EditTask/ReadOnlySectionWrapper.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/ReadOnlySectionWrapper.jsx
@@ -9,17 +9,29 @@
  * @returns {ReactNode}
 */
 export default function ReadOnlySectionWrapper(WrappedComponent, editable, value, option) {
+  //Need to remove HTML tags from Editor field
+  function stripHtml(html) {
+    if (html === null || html === undefined) {
+      return ''
+    }
+    let doc = new DOMParser().parseFromString(html, 'text/html');
+    return doc.body.textContent || "";
+  }
+
   if (editable){
     return WrappedComponent
   } 
+
+  let displayValue = stripHtml(value)
+
   if(option){
     if (option.componentOnly){
-      return value
+      return displayValue
     }
   }
   return (
     <td style={{backgroundColor: '#e9ecef'}}>
-      <span>{value}</span>
+      <span>{displayValue}</span>
     </td>
   )
 }

--- a/src/components/Projects/WBS/WBSDetail/components/TagsSearch.jsx
+++ b/src/components/Projects/WBS/WBSDetail/components/TagsSearch.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import TagSent from './TagSent';
 import './TagsSearch.css';
+import ReadOnlySectionWrapper from '../EditTask/ReadOnlySectionWrapper';
 
 function TagsSearch({ placeholder, members, addResources, removeResource, resourceItems, disableInput }) {
   const [isHidden, setIsHidden] = useState(false);
@@ -63,13 +64,17 @@ function TagsSearch({ placeholder, members, addResources, removeResource, resour
     <div className="d-flex flex-column px-0">
       <div className="d-flex flex-column mb-1 px-0">
         <div className="align-items-start justify-content-start w-100 px-0 position-relative">
-          <input
-            type="text"
-            placeholder={placeholder}
-            className="border border-dark rounded form-control px-2"
-            onChange={handleFilter}
-            disabled={disableInput}
-          />
+          {ReadOnlySectionWrapper(
+            <input
+              type="text"
+              placeholder={placeholder}
+              className="border border-dark rounded form-control px-2"
+              onChange={handleFilter}
+            />,
+            !disableInput,
+            null,
+            {componentOnly:true}
+          )}
           {filteredData.length !== 0 ? (
             <ul
               className={`my-element ${

--- a/src/components/Projects/WBS/WBSDetail/components/TagsSearch.jsx
+++ b/src/components/Projects/WBS/WBSDetail/components/TagsSearch.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import TagSent from './TagSent';
 import './TagsSearch.css';
 
-function TagsSearch({ placeholder, members, addResources, removeResource, resourceItems }) {
+function TagsSearch({ placeholder, members, addResources, removeResource, resourceItems, disableInput }) {
   const [isHidden, setIsHidden] = useState(false);
   const [filteredData, setFilteredData] = useState([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -68,6 +68,7 @@ function TagsSearch({ placeholder, members, addResources, removeResource, resour
             placeholder={placeholder}
             className="border border-dark rounded form-control px-2"
             onChange={handleFilter}
+            disabled={disableInput}
           />
           {filteredData.length !== 0 ? (
             <ul
@@ -87,7 +88,7 @@ function TagsSearch({ placeholder, members, addResources, removeResource, resour
                     }
                     onClick={event => handleClick(event, member)}
                   >
-                    {member.firstName + ' ' + member.lastName}
+                    {`${member.firstName  } ${  member.lastName}`}
                   </li>
                 </a>
               ))}

--- a/src/components/TeamLocations/MarkerPopup.jsx
+++ b/src/components/TeamLocations/MarkerPopup.jsx
@@ -1,0 +1,73 @@
+import { useState, useEffect, useRef } from 'react';
+import { Popup ,CircleMarker } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import './TeamLocations.css';
+import { Button } from 'reactstrap';
+import { boxStyle } from 'styles';
+
+const MarkerPopup = ({ profile, userName, isAbleToEdit, editHandler, removeLocation, isOpen ,randomLocationOffset}) => {
+  const popupRef = useRef();
+
+  useEffect(() => {
+  
+    if ( popupRef.current !== undefined) {
+        if(isOpen){
+            popupRef.current.openPopup();
+        }else{
+            popupRef.current.closePopup();
+        }
+    }
+  }, [isOpen]);
+
+  return (
+    <CircleMarker
+      center={[
+        profile.location.coords.lat,
+        profile.location.coords.lng
+      ]}
+      key={profile._id}
+      color={profile.isActive ? 'green' : 'gray'}
+      // eventHandlers={{
+      //   mouseover: e => {
+      //     e.target.openPopup();
+      //   },
+
+      // }}
+      ref={popupRef}
+    
+    >
+      <Popup autoClose={false}>
+        <div>
+          {profile.title && profile.title}
+          {userName && <div>Name: {userName}</div>}
+          {profile.jobTitle && <div>{`Title: ${profile.jobTitle}`}</div>}
+          <div>{`Location: ${profile.location.city || profile.location.userProvided}`}</div>
+          {isAbleToEdit ? (
+            <div className="mt-3">
+              <Button
+                color="Primary"
+                className="btn btn-outline-success mr-1 btn-sm"
+                onClick={() => editHandler(profile)}
+                style={boxStyle}
+              >
+                Edit
+              </Button>
+              {profile.type === 'm_user' && profile._id ? (
+                <Button
+                  color="danger"
+                  className="btn btn-outline-error mr-1 btn-sm"
+                  onClick={() => removeLocation(profile._id)}
+                  style={boxStyle}
+                >
+                  Remove
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </Popup>
+    </CircleMarker>
+  );
+};
+
+export default MarkerPopup;

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -4,11 +4,12 @@ import ToggleSwitch from './UserProfileEdit/ToggleSwitch';
 import './UserProfile.scss';
 import './UserProfileEdit/UserProfileEdit.scss';
 import { Button } from 'react-bootstrap';
+import ScheduleExplanationModal from './ScheduleExplanationModal/ScheduleExplanationModal';
 import ScheduleReasonModal from './ScheduleReasonModal/ScheduleReasonModal';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useReducer } from 'react';
 import Spinner from 'react-bootstrap/Spinner';
-import { addReason, patchReason } from 'actions/reasonsActions';
+import { addReason, patchReason, getAllReasons } from 'actions/reasonsActions';
 import moment from 'moment-timezone';
 import { Modal } from 'react-bootstrap';
 import { boxStyle } from 'styles';
@@ -51,6 +52,14 @@ const BlueSquareLayout = props => {
   const { userProfile, handleUserProfile, handleBlueSquare, canEdit } = props;
   const { privacySettings } = userProfile;
   const [show, setShow] = useState(false);
+  // ===============================================================
+  const [showExplanation, setShowExplanation]= useState(false);
+  const [allreasons, setAllReasons]= useState("");
+  const [numberOfReasons, setNumberOfReasons] = useState("");
+  const [isInfringementMoreThanFive, setIsInfringementMoreThanFive]= useState(false);
+  const [infringementsNum, setInfringementsNum] = useState("");
+  const [addsReason, setAddsReason] = useState(false); // this flag will be set to true, each time a scheduled reason has been added - sucheta
+  // ===============================================================
   const [reason, setReason] = useState('');
   const [date, setDate] = useState(
     moment
@@ -94,7 +103,6 @@ const BlueSquareLayout = props => {
     } else { //add/create reason
       fetchDispatch({ type: 'FETCHING_STARTED' });
       const response = await addReason(userProfile._id, { date: date, message: reason });
-      console.log(response);
       if (response.status !== 200) {
         fetchDispatch({
           type: 'ERROR',
@@ -102,11 +110,66 @@ const BlueSquareLayout = props => {
         });
       } else {
         fetchDispatch({ type: 'SUCCESS' });
+        setAddsReason(true);
       }
     }
     setIsReasonUpdated(false);
+    setAddsReason(false);
   };
 
+// ===============================================================
+// This handler is used for Explanation Modal, that open when <a>Click to learn why </a> is clicked 
+const openExplanationModal = useCallback(() => { 
+  setShowExplanation(true);
+}, []);
+// This handler is used to close Info Modal, -
+const closeExplanationModal  = useCallback(() => {
+  setShowExplanation(false);
+}, []);
+
+ // checks for blueSquare scheduled reasons 
+ useEffect(()=>{
+  let isMounted = true;
+  const checkReasons = async ()=>{
+    fetchDispatch({type: 'FETCHING_STARTED'})
+    const response = await getAllReasons(userProfile._id);
+    if (response.status !== 200) {
+      fetchDispatch({
+        type: 'ERROR',
+        payload: { message: response.message, errorCode: response.errorCode },
+      });
+    } else {
+      fetchDispatch({ type: 'SUCCESS' });
+      if (isMounted){
+        setAllReasons(response.data.reasons)
+        setNumberOfReasons(response.data.reasons.length);
+      }
+
+      }
+  }
+  checkReasons()
+  return () => isMounted = false;
+
+}, [addsReason]);
+// checks infringement counts
+useEffect(()=>{
+  const checkInfringementCount = ()=>{
+    setInfringementsNum(userProfile.infringements.length)
+    if(userProfile.role === "Administrator" || userProfile.role === "Owner"){
+      setIsInfringementMoreThanFive(false);
+      return
+    }else{
+      if(infringementsNum >= 5){
+        setIsInfringementMoreThanFive(true)
+      }
+      else{
+        setIsInfringementMoreThanFive(false)
+      }
+    }
+  }
+  checkInfringementCount();
+}, [userProfile])
+// ===============================================================
   if (canEdit) {
     return (
       <div data-testid="blueSqaure-field">
@@ -122,9 +185,35 @@ const BlueSquareLayout = props => {
           ) : null}
         </div>
 
-        <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} />
+        {/* <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} /> */}
+        <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} isInfringementMoreThanFive={isInfringementMoreThanFive} userRole={userProfile.role} numberOfReasons={numberOfReasons} infringementsNum={infringementsNum}/>
+        {/* Replaces Schedule Blue Square button when there are more than 5 blue squares or scheduled reasons - by Sucheta */}
         <div className="mt-4 w-100">
-          <Button
+          {
+              ((isInfringementMoreThanFive || numberOfReasons >= 5 || (infringementsNum + numberOfReasons >= 5 )) && !(userProfile.role === "Administrator" || userProfile.role === "Owner") )?  <>
+              <Button
+              //  variant='warning'
+               onClick={openExplanationModal}
+               className="w-100 text-success-emphasis"
+                size="md"
+                style={boxStyle}
+                id='stopSchedulerButton'
+              >
+                {fetchState.isFetching ? (
+                  <Spinner size="sm" animation="border" />
+                ) : (
+                  <>
+                  <span>Can't Schedule Time Off</span>
+                  <br/>
+                  <span 
+                   className='mt-0'
+                   style={{fontSize: ".8em"}}>
+                    Click to learn why
+                  </span>
+                  </>
+                  )}
+              </Button> 
+              </> : <Button
             variant="primary"
             onClick={handleOpen}
             className="w-100"
@@ -139,8 +228,19 @@ const BlueSquareLayout = props => {
             ) : (
               'Schedule Blue Square Reason'
             )}
-          </Button>
+          </Button>}
         </div>
+        {(infringementsNum >= 5 || numberOfReasons >= 5 || (infringementsNum + numberOfReasons >= 5 )) && showExplanation && (
+          <Modal show={showExplanation} onHide={closeExplanationModal}>
+            <ScheduleExplanationModal
+              onHide={closeExplanationModal}
+              handleClose = {closeExplanationModal}
+              infringementsNum = {infringementsNum}
+              reasons = {allreasons}
+              infringements = {userProfile.infringements}
+            />
+          </Modal>
+        )}
         {show && (
           <Modal show={show} onHide={handleClose}>
             <ScheduleReasonModal
@@ -157,6 +257,8 @@ const BlueSquareLayout = props => {
               userId={userProfile._id}
               IsReasonUpdated={IsReasonUpdated}
               setIsReasonUpdated={setIsReasonUpdated}
+              infringementsNum = {infringementsNum}
+              numberOfReasons = {numberOfReasons}
             />
           </Modal>
         )}

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -52,7 +52,7 @@ const BlueSquare = (props) => {
           : null}
       </div>
       {/* Check for userRole, infringements and scheduled reasons to render + button - Sucheta*/}
-      {userRole === "Owner" || userRole === "Adminnistrator"? <div
+      {userRole === "Owner" || userRole === "Administrator" ? (<div
           onClick={() => {
             handleBlueSquare(true, 'addBlueSquare', '');
           }}
@@ -61,7 +61,7 @@ const BlueSquare = (props) => {
           data-testid="addBlueSquare"
         >
           +
-        </div> : isInfringementAuthorizer && !(infringementsNum >=5 || numberOfReasons >= 5 || (numberOfReasons + infringementsNum >= 5) ) &&(
+        </div>) : ( isInfringementAuthorizer && !(infringementsNum >=5 || numberOfReasons >= 5 || (numberOfReasons + infringementsNum >= 5) ) &&(
         <div
           onClick={() => {
             handleBlueSquare(true, 'addBlueSquare', '');
@@ -71,7 +71,7 @@ const BlueSquare = (props) => {
           data-testid="addBlueSquare"
         >
           +
-        </div>
+        </div>)
       )}
       <br />
     </div>

--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -8,7 +8,7 @@ import { formatDateFromDescriptionString } from 'utils/formatDateFromDescription
 const BlueSquare = (props) => {
   const isInfringementAuthorizer = props.hasPermission('infringementAuthorizer');
   const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
-  const { blueSquares, handleBlueSquare } = props;
+  const { blueSquares, handleBlueSquare, numberOfReasons, infringementsNum, userRole } = props;
 
   return (
     <div className="blueSquareContainer">
@@ -51,8 +51,17 @@ const BlueSquare = (props) => {
             ))
           : null}
       </div>
-
-      {isInfringementAuthorizer && (
+      {/* Check for userRole, infringements and scheduled reasons to render + button - Sucheta*/}
+      {userRole === "Owner" || userRole === "Adminnistrator"? <div
+          onClick={() => {
+            handleBlueSquare(true, 'addBlueSquare', '');
+          }}
+          className="blueSquareButton"
+          color="primary"
+          data-testid="addBlueSquare"
+        >
+          +
+        </div> : isInfringementAuthorizer && !(infringementsNum >=5 || numberOfReasons >= 5 || (numberOfReasons + infringementsNum >= 5) ) &&(
         <div
           onClick={() => {
             handleBlueSquare(true, 'addBlueSquare', '');

--- a/src/components/UserProfile/ScheduleExplanationModal/ScheduleExplanationModal.jsx
+++ b/src/components/UserProfile/ScheduleExplanationModal/ScheduleExplanationModal.jsx
@@ -1,0 +1,43 @@
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+import { boxStyle } from 'styles';
+
+function SchedulerExplanationModal({infringementsNum,handleClose, infringements, reasons}) {
+  return (
+    <div
+      className="modal show"
+      style={{ display: 'block', position: 'initial' }}
+    >
+      <Modal.Dialog>
+        <Modal.Header closeButton>
+          <Modal.Title>Please Refer To The Explanation </Modal.Title>
+        </Modal.Header>
+        <Modal.Body scrollable="true">
+         {/* <p> You have <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares already and <span style={{fontWeight:500, color:"green"}}>5</span> is the maximum allowed per year. Please contact your Administrator if you need to request time off</p> */}
+          <p>Including your time already requested off, you have used the equivalent of <span style={{color:"red",fontWeight:500}}>{infringementsNum}</span> blue squares and <span style={{color:"red",fontWeight:500}}>{reasons.length}</span> schedule time offs. <span style={{fontWeight:500, color:"green"}}>5</span> is the maximum allowed per year. Please remove a time-off request below or contact your Administrator if you need to request time off in addition to what is listed here:
+</p>      
+
+          {(infringements.length > 0) && <><h5>INFRINGEMENTS</h5><ol className='p-3 ml-2'>{infringements.map((el,index)=>{
+            return <li key={el._id} className='p-2'>{el.description}</li>
+          })}</ol></>}
+          {reasons.length > 0 && <>
+          <h5>SCHEDULED REASONS</h5>
+          <ul className='p-3 ml-2'>
+          {reasons.map((el,index)=>{
+            return <li key={el._id} className='p-2'>{new Date(el.date).toLocaleDateString()} - {el.reason}</li>})}
+          </ul>
+          </>}
+
+          <p><em>Note</em>: Blue squares expire after 1 calendar year from their issuance date.</p> 
+
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleClose} style={boxStyle}>Close</Button>
+        </Modal.Footer>
+      </Modal.Dialog>
+    </div>
+  );
+}
+
+export default SchedulerExplanationModal;

--- a/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
+++ b/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
@@ -27,6 +27,8 @@ const ScheduleReasonModal = ({
   userId,
   IsReasonUpdated,
   setIsReasonUpdated,
+  numberOfReasons,
+  infringementsNum
 }) => {
   useEffect(() => {
     const initialFetching = async () => {
@@ -49,6 +51,19 @@ const ScheduleReasonModal = ({
     };
     initialFetching();
   }, [date]);
+
+// ===============================================================
+  // This useEffect will make sure to close the modal that allows for users to schedule reasons - Sucheta
+  useEffect(()=>{
+    if(user.role === "Owner" || user.role === "Administrator"){
+      return
+    }else{
+      if (infringementsNum >= 5 || numberOfReasons >= 5 || (infringementsNum + numberOfReasons >= 5)){
+        handleClose();
+      }
+    }
+  },[numberOfReasons,infringementsNum])
+// ===============================================================
 
   const [confirmationModal, setConfirmationModal] = useState(false);
   const [offTimeWeeks, setOffTimeWeeks] = useState([]);
@@ -134,7 +149,7 @@ const ScheduleReasonModal = ({
                   .endOf('week')
                   .toISOString()
                   .split('T')[0];
-                console.log(dateSelectedTz);
+                // console.log(dateSelectedTz);
                 setDate(dateSelectedTz);
               }}
               filterDate={filterSunday}

--- a/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
+++ b/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
@@ -96,9 +96,9 @@ const ScheduleReasonModal = ({
     return date.format('MM/DD/YYYY');
   };
 
-  const filterSunday = date => {
-    const losAngelesDate = moment(date).tz('America/Los_Angeles');
-    return losAngelesDate.day() === 6; // Sunday
+  const filterSunday = (date) => {
+    const day = date.getDay();
+    return day === 0;
   };
 
   const handleSaveReason = e => {
@@ -149,7 +149,6 @@ const ScheduleReasonModal = ({
                   .endOf('week')
                   .toISOString()
                   .split('T')[0];
-                // console.log(dateSelectedTz);
                 setDate(dateSelectedTz);
               }}
               filterDate={filterSunday}

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -472,10 +472,10 @@ function UserProfile(props) {
       setModalTitle('Blue Square');
     } else if (operation === 'update') {
       const currentBlueSquares = [...userProfile?.infringements] || [];
-      if (dateStamp != null && currentBlueSquares !== []) {
+      if (dateStamp != null && currentBlueSquares.length !== 0) {
         currentBlueSquares.find(blueSquare => blueSquare._id === id).date = dateStamp;
       }
-      if (summary != null && currentBlueSquares !== []) {
+      if (summary != null && currentBlueSquares.length !== 0) {
         currentBlueSquares.find(blueSquare => blueSquare._id === id).description = summary;
       }
 
@@ -483,7 +483,7 @@ function UserProfile(props) {
       setOriginalUserProfile({ ...userProfile, infringements: currentBlueSquares });
     } else if (operation === 'delete') {
       let newInfringements = [...userProfile?.infringements] || [];
-      if (newInfringements !== []) {
+      if (newInfringements.length !== 0) {
         newInfringements = newInfringements.filter(infringement => infringement._id !== id);
         setUserProfile({ ...userProfile, infringements: newInfringements });
         setOriginalUserProfile({ ...userProfile, infringements: newInfringements });

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -201,7 +201,23 @@
 .profile-functions-tablet {
   display: none;
 }
+// Changed hover, focus and active class for the Stop Scheduler Button
+#stopSchedulerButton{
+  background-color:#ffc107;
+  border:#ffc107;
 
+  &:hover{
+    // background-color: #fff3cd;
+    // border: #fff3cd ;
+    background-color: #ffcd39;
+    border:  #ffcd39;
+  }
+  &:active, &:focus{
+    background-color: #997404;
+    border: #997404;
+  }
+
+}
 @media only screen and (max-width: 1024px) {
   .profileContainer {
     justify-content: space-around;


### PR DESCRIPTION
# Description
(PRIORITY HIGH) Jae: (WIP Sucheta ) Replace the blue square self-scheduler for anyone with 5 or more blue squares (anyone other than Owner/Admin)

-  Related PRs#[1542](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1542)+ #[614](https://github.com/OneCommunityGlobal/HGNRest/pull/614), [1081](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1081)

- Profile Page>Below Blue Squares

- Replace with something that is a different color (not red) that says `Can’t Schedule Time Off
(click to learn why)`
- This is needed because people with 5 or more blue squares should no longer be on the team and, if they still are, will 
need an Admin to enter their time off for them
- It should account for any future scheduled time off too (see above)
- When they click the new button, it should say this if 5 or more blue squares:
*You have X blue squares already and 5 are the maximum allowed per year. Please contact your Administrator if you need to request time off.

Note: Blue squares drop off 1 calendar year after they are issued. *

-When they click the new button, it should say this if they have scheduled time off equaling 5 or more blue squares:

*Including your time already requested off, you have used the equivalent of X blue squares. 5 is the maximum allowed per year. Please remove a time-off request below or contact your Administrator if you need to request time off in addition to what is listed here:

 - Time off request 1
 - Time off request 2
Etc.

Note: Blue squares drop off 1 calendar year after they are issued. *

## Related PRS (if any):
This frontend PR is an updated version of the #[1715](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1715) frontend PR.
Backend PR none.
…

## Main changes explained:

- Created component: `components > UserProfile > ScheduleExplanationModal`
- Add new handler functions to `BlueSquareLayout.jsx`, which opens a modal based on user roles and the number of BlueSquares assigned or scheduled.
- The button Schedule Blue Square Reason changes to `Can't Schedule Time Off`,  if `((infringementsNum >= 5|| numberOfReasons >= 5 || (infringementsNum + numberOfReasons >= 5 )) && !(userProfile.role === "Administrator" || userProfile.role === "Owner"))`
- The ability to add and schedule blueSquares dependent on roles and number of infringements and/ or scheduled reasons.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log as `(volunteer/ manager/ assistant manager)` user
5. Go to `dashboard→ View Profile → BlueSquare section →`…
6. If the numbers of BlueSquare are less than 5 the Users with permission to `Schedule blueSquares`, should see the `Schedule Blue Square` button. Otherwise, the button changes to `Can't Schedule Time Off Click to learn why`.
7. Click on the button to see a modal with an explanation of why scheduling has been disabled.


## Screenshots or videos of changes:
**Before change:**
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/ee124e32-79db-4fb4-88bc-60cd8eab30d6



**Please refer to this demo:**
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/83eb0f7d-20ad-4ec6-8732-42fa08816ea9


## Note:
This PR is an updated version of [PR1715](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1715) 
