### PR TITLE
Renan Luiz - Manager Account able to submit summary for Admin User

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-select": "^5.7.2",
     "react-sticky": "^6.0.3",
     "react-table": "^6.10.0",
-    "react-toastify": "^5.3.1",
+    "react-toastify": "^5.5.0",
     "react-tooltip": "^4.2.10",
     "react-use-websocket": "^3.0.0",
     "reactjs-popup": "^2.0.5",

--- a/src/components/LeaderBoard/Leaderboard.css
+++ b/src/components/LeaderBoard/Leaderboard.css
@@ -24,7 +24,10 @@
     border-top-color: rgb(222, 226, 230);
   }
 }
-
+.title-dashboard {
+  font-size: 15px;
+  text-align: center;
+}
 .boldClass {
   color: #007bff;
   font-weight: bold;

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -111,7 +111,6 @@ function LeaderBoard({
   const handleTimeOffModalOpen = request => {
     showTimeOffRequestModal(request);
   };
-  //use variable instead of string
 
   const manager = 'Manager';
   const adm = 'Administrator';
@@ -121,9 +120,9 @@ function LeaderBoard({
     // check the logged in user is manager and if the dashboard is admin and owner
     if (loggedInUser.role === manager && [adm, owner].includes(item.role)) {
       // check the logged in user is admin and if dashboard is owner
-      toast.error("you don't have the permission to access this user's dashboard");
+      toast.error("Oops! You don't have the permission to access this user's dashboard!");
     } else if (loggedInUser.role === adm && [owner].includes(item.role)) {
-      toast.error("you don't have the permission to access this user's dashboard");
+      toast.error("oops! You don't have the permission to access this user's dashboard!");
     }
     // check the logged in user isn't manager, administrator or owner and if they can access the dashboard
     else if (
@@ -133,7 +132,7 @@ function LeaderBoard({
     ) {
       if ([manager, adm, owner].includes(item.role)) {
         // prevent access
-        toast.error("you don't have the permission to access this user's dashboard");
+        toast.error("oops! You don't have the permission to access this user's dashboard!");
       } else {
         // allow access to the painel
         dashboardToggle(item);
@@ -249,7 +248,9 @@ function LeaderBoard({
                     <Modal isOpen={isDashboardOpen === item.personId} toggle={dashboardToggle}>
                       <ModalHeader toggle={dashboardToggle}>Jump to personal Dashboard</ModalHeader>
                       <ModalBody>
-                        <p>Are you sure you wish to view the dashboard for {item.name} ?</p>
+                        <p className="title-dashboard">
+                          Are you sure you wish to view the dashboard for {item.name}?
+                        </p>
                       </ModalBody>
                       <ModalFooter>
                         <Button variant="primary" onClick={() => showDashboard(item)}>

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -180,7 +180,7 @@ function LeaderBoard({
                   <div style={{ textAlign: 'left' }}>
                     <span className="d-sm-none">Tot. Time</span>
                     <span className="d-none d-sm-inline-block" title={mouseoverTextValue}>
-                      Total Time{' '}
+                      Total Time
                     </span>
                   </div>
                   {isOwner && (
@@ -242,7 +242,7 @@ function LeaderBoard({
                       role="button"
                       tabIndex={0}
                       onClick={() => {
-                        dashboardToggle(item);
+                        loggedInUser.role === 'Manager' ? dashboardToggle(item) : null;
                       }}
                       onKeyDown={e => {
                         if (e.key === 'Enter') {

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -122,7 +122,7 @@ function LeaderBoard({
       // check the logged in user is admin and if dashboard is owner
       toast.error("Oops! You don't have the permission to access this user's dashboard!");
     } else if (loggedInUser.role === adm && [owner].includes(item.role)) {
-      toast.error("oops! You don't have the permission to access this user's dashboard!");
+      toast.error("Oops! You don't have the permission to access this user's dashboard!");
     }
     // check the logged in user isn't manager, administrator or owner and if they can access the dashboard
     else if (
@@ -132,7 +132,7 @@ function LeaderBoard({
     ) {
       if ([manager, adm, owner].includes(item.role)) {
         // prevent access
-        toast.error("oops! You don't have the permission to access this user's dashboard!");
+        toast.error("Oops! You don't have the permission to access this user's dashboard!");
       } else {
         // allow access to the painel
         dashboardToggle(item);

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -111,24 +111,29 @@ function LeaderBoard({
   const handleTimeOffModalOpen = request => {
     showTimeOffRequestModal(request);
   };
+  //use variable instead of string
+
+  const manager = 'Manager';
+  const adm = 'Administrator';
+  const owner = 'Owner';
 
   const handleDashboardAccess = item => {
-    // check the logged in user is manager and if the dashboard are admin and owner
-    if (loggedInUser.role === 'Manager' && ['Administrator', 'Owner'].includes(item.role)) {
+    // check the logged in user is manager and if the dashboard is admin and owner
+    if (loggedInUser.role === manager && [adm, owner].includes(item.role)) {
       // check the logged in user is admin and if dashboard is owner
-      toast.error("you don't have the permission to access this painel");
-    } else if (loggedInUser.role === 'Administrator' && ['Owner'].includes(item.role)) {
-      toast.error("you don't have the permission to access this painel");
+      toast.error("you don't have the permission to access this user's dashboard");
+    } else if (loggedInUser.role === adm && [owner].includes(item.role)) {
+      toast.error("you don't have the permission to access this user's dashboard");
     }
     // check the logged in user isn't manager, administrator or owner and if they can access the dashboard
     else if (
-      loggedInUser.role !== 'Manager' &&
-      loggedInUser.role !== 'Administrator' &&
-      loggedInUser.role !== 'Owner'
+      loggedInUser.role !== manager &&
+      loggedInUser.role !== adm &&
+      loggedInUser.role !== owner
     ) {
-      if (['Manager', 'Administrator', 'Owner'].includes(item.role)) {
+      if ([manager, adm, owner].includes(item.role)) {
         // prevent access
-        toast.error("you don't have the permission to access this painel");
+        toast.error("you don't have the permission to access this user's dashboard");
       } else {
         // allow access to the painel
         dashboardToggle(item);
@@ -244,7 +249,7 @@ function LeaderBoard({
                     <Modal isOpen={isDashboardOpen === item.personId} toggle={dashboardToggle}>
                       <ModalHeader toggle={dashboardToggle}>Jump to personal Dashboard</ModalHeader>
                       <ModalBody>
-                        <p>Are you sure you wish to view this {item.name} dashboard?</p>
+                        <p>Are you sure you wish to view the dashboard for {item.name} ?</p>
                       </ModalBody>
                       <ModalFooter>
                         <Button variant="primary" onClick={() => showDashboard(item)}>

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -112,6 +112,32 @@ function LeaderBoard({
     showTimeOffRequestModal(request);
   };
 
+  const handleDashboardAccess = item => {
+    // check the logged in user is manager and if the dashboard are admin and owner
+    if (loggedInUser.role === 'Manager' && ['Administrator', 'Owner'].includes(item.role)) {
+      // check the logged in user is admin and if dashboard is owner
+      toast.error("you don't have the permission to access this painel");
+    } else if (loggedInUser.role === 'Administrator' && ['Owner'].includes(item.role)) {
+      toast.error("you don't have the permission to access this painel");
+    }
+    // check the logged in user isn't manager, administrator or owner and if they can access the dashboard
+    else if (
+      loggedInUser.role !== 'Manager' &&
+      loggedInUser.role !== 'Administrator' &&
+      loggedInUser.role !== 'Owner'
+    ) {
+      if (['Manager', 'Administrator', 'Owner'].includes(item.role)) {
+        // prevent access
+        toast.error("you don't have the permission to access this painel");
+      } else {
+        // allow access to the painel
+        dashboardToggle(item);
+      }
+    } else {
+      // allow access to the painel
+      dashboardToggle(item);
+    }
+  };
   return (
     <div>
       <h3>
@@ -242,14 +268,11 @@ function LeaderBoard({
                       role="button"
                       tabIndex={0}
                       onClick={() => {
-                        if (loggedInUser.role === 'Manager') {
-                          return dashboardToggle(item);
-                        }
-                        return null;
+                        handleDashboardAccess(item);
                       }}
                       onKeyDown={e => {
                         if (e.key === 'Enter') {
-                          dashboardToggle(item);
+                          handleDashboardAccess(item);
                         }
                       }}
                     >

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -242,7 +242,10 @@ function LeaderBoard({
                       role="button"
                       tabIndex={0}
                       onClick={() => {
-                        loggedInUser.role === 'Manager' ? dashboardToggle(item) : null;
+                        if (loggedInUser.role === 'Manager') {
+                          return dashboardToggle(item);
+                        }
+                        return null;
                       }}
                       onKeyDown={e => {
                         if (e.key === 'Enter') {

--- a/src/utils/leaderboardPermissions.js
+++ b/src/utils/leaderboardPermissions.js
@@ -17,11 +17,11 @@ export const assignStarDotColors = (hoursLogged, weeklyCommittedHours) => {
     ? 'purple'
     : hoursLogged >= weeklyCommittedHours * FUCHSIA_TIER &&
       hoursLogged < weeklyCommittedHours * PURPLE_TIER
-    ? 'fuchsia'
-    : hoursLogged >= weeklyCommittedHours * DARKGREEN_TIER &&
-      hoursLogged < weeklyCommittedHours * FUCHSIA_TIER
-    ? 'darkgreen'
-    : 'green';
+      ? 'fuchsia'
+      : hoursLogged >= weeklyCommittedHours * DARKGREEN_TIER &&
+        hoursLogged < weeklyCommittedHours * FUCHSIA_TIER
+        ? 'darkgreen'
+        : 'green';
 };
 
 export const showStar = (hoursLogged, weeklyCommittedHours) => {


### PR DESCRIPTION
# Description
![download com](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/91035340/a8ebaf9b-d56b-4420-b3f9-fb35960f0aef)

## Related PRS (if any):

This frontend PR is related to the latest backend

## Main changes explained:

Added a logical condition to allow the managers can't access administrators or owners dashboard
Added a logical condition to allow the administrators can't owners dashboard
Added a logical condition to allow no users can access administrators, managers or owners dashboard
Added toast functions to allow the UI messages 
replaced the phrase "in this dashboard {item.name}" for "the dashboard for {item.name}"
replaced the phrase "this painel" for "this user's dashboard"
Added capatilize font and exclamation point
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as manager user, go to dashboard, go to Leaderboard, click status button, verify the following condicionals
6. managers and above (administrators and owners) can access others dashboards, but managers can't be able to access Admin/Owner dashboard
7. log as administrator user, go to dashboard, go to Leaderboard, click status button, verify the following condicionals
8. administrators and above (managers and owners) can access others dashboards, but administrators can't be able to access Owners dashboard
9. log as owner user, go to dashboard, go to Leaderboard, click status button, verify the following condicionals
10. Owners and above (administrators and owners) can be able to access all dashboards
11. log as any user (without beeing administrators, owners and managers) go to dashboards, go to Leaderboard, click status button, verify the following condicionals
12. All users (without beeing administrators, owners and managers) can access others dashboards, but they can't be able to administrators, owners and managers
## Screenshots or videos of changes:

logged user as manager

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/91035340/74be4582-725d-4233-bc93-519b4a75493b

logged user as administrator

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/91035340/aa68e8e8-000c-467b-ab28-f1f5f3be481c

logged user as owner


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/91035340/737a5857-401c-4326-8e5c-068dfbe94a64

others logged users

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/91035340/f24a8543-7213-4c62-b0c3-fca75d7ccd56





## Note:
some users put title name doesn't match the rule, for example, there is a role the title name is userowner133, but the role is volunteer, so the dashboard will open, only ignore it


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/91035340/56ef0e12-feb1-43be-b7f8-d5660ab1e48f




