### PR TITLE
XiaoW_Hotfix of adding a temporary fix to the task check for displaying timeentry correctly

### DIFF
--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -63,7 +63,8 @@ const TimeEntry = (props) => {
     ({ projectName, projectCategory } = timeEntryProject);
     if (taskId) {
       const timeEntryTask = displayUserTasks.find(task => task._id === taskId);
-      ({ taskName, taskClassification = '' } = timeEntryTask);
+      console.log('timeEntryTask', timeEntryTask)
+      if (timeEntryTask) ({ taskName, taskClassification = '' } = timeEntryTask); // temporary fix for timeentry of tasks not have current user as resource
     }
   }
   


### PR DESCRIPTION
# Description
If a user logged a time entry to a task and got removed from that task resources, the user's timelog page will not display due to a mismatch of the timeentry. This is a temporary fix to this situation. Further decision of how should app deal with this needs to be made.
