### PR TITLE
Yi - User Profile: Remove inactive accounts from summary intro

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -209,35 +209,36 @@ function UserProfile(props) {
 
   const loadSummaryIntroDetails = async (teamId, user) => {
     const currentManager = user;
+    try {
+      const res = await axios.get(ENDPOINTS.TEAM_USERS(teamId));
+      const { data } = res;
 
-    const res = await axios.get(ENDPOINTS.TEAM_USERS(teamId));
-    const { data } = res;
+      const activeMembers = data.filter(member => member._id !== currentManager._id && member.isActive);
 
-    const memberSubmitted = [];
-    const memberNotSubmitted = [];
+      const memberSubmitted = activeMembers
+        .filter(member => member.weeklySummaries[0].summary !== '')
+        .map(member => `${member.firstName} ${member.lastName}`);
 
-    data.forEach(member => {
-      if (member._id !== currentManager._id) {
-        if (member.weeklySummaries[0].summary !== '') {
-          memberSubmitted.push(`${member.firstName} ${member.lastName}`);
-        } else {
-          memberNotSubmitted.push(`${member.firstName} ${member.lastName}`);
-        }
-      }
-    });
+      const memberNotSubmitted = activeMembers
+        .filter(member => member.weeklySummaries[0].summary === '')
+        .map(member => `${member.firstName} ${member.lastName}`);
 
-    const memberSubmittedString =
-      memberSubmitted.length !== 0
-        ? memberSubmitted.join(', ')
-        : '<list all team members names included in the summary>';
-    const memberDidntSubmitString =
-      memberNotSubmitted.length !== 0
-        ? memberNotSubmitted.join(', ')
-        : '<list all team members names NOT included in the summary>';
+      const memberSubmittedString =
+        memberSubmitted.length !== 0
+          ? memberSubmitted.join(', ')
+          : '<list all team members names included in the summary>';
 
-    const summaryIntroString = `This week’s summary was managed by ${currentManager.firstName} ${currentManager.lastName} and includes ${memberSubmittedString}. These people did NOT provide a summary ${memberDidntSubmitString}. <Insert the proofread and single-paragraph summary created by ChatGPT>`;
+      const memberDidntSubmitString =
+        memberNotSubmitted.length !== 0
+          ? memberNotSubmitted.join(', ')
+          : '<list all team members names NOT included in the summary>';
 
-    setSummaryIntro(summaryIntroString);
+      const summaryIntroString = `This week’s summary was managed by ${currentManager.firstName} ${currentManager.lastName} and includes ${memberSubmittedString}. These people did NOT provide a summary ${memberDidntSubmitString}. <Insert the proofread and single-paragraph summary created by ChatGPT>`;
+
+      setSummaryIntro(summaryIntroString);
+    } catch (error) {
+      console.error('Error fetching team users:', error);
+    }
   };
 
   const loadUserTasks = async () => {


### PR DESCRIPTION
# Description

When clicking `Generate Summary Intro` button on the user profile, it generates an intro for the weekly summary to state who on their team submitted summaries. Now, inactive users are ignored when generating the summary.


<img width="813" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59299011/3a7a3382-bb5a-44d4-8e69-982a23b971f7">

## Related PRS (if any):
This frontend PR is related to the dev backend.


## Main changes explained:
- Ignore inactive users when generating summary intro.
- Add error handling.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as a user that is in any team
5. go to dashboard → `View Profile` -> Click `Generate Summary Intro` button
6. verify if inactive users in the team are ignored in the report.

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59299011/4dfd7d66-2a48-498a-ba63-6507cd6565e2
