### PR TITLE
Roberto-adds optional chaining to .completedTask so process doesn't crash

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -328,7 +328,7 @@ const Timelog = props => {
     })
     disPlayUserTasks.forEach(task => {
       const { projectId, wbsId, _id: taskId, resources } = task;
-      const isTaskCompletedForTimeEntryUser = resources.find(resource => resource.userID === displayUserProfile._id).completedTask;
+      const isTaskCompletedForTimeEntryUser = resources.find(resource => resource.userID === displayUserProfile._id)?.completedTask;
       if (!isTaskCompletedForTimeEntryUser) {
         projectsObject[projectId].WBSObject[wbsId].taskObject[taskId] = task;
       }

--- a/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
@@ -50,8 +50,7 @@ const UserProjectsTable = React.memo(props => {
       return userProjects?.map(project => {
         const tasks = [];
         sortedTasksByNumber?.forEach(task => {
-          const isCompletedTask = task?.resources?.find(user => user.userID === props.userId)
-            .completedTask;
+          const isCompletedTask = task?.resources?.find(user => user.userID === props.userId)?.completedTask;
           if (task?.projectId?.includes(project._id)) {
             if (situation === 'active' && !isCompletedTask) {
               tasks.push(task);
@@ -233,7 +232,7 @@ const UserProjectsTable = React.memo(props => {
                       project.tasks.map(task => {
                         const isCompletedTask = task.resources.find(
                           ({ userID }) => userID === props.userId,
-                        ).completedTask;
+                        )?.completedTask;
                         return (
                           <tr key={task._id}>
                             <td>{task.num}</td>
@@ -428,7 +427,7 @@ const UserProjectsTable = React.memo(props => {
                       project.tasks.map(task => {
                         const isCompletedTask = task.resources.find(
                           ({ userID }) => userID === props.userId,
-                        ).completedTask;
+                        )?.completedTask;
                         return (
                           <tr key={task._id}>
                             <td>{task.num}</td>


### PR DESCRIPTION
# Description
Going back and forth between userprofiles sometimes results in a page crash.

## Related PRS (if any):
Test with latest backend

## Main changes explained:
- In timelog component and userProjectsTable, theres a .completedTask attribute being evaluated on some variables. In some cases this caused userprofile page to crash. Adding optional chaining helps avoid that error.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as any user
5. visit any user's profile page other than yours, then click on the userprofile icon in the header, try going back and forth revisiting those two userprofile pages to make sure it doesn't crash.


## Screenshots or videos of changes:
### Before: 
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/117053202/9aaf7b01-61b6-4f44-8c7a-3854a8295d66

### After: 


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/117053202/0de4c47d-8a4d-4970-9112-d9cb5da5be2a



## Note:
If you end up seeing a memory leak error in your console that is a separate issue needed to be addressed.
