### PR TITLE
Shivansh - Added a filter to select lastest max badge

### DIFF
--- a/src/components/Badge/Badge.jsx
+++ b/src/components/Badge/Badge.jsx
@@ -17,6 +17,7 @@ import './Badge.css';
 import NewBadges from './NewBadges';
 import OldBadges from './OldBadges';
 import BadgeSummaryViz from 'components/Reports/BadgeSummaryViz';
+import { WEEK_DIFF } from '../../constants/badge';
 import { getUserProfile } from '../../actions/userProfile';
 import { boxStyle } from 'styles';
 
@@ -49,9 +50,13 @@ const Badge = props => {
 
   const generateBadgeText = (totalBadge, badgeCollection, personalBestMaxHrs) => {
     if (!totalBadge) return 'You have no badges. ';
+    
+    const newBadges = badgeCollection.filter(
+      value => Date.now() - new Date(value.lastModified).getTime() <= WEEK_DIFF,
+    );
 
     const roundedHours = Math.floor(personalBestMaxHrs);
-    const personalMaxText = badgeCollection.find(badgeObj => badgeObj.badge.type === 'Personal Max')
+    const personalMaxText = newBadges.find(badgeObj => badgeObj.badge.type === 'Personal Max')
       ? ` and a personal best of ${roundedHours} ${roundedHours === 1 ? 'hour' : 'hours'} in a week`
       : '';
 


### PR DESCRIPTION
# Description
![Screenshot 2024-01-27 at 1 38 13 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/6f3a5f79-8b2d-4232-9258-00b02879659b)


## Main changes explained:
- Added additional filter in the generate text method
- This filters the lastest/new badges , and then search of the new max badge within these filtered badges.

## How to test:
**Check the video for easy understanding.**
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. Go to MongoDB dev database using MongoDB Compass application, and update "**personalBestMaxHrs**" for this admin user with some value.
5. go to dashboard→ View Profile→ Assign New Max Badge to this admin user.
7. verify on the dashboard that new max badge is visible and the congratulatory text is also updated. This text "a personal best of <> hours in a week" should be visible.
8. Now, update the last modified date of this badge to a past date of more than 10 days, from MongoDB compass.
9. Wait for 15-20 mins, since this is a manual update in the database, it takes some time to load latest values.
10. Now check in the Badges section in the Dashboard, you will see that the badge we just assigned moved to **Badges Earned Before Last Week** section, and the text is also updated to normal value. This text "a personal best of <> hours in a week" should not be visible.

## Screenshots or videos:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/12b7f823-cd34-4fcc-8bf0-b23433f1250e

**Before:**
<img width="600" alt="Before" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/dce828a7-629d-49d1-ada9-620334cea308">

**After:**
<img width="600" alt="After"  src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/83b87926-600c-4acd-a032-2a8aba80c6ff">

## Note:
**To conclude, this text "a personal best of <> hours in a week" should only be visible when this badge is assigned within the past week.**
