### PR TITLE
Anirudh conditional formatting multiwordnames

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -41,7 +41,29 @@ function Task(props) {
   const tableRowRef = useRef();
 
   const initialsSet = new Set();
-  const colors = ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff', '#00ffff'];
+  const colors = [
+    "#FF0000", // red
+    "#0000FF", // blue
+    "#00FF00", // green
+    "#FFFF00", // yellow
+    "#FFA500", // orange
+    "#800080", // purple
+    "#FFC0CB", // pink
+    "#00FFFF", // cyan
+    "#FF00FF", // magenta
+    "#008080", // teal
+    "#00FF00", // lime
+    "#A52A2A", // brown
+    "#000000", // black
+    "#FFFFFF", // white
+    
+    "#C0C0C0", // silver
+    "#FFD700", // gold
+    "#000080", // navy
+    "#800000", // maroon
+    "#808000"  // olive
+  ];
+  
 
   /*
   * -------------------------------- functions --------------------------------
@@ -80,7 +102,8 @@ function Task(props) {
     }else{
       initialsSet.add(initials);
     }
-    return color;
+    console.log("Initials set: ", initialsSet)
+    return color + '33';
   }
 
   /*

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -90,6 +90,7 @@ function Task(props) {
     props.deleteWBSTask(taskId, mother);
   };
 
+  //Function to get background color
   function getBackgroundColor(initials) {
     let color = '#bbb';
     if (initialsSet.has(initials)) {
@@ -126,6 +127,7 @@ function Task(props) {
   }, [props.openAll]);
 
   useEffect(() => {
+    //Clearing the initials set 
     initialsSet.clear();
   });
 
@@ -199,7 +201,7 @@ function Task(props) {
                 ? props.resources
                     .filter((elm, i) => i < 2 || showMoreResources)
                     .map((elm, i) => {
-                      const name = elm.name;
+                      const name = elm.name; //Getting initials and formatting them here
                       const initials = elm.name
                         .split(' ')
                         .filter(
@@ -208,6 +210,7 @@ function Task(props) {
                         .map(n => n[0])
                         .join('')
                         .toUpperCase();
+                        //getting background color here
                       const backgroundColor = getBackgroundColor(initials);
                       return (
                         <a

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -23,6 +23,9 @@ function Task(props) {
   // props from store
   const { tasks } = props;
 
+  const names = props.resources.map(element => element.name);
+  const colors_objs = assignColorsToInitials(names);
+
   const startedDate = new Date(props.startedDatetime);
   const dueDate = new Date(props.dueDatetime);
 
@@ -35,29 +38,6 @@ function Task(props) {
   const [children, setChildren] = useState([]);
   const [showMoreResources, setShowMoreResources] = useState(false);
   const tableRowRef = useRef();
-
-  const initialsSet = new Set();
-  const colors = [
-    '#FF0000', // red
-    '#0000FF', // blue
-    '#00FF00', // green
-    '#FFFF00', // yellow
-    '#FFA500', // orange
-    '#800080', // purple
-    '#FFC0CB', // pink
-    '#00FFFF', // cyan
-    '#FF00FF', // magenta
-    '#008080', // teal
-    '#00FF00', // lime
-    '#A52A2A', // brown
-    '#000000', // black
-    '#FFFFFF', // white
-    '#C0C0C0', // silver
-    '#FFD700', // gold
-    '#000080', // navy
-    '#800000', // maroon
-    '#808000', // olive
-  ];
 
   /*
    * -------------------------------- functions --------------------------------
@@ -90,16 +70,53 @@ function Task(props) {
     props.deleteWBSTask(taskId, mother);
   };
 
-  //Function to get background color
-  function getBackgroundColor(initials) {
-    let color = '#bbb';
-    if (initialsSet.has(initials)) {
-      const count = Math.floor(Math.random() * colors.length - 1);
-      color = colors[count % colors.length];
-    } else {
-      initialsSet.add(initials);
+  function assignColorsToInitials(names) {
+    const colorsHex = [
+      '#FF0000', // red
+      '#0000FF', // blue
+      '#00FF00', // green
+      '#FFFF00', // yellow
+      '#FFA500', // orange
+      '#800080', // purple
+      '#FFC0CB', // pink
+      '#00FFFF', // cyan
+      '#FF00FF', // magenta
+      '#008080', // teal
+      '#00FF00', // lime
+      '#A52A2A', // brown
+      '#000000', // black
+      '#FFD700', // gold
+      '#000080', // navy
+      '#800000', // maroon
+      '#808000', // olive
+    ];
+    let colors = {};
+    let colorIndex = {};
+    // Calculate initials and map colors
+    for (let name of names) {
+      const initials = name
+        .split(' ')
+        .filter((n, index) => index === 0 || index === name.split(' ').length - 1)
+        .map(n => n[0])
+        .join('')
+        .toUpperCase();
+      // If the initials haven't been encountered yet, assign a base color
+      if (!colorIndex[initials]) {
+        colors[name] = {
+          color: '#bbb', // Base color
+          initials: initials, // Store initials for reference
+        };
+        colorIndex[initials] = 1;
+      } else {
+        // If initials have been encountered, assign a new color
+        colors[name] = {
+          color: colorsHex[Math.floor(Math.random() * colorsHex.length)] + '33', // Assign color
+          initials: initials, // Store initials for reference
+        };
+        colorIndex[initials]++; // Increment color index
+      }
     }
-    return color + '33';
+    return colors;
   }
 
   /*
@@ -125,11 +142,6 @@ function Task(props) {
   useEffect(() => {
     setIsOpen(props.openAll);
   }, [props.openAll]);
-
-  useEffect(() => {
-    //Clearing the initials set 
-    initialsSet.clear();
-  });
 
   return (
     <>
@@ -210,8 +222,8 @@ function Task(props) {
                         .map(n => n[0])
                         .join('')
                         .toUpperCase();
-                        //getting background color here
-                      const backgroundColor = getBackgroundColor(initials);
+                      //getting background color here
+                      const bg = colors_objs[name].color;
                       return (
                         <a
                           key={`res_${i}`}
@@ -222,7 +234,7 @@ function Task(props) {
                           rel="noreferrer"
                         >
                           {!elm.profilePic || elm.profilePic === '/defaultprofilepic.png' ? (
-                            <span className="dot" style={{ backgroundColor }}>
+                            <span className="dot" style={{ backgroundColor: bg }}>
                               {initials}{' '}
                             </span>
                           ) : (

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -81,10 +81,10 @@ function Task(props) {
   //Color change based on initials 
   function getBackgroundColor(initials) {
     if (existingInitials.has(initials)) {
-      return '#bbb'; // No background color if the initials already exist
+      return getRandomColor(); // Return a random color if initials already exist
     } else {
-      setExistingInitials(prevSet => new Set(prevSet.add(initials))); // Add initials to the set of existing initials
-      return getRandomColor(); // Return a random color for the new initials
+      existingInitials.add(initials);
+      return '#bbb'; // No background color
     }
   }
 
@@ -187,9 +187,7 @@ function Task(props) {
                     .filter((n, index) => index===0 || index===elm.name.split(' ').length - 1)
                     .map(n=>n[0])
                     .join('').toUpperCase();
-                    
                     const backgroundColor = getBackgroundColor(initials);
-                    
                     return (
                       <a
                         key={`res_${i}`}

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -70,6 +70,16 @@ function Task(props) {
     props.deleteWBSTask(taskId, mother);
   };
 
+  function getInitials(name){
+    const initials = name
+    .split(' ')
+    .filter((n, index) => index === 0 || index === name.split(' ').length - 1)
+    .map(n => n[0])
+    .join('')
+    .toUpperCase();
+    return initials;
+  }
+
   function assignColorsToInitials(names) {
     const colorsHex = [
       '#FF0000', // red
@@ -94,12 +104,7 @@ function Task(props) {
     let colorIndex = {};
     
     for (let name of names) {
-      const initials = name
-        .split(' ')
-        .filter((n, index) => index === 0 || index === name.split(' ').length - 1)
-        .map(n => n[0])
-        .join('')
-        .toUpperCase();
+      const initials = getInitials(name);
       // If the initials haven't been encountered yet, assign a base color
       if (!colorIndex[initials]) {
         colors[name] = {
@@ -214,14 +219,7 @@ function Task(props) {
                     .filter((elm, i) => i < 2 || showMoreResources)
                     .map((elm, i) => {
                       const name = elm.name; //Getting initials and formatting them here
-                      const initials = elm.name
-                        .split(' ')
-                        .filter(
-                          (n, index) => index === 0 || index === elm.name.split(' ').length - 1,
-                        )
-                        .map(n => n[0])
-                        .join('')
-                        .toUpperCase();
+                      const initials = getInitials(name);
                       //getting background color here
                       const bg = colors_objs[name].color;
                       return (

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -92,7 +92,7 @@ function Task(props) {
     ];
     let colors = {};
     let colorIndex = {};
-    // Calculate initials and map colors
+    
     for (let name of names) {
       const initials = name
         .split(' ')
@@ -104,16 +104,16 @@ function Task(props) {
       if (!colorIndex[initials]) {
         colors[name] = {
           color: '#bbb', // Base color
-          initials: initials, // Store initials for reference
+          initials: initials, 
         };
         colorIndex[initials] = 1;
       } else {
         // If initials have been encountered, assign a new color
         colors[name] = {
-          color: colorsHex[Math.floor(Math.random() * colorsHex.length)] + '33', // Assign color
-          initials: initials, // Store initials for reference
+          color: colorsHex[Math.floor(Math.random() * colorsHex.length)] + '30', 
+          initials: initials, 
         };
-        colorIndex[initials]++; // Increment color index
+        colorIndex[initials]++; 
       }
     }
     return colors;

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -40,6 +40,10 @@ function Task(props) {
   const [showMoreResources, setShowMoreResources] = useState(false);
   const tableRowRef = useRef();
 
+  const [assignedColors, setAssignedColors] = useState({});
+  const [existingInitials, setExistingInitials] = useState(new Set());
+
+
   /*
   * -------------------------------- functions --------------------------------
   */
@@ -68,6 +72,21 @@ function Task(props) {
   const deleteOneTask = (taskId, mother) => {
     props.deleteWBSTask(taskId, mother);
   };
+
+  function getRandomColor() {
+    const randomColor = '#' + Math.floor(Math.random()*16777215).toString(16); // Random color
+    return randomColor + '33'; // Adding opacity (33 in hexadecimal) for lighter color
+  }
+
+  //Color change based on initials 
+  function getBackgroundColor(initials) {
+    if (existingInitials.has(initials)) {
+      return '#bbb'; // No background color if the initials already exist
+    } else {
+      setExistingInitials(prevSet => new Set(prevSet.add(initials))); // Add initials to the set of existing initials
+      return getRandomColor(); // Return a random color for the new initials
+    }
+  }
 
   /*
   * -------------------------------- useEffects --------------------------------
@@ -164,6 +183,13 @@ function Task(props) {
                 ? props.resources
                   .filter((elm, i) => i < 2 || showMoreResources)
                   .map((elm, i) => {
+                    const initials = elm.name.split(' ')
+                    .filter((n, index) => index===0 || index===elm.name.split(' ').length - 1)
+                    .map(n=>n[0])
+                    .join('').toUpperCase();
+                    
+                    const backgroundColor = getBackgroundColor(initials);
+                    
                     return (
                       <a
                         key={`res_${i}`}
@@ -173,8 +199,10 @@ function Task(props) {
                         target="_blank"
                         rel="noreferrer"
                       >
-                        {!elm.profilePic || elm.profilePic === "/defaultprofilepic.png"
-                          ? <span className="dot">{elm.name.split(' ').map(n => n[0]).join('').toUpperCase()}</span>
+                        {!elm.profilePic || elm.profilePic === "/defaultprofilepic.png" ?
+                        <span className="dot" style={{ backgroundColor }}>{initials} </span>
+                          // ? <span className="dot">{elm.name.split(' ').map(n => n[0]).join('').toUpperCase()}</span>
+                          // ? <span className="dot" style={{ backgroundColor }}>{elm.name.split(' ').filter((n, index) => index === 0 || index === elm.name.split(' ').length - 1).map(n => n[0]).join('').toUpperCase()}</span>
                           : <img className="img-circle" src={elm.profilePic} />}
                       </a>
                     );

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -1,10 +1,6 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
-import {
-  Modal,
-  ModalBody,
-  Button,
-} from 'reactstrap';
+import { Modal, ModalBody, Button } from 'reactstrap';
 import { BsFillCaretDownFill, BsFillCaretUpFill, BsFillCaretLeftFill } from 'react-icons/bs';
 import ControllerRow from '../ControllerRow';
 import {
@@ -22,8 +18,8 @@ import { formatDate } from 'utils/formatDate';
 
 function Task(props) {
   /*
-  * -------------------------------- variable declarations --------------------------------
-  */
+   * -------------------------------- variable declarations --------------------------------
+   */
   // props from store
   const { tasks } = props;
 
@@ -42,44 +38,44 @@ function Task(props) {
 
   const initialsSet = new Set();
   const colors = [
-    "#FF0000", // red
-    "#0000FF", // blue
-    "#00FF00", // green
-    "#FFFF00", // yellow
-    "#FFA500", // orange
-    "#800080", // purple
-    "#FFC0CB", // pink
-    "#00FFFF", // cyan
-    "#FF00FF", // magenta
-    "#008080", // teal
-    "#00FF00", // lime
-    "#A52A2A", // brown
-    "#000000", // black
-    "#FFFFFF", // white
-    
-    "#C0C0C0", // silver
-    "#FFD700", // gold
-    "#000080", // navy
-    "#800000", // maroon
-    "#808000"  // olive
+    '#FF0000', // red
+    '#0000FF', // blue
+    '#00FF00', // green
+    '#FFFF00', // yellow
+    '#FFA500', // orange
+    '#800080', // purple
+    '#FFC0CB', // pink
+    '#00FFFF', // cyan
+    '#FF00FF', // magenta
+    '#008080', // teal
+    '#00FF00', // lime
+    '#A52A2A', // brown
+    '#000000', // black
+    '#FFFFFF', // white
+    '#C0C0C0', // silver
+    '#FFD700', // gold
+    '#000080', // navy
+    '#800000', // maroon
+    '#808000', // olive
   ];
-  
 
   /*
-  * -------------------------------- functions --------------------------------
-  */
+   * -------------------------------- functions --------------------------------
+   */
   const toggleModel = () => setModal(!modal);
 
   const openChild = () => {
     setIsOpen(!isOpen);
   };
 
-  const getAncestorNames = (motherId) => {
+  const getAncestorNames = motherId => {
     const motherTask = tasks.find(task => task._id === motherId);
     if (motherTask) {
       const motherTaskName = motherTask.taskName;
       const grandMotherTaskNames = motherTask.mother ? getAncestorNames(motherTask.mother) : '';
-      return grandMotherTaskNames ? grandMotherTaskNames + ' <br /> ' + motherTaskName + ' /' : motherTaskName + ' /';
+      return grandMotherTaskNames
+        ? grandMotherTaskNames + ' <br /> ' + motherTaskName + ' /'
+        : motherTaskName + ' /';
     } else {
       return '';
     }
@@ -88,36 +84,35 @@ function Task(props) {
   const activeController = () => {
     props.setControllerId(props.taskId);
     setControllerRow(!controllerRow);
-  }
+  };
 
   const deleteOneTask = (taskId, mother) => {
     props.deleteWBSTask(taskId, mother);
   };
 
   function getBackgroundColor(initials) {
-    let color = "#bbb";
-    if(initialsSet.has(initials)){
-      const count = Math.floor(Math.random() * colors.length-1)
+    let color = '#bbb';
+    if (initialsSet.has(initials)) {
+      const count = Math.floor(Math.random() * colors.length - 1);
       color = colors[count % colors.length];
-    }else{
+    } else {
       initialsSet.add(initials);
     }
-    console.log("Initials set: ", initialsSet)
     return color + '33';
   }
 
   /*
-  * -------------------------------- useEffects --------------------------------
-  */
+   * -------------------------------- useEffects --------------------------------
+   */
   useEffect(() => {
     if (props.controllerId !== props.taskId) setControllerRow(false);
-  }, [props.controllerId])
+  }, [props.controllerId]);
 
   useEffect(() => {
     const childTasks = tasks.filter(task => task.mother === props.taskId);
     const filteredChildren = props.filterTasks(childTasks, props.filterState);
     setChildren(filteredChildren);
-  }, [props.filterState, tasks])
+  }, [props.filterState, tasks]);
 
   useEffect(() => {
     if (tableRowRef.current) {
@@ -127,13 +122,13 @@ function Task(props) {
   }, []);
 
   useEffect(() => {
-      setIsOpen(props.openAll);
+    setIsOpen(props.openAll);
   }, [props.openAll]);
 
-  useEffect(()=>{
+  useEffect(() => {
     initialsSet.clear();
   });
- 
+
   return (
     <>
       {props.taskId ? (
@@ -154,12 +149,7 @@ function Task(props) {
               } tag_color_lv_${props.level}`}
             ></td>
             <td>
-              <Button
-                color="primary"
-                size="sm"
-                onClick={activeController}
-                style={boxStyle}
-              >
+              <Button color="primary" size="sm" onClick={activeController} style={boxStyle}>
                 <span className="action-edit-btn">EDIT</span>
                 {controllerRow ? <BsFillCaretUpFill /> : <BsFillCaretDownFill />}
               </Button>
@@ -173,21 +163,25 @@ function Task(props) {
               {props.num.replaceAll('.0', '')}
             </td>
             <td className="taskName">
-              {<div className={`level-space-${props.level}`} data-tip={`${getAncestorNames(props.mother)}`}>
-                    <span
-                      onClick={openChild}
-                      id={`task_name_${props.taskId}`}
-                      className={props.hasChildren ? 'has_children' : ''}
-                    >
-                      {props.hasChildren ? (
-                        <i
-                          className={`fa fa-folder${isOpen ? '-open' : ''}`}
-                          aria-hidden="true"
-                        ></i>
-                      ) : ''}{' '}
-                      {props.name}
-                    </span>
-              </div>}
+              {
+                <div
+                  className={`level-space-${props.level}`}
+                  data-tip={`${getAncestorNames(props.mother)}`}
+                >
+                  <span
+                    onClick={openChild}
+                    id={`task_name_${props.taskId}`}
+                    className={props.hasChildren ? 'has_children' : ''}
+                  >
+                    {props.hasChildren ? (
+                      <i className={`fa fa-folder${isOpen ? '-open' : ''}`} aria-hidden="true"></i>
+                    ) : (
+                      ''
+                    )}{' '}
+                    {props.name}
+                  </span>
+                </div>
+              }
             </td>
             <td>
               {props.priority === 'Primary' ? (
@@ -203,38 +197,48 @@ function Task(props) {
             <td className="desktop-view">
               {props.resources.length
                 ? props.resources
-                  .filter((elm, i) => i < 2 || showMoreResources)
-                  .map((elm, i) => {
-                    const name = elm.name;
-                    const initials = elm.name.split(' ')
-                    .filter((n, index) => index===0 || index===elm.name.split(' ').length - 1)
-                    .map(n=>n[0])
-                    .join('').toUpperCase();
-                    const backgroundColor = getBackgroundColor(initials);
-                    return (
-                      <a
-                        key={`res_${i}`}
-                        data-tip={elm.name}
-                        className="name"
-                        href={`/userprofile/${elm.userID}`}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        {!elm.profilePic || elm.profilePic === "/defaultprofilepic.png" ?
-                        <span className="dot" style={{ backgroundColor }}>{initials} </span>
-                          : <img className="img-circle" src={elm.profilePic} />}
-                      </a>
-                    );
-                  })
+                    .filter((elm, i) => i < 2 || showMoreResources)
+                    .map((elm, i) => {
+                      const name = elm.name;
+                      const initials = elm.name
+                        .split(' ')
+                        .filter(
+                          (n, index) => index === 0 || index === elm.name.split(' ').length - 1,
+                        )
+                        .map(n => n[0])
+                        .join('')
+                        .toUpperCase();
+                      const backgroundColor = getBackgroundColor(initials);
+                      return (
+                        <a
+                          key={`res_${i}`}
+                          data-tip={elm.name}
+                          className="name"
+                          href={`/userprofile/${elm.userID}`}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {!elm.profilePic || elm.profilePic === '/defaultprofilepic.png' ? (
+                            <span className="dot" style={{ backgroundColor }}>
+                              {initials}{' '}
+                            </span>
+                          ) : (
+                            <img className="img-circle" src={elm.profilePic} />
+                          )}
+                        </a>
+                      );
+                    })
                 : null}
-              {props.resources.length > 2
-                ? <a
-                    className="resourceMoreToggle"
-                    onClick={() => setShowMoreResources(!showMoreResources)}
-                  >
-                    <span className="dot">{showMoreResources ? <BsFillCaretLeftFill /> : `${props.resources.length - 2}+`}</span>
-                  </a>
-                : null}
+              {props.resources.length > 2 ? (
+                <a
+                  className="resourceMoreToggle"
+                  onClick={() => setShowMoreResources(!showMoreResources)}
+                >
+                  <span className="dot">
+                    {showMoreResources ? <BsFillCaretLeftFill /> : `${props.resources.length - 2}+`}
+                  </span>
+                </a>
+              ) : null}
             </td>
             <td>
               {props.isAssigned ? (
@@ -287,15 +291,11 @@ function Task(props) {
               {parseFloat(props.estimatedHours).toFixed(2)}
             </td>
             <td className="desktop-view">
-              {startedDate.getFullYear() !== 1969
-                ? formatDate(startedDate)
-                : null}
+              {startedDate.getFullYear() !== 1969 ? formatDate(startedDate) : null}
               <br />
             </td>
             <td className="desktop-view">
-              {dueDate.getFullYear() !== 1969
-                ? formatDate(dueDate)
-                : null}
+              {dueDate.getFullYear() !== 1969 ? formatDate(dueDate) : null}
             </td>
             <td className="desktop-view">
               {props.links.map((link, i) =>
@@ -307,7 +307,7 @@ function Task(props) {
               )}
             </td>
             <td className="desktop-view" onClick={toggleModel}>
-              <i className="fa fa-book" aria-hidden="true" data-tip="More info"/>
+              <i className="fa fa-book" aria-hidden="true" data-tip="More info" />
             </td>
             <Modal isOpen={modal} toggle={toggleModel}>
               <ModalBody>
@@ -378,54 +378,56 @@ function Task(props) {
           ) : null}
         </>
       ) : null}
-      {isOpen && children.length ? children.map((task, i) => (
-        <ConnectedTask
-          key={`${task._id}${i}`}
-          taskId={task._id}
-          level={task.level}
-          num={task.num}
-          name={task.taskName}
-          priority={task.priority}
-          resources={task.resources}
-          isAssigned={task.isAssigned}
-          status={task.status}
-          hoursBest={task.hoursBest}
-          hoursMost={task.hoursMost}
-          hoursWorst={task.hoursWorst}
-          estimatedHours={task.estimatedHours}
-          startedDatetime={task.startedDatetime}
-          dueDatetime={task.dueDatetime}
-          links={task.links}
-          projectId={props.projectId}
-          wbsId={props.wbsId}
-          parentId1={task.parentId1}
-          parentId2={task.parentId2}
-          parentId3={task.parentId3}
-          mother={task.mother}
-          openAll={props.openAll}
-          deleteWBSTask={props.deleteWBSTask}
-          hasChildren={task.hasChildren}
-          siblings={children}
-          whyInfo={task.whyInfo}
-          intentInfo={task.intentInfo}
-          endstateInfo={task.endstateInfo}
-          childrenQty={task.childrenQty}
-          filterTasks={props.filterTasks}
-          filterState={props.filterState}
-          controllerId={props.controllerId}
-          setControllerId={props.setControllerId}
-          load={props.load}
-          pageLoadTime={props.pageLoadTime}
-          setIsLoading={props.setIsLoading}
-        />)
-      ) : null}
+      {isOpen && children.length
+        ? children.map((task, i) => (
+            <ConnectedTask
+              key={`${task._id}${i}`}
+              taskId={task._id}
+              level={task.level}
+              num={task.num}
+              name={task.taskName}
+              priority={task.priority}
+              resources={task.resources}
+              isAssigned={task.isAssigned}
+              status={task.status}
+              hoursBest={task.hoursBest}
+              hoursMost={task.hoursMost}
+              hoursWorst={task.hoursWorst}
+              estimatedHours={task.estimatedHours}
+              startedDatetime={task.startedDatetime}
+              dueDatetime={task.dueDatetime}
+              links={task.links}
+              projectId={props.projectId}
+              wbsId={props.wbsId}
+              parentId1={task.parentId1}
+              parentId2={task.parentId2}
+              parentId3={task.parentId3}
+              mother={task.mother}
+              openAll={props.openAll}
+              deleteWBSTask={props.deleteWBSTask}
+              hasChildren={task.hasChildren}
+              siblings={children}
+              whyInfo={task.whyInfo}
+              intentInfo={task.intentInfo}
+              endstateInfo={task.endstateInfo}
+              childrenQty={task.childrenQty}
+              filterTasks={props.filterTasks}
+              filterState={props.filterState}
+              controllerId={props.controllerId}
+              setControllerId={props.setControllerId}
+              load={props.load}
+              pageLoadTime={props.pageLoadTime}
+              setIsLoading={props.setIsLoading}
+            />
+          ))
+        : null}
     </>
   );
 }
 
 const mapStateToProps = state => ({
   tasks: state.tasks.taskItems,
- });
+});
 
 const ConnectedTask = connect(mapStateToProps, {
   moveTasks,

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -40,9 +40,8 @@ function Task(props) {
   const [showMoreResources, setShowMoreResources] = useState(false);
   const tableRowRef = useRef();
 
-  const [assignedColors, setAssignedColors] = useState({});
-  const [existingInitials, setExistingInitials] = useState(new Set());
-
+  const initialsSet = new Set();
+  const colors = ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff', '#00ffff'];
 
   /*
   * -------------------------------- functions --------------------------------
@@ -73,19 +72,15 @@ function Task(props) {
     props.deleteWBSTask(taskId, mother);
   };
 
-  function getRandomColor() {
-    const randomColor = '#' + Math.floor(Math.random()*16777215).toString(16); // Random color
-    return randomColor + '33'; // Adding opacity (33 in hexadecimal) for lighter color
-  }
-
-  //Color change based on initials 
   function getBackgroundColor(initials) {
-    if (existingInitials.has(initials)) {
-      return getRandomColor(); // Return a random color if initials already exist
-    } else {
-      existingInitials.add(initials);
-      return '#bbb'; // No background color
+    let color = "#bbb";
+    if(initialsSet.has(initials)){
+      const count = Math.floor(Math.random() * colors.length-1)
+      color = colors[count % colors.length];
+    }else{
+      initialsSet.add(initials);
     }
+    return color;
   }
 
   /*
@@ -112,6 +107,10 @@ function Task(props) {
       setIsOpen(props.openAll);
   }, [props.openAll]);
 
+  useEffect(()=>{
+    initialsSet.clear();
+  });
+ 
   return (
     <>
       {props.taskId ? (
@@ -183,6 +182,7 @@ function Task(props) {
                 ? props.resources
                   .filter((elm, i) => i < 2 || showMoreResources)
                   .map((elm, i) => {
+                    const name = elm.name;
                     const initials = elm.name.split(' ')
                     .filter((n, index) => index===0 || index===elm.name.split(' ').length - 1)
                     .map(n=>n[0])
@@ -199,8 +199,6 @@ function Task(props) {
                       >
                         {!elm.profilePic || elm.profilePic === "/defaultprofilepic.png" ?
                         <span className="dot" style={{ backgroundColor }}>{initials} </span>
-                          // ? <span className="dot">{elm.name.split(' ').map(n => n[0]).join('').toUpperCase()}</span>
-                          // ? <span className="dot" style={{ backgroundColor }}>{elm.name.split(' ').filter((n, index) => index === 0 || index === elm.name.split(' ').length - 1).map(n => n[0]).join('').toUpperCase()}</span>
                           : <img className="img-circle" src={elm.profilePic} />}
                       </a>
                     );

--- a/src/components/Projects/WBS/WBSDetail/Task/task.css
+++ b/src/components/Projects/WBS/WBSDetail/Task/task.css
@@ -7,6 +7,7 @@
   word-break: break-all;
 }
 
+
 .remove-link {
   margin-right: 5px;
   color: red;


### PR DESCRIPTION
# Description
This PR formats the names of people in a task to 2 initials and the background color for duplicate initials changes.
![Screenshot 2024-02-20 at 3 59 19 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/44672833/85060805-0346-4f44-a210-273e3e08b0a5)
Video explanation - https://www.loom.com/share/db552be3617e45409345e642039d6cca

## Related PRS (if any):
This frontend PR is related to the latest development backend

## Main changes explained:
- Format the names of people displayed in a WBS task with 2 initials, the first name's and the last name's (Eg. John Doe -> JD, John Lin Doe-> JD)
- If two initials are the same, the second one is shown with a different background color (Eg. The background color for John Lin Doe will be different but it will be #bbb(default) for John Doe

## How to test:
1. check into the current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log in as admin/owner user
5. go to dashboard→ Other links→ Projects -> WBS -> choose any WBS
6. Under the resources tab, the formatted initials will be displayed 

## Screenshots or videos of changes:
Before-
![Screenshot 2024-02-20 at 4 10 14 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/44672833/1d521195-251f-471f-9a59-83ed36a00deb)

After-
![Screenshot 2024-02-20 at 4 10 40 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/44672833/488e754a-a7a6-4b49-bc9a-2036562dbfdb)

Video-
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/44672833/c69030fe-39c5-4d69-9151-38e9e47e4574



## Note:
Whenever you reload or the component mounts again (Like when you click the arrow to show more names), the randomly assigned colors change as we are fetching a random color every time, but the colors for the first initials don't change and stay the default #bbb
