### PR TITLE
Nahiyan-Improve profile page teams tab UX

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/AddTeamPopup.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/AddTeamPopup.jsx
@@ -80,7 +80,7 @@ const AddTeamPopup = React.memo(props => {
   }, [newTeamName, newTeamIsActive, dispatch]);
 
   return (
-    <Modal isOpen={props.open} toggle={closePopup}>
+    <Modal isOpen={props.open} toggle={closePopup} autoFocus={false}>
       <ModalHeader toggle={closePopup}>Add Team</ModalHeader>
       <ModalBody style={{ textAlign: 'center' }}>
         <label style={{textAlign: 'left'}}>Add to Team</label>

--- a/src/components/UserProfile/TeamsAndProjects/AddTeamsAutoComplete.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/AddTeamsAutoComplete.jsx
@@ -21,6 +21,7 @@ const AddTeamsAutoComplete = React.memo(props => {
       <Input
         type="text"
         value={props.searchText}
+        autoFocus={true}
         onChange={e => {
           props.setSearchText(e.target.value);
           props.setNewTeamName(e.target.value);

--- a/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
@@ -23,6 +23,7 @@ const TeamsTab = props => {
     codeValid,
     setCodeValid,
     saved,
+    savedTeams,
   } = props;
   const [addTeamPopupOpen, setaddTeamPopupOpen] = useState(false);
   const [renderedOn, setRenderedOn] = useState(0);
@@ -47,11 +48,13 @@ const TeamsTab = props => {
   const onSelectDeleteTeam = teamId => {
     setRemovedTeams([...removedTeams, teamId]);
     onDeleteTeam(teamId);
+    if(savedTeams)savedTeams(false);
   };
 
   const onSelectAssignTeam = team => {
     if(userProfile._id){
-      addTeamMember(team._id, userProfile._id, userProfile.firstName, userProfile.lastName)
+      addTeamMember(team._id, userProfile._id, userProfile.firstName, userProfile.lastName);
+      if (savedTeams)savedTeams(true);
     }
     onAssignTeam(team);
     setRenderedOn(Date.now());

--- a/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
@@ -23,7 +23,7 @@ const TeamsTab = props => {
     codeValid,
     setCodeValid,
     saved,
-    savedTeams,
+    isTeamSaved,
   } = props;
   const [addTeamPopupOpen, setaddTeamPopupOpen] = useState(false);
   const [renderedOn, setRenderedOn] = useState(0);
@@ -48,13 +48,13 @@ const TeamsTab = props => {
   const onSelectDeleteTeam = teamId => {
     setRemovedTeams([...removedTeams, teamId]);
     onDeleteTeam(teamId);
-    if(savedTeams)savedTeams(false);
+    if(isTeamSaved) isTeamSaved(false);
   };
 
   const onSelectAssignTeam = team => {
     if(userProfile._id){
       addTeamMember(team._id, userProfile._id, userProfile.firstName, userProfile.lastName);
-      if (savedTeams)savedTeams(true);
+      if(isTeamSaved) isTeamSaved(true);
     }
     onAssignTeam(team);
     setRenderedOn(Date.now());

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -98,6 +98,7 @@ function UserProfile(props) {
   const [summaryName, setSummaryName] = useState('');
   const [showSummary, setShowSummary] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [savedTeams, setSavedTeams] = useState(false);
   const [summaryIntro, setSummaryIntro] = useState('');
 
   const userProfileRef = useRef();
@@ -982,6 +983,7 @@ function UserProfile(props) {
                   codeValid={codeValid}
                   setCodeValid={setCodeValid}
                   saved={saved}
+                  savedTeams={(isSaved) => setSavedTeams(isSaved)}
                 />
               </TabPane>
               <TabPane tabId="4">
@@ -1383,7 +1385,8 @@ function UserProfile(props) {
                       !formValid.email ||
                       !codeValid ||
                       (userStartDate > userEndDate && userEndDate !== '') ||
-                      (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
+                      (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual) ||
+                      savedTeams
                     }
                     userProfile={userProfile}
                     setSaved={() => setSaved(true)}

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -98,7 +98,7 @@ function UserProfile(props) {
   const [summaryName, setSummaryName] = useState('');
   const [showSummary, setShowSummary] = useState(false);
   const [saved, setSaved] = useState(false);
-  const [savedTeams, setSavedTeams] = useState(false);
+  const [isTeamSaved, setIsTeamSaved] = useState(false);
   const [summaryIntro, setSummaryIntro] = useState('');
 
   const userProfileRef = useRef();
@@ -724,7 +724,7 @@ function UserProfile(props) {
             </div>
           </Col>
           <Col md="8">
-            {!isProfileEqual || !isTasksEqual || !isTeamsEqual || !isProjectsEqual ? (
+            {!isProfileEqual || !isTasksEqual || (!isTeamsEqual && !isTeamSaved) || !isProjectsEqual ? (
               <Alert color="warning">
                 Please click on &quot;Save changes&quot; to save the changes you have made.{' '}
               </Alert>
@@ -975,7 +975,8 @@ function UserProfile(props) {
                     !formValid.firstName ||
                     !formValid.lastName ||
                     !formValid.email ||
-                    !(isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
+                    !(isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual) &&
+                    !isTeamSaved
                   }
                   canEditTeamCode={props.hasPermission('editTeamCode') || requestorRole === 'Owner' || requestorRole === 'Administrator'}
                   setUserProfile={setUserProfile}
@@ -983,7 +984,7 @@ function UserProfile(props) {
                   codeValid={codeValid}
                   setCodeValid={setCodeValid}
                   saved={saved}
-                  savedTeams={(isSaved) => setSavedTeams(isSaved)}
+                  isTeamSaved={(isSaved) => setIsTeamSaved(isSaved)}
                 />
               </TabPane>
               <TabPane tabId="4">
@@ -1386,7 +1387,7 @@ function UserProfile(props) {
                       !codeValid ||
                       (userStartDate > userEndDate && userEndDate !== '') ||
                       (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual) ||
-                      savedTeams
+                      isTeamSaved
                     }
                     userProfile={userProfile}
                     setSaved={() => setSaved(true)}


### PR DESCRIPTION
# Description
Within the user profile page and on the `Teams` tab, there seems to be an issue when assigning the user to a team, it asks to save changes before adding the user to another team. This is incorrect as it already saves when clicking the `confirm` button within the `Add team` popup. Also, there is no autofocus on the input when the popup appears. 
**Below is Jae's video clearly defining the issue at hand.**
[Jae's video](https://www.loom.com/share/20a988f39cb848d1855735bd7962e06f?sid=361e3ea7-80d7-4689-99bf-f97b5135698e)

## Related PRS (if any):
Use development backend

## Main changes explained:
- The cursor is on the `Add team` popup input automatically
- After adding the user to a team, the `save changes` button is disabled
- After adding the user to a team, the `save changes alert` does not appear
- After adding the user to a team, the `assign team` button is **not** disabled

## How to test:
1. check into the current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log in as owner
5. go to dashboard→ View Profile → Teams tab → Assign team
6. verify the following: 
- Cursor is on input
- You can add user to multiple teams
- When you close out of the `Add team` popup, the `Save Changes` button is disabled
- The alert where it asks you to save changes does not show up after closing out of the `Add team` popup
- The `Assign Team `button is not disabled afterward
- Go to other links → teams. Verify that the user is added to the team(s)

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/13fe3478-e424-47a0-b442-d75d48cff177
