### PR TITLE
Nathan permissions unit test utility

### DIFF
--- a/src/__tests__/mockStates.js
+++ b/src/__tests__/mockStates.js
@@ -1,3 +1,5 @@
+import { getAllPermissionKeys } from 'components/PermissionsManagement/PermissionsConst';
+
 export const allTeamsMock = {
   fetching: false,
   fetched: true,
@@ -1226,3 +1228,14 @@ export const rolesMock = {
 describe('Stop Error', () => {
   it('should not error out due to no tests (mockStates.js)', () => {});
 });
+
+// takes a list of permissions and returns a list of all other permissions
+const allPermissionsExcept = (permissions) => {
+  return getAllPermissionKeys().filter(perm => !permissions.includes(perm))
+}
+
+// takes a list of relevant permissions and returns two auth objects, one with the permissions and the other with all permissions not listed
+export const createAuthMocks = (permissions) => {
+
+  return onlyPermissions, allOtherPermissions;
+};

--- a/src/__tests__/mockStates.js
+++ b/src/__tests__/mockStates.js
@@ -1254,7 +1254,7 @@ export const createAuthMocks = (permissions) => {
     firstName: 'Dev',
     profilePic:''
   };
-  const onlyPermissions = {...authTemplate, permissions: {frontPermissions: [...permissions]}};
+  const onlyPermissions = {...authTemplate, permissions: {frontPermissions: permissions}};
   const allOtherPermissions = {...authTemplate, permissions: {frontPermissions: [...allPermissionsExcept(permissions)]}};
   return [onlyPermissions, allOtherPermissions];
 };

--- a/src/__tests__/mockStates.js
+++ b/src/__tests__/mockStates.js
@@ -1221,6 +1221,10 @@ export const rolesMock = {
           'editTeamCode',
         ],
       },
+      {
+        roleName: 'Fake Test Role',
+        permissions: [],
+      },
     ]
   }
 }

--- a/src/__tests__/mockStates.js
+++ b/src/__tests__/mockStates.js
@@ -1255,6 +1255,6 @@ export const createAuthMocks = (permissions) => {
     profilePic:''
   };
   const onlyPermissions = {...authTemplate, permissions: {frontPermissions: permissions}};
-  const allOtherPermissions = {...authTemplate, permissions: {frontPermissions: [...allPermissionsExcept(permissions)]}};
+  const allOtherPermissions = {...authTemplate, permissions: {frontPermissions: allPermissionsExcept(permissions)}};
   return [onlyPermissions, allOtherPermissions];
 };

--- a/src/__tests__/mockStates.js
+++ b/src/__tests__/mockStates.js
@@ -1,4 +1,4 @@
-import { getAllPermissionKeys } from 'components/PermissionsManagement/PermissionsConst';
+import { getAllPermissionKeys } from '../components/PermissionsManagement/PermissionsConst.js';
 
 export const allTeamsMock = {
   fetching: false,
@@ -1236,6 +1236,21 @@ const allPermissionsExcept = (permissions) => {
 
 // takes a list of relevant permissions and returns two auth objects, one with the permissions and the other with all permissions not listed
 export const createAuthMocks = (permissions) => {
-
-  return onlyPermissions, allOtherPermissions;
+  var authTemplate = {
+    // isAdmin: true,
+    user: {
+      userid: '5edf141c78f1380017b829a6',
+      role: 'Fake Test Role',
+      expiryTimestamp: '2020-08-22T22:51:06.544Z',
+      iat: 1597272666,
+    },
+    permissions: {
+      frontPermissions: []
+    },
+    firstName: 'Dev',
+    profilePic:''
+  };
+  const onlyPermissions = {...authTemplate, permissions: {frontPermissions: [...permissions]}};
+  const allOtherPermissions = {...authTemplate, permissions: {frontPermissions: [...allPermissionsExcept(permissions)]}};
+  return [onlyPermissions, allOtherPermissions];
 };

--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -1,3 +1,20 @@
+export const getAllPermissionKeys = () => {
+  return getAllSubpermissionKeys(permissionLabels);
+};
+
+const getAllSubpermissionKeys = (permissions) => {
+  const keys = [];
+  for(permission in permissions){
+    if(permission.subperms){
+      keys.concat(getAllSubpermisisonKeys(permission.subperms))
+    }
+    else {
+      keys.append(permission)
+    }
+  }
+  return keys;
+};
+
 export const permissionLabels = [
   {
     label: 'Reports',

--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -1,10 +1,13 @@
+// returns an array of all the keys for permissions
 export const getAllPermissionKeys = () => {
   return getAllSubpermissionKeys(permissionLabels);
 };
 
+// recursive function that returns the permission keys given an array of permission objects (from permissionLabels below)
 const getAllSubpermissionKeys = (permissions) => {
   const keys = [];
   permissions.forEach((permission) => {
+    // recursive call for nested permissions
     if(permission.subperms){
       keys.push(...getAllSubpermissionKeys(permission.subperms))
     }

--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -4,14 +4,14 @@ export const getAllPermissionKeys = () => {
 
 const getAllSubpermissionKeys = (permissions) => {
   const keys = [];
-  for(permission in permissions){
+  permissions.forEach((permission) => {
     if(permission.subperms){
-      keys.concat(getAllSubpermisisonKeys(permission.subperms))
+      keys.push(...getAllSubpermissionKeys(permission.subperms))
     }
     else {
-      keys.append(permission)
+      keys.push(permission.key)
     }
-  }
+  });
   return keys;
 };
 


### PR DESCRIPTION
# Description
Creates a utility for creating auth objects with and without specified permissions to enable easier testing of specific permissions.

## Main changes explained:
- Created `getAllPermissionKeys()` in `PermissionsConst.js` for creating a flat list of every permission.
- Created `createAuthMocks()` in `mockStates.js` for creating test auth objects with only relevant permissions and with every permission except those.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. create a unit test using `createAuthMocks()` to test a permission or add it to an existing unit test
