### PR TITLE
Tapan - Fixed UI for Create New Role Without Name and Permission

### DIFF
--- a/src/components/PermissionsManagement/NewRolePopUp.jsx
+++ b/src/components/PermissionsManagement/NewRolePopUp.jsx
@@ -42,6 +42,7 @@ function CreateNewRolePopup({ toggle, addNewRole, roleNames }) {
     const regexTest = noSymbolsRegex.test(value);
     const duplicateTest = checkIfDuplicate(value);
     if (value.trim() === '') {
+      /* Changes Made */
       setNewRoleName(value);
       setErrorMessage('Please enter a role name');
       setIsValidRole(false);

--- a/src/components/PermissionsManagement/NewRolePopUp.jsx
+++ b/src/components/PermissionsManagement/NewRolePopUp.jsx
@@ -18,7 +18,11 @@ function CreateNewRolePopup({ toggle, addNewRole, roleNames }) {
   const handleSubmit = async e => {
     e.preventDefault();
 
-    if (!isValidRole) {
+    if (newRoleName.trim() === '') {
+      toast.error('Please enter a role name');
+    } else if (permissionsChecked.length === 0) {
+      toast.error('Please select at least one permission');
+    } else if (!isValidRole) {
       toast.error('Please enter a valid role name');
     } else if (!isNotDuplicateRole) {
       toast.error('Please enter a non duplicate role name');


### PR DESCRIPTION
# Description

<img width="736" alt="Screenshot 2024-03-07 at 1 58 00 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73526712/055019a9-e563-4ffc-a914-28f664118938">

Demo of Bug - [https://www.dropbox.com/scl/fi/ei3ag16xb57isrx2ek7ak/Create-new-role-click-with-empty-fields-white-screen.mp4?rlkey=vb01psyvwwwmeyoigwmm1x1j7&e=1&dl=0](url)

## Related PRS (if any):
N/A
…

## Main changes explained:
- Fixed UI for handling new role request when rolename and permission are empty
- Role Name needs to be given
- Atleast one permission needs be to selected

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. Other Links -> Permissions Management -> Add New Role -> Create
6. Try to create a role without giving rolename and without selecting any permission, it should thrown an error in UI. 

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73526712/46659daa-fc24-4976-826a-5a175e539425

