### PR TITLE
Nahiyan_Added padding to the projects and teams report container

### DIFF
--- a/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
+++ b/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
@@ -7,6 +7,7 @@
   background-color: #faf7fd;
   padding: 40px 0 0 24px;
   align-items: start;
+  padding: 2vh 7vw;
 }
 
 .report-page-content {


### PR DESCRIPTION
# Description
The projects report page and the teams' report page needed some padding.

## Related PRS (if any):
Use dev backend

## Main changes explained:
Just added some padding vertically and horizontally in the Report Page container

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→Reports-> Reports -> Projects/Teams -> Click on any project/team
6. Verify that there is padding and that elements are not touching the edge

## Screenshots or videos of changes:
Before:
![Screenshot 2024-02-20 140941](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/6d8dea02-dcd5-4a2d-ae19-36936a6b4705)
![Screenshot 2024-02-20 141009](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/348aa735-4b04-417c-80f9-c6a22a36bc06)



After:
![Screenshot 2024-02-20 140902](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/038461bd-230d-4328-ae7e-b2b85a4f6ed9)
![Screenshot 2024-02-20 140830](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/d1011d0e-0274-4976-9e64-53f1a1565707)

