### PR TITLE
Leo Add more specific link validation for GDoc links

### DIFF
--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -58,17 +58,6 @@ const EditLinkModal = props => {
   const [isMediaFolderLinkChanged, setIsMediaFolderLinkChanged] = useState(false);
   const [isValidLink, setIsValidLink] = useState(true);
 
-  const isValidGoogleDocsUrl = (url) => {
-    const pattern = /^https:\/\/docs\.google\.com\/document\/d\/[a-zA-Z0-9-_]+/;
-    return pattern.test(url);
-  };
-
-  const isValidMediaUrl = (url) => {
-    const pattern = /^(?:https?:\/\/)?[\w.-]+\.[a-zA-Z]{2,}(?:\/\S*)?$/;
-    return pattern.test(url);
-  };
-
-
   const handleNameChanges = (e, links, index, setLinks) => {
     const updateLinks = [...links];
     updateLinks[index] = { ...updateLinks[index], Name: e.target.value };
@@ -163,7 +152,7 @@ const EditLinkModal = props => {
     if (isGoogleDocsValid && isMediaFolderValid) {
       const linksToUpdate = [googleLink, mediaFolderLink, ...adminLinks];
       await updateLink(personalLinks, linksToUpdate, mediaFolderLink.Link);
-      handleSubmit(); 
+      handleSubmit();
       setIsValidLink(true);
       setIsChanged(false);
       closeModal();
@@ -376,7 +365,7 @@ const EditLinkModal = props => {
               </Card>
               {!isValidLink && (
                 <p className='invalid-help-context' data-testid='invalid-url-warning' >
-                  Please ensure each link has a unique and not empty, and enter valid URLs.
+                  Please enter valid URLs for each link.
                 </p>
               )}
             </CardBody>

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -43,8 +43,8 @@ const EditLinkModal = props => {
   const [adminLinks, setAdminLinks] = useState(
     userProfile.adminLinks
       ? userProfile.adminLinks
-          .filter(link => link.Name !== 'Google Doc')
-          .filter(link => link.Name !== 'Media Folder')
+        .filter(link => link.Name !== 'Google Doc')
+        .filter(link => link.Name !== 'Media Folder')
       : [],
   );
   const [personalLinks, setPersonalLinks] = useState(
@@ -57,6 +57,18 @@ const EditLinkModal = props => {
   const [isWarningPopupOpen, setIsWarningPopupOpen] = useState(false);
   const [isMediaFolderLinkChanged, setIsMediaFolderLinkChanged] = useState(false);
   const [isValidLink, setIsValidLink] = useState(true);
+
+  const isValidGoogleDocsUrl = (url) => {
+    const pattern = /^https:\/\/docs\.google\.com\/document\/d\/[a-zA-Z0-9-_]+/;
+    return pattern.test(url);
+  };
+
+  const isValidMediaUrl = (url) => {
+    // This is a placeholder. You should define what constitutes a valid media URL for your application.
+    const pattern = /^(?:https?:\/\/)?[\w.-]+\.[a-zA-Z]{2,}(?:\/\S*)?$/;
+    return pattern.test(url);
+  };
+
 
   const handleNameChanges = (e, links, index, setLinks) => {
     const updateLinks = [...links];
@@ -72,18 +84,18 @@ const EditLinkModal = props => {
   };
 
   const handleMediaFolderLinkChanges = (e) => {
-    if (!mediaFolderLink.Link){
+    if (!mediaFolderLink.Link) {
       // Prevent warning popup appear if empty media folder link
       setIsMediaFolderLinkChanged(true);
       setMediaFolderLink({ ...mediaFolderLink, Link: e.target.value.trim() });
       setIsChanged(true);
-    } 
+    }
     else {
       setMediaFolderLink({ ...mediaFolderLink, Link: e.target.value.trim() });
       setIsChanged(true);
-      if (!isMediaFolderLinkChanged && !isWarningPopupOpen){ // Fisrt time media folder link is changed
-          setIsMediaFolderLinkChanged(true);
-          setIsWarningPopupOpen(true);
+      if (!isMediaFolderLinkChanged && !isWarningPopupOpen) { // Fisrt time media folder link is changed
+        setIsMediaFolderLinkChanged(true);
+        setIsWarningPopupOpen(true);
       }
     }
   }
@@ -114,7 +126,7 @@ const EditLinkModal = props => {
   const isDifferentMediaUrl = () => {
     //* This is to compare the mediaUrl with Media Folder link when editing in the input area.
     //* Because mediaUrl is a differnt object, but the link should be the same as Media Folder's link.
-    if (userProfile.mediaUrl !== mediaFolderLink.Link  && userProfile.mediaUrl !== '') {
+    if (userProfile.mediaUrl !== mediaFolderLink.Link && userProfile.mediaUrl !== '') {
       setMediaFolderDiffWarning(true);
     } else {
       setMediaFolderDiffWarning(false);
@@ -145,36 +157,24 @@ const EditLinkModal = props => {
   };
 
   const handleUpdate = async () => {
-    const isGoogleDocsValid = isValidUrl(googleLink.Link);
-    const isDropboxValid = isValidUrl(mediaFolderLink.Link);
-    const updatable =
-      (isGoogleDocsValid && isDropboxValid) ||
-      (googleLink.Link === '' && mediaFolderLink.Link === '') ||
-      (isGoogleDocsValid && mediaFolderLink.Link === '') ||
-      (isDropboxValid && googleLink.Link === '');
-    if (updatable) {
-      // * here the 'adminLinks' should be the total of 'googleLink' and 'adminLink'
-      // Media Folder link should update the mediaUrl in userProfile
-      if (mediaFolderLink.Link) {
-        await updateLink(
-          personalLinks,
-          [googleLink, mediaFolderLink, ...adminLinks],
-          mediaFolderLink.Link,
-        );
-        // Update ref to reflect updated original Media Folder Link
-          originalMediaFolderLink.current = mediaFolderLink.Link;
-      } else {
-        await updateLink(personalLinks, [googleLink, mediaFolderLink, ...adminLinks]);
-      }
-      handleSubmit();
+    // Validate the Google Doc and Media Folder links
+    const isGoogleDocsValid = googleLink.Link === '' || isValidGoogleDocsUrl(googleLink.Link);
+    const isMediaFolderValid = mediaFolderLink.Link === '' || isValidMediaUrl(mediaFolderLink.Link);
+
+    if (isGoogleDocsValid && isMediaFolderValid) {
+      // If both URLs are valid, proceed with the update logic
+      const linksToUpdate = [googleLink, mediaFolderLink, ...adminLinks];
+      await updateLink(personalLinks, linksToUpdate, mediaFolderLink.Link);
+      handleSubmit(); // If you have additional logic to handle after submitting the form
       setIsValidLink(true);
       setIsChanged(false);
       closeModal();
-      setIsMediaFolderLinkChanged(false);
     } else {
+      // If any URL is invalid, set an error state
       setIsValidLink(false);
     }
   };
+
 
   useEffect(() => {
     isDifferentMediaUrl();
@@ -220,7 +220,7 @@ const EditLinkModal = props => {
                         id="media-folder-link"
                         placeholder="Enter Dropbox link"
                         value={mediaFolderLink.Link}
-                        onChange={e => {handleMediaFolderLinkChanges(e)}}
+                        onChange={e => { handleMediaFolderLinkChanges(e) }}
                       />
                     </div>
                     {adminLinks?.map((link, index) => {
@@ -396,37 +396,37 @@ const EditLinkModal = props => {
           >
             Update
           </Button>
-          <Button 
-            color="primary" 
-            onClick={()=>{
-              setIsMediaFolderLinkChanged(false); 
-              setMediaFolderLink({ ...mediaFolderLink, Link:originalMediaFolderLink.current });
+          <Button
+            color="primary"
+            onClick={() => {
+              setIsMediaFolderLinkChanged(false);
+              setMediaFolderLink({ ...mediaFolderLink, Link: originalMediaFolderLink.current });
               closeModal();
-              }
-            } 
+            }
+            }
             style={boxStyle}>
-              Cancel
+            Cancel
           </Button>
         </ModalFooter>
 
-        <Modal data-testid='popup-warning' isOpen={isWarningPopupOpen} toggle={()=> setIsWarningPopupOpen(!isWarningPopupOpen)}  >
+        <Modal data-testid='popup-warning' isOpen={isWarningPopupOpen} toggle={() => setIsWarningPopupOpen(!isWarningPopupOpen)}  >
           <ModalHeader>Warning!</ModalHeader>
           <ModalBody>
             Whoa Tiger, don’t do this! This link was added by an Admin when you were set up in the system. It is used by the Admin Team and your Manager(s) for reviewing your work. You should only change it if you are ABSOLUTELY SURE the one you are changing it to is more correct than the one here already.
           </ModalBody>
           <ModalFooter>
-            <Button color='primary'  onClick={() =>{setIsWarningPopupOpen(!isWarningPopupOpen)}}>Confirm</Button>
+            <Button color='primary' onClick={() => { setIsWarningPopupOpen(!isWarningPopupOpen) }}>Confirm</Button>
             {/* Cancel button put original Media Folder link into the input */}
             <Button onClick={() => {
-                setIsWarningPopupOpen(!isWarningPopupOpen); 
-                setIsMediaFolderLinkChanged(false); 
-                setMediaFolderLink({ ...mediaFolderLink, Link:originalMediaFolderLink.current });
-              }}
+              setIsWarningPopupOpen(!isWarningPopupOpen);
+              setIsMediaFolderLinkChanged(false);
+              setMediaFolderLink({ ...mediaFolderLink, Link: originalMediaFolderLink.current });
+            }}
             >
               Cancel
             </Button>
           </ModalFooter>
-        </Modal> 
+        </Modal>
 
       </Modal>
     </React.Fragment>

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -64,7 +64,6 @@ const EditLinkModal = props => {
   };
 
   const isValidMediaUrl = (url) => {
-    // This is a placeholder. You should define what constitutes a valid media URL for your application.
     const pattern = /^(?:https?:\/\/)?[\w.-]+\.[a-zA-Z]{2,}(?:\/\S*)?$/;
     return pattern.test(url);
   };

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -92,7 +92,7 @@ const EditLinkModal = props => {
     else {
       setMediaFolderLink({ ...mediaFolderLink, Link: e.target.value.trim() });
       setIsChanged(true);
-      if (!isMediaFolderLinkChanged && !isWarningPopupOpen) { // Fisrt time media folder link is changed
+      if (!isMediaFolderLinkChanged && !isWarningPopupOpen) { // First time media folder link is changed
         setIsMediaFolderLinkChanged(true);
         setIsWarningPopupOpen(true);
       }
@@ -161,15 +161,13 @@ const EditLinkModal = props => {
     const isMediaFolderValid = mediaFolderLink.Link === '' || isValidMediaUrl(mediaFolderLink.Link);
 
     if (isGoogleDocsValid && isMediaFolderValid) {
-      // If both URLs are valid, proceed with the update logic
       const linksToUpdate = [googleLink, mediaFolderLink, ...adminLinks];
       await updateLink(personalLinks, linksToUpdate, mediaFolderLink.Link);
-      handleSubmit(); // If you have additional logic to handle after submitting the form
+      handleSubmit(); 
       setIsValidLink(true);
       setIsChanged(false);
       closeModal();
     } else {
-      // If any URL is invalid, set an error state
       setIsValidLink(false);
     }
   };

--- a/src/utils/checkValidURL.js
+++ b/src/utils/checkValidURL.js
@@ -1,11 +1,11 @@
 export const isValidGoogleDocsUrl = url => {
   url = url.trim();
-  const googleDocsPattern = /^https:\/\/docs\.google\.com\/document\/d\/[a-zA-Z0-9_-]+\/edit(?:\?.*)?$/;
+  const googleDocsPattern = /^(https?:\/\/)?(www\.)?docs\.google\.com\/document\/d\/[a-zA-Z0-9-_]+/;
   return googleDocsPattern.test(url);
 };
 
 export const isValidMediaUrl = url => {
   url = url.trim();
-  var urlPattern = /^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)?$/;
+  var urlPattern = /^(?:https?:\/\/)?[\w.-]+\.[a-zA-Z]{2,}(?:\/\S*)?$/;
   return urlPattern.test(url);
 };


### PR DESCRIPTION
# Description
![1706923423396](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/f11948df-8503-4a7b-8c0c-49c43cdb440d)


## Main changes explained:
- Updated EditLinkModal component to include validation for Google Doc URLs using isValidGoogleDocsUrl.
- Modified validation logic to accept any valid URL for the Media Folder input field.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to nav bar→ Welcome, XXX→View Profile→Edit(Under the Profile pic)
6. enter various URLs in the Google Doc link to test if only google doc links are allowed
7. verify that any valid URL can be entered in the Media Folder link

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/79f7152b-8259-49e6-9aad-92bc81ba3aaa

