### PR TITLE
Kaikanes Reports page console errors fix

### DIFF
--- a/src/components/Reports/BadgeSummaryPreview.jsx
+++ b/src/components/Reports/BadgeSummaryPreview.jsx
@@ -54,7 +54,7 @@ function BadgeSummaryPreview({ badges }) {
                 {sortedBadges?.length === 0 && <div>No badges to show</div>}
                 {sortedBadges &&
                   sortedBadges.map((value, index) => (
-                    <div className="badge_image_md">
+                    <div key={value._id} className="badge_image_md">
                       <img
                         src={value.badge.imageUrl}
                         id={`popover_${index.toString()}`}
@@ -87,7 +87,7 @@ function BadgeSummaryPreview({ badges }) {
               <div style={{ display: 'flex', flexWrap: 'wrap' }}>
                 {sortedBadges &&
                   sortedBadges.map((value, index) => (
-                    <div className="badge_image_sm">
+                    <div key={value._id} className="badge_image_sm">
                       <img
                         src={value.badge.imageUrl}
                         id={`popover1_${index.toString()}`}

--- a/src/components/Reports/TableFilter/TableFilter.jsx
+++ b/src/components/Reports/TableFilter/TableFilter.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, forwardRef } from 'react';
 import DatePicker from 'react-datepicker';
 import { FiCalendar } from 'react-icons/fi';
 import 'react-datepicker/dist/react-datepicker.css';
@@ -7,7 +7,7 @@ import { Checkbox } from 'components/common/Checkbox';
 import TextSearchBox from '../../UserManagement/TextSearchBox';
 import DropDownSearchBox from '../../UserManagement/DropDownSearchBox';
 
-function InputWithCalendarIcon({ value, onClick }) {
+const InputWithCalendarIcon = forwardRef(({ value, onClick }, ref) => {
   return (
     <>
       <input
@@ -15,11 +15,13 @@ function InputWithCalendarIcon({ value, onClick }) {
         className="table-filter-datePicker table-filter-item table-filter-input"
         value={value}
         onClick={onClick}
+        ref={ref}
+        readOnly
       />
       <FiCalendar className="date-picker-icon" onClick={onClick} />
     </>
   );
-}
+});
 
 function TableFilter({
   onTaskNameSearch,


### PR DESCRIPTION
When viewing a user on the `peoplereport` page multiple warnings are displayed in the console. 
adding keys to the BadgeSummaryPreiview page `key={value._id}`
and
 importing and using `forwardRef` for the InputWithCalendarIcon function and adding a `readOnly` property to the input feild.
 Removes these console errors.



## Related PRS (if any):
This frontend only PR 

## Main changes explained:
- add key values to `BadgeSummaryPreiview` 
- imported and used `forwardRef` in function component
- adding `readOnly` to input feild

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as Admin or Owner (anyone who can use/see reports page)
5. go to dashboard→ reports→ people→ select user and open console
6. verify the console does not display the warnings

## Screenshots or videos of changes:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114305309/89b0ef1e-3600-4763-9812-235300e135b4)


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114305309/b7332bff-c60e-4eef-a417-8811dc3b8ae4

