### PR TITLE
Fix Users needs to be on a Team to see it’s own tasks

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -143,8 +143,9 @@ const Timelog = props => {
     The problem: even after unassigning tasks the array keeps the wbs data.
     That breaks this feature. Necessary to check if this array should keep data or be reset when unassinging tasks.*/
 
-    //if user role is volunteer or core team and they don't have tasks assigned, then default tab is timelog.
-    if (role === 'Volunteer' && !userHaveTask) {
+    //if users don't have tasks assigned, then default tab is timelog.
+    console.log(userHaveTask);
+    if (!userHaveTask) {
       tab = 1;
     }
 


### PR DESCRIPTION
# Description
![Screenshot 2024-02-15 at 8 59 35 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/103622026/422a90d3-ebc0-48d6-9929-77d713981864)

Fix Users needs to be on a Team to see it’s own tasks
If the person is not in a team but has a task assigned, the task tab is still the first tab being seen. If no task is assigned, it will show the current week’s time log tab.  

## Related PRS (if any):
This frontend PR is related to the latest backend.

## Main changes explained:
edit the default tab showing to the user based on the whether the user has task assigned

## How to test:
1. check into current branch
2. do npm run start:local to run this PR locally
3. Clear site data/cache
4. log in as any user who does not have permission to see all the tasks
5. Remove the user from teams if any → If no task is assigned to the user when you go to the dashboard it will show the time log tab → Assign a task to the user with the owner/admin account → log in again as the previous user → go to the dashboard it will show the task tab by default
6. verify that If the person is not in a team but has a task assigned, the task tab is still the first tab being seen when you navigate to the dashboard. If no task is assigned and the person is not in a team, it will show the current week’s time log tab by default.  

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/103622026/700a973a-6179-4538-8fb2-bb8733a5cded


## Note:
1. These potential errors are unrelated

<img width="549" alt="Screenshot 2024-02-15 at 9 08 12 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/103622026/7e3bed87-35df-4814-9cf2-f34a06fc75ee">
