### PR TITLE
Nathan hotfix add wbs see Projects page

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -65,6 +65,8 @@ export const Header = props => {
   const canSeeProjectManagementTab =
     props.hasPermission('seeProjectManagement') || props.hasPermission('seeProjectManagementTab');
   const canPostProject = props.hasPermission('postProject');
+  // WBS
+  const canPostWBS = props.hasPermission('postWbs');
   // Tasks
   const canUpdateTask = props.hasPermission('updateTask') || props.auth.user?.permissions?.frontPermissions.includes('updateTask');
   // Teams
@@ -268,6 +270,7 @@ export const Header = props => {
                 canCreateBadges ||
                 canPostProject ||
                 canUpdateTask ||
+                canPostWBS ||
                 canSeeProjectManagementTab ||
                 canDeleteTeam ||
                 canPutTeam ||
@@ -295,7 +298,7 @@ export const Header = props => {
                     ) : (
                       <React.Fragment></React.Fragment>
                     )}
-                    {(canPostProject || canUpdateTask || canSeeProjectManagementTab) && (
+                    {(canPostProject || canUpdateTask || canPostWBS|| canSeeProjectManagementTab) && (
                       <DropdownItem tag={Link} to="/projects">
                         {PROJECTS}
                       </DropdownItem>

--- a/src/routes.js
+++ b/src/routes.js
@@ -155,7 +155,7 @@ export default (
             RoutePermissions.projectManagement_fullFunctionality,
             RoutePermissions.projectManagement_addTeamMembersUploadNewWBS,
             RoutePermissions.updateTask
-          ]}
+          ].flat()}
         />
         <ProtectedRoute
           path="/projects"

--- a/src/utils/routePermissions.js
+++ b/src/utils/routePermissions.js
@@ -4,7 +4,7 @@ export const RoutePermissions = {
   inventoryProject: '',
   inventoryProjectWbs: '',
   weeklySummariesReport: 'getWeeklySummaries',
-  projects: 'postProject',
+  projects: ['postProject', 'postWbs'],
   projectManagement_fullFunctionality: 'seeProjectManagement',
   projectManagement_addTeamMembersUploadNewWBS: 'seeProjectManagementTab',
   userManagement: 'postUserProfile',


### PR DESCRIPTION
# Description
This PR lets the `postWbs` permission have access to the Projects page.

## Main changes explained:
- add `postWbs` to routePermissions for Projects page
- add `postWbs` to header to see Other Links -> Projects

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. login as owner user
5. give "Add WBS" permission in Other Links -> Permissions Management -> Manage User Permissions to a volunteer
6. login as that volunteer
7. try to access Projects under Other Links -> Projects

