### PR TITLE
Nathan fix route permissions

### DIFF
--- a/src/components/BMDashboard/BMHeader/BMHeader.jsx
+++ b/src/components/BMDashboard/BMHeader/BMHeader.jsx
@@ -68,8 +68,6 @@ export const Header = props => {
   // Badges
   const canCreateBadges = props.hasPermission('createBadges');
   // Projects
-  const canSeeProjectManagementTab =
-    props.hasPermission('seeProjectManagement') || props.hasPermission('seeProjectManagementTab');
   const canPostProject = props.hasPermission('postProject');
   // Tasks
   const canUpdateTask = props.hasPermission('updateTask');
@@ -219,7 +217,6 @@ export const Header = props => {
                 canPutUserProfileImportantInfo ||
                 canCreateBadges ||
                 canPostProject ||
-                canSeeProjectManagementTab ||
                 canDeleteTeam ||
                 canPutTeam ||
                 canCreatePopup ||
@@ -246,7 +243,7 @@ export const Header = props => {
                     ) : (
                       <React.Fragment></React.Fragment>
                     )}
-                    {(canPostProject || canSeeProjectManagementTab) && (
+                    {canPostProject && (
                       <DropdownItem tag={Link} to="/projects">
                         {PROJECTS}
                       </DropdownItem>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -55,30 +55,39 @@ export const Header = props => {
   const canGetReports = props.hasPermission('getReports');
   const canGetWeeklySummaries = props.hasPermission('getWeeklySummaries');
   // Users
-
-  const canPostUserProfile = props.hasPermission('postUserProfile');
-  const canDeleteUserProfile = props.hasPermission('deleteUserProfile');
-  const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
+  const canAccessUserManagement = props.hasPermission('postUserProfile')
+    || props.hasPermission('deleteUserProfile')
+    || props.hasPermission('putUserProfileImportantInfo');
   // Badges
-  const canCreateBadges = props.hasPermission('createBadges');
+  const canAccessBadgeManagement = props.hasPermission('createBadges');
   // Projects
-  const canSeeProjectManagementTab =
-    props.hasPermission('seeProjectManagement') || props.hasPermission('seeProjectManagementTab');
-  const canPostProject = props.hasPermission('postProject');
-  // WBS
-  const canPostWBS = props.hasPermission('postWbs');
+  const canAccessProjects = props.hasPermission('postProject')
+    || props.hasPermission('deleteProject')
+    || props.hasPermission('putProject')
+    || props.hasPermission('getProjectMembers')
+    || props.hasPermission('assignProjectToUsers')
+    || props.hasPermission('category/non-permission')
+    || props.hasPermission('postWbs')
+    || props.hasPermission('deleteWbs')
+    || props.hasPermission('category/non-permission')
+    || props.hasPermission('postTask')
+    || props.hasPermission('updateTask')
+    || props.hasPermission('deleteTask');
   // Tasks
-  const canUpdateTask = props.hasPermission('updateTask') || props.auth.user?.permissions?.frontPermissions.includes('updateTask');
+  const canUpdateTask = props.hasPermission('updateTask');
   // Teams
-  const canDeleteTeam = props.hasPermission('deleteTeam');
-  const canPutTeam = props.hasPermission('putTeam');
+  const canAccessTeams = props.hasPermission('postTeam')
+    || props.hasPermission('putTeam')
+    || props.hasPermission('deleteTeam')
+    || props.hasPermission('assignTeamToUsers');
   // Popups
-  const canCreatePopup = props.hasPermission('createPopup');
-  const canUpdatePopup = props.hasPermission('updatePopup');
-  // Roles
-  const canPutRole = props.hasPermission('putRole');
+  const canAccessPopups = props.hasPermission('createPopup')
+    || props.hasPermission('updatePopup');
   // Permissions
-  const canManageUser = props.hasPermission('putUserProfilePermissions');
+  const canAccessPermissionsManagement = props.hasPermission('postRole')
+    || props.hasPermission('putRole')
+    || props.hasPermission('deleteRole')
+    || props.hasPermission('putUserProfilePermissions')
 
   const userId = user.userid;
   const [isModalVisible, setModalVisible] = useState(false);
@@ -264,27 +273,18 @@ export const Header = props => {
                   </i>
                 </NavLink>
               </NavItem>
-              {(canPostUserProfile ||
-                canDeleteUserProfile ||
-                canPutUserProfileImportantInfo ||
-                canCreateBadges ||
-                canPostProject ||
-                canUpdateTask ||
-                canPostWBS ||
-                canSeeProjectManagementTab ||
-                canDeleteTeam ||
-                canPutTeam ||
-                canCreatePopup ||
-                canUpdatePopup ||
-                canManageUser) && (
+              {(canAccessUserManagement ||
+                canAccessBadgeManagement ||
+                canAccessProjects ||
+                canAccessTeams ||
+                canAccessPopups ||
+                canAccessPermissionsManagement) && (
                 <UncontrolledDropdown nav inNavbar>
                   <DropdownToggle nav caret>
                     <span className="dashboard-text-link">{OTHER_LINKS}</span>
                   </DropdownToggle>
                   <DropdownMenu>
-                    {canPostUserProfile ||
-                    canDeleteUserProfile ||
-                    canPutUserProfileImportantInfo ? (
+                    {canAccessUserManagement ? (
                       <DropdownItem tag={Link} to="/usermanagement">
                         {USER_MANAGEMENT}
                       </DropdownItem>
@@ -298,17 +298,17 @@ export const Header = props => {
                     ) : (
                       <React.Fragment></React.Fragment>
                     )}
-                    {(canPostProject || canUpdateTask || canPostWBS|| canSeeProjectManagementTab) && (
+                    {(canAccessProjects) && (
                       <DropdownItem tag={Link} to="/projects">
                         {PROJECTS}
                       </DropdownItem>
                     )}
-                    {(canDeleteTeam || canPutTeam) && (
+                    {(canAccessTeams) && (
                       <DropdownItem tag={Link} to="/teams">
                         {TEAMS}
                       </DropdownItem>
                     )}
-                    {(canPutRole || canManageUser) && (
+                    {(canAccessPermissionsManagement) && (
                       <>
                         <DropdownItem divider />
                         <DropdownItem tag={Link} to="/permissionsmanagement">

--- a/src/components/Projects/Members/Member/Member.jsx
+++ b/src/components/Projects/Members/Member/Member.jsx
@@ -12,8 +12,8 @@ import PropTypes from 'prop-types';
 
 const Member = props => {
   const canGetUserProfiles = props.hasPermission('getUserProfiles');
-  //const canAssignProjectToUsers = props.hasPermission('assignProjectToUsers') || props.hasPermission('seeProjectManagement') || props.hasPermission('seeProjectManagementTab');
-  const canUnassignUserInProject = props.hasPermission('unassignUserInProject') || props.hasPermission('seeProjectManagement');
+  //const canAssignProjectToUsers = props.hasPermission('assignProjectToUsers');
+  const canUnassignUserInProject = props.hasPermission('unassignUserInProject');
   return (
     <React.Fragment>
       <tr className="members__tr">

--- a/src/components/Projects/Members/Members.jsx
+++ b/src/components/Projects/Members/Members.jsx
@@ -25,9 +25,9 @@ const Members = props => {
   const [showFindUserList, setShowFindUserList] = useState(false);
   const [membersList, setMembersList] = useState(props.state.projectMembers.members);
 
-  const canGetProjectMembers = props.hasPermission('getProjectMembers') || props.hasPermission('seeProjectManagement') || props.hasPermission('seeProjectManagementTab');
-  const canAssignProjectToUsers = props.hasPermission('assignProjectToUsers') || props.hasPermission('seeProjectManagement') || props.hasPermission('seeProjectManagementTab');
-  const canUnassignUserInProject = props.hasPermission('unassignUserInProject') || props.hasPermission('seeProjectManagement');
+  const canGetProjectMembers = props.hasPermission('getProjectMembers');
+  const canAssignProjectToUsers = props.hasPermission('assignProjectToUsers');
+  const canUnassignUserInProject = props.hasPermission('unassignUserInProject');
 
   useEffect(() => {
     props.fetchAllMembers(projectId);

--- a/src/components/Projects/Project/Project.jsx
+++ b/src/components/Projects/Project/Project.jsx
@@ -17,7 +17,6 @@ const Project = props => {
 
   const canPutProject = props.hasPermission('putProject');
   const canDeleteProject = props.hasPermission('deleteProject');
-  const canSeeProjectManagementFullFunctionality = props.hasPermission('seeProjectManagement');
 
   const updateActive = () => {
     props.onClickActive(props.projectId, name, category, active);
@@ -46,7 +45,7 @@ const Project = props => {
         <div>{props.index + 1}</div>
       </th>
       <td className="projects__name--input">
-        {(canPutProject || canSeeProjectManagementFullFunctionality) ? (
+        {(canPutProject) ? (
           <input
             type="text"
             className="form-control"
@@ -59,7 +58,7 @@ const Project = props => {
         )}
       </td>
       <td className="projects__category--input">
-        {(canPutProject || canSeeProjectManagementFullFunctionality) ? (
+        {(canPutProject) ? (
           <select
             value={props.category}
             onChange={e => {
@@ -116,7 +115,7 @@ const Project = props => {
         </NavItem>
       </td>
 
-      {(canDeleteProject || canSeeProjectManagementFullFunctionality) ? (
+      {(canDeleteProject) ? (
         <td>
           <button
             type="button"

--- a/src/components/Projects/ProjectTableHeader/ProjectTableHeader.jsx
+++ b/src/components/Projects/ProjectTableHeader/ProjectTableHeader.jsx
@@ -22,7 +22,7 @@ import { Button } from 'reactstrap';
 
 const ProjectTableHeader = props => {
   const { role } = props; // Access the 'role' prop
-  const canDeleteProject = props.hasPermission('deleteProject') || props.hasPermission('seeProjectManagement');
+  const canDeleteProject = props.hasPermission('deleteProject');
 
   return (
     <tr>

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -159,7 +159,7 @@ handleSort = (e)=>{
 
     const role = this.props.state.userProfile.role;
 
-    const canPostProject = this.props.hasPermission('postProject') || this.props.hasPermission('seeProjectManagement');
+    const canPostProject = this.props.hasPermission('postProject');
 
     if (status === 400 && trackModelMsg) {
       showModalMsg = true;

--- a/src/components/Projects/WBS/AddWBS/AddWBS.jsx
+++ b/src/components/Projects/WBS/AddWBS/AddWBS.jsx
@@ -11,7 +11,7 @@ import hasPermission from 'utils/permissions';
 const AddWBS = props => {
   const [showAddButton, setShowAddButton] = useState(false);
   const [newName, setNewName] = useState('');
-  const canPostWBS = props.hasPermission('postWbs') || props.hasPermission('seeProjectManagement') || props.hasPermission('seeProjectManagementTab');
+  const canPostWBS = props.hasPermission('postWbs');
 
   const changeNewName = newName => {
     if (newName.length !== 0) {

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -44,7 +44,7 @@ function WBSTasks(props) {
   const myRef = useRef(null);
 
   // permissions
-  const canPostTask = props.hasPermission('postTask') || props.hasPermission('seeProjectManagement');
+  const canPostTask = props.hasPermission('postTask');
 
   /*
   * -------------------------------- functions --------------------------------

--- a/src/components/Projects/WBS/WBSItem/WBSItem.jsx
+++ b/src/components/Projects/WBS/WBSItem/WBSItem.jsx
@@ -15,7 +15,7 @@ import { boxStyle } from 'styles';
 const WBSItem = props => {
   const [showModalDelete, setShowModalDelete] = useState(false);
 
-  const canDeleteWBS = props.hasPermission('deleteWbs') || props.hasPermission('seeProjectManagement');
+  const canDeleteWBS = props.hasPermission('deleteWbs');
 
   const confirmDelete = () => {
     props.deleteWbs(props.wbsId);

--- a/src/routes.js
+++ b/src/routes.js
@@ -151,12 +151,7 @@ export default (
           component={Projects}
           fallback
           allowedRoles={[UserRole.Administrator, UserRole.Owner, UserRole.Manager]}
-          routePermissions={[
-            RoutePermissions.projects,
-            RoutePermissions.projectManagement_fullFunctionality,
-            RoutePermissions.projectManagement_addTeamMembersUploadNewWBS,
-            RoutePermissions.updateTask
-          ].flat()}
+          routePermissions={RoutePermissions.projects}
         />
         <ProtectedRoute
           path="/projects"
@@ -199,7 +194,7 @@ export default (
           exact
           component={UserRoleTab}
           fallback
-          routePermissions={RoutePermissions.permissionsManagementRole}
+          routePermissions={RoutePermissions.permissionsManagement}
         />
         <ProtectedRoute
           path="/teams"

--- a/src/utils/routePermissions.js
+++ b/src/utils/routePermissions.js
@@ -1,18 +1,37 @@
-//  Necessary permission to access a route
+//  Necessary permission(s) to access a route. Only one in the list is required.
 // Route : Permissions
 export const RoutePermissions = {
+  reports: 'getReports',
+  weeklySummariesReport: 'getWeeklySummaries',
+  userManagement: 'postUserProfile',
+  badgeManagement: [
+    'seeBadges',
+    'createBadges',
+    'updateBadges',
+    'deleteBadges'
+  ],
+  projects: [
+    'postProject',
+    'deleteProject',
+    'putProject',
+    'getProjectMembers',
+    'assignProjectToUsers',
+    'category/non-permission',
+    'postWbs',
+    'deleteWbs',
+    'category/non-permission',
+    'postTask',
+    'updateTask',
+    'deleteTask'
+  ],
+  teams: [
+    'postTeam',
+    'putTeam',
+    'deleteTeam',
+    'assignTeamToUsers'
+  ],
+  permissionsManagement: 'putRole',
+  userPermissionsManagement: 'putUserProfilePermissions',
   inventoryProject: '',
   inventoryProjectWbs: '',
-  weeklySummariesReport: 'getWeeklySummaries',
-  projects: ['postProject', 'postWbs'],
-  projectManagement_fullFunctionality: 'seeProjectManagement',
-  projectManagement_addTeamMembersUploadNewWBS: 'seeProjectManagementTab',
-  userManagement: 'postUserProfile',
-  updateTask: 'updateTask',
-  badgeManagement: 'createBadges',
-  userPermissionsManagement: 'putUserProfilePermissions',
-  permissionsManagement: 'putRole',
-  permissionsManagementRole: 'putRole',
-  teams: 'putTeam',
-  reports: 'getReports',
 };


### PR DESCRIPTION
# Description
This PR adds more permissions to have access to pages where they are relevant.

## Main changes explained:
- Remove `seeProjectManagement` and `seeProjectManagementTab` outdated permissions
- Updated Header to check for more permissions for access to Other Links
- Updated routePermissions.js with additional relevant permissions

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. login as different users
5. go to the dashboard
6. should still have access to all previously accessible pages through the header -> Other Links