### PR TITLE
Akanksha took this over and couldn't reproduce issue - Fix tangible hours display issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+# * text eol=lf

--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -56,8 +56,9 @@ const TimeEntry = ({ data, displayYear, userProfile, LoggedInuserId, curruserId 
       ...data,
       isTangible: !data.isTangible,
       timeSpent: `${data.hours}:${data.minutes}:00`,
+      curruserId: curruserId,
     };
-    dispatch(editTimeEntry(data._id, newData));
+    dispatch(editTimeEntry(data._id, newData, data.dateOfWork));
 
     //Update intangible hours property in userprofile
     const formattedHours = parseFloat(data.hours) + parseFloat(data.minutes) / 60;

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -95,7 +95,6 @@ const Timelog = props => {
 
   const LoggedInuserId = auth.user.userid;
   const curruserId = props?.match?.params?.userId || props.asUser;
-
   const defaultTab = () => {
     //change default to time log tab(1) in the following cases:
     const role = auth.user.role;


### PR DESCRIPTION
# Description
Converting Time Entry to Tangible does not add hours to respective task. After user uncheck tangible hours in their task and click it again, the hours don't get added back to the task.
Fixes # High


## Related PRS (if any):
N/A

## Main changes explained:
- add missed attribute between components

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. test as the video does, and test if the tangible hours displayed correctly after uncheck the tangible hours and click again.  Here is the video link: https://www.loom.com/share/99f00038e5fc4766817a3e26b581cf36


## Screenshots or videos of changes:

TO BE DONE
