### PR TITLE
Peterson_Fix_Weekly_Summaries_edit_Last_week's

### DIFF
--- a/src/actions/weeklySummaries.js
+++ b/src/actions/weeklySummaries.js
@@ -79,7 +79,8 @@ export const updateWeeklySummaries = (userId, weeklySummariesData) => {
 
       // Merge the weekly summaries related changes with the user's profile.
       const {mediaUrl, weeklySummaries, weeklySummariesCount } = weeklySummariesData;
-      console.log('respon get', response.data)
+      
+      // console.log('respon get', response.data)
       // update the changes on weekly summaries link into admin links
       let doesMediaFolderExist = false;
       for (const link of adminLinks) {

--- a/src/components/Timelog/WeeklySummaries.jsx
+++ b/src/components/Timelog/WeeklySummaries.jsx
@@ -1,22 +1,37 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect} from 'react';
 import parse from 'html-react-parser';
 import './Timelog.css'
-import updateWeeklySummaries from 'actions/weeklySummaries';
+import {updateWeeklySummaries} from '../../actions/weeklySummaries';
 import { getUserProfile, updateUserProfile } from 'actions/userProfile';
 import hasPermission from 'utils/permissions';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { Editor } from '@tinymce/tinymce-react';
 import { userProfileByIdReducer } from 'reducers/userProfileByIdReducer';
+import Spinner from 'react-bootstrap/Spinner';
 
 const WeeklySummaries = ({ userProfile }) => {
+
+  useEffect(() => {
+      setEditedSummaries([
+        userProfile.weeklySummaries[0]?.summary || '',
+        userProfile.weeklySummaries[1]?.summary || '',
+        userProfile.weeklySummaries[2]?.summary || '',
+      ]);
+    
+  }, [userProfile]);
+
   // Initialize state variables for editing and original summaries
+  
   const [editing, setEditing] = useState([false, false, false]);
+
   const [editedSummaries, setEditedSummaries] = useState([
     userProfile.weeklySummaries[0]?.summary || '',
     userProfile.weeklySummaries[1]?.summary || '',
     userProfile.weeklySummaries[2]?.summary || '',
   ]);
   const [originalSummaries, setOriginalSummaries] = useState([...editedSummaries]);
+
+  const [LoadingHandleSave, setLoadingHandleSave] = useState(null);
 
   const dispatch = useDispatch();
   const canEdit = dispatch(hasPermission('putUserProfile'));
@@ -54,10 +69,12 @@ const WeeklySummaries = ({ userProfile }) => {
   };
 
   const handleSave = async (index) => {
+    setLoadingHandleSave(index);
     // Save the edited summary content and toggle off editing mode
     const editedSummary = editedSummaries[index];
     // Check if the edited summary is not blank and contains at least 50 words
     const wordCount = editedSummary.split(/\s+/).filter(Boolean).length;
+
     if (editedSummary.trim() !== '' && wordCount >= 50) {
       const updatedUserProfile = {
         ...userProfile,
@@ -65,9 +82,14 @@ const WeeklySummaries = ({ userProfile }) => {
           i === index ? { ...item, summary: editedSummary } : item
         )
       };
-  
-    await dispatch(updateUserProfile(userProfile._id, updatedUserProfile));
+
+    // This code updates the summary.  
+    await dispatch(updateUserProfile(userProfile));
+    
+    // This code saves edited weekly summaries in MongoDB.
+    await dispatch(updateWeeklySummaries(userProfile._id, updatedUserProfile));
     await dispatch(getUserProfile(userProfile._id));
+    await setLoadingHandleSave(null);
       // Toggle off editing mode
       toggleEdit(index);
     } else {
@@ -96,7 +118,12 @@ const WeeklySummaries = ({ userProfile }) => {
             value={editedSummaries[index]}
             onEditorChange={(content) => handleSummaryChange({ target: { value: content } }, index)}
           />
-          <button className = "button save-button" onClick={() => handleSave(index)}>Save</button>
+
+          <button className = "button save-button" onClick={() => handleSave(index)} 
+          disabled={LoadingHandleSave === index} >
+          { LoadingHandleSave === index? <Spinner animation="border" size="sm" /> : 'Save' }
+          </button>
+
           <button className = "button cancel-button" onClick={() => handleCancel(index)}>Cancel</button>
         </div>
       );


### PR DESCRIPTION
# Description
In the HGN software, specifically within the 'Tasks and Timelogs' card on the Dashboard, there is a tab named 'Weekly Summaries,' which displays three editable summaries. Upon clicking the 'edit' button below each summary, two additional buttons, 'save' and 'cancel,' appear. The bug was found in the 'save' button functionality, which, when triggered, initiated a 'put' request resulting in two errors. The first error occurred because Node did not receive information from React, resulting in an HTTP status code 500, indicating a server error. The second error was related to the frontend-to-backend request: the request URL should have contained the user ID but was instead sent as 'undefined.'

## priority  Medium

## Related PRS (if any):
This frontend PR is associated with the following backend PR: https://github.com/OneCommunityGlobal/HGNRest/pull/781

## Main changes explained:
The WeeklySummaries component has been modified to fix the bugs.

## How to test:
1. check into current branch
2. do `npm install` and `npm start` to run this PR locally
3. log as any user.
4. Go to Dashboard →  Weekly Summaries.
5. Click the "Edit" button.
6. After editing the desired summary, click the "Save" button.
7. Open the browser's Developer Tools by pressing F12 or right-clicking and selecting 'Inspect.' Navigate to the 'Console' tab. Check if the following errors appear in the console: ![a](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73541319/b3d53504-93b2-4e8c-9e82-239aca12be7f)  
8. If the errors shown in the image above do not appear and the summary has been edited successfully, reload the page and check if the summary remains edited.

## Screenshots or videos of changes:

![Peterson_Fix_Weekly_Summaries_edit_Last_week’s](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73541319/63af3e73-44ec-4b78-973b-a0e9dda17dc4)

## Note:
The console is going to have some errors not related to this PR. These can be disregarded because the code changed by this PR will not introduce these errors to the "development" branch when it gets merged.