### PR TITLE
Roberto-adds the toast import so toast message appear

### DIFF
--- a/src/components/UserProfile/AssignBadgePopup.jsx
+++ b/src/components/UserProfile/AssignBadgePopup.jsx
@@ -6,6 +6,7 @@ import AssignTableRow from '../Badge/AssignTableRow';
 import { assignBadgesByUserID, clearNameAndSelected } from '../../actions/badgeManagement';
 import { ENDPOINTS } from '../../utils/URL';
 import { boxStyle } from '../../styles';
+import { toast } from 'react-toastify';
 
 function AssignBadgePopup(props) {
   const [searchedName, setSearchedName] = useState('');


### PR DESCRIPTION
# Description
Looks like the `import { toast } from 'react-toastify';` was  accidentally deleted in some commit and merged, causing there to be an error populating in the console whenever adding a new badge to a user through their user profile page.

## Main changes explained:
- Adds the import statement back to the AssignBadgePopup.jsx file to get rid of error, toast modals are now visible when failing or success actions.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to user profile page→ assign badges 
6. verify assigning a badge results in a toast modal being present and no error in console related to the badges. If success a green toast modal should show up, if failing then a red one would appear.

