### PR TITLE
Christy - make WBS names active links

### DIFF
--- a/src/components/Reports/ProjectReport/ProjectReport.jsx
+++ b/src/components/Reports/ProjectReport/ProjectReport.jsx
@@ -10,14 +10,24 @@ import { ReportPage } from '../sharedComponents/ReportPage';
 import { Paging } from '../../common/Paging';
 import { TasksTable } from '../TasksTable';
 import { WbsTable } from '../WbsTable';
+import hasPermission from '../../../utils/permissions';
+import viewWBSpermissionsRequired from '../../../utils/viewWBSpermissionsRequired';
 import { projectReportViewData } from './selectors';
 import '../../Teams/Team.css';
 import './ProjectReport.css';
 
-export const ProjectReport = ({ match }) => {
-  const [memberCount, setMemberCount] = useState(0);
+// eslint-disable-next-line import/prefer-default-export
+export function ProjectReport({ match }) {
   const dispatch = useDispatch();
-  const { wbs, projectMembers, isActive, projectName, wbsTasksID, isLoading } = useSelector(
+  const [memberCount, setMemberCount] = useState(0);
+
+  const isAdmin = useSelector(state => state.auth.user.role) === 'Administrator';
+  const checkAnyPermission = permissions => {
+    return permissions.some(permission => dispatch(hasPermission(permission)));
+  };
+  const canViewWBS = isAdmin || checkAnyPermission(viewWBSpermissionsRequired);
+
+  const { wbs, projectMembers, isActive, projectName, wbsTasksID } = useSelector(
     projectReportViewData,
   );
 
@@ -48,7 +58,7 @@ export const ProjectReport = ({ match }) => {
       <div className="wbs-and-members-blocks-wrapper">
         <ReportPage.ReportBlock className="wbs-and-members-blocks">
           <Paging totalElementsCount={wbs.WBSItems.length}>
-            <WbsTable wbs={wbs} />
+            <WbsTable wbs={wbs} match={match} canViewWBS={canViewWBS} />
           </Paging>
         </ReportPage.ReportBlock>
         <ReportPage.ReportBlock className="wbs-and-members-blocks">
@@ -61,10 +71,10 @@ export const ProjectReport = ({ match }) => {
         </ReportPage.ReportBlock>
       </div>
       <div className="tasks-block">
-      <ReportPage.ReportBlock>
-        <TasksTable WbsTasksID={wbsTasksID} />
-      </ReportPage.ReportBlock>
+        <ReportPage.ReportBlock>
+          <TasksTable WbsTasksID={wbsTasksID} />
+        </ReportPage.ReportBlock>
       </div>
     </ReportPage>
   );
-};
+}

--- a/src/components/Reports/WbsTable/WbsTable.jsx
+++ b/src/components/Reports/WbsTable/WbsTable.jsx
@@ -1,36 +1,45 @@
-import { Stub } from 'components/common/Stub';
 import React from 'react';
+import { Stub } from 'components/common/Stub';
 import './WbsTable.css';
 
-export const WbsTable = ({ wbs, skip, take }) => {
+// eslint-disable-next-line import/prefer-default-export
+export function WbsTable({ wbs, skip, take, match, canViewWBS }) {
   let WbsList = [];
-  if (wbs.fetched) {
-    if (wbs.WBSItems.length > 0) {
-      WbsList = wbs.WBSItems.slice(skip, skip + take).map((item, index) => (
-        <div className="wbs-table-row" id={'tr_' + item._id} key={item._id}>
-          <div>{skip + index + 1}</div>
-          <div>{item.wbsName}</div>
-          <div className="projects__active--input">
-            {item.isActive ? (
-              <tasks className="isActive">
-                <i className="fa fa-circle" aria-hidden="true"></i>
-              </tasks>
-            ) : (
-              <div className="isNotActive">
-                <i className="fa fa-circle-o" aria-hidden="true"></i>
-              </div>
-            )}
-          </div>
-          <div>{window.innerWidth >= 1100 ? item._id : item._id.substring(0, 10)}</div>
+  const projectId = match?.params?.projectId;
+
+  if (wbs.fetched && wbs.WBSItems.length > 0) {
+    WbsList = wbs.WBSItems.slice(skip, skip + take).map((item, index) => (
+      <div className="wbs-table-row" id={`tr_${item._id}`} key={item._id}>
+        <div>{skip + index + 1}</div>
+        <div>
+          {canViewWBS ? (
+            <a href={`/wbs/tasks/${item._id}/${projectId}/${item.wbsName}`}>{item.wbsName}</a>
+          ) : (
+            <div>{item.wbsName}</div>
+          )}
         </div>
-      ));
-    }
+        <div className="projects__active--input">
+          {item.isActive ? (
+            <tasks className="isActive">
+              <i className="fa fa-circle" aria-hidden="true"></i>
+            </tasks>
+          ) : (
+            <div className="isNotActive">
+              <i className="fa fa-circle-o" aria-hidden="true" />
+            </div>
+          )}
+        </div>
+        <div>{window.innerWidth >= 1100 ? item._id : item._id.substring(0, 10)}</div>
+      </div>
+    ));
   }
 
   return (
     <div className="wbs-table">
-      <h5 style={{marginBottom: '2.125rem'}} className="wbs-table-title">WBS</h5>
-      <div style={{marginBottom: '0px'}} className="reports-table-head wbs-table-row">
+      <h5 style={{ marginBottom: '2.125rem' }} className="wbs-table-title">
+        WBS
+      </h5>
+      <div style={{ marginBottom: '0px' }} className="reports-table-head wbs-table-row">
         <div className="wbs-table-cell">#</div>
         <div className="wbs-table-cell">Name</div>
         <div className="wbs-table-cell">Active</div>
@@ -39,4 +48,4 @@ export const WbsTable = ({ wbs, skip, take }) => {
       <div>{WbsList.length > 0 ? WbsList : <Stub />}</div>
     </div>
   );
-};
+}

--- a/src/utils/viewWBSpermissionsRequired.js
+++ b/src/utils/viewWBSpermissionsRequired.js
@@ -1,0 +1,11 @@
+const viewWBSpermissionsRequired = [
+  'postWbs',
+  'deleteWbs',
+  'postTask',
+  'updateTask',
+  'deleteTask',
+  'resolveTask',
+  'putReviewStatus',
+];
+
+export default viewWBSpermissionsRequired;


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59427068/1af91677-c831-4f23-a09d-d6b722e8fbfc)


This PR converts WBS names into active links within the Projects section of the Admin user's Reports page. Besides, WBS names are displayed as active links only for users with permissions, enabling direct navigation to the WBS details.
…

## Related PRS (if any):
None.
…

## Main changes explained:
- Update file WbsTable.jsx: Converts WBS names into active, clickable links within the Projects section of the Admin user's Reports page.
- Update file ProjectReport.jsx: Enforces permission checks so that only users with the appropriate permissions can click the WBS links. Users without permission will not see the links.
…

## How to test:
1. Check into current branch.
2. Do npm install and npm run start:local to run this PR locally.
3. Clear site data/cache.
4. Log in with an Admin account.
5. Go to dashboard→ Reports→ Reports→ Projects→ Choose one project → WBS names should be active links here.
6. Log in with a user account that has been granted below any of the listed permissions related to Work Breakdown Structures.

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59427068/2da37bd3-2146-4afa-a457-287afc172c5f)

7. Go to dashboard→ Reports→ Reports→ Projects→ Choose one project → WBS names should be active links here.
8. Log in with a user account that has no permission related to Work Breakdown Structures.
9. Go to dashboard→ Reports→ Reports→ Projects→ Choose one project → WBS names will not be links.

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59427068/13fcec3a-d642-401e-a037-9509c106bf99



## Note:
This permission must be enabled to test the PR.
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59427068/beae4c4d-6c8f-49f7-abb1-d5f0b56b6b8c)

