### PR TITLE
Shivansh Added Security rechecks for Delete Team and User

### DIFF
--- a/src/components/Teams/DeleteTeamPopup.jsx
+++ b/src/components/Teams/DeleteTeamPopup.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import { boxStyle } from 'styles';
+import { connect } from 'react-redux';
+import hasPermission from 'utils/permissions';
 
 export const DeleteTeamPopup = React.memo(props => {
   const closePopup = () => {
     props.onClose();
   };
+  const canDeleteTeam = props.hasPermission('deleteTeam');
+  const canPutTeam = props.hasPermission('putTeam');
 
   return (
     <Modal isOpen={props.open} toggle={closePopup}>
@@ -17,24 +21,33 @@ export const DeleteTeamPopup = React.memo(props => {
         </span>
       </ModalBody>
       <ModalFooter>
-        <Button
-          color="danger"
-          onClick={async () => {
-            await props.onDeleteClick(props.selectedTeamId);
-          }}
-          style={boxStyle}
-        >
-          Confirm
-        </Button>
-        <Button
-          color="warning"
-          onClick={async () => {
-            await props.onSetInactiveClick(props.selectedTeamName, props.selectedTeamId, false, props.selectedTeamCode);
-          }}
-          style={boxStyle}
-        >
-          Set Inactive
-        </Button>
+        {(canDeleteTeam || canPutTeam) && (
+          <>
+            <Button
+            color="danger"
+            onClick={async () => {
+              await props.onDeleteClick(props.selectedTeamId);
+            }}
+            style={boxStyle}
+            >
+              Confirm
+            </Button>
+            <Button
+              color="warning"
+              onClick={async () => {
+                await props.onSetInactiveClick(props.selectedTeamName, props.selectedTeamId, false, props.selectedTeamCode);
+              }}
+              style={boxStyle}
+            >
+              Set Inactive
+            </Button>
+          </>
+        )}
+        {!(canDeleteTeam || canPutTeam) && (
+          <>
+            Unauthorized Action
+          </>
+        )}
         <Button color="primary" onClick={closePopup} style={boxStyle}>
           Close
         </Button>
@@ -42,4 +55,4 @@ export const DeleteTeamPopup = React.memo(props => {
     </Modal>
   );
 });
-export default DeleteTeamPopup;
+export default connect(null, { hasPermission })(DeleteTeamPopup);

--- a/src/components/Teams/__tests__/DeleteTeamPopup.test.js
+++ b/src/components/Teams/__tests__/DeleteTeamPopup.test.js
@@ -2,8 +2,13 @@ import React from 'react';
 import DeleteTeamPopup from 'components/Teams/DeleteTeamPopup';
 import { screen, fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../__tests__/utils';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { authMock, userProfileMock, rolesMock } from '../../../__tests__/mockStates';
 
 const mock = jest.fn();
+const mockStore = configureStore([thunk]);
+let store;
 
 const defaultProps = {
   open: true,
@@ -15,9 +20,18 @@ const defaultProps = {
   selectedTeamId: 1,
 };
 
+beforeEach(() => {
+  store = mockStore({
+    auth: authMock,
+    userProfile: userProfileMock,
+    role: rolesMock.role,
+    ...defaultProps,
+  });
+});
+
 describe('DeleteTeamPopup', () => {
   it('should call closePopup function', () => {
-    renderWithProvider(<DeleteTeamPopup {...defaultProps} />);
+    renderWithProvider(<DeleteTeamPopup {...defaultProps} />, { store });
 
     const closeButton = screen.getByText('Close');
     fireEvent.click(closeButton);
@@ -26,7 +40,7 @@ describe('DeleteTeamPopup', () => {
   });
 
   it('should call onSetInactiveClick when "Set Inactive" button is clicked', () => {
-    renderWithProvider(<DeleteTeamPopup {...defaultProps} />);
+    renderWithProvider(<DeleteTeamPopup {...defaultProps} />, { store });
 
     const setInactiveButton = screen.getByText('Set Inactive');
     fireEvent.click(setInactiveButton);
@@ -35,7 +49,7 @@ describe('DeleteTeamPopup', () => {
   });
 
   it('should call onDeleteClick when "Confirm" button is clicked', () => {
-    renderWithProvider(<DeleteTeamPopup {...defaultProps} />);
+    renderWithProvider(<DeleteTeamPopup {...defaultProps} />, { store });
 
     const confirmButton = screen.getByText('Confirm');
     fireEvent.click(confirmButton);
@@ -45,7 +59,7 @@ describe('DeleteTeamPopup', () => {
   });
 
   it('should render the modal when open is true', () => {
-    renderWithProvider(<DeleteTeamPopup {...defaultProps} />);
+    renderWithProvider(<DeleteTeamPopup {...defaultProps} />, { store });
 
     const modal = screen.getByText('Delete');
     expect(modal).toBeInTheDocument();

--- a/src/components/UserManagement/DeleteUserPopup.jsx
+++ b/src/components/UserManagement/DeleteUserPopup.jsx
@@ -13,6 +13,9 @@ import {
 } from '../../languages/en/messages';
 import { CLOSE } from '../../languages/en/ui';
 import { boxStyle } from 'styles';
+import { connect } from 'react-redux';
+import hasPermission from 'utils/permissions';
+
 /**
  * Modal popup to delete the user profile
  */
@@ -20,6 +23,7 @@ const DeleteUserPopup = React.memo(props => {
   const closePopup = e => {
     props.onClose();
   };
+  const canDeleteUser = props.hasPermission('deleteUserProfile');
 
   return (
     <Modal isOpen={props.open} toggle={closePopup}>
@@ -32,35 +36,44 @@ const DeleteUserPopup = React.memo(props => {
         </p>
         <p>{USER_DELETE_CONFIRMATION_SECOND_LINE}</p>
         <div style={{ textAlign: 'center', paddingTop: '10px' }}>
-          <Button
-            color="primary btn-danger"
-            onClick={() => {
-              props.onDelete(UserDeleteType.HardDelete);
-            }}
-            style={boxStyle}
-          >
-            {USER_DELETE_DATA_FOREVER}
-          </Button>
-          <DivSpacer />
-          <Button
-            color="primary btn-warning"
-            onClick={() => {
-              props.onDelete(UserDeleteType.Inactive);
-            }}
-            style={boxStyle}
-          >
-            {USER_DELETE_DATA_INACTIVE}
-          </Button>
-          <DivSpacer />
-          <Button
-            color="primary btn-success "
-            onClick={() => {
-              props.onDelete(UserDeleteType.SoftDelete);
-            }}
-            style={boxStyle}
-          >
-            {USER_DELETE_DATA_ARCHIVE}
-          </Button>
+          {(canDeleteUser) && (
+            <>
+              <Button
+                color="primary btn-danger"
+                onClick={() => {
+                  props.onDelete(UserDeleteType.HardDelete);
+                }}
+                style={boxStyle}
+              >
+                {USER_DELETE_DATA_FOREVER}
+              </Button>
+              <DivSpacer />
+              <Button
+                color="primary btn-warning"
+                onClick={() => {
+                  props.onDelete(UserDeleteType.Inactive);
+                }}
+                style={boxStyle}
+              >
+                {USER_DELETE_DATA_INACTIVE}
+              </Button>
+              <DivSpacer />
+              <Button
+                color="primary btn-success "
+                onClick={() => {
+                  props.onDelete(UserDeleteType.SoftDelete);
+                }}
+                style={boxStyle}
+              >
+                {USER_DELETE_DATA_ARCHIVE}
+              </Button>
+            </>
+          )}
+          {!(canDeleteUser) && (
+            <>
+              Unauthorized Action
+            </>
+          )}
         </div>
       </ModalBody>
       <ModalFooter>
@@ -76,4 +89,4 @@ const DivSpacer = React.memo(() => {
   return <div style={{ padding: '5px' }}></div>;
 });
 
-export default DeleteUserPopup;
+export default connect(null, { hasPermission })(DeleteUserPopup);

--- a/src/components/UserManagement/__test__/DeleteUserPopup.test.js
+++ b/src/components/UserManagement/__test__/DeleteUserPopup.test.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
+import { renderWithProvider } from '../../../__tests__/utils';
 import userEvent from '@testing-library/user-event';
 import DeleteUserPopup from '../DeleteUserPopup';
 import { UserDeleteType } from '../../../utils/enums';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { authMock, userProfileMock, rolesMock } from '../../../__tests__/mockStates';
 
 import {
   USER_DELETE_CONFIRMATION_FIRST_LINE,
@@ -13,11 +17,30 @@ import {
   USER_DELETE_OPTION_HEADING
 } from '../../../languages/en/messages';
 
+const mockStore = configureStore([thunk]);
+const onClose = jest.fn();
+const onDelete = jest.fn();
+let store;
+
+const defaultProps = {
+  open: true,
+  onClose: onClose,
+  onDelete: onDelete,
+};
+
+beforeEach(() => {
+  store = mockStore({
+    auth: authMock,
+    userProfile: userProfileMock,
+    role: rolesMock.role,
+    ...defaultProps,
+  });
+});
+
 describe('delete user popup', () => {
-  const onClose = jest.fn();
-  const onDelete = jest.fn();
+  
   beforeEach(() => {
-    render(<DeleteUserPopup open onClose={onClose} onDelete={onDelete} />);
+    renderWithProvider(<DeleteUserPopup {...defaultProps} />, {store});
   });
   describe('Structure', () => {
     it('should render the modal', () => {
@@ -59,10 +82,9 @@ describe('delete user popup', () => {
 });
 
 describe('delete user popup additional tests', () => {
-  const onClose = jest.fn();
-  const onDelete = jest.fn();
+
   beforeEach(() => {
-    render(<DeleteUserPopup open onClose={onClose} onDelete={onDelete} />);
+    renderWithProvider(<DeleteUserPopup {...defaultProps} />, {store});
   });
   describe('Texts display', () => {
     it('should render USER_DELETE_CONFIRMATION_FIRST_LINE', () => {


### PR DESCRIPTION
# Description
![Screenshot 2023-12-30 at 9 10 37 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/a47fcc6e-72c5-4949-bb1e-e7599615fda0)


## Related PRS (if any):
Old PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1765  has been closed, instead review this one. There is no dependency.


## Main changes explained:
- **Added permission check in DeleteTeamPopup.jsx**
Authorized and Unauthorized User DeleteTeamPopup preview:
<img width="350" alt="Screenshot 2023-12-30 at 9 02 45 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/1f79b701-d498-45c0-8ea7-3854ef3759fc">

<img width="350" alt="Screenshot 2023-12-30 at 9 01 59 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/a3a71db3-a511-449e-8a3f-3dc772326875">

- **Added permission check in DeleteUserPopup.jsx**
Authorized and Unauthorized User DeleteUserPopup preview:

<img width="350" alt="Screenshot 2023-12-30 at 9 00 50 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/214a39db-0c5a-471e-a8d8-3b90ff5541b9">

<img width="350" alt="Screenshot 2023-12-30 at 9 00 11 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/26687177/d8b15bd8-239a-486b-af2b-ba5c07005717">


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally 
3. log as admin user
4. **Check User Delete functionality**
4.1 Create a new user 
4.2 Now check if you are able to delete this user
4.3 If you are able to delete the user without any issues, this functionality is working as expected.
5. **Check Team Delete functionality**
5.1 Create a new team 
5.2 Now check if you are able to delete this team
5.3 If you are able to delete the team without any issues, this functionality is working as expected.

## Screenshots or videos of changes:

Changes explained above