### PR TITLE
Peteson fix the saving functionality so that the reason doesn’t disappear after switching dates

### DIFF
--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -98,11 +98,12 @@ const BlueSquareLayout = props => {
         });
       } else {
         fetchDispatch({ type: 'SUCCESS' }); 
+        // The date will be saved in the local storage to be used for recovering the value of the reason.
+      localStorage.setItem('date', date);  
       }
       setShow(true);
 
-      // The date will be saved in the local storage to be used for recovering the value of the reason.
-      localStorage.setItem('date', date);  
+      
 
     } else { //add/create reason
       fetchDispatch({ type: 'FETCHING_STARTED' });
@@ -114,14 +115,15 @@ const BlueSquareLayout = props => {
         });
       } else {
         fetchDispatch({ type: 'SUCCESS' });
+        // The date will be saved in the local storage to be used for recovering the value of the reason.
+      localStorage.setItem('date', date);  
         setAddsReason(true);
       }
     }
     setIsReasonUpdated(false);
     setAddsReason(false);
 
-    // The date will be saved in the local storage to be used for recovering the value of the reason.
-    localStorage.setItem('date', date);  
+ 
 
   };
 

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -103,6 +103,7 @@ const BlueSquareLayout = props => {
 
       // The date will be saved in the local storage to be used for recovering the value of the reason.
       localStorage.setItem('date', date);  
+
     } else { //add/create reason
       fetchDispatch({ type: 'FETCHING_STARTED' });
       const response = await addReason(userProfile._id, { date: date, message: reason });
@@ -121,6 +122,7 @@ const BlueSquareLayout = props => {
 
     // The date will be saved in the local storage to be used for recovering the value of the reason.
     localStorage.setItem('date', date);  
+
   };
 
 // ===============================================================

--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -97,9 +97,12 @@ const BlueSquareLayout = props => {
           payload: { message: response.message, errorCode: response.errorCode },
         });
       } else {
-        fetchDispatch({ type: 'SUCCESS' });
-        }
+        fetchDispatch({ type: 'SUCCESS' }); 
+      }
       setShow(true);
+
+      // The date will be saved in the local storage to be used for recovering the value of the reason.
+      localStorage.setItem('date', date);  
     } else { //add/create reason
       fetchDispatch({ type: 'FETCHING_STARTED' });
       const response = await addReason(userProfile._id, { date: date, message: reason });
@@ -115,6 +118,9 @@ const BlueSquareLayout = props => {
     }
     setIsReasonUpdated(false);
     setAddsReason(false);
+
+    // The date will be saved in the local storage to be used for recovering the value of the reason.
+    localStorage.setItem('date', date);  
   };
 
 // ===============================================================

--- a/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
+++ b/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
@@ -57,14 +57,14 @@ const ScheduleReasonModal = ({
 // This 'if' statement will be executed when the modal is opened or when the date is changed. 
 //If the text area with the label 'What is your reason for requesting this time off' has been filled out, the 'if' statement will be ignored.
        
-      if (reason === '') { 
-        responseReason.data.reasons.find((item) => {
-          const newDate = item.date.slice(0,-14);
-          if(localStorageGetItemDate === newDate || !localStorageGetItemDate){
-          item.reason === ''?  setIsReasonUpdated(false) : setIsReasonUpdated(true);
-          setReason(item.reason); 
-            
-            }
+if (reason === '') { 
+  responseReason.data.reasons.find((item) => {
+    const newDate = item.date.slice(0,-14);
+    if(localStorageGetItemDate === newDate || !localStorageGetItemDate){
+    item.reason === ''?  setIsReasonUpdated(false) : setIsReasonUpdated(true);
+    setReason(item.reason); 
+      
+      }
             
           });
 


### PR DESCRIPTION
# Description
In the user profile section, there is a blue button labeled 'Schedule Blue Square Reason,' which opens a modal containing one input field and one text area field. The input field is used to specify the date of the next Sunday when the developer will return to work, while the text area field is for specifying the reason for the leave request. The identified bug pertains to the text area field not retrieving the last entered text when the modal is reopened or when the date input is changed or the page is reloaded.

## priority medium

## Related PRS (if any):
None
…

## Main changes explained:
The text area will recover the last thing that was written or saved after the date is changed, the modal is reopened, or the page is reloaded.

After the message "Reason Scheduling Saved!" appears, the date will be saved to local storage and will be used to recover the last entry in the text area labeled "What is your reason for requesting this time off?".
…

## How to test:
1 check into current branch.
2. do `npm install` and `npm run start` to run this PR locally.
3. log as any user.
4. Go to view profile.
5. Click on the "Schedule Blue Square Reason" button.
6. Write in the text area field, "What is your reason for requesting this time off?"
7. After clicking the "Save" button, a second modal will open. Click on the "Confirm" button. 
8. After the message "Reason Scheduling Saved" appears, check if the date is saved in your local storage. Reopen the modal or change the date input or reload the page and check if the text area recovers the last reason that was saved 


## Screenshots or videos of changes:

Before my fix: https://www.dropbox.com/scl/fi/5qcycgx7j9lf80gj1z8dw/Blue-Square-Scheduler-Bug-Summary.mov?rlkey=97rh2g94krrr6c6uyoj5o9mx4&e=2&dl=0

After my fix: ![Peterson fix the saving functionality so that the reason doesn’t disappear after switching dates](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73541319/8a936a36-b242-4813-869c-6257c2c24ec7)


## Note:
The console is going to have some errors not related to this PR. These can be disregarded because the code changed by this PR will not introduce these errors to the "development" branch when it gets merged.
