### PR TITLE
Roberto-adds more optional chaining to userProfile page crash

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
@@ -227,8 +227,8 @@ const UserProjectsTable = React.memo(props => {
                 <tbody>
                   {props.userProjectsById.length > 0 ? (
                     filteredTasks?.map(project =>
-                      project.tasks.map(task => {
-                        const isCompletedTask = task.resources.find(
+                      project?.tasks?.map(task => {
+                        const isCompletedTask = task?.resources?.find(
                           ({ userID }) => userID === props.userId,
                         )?.completedTask;
                         return (
@@ -404,8 +404,8 @@ const UserProjectsTable = React.memo(props => {
                 <tbody>
                   {props.userProjectsById.length > 0 ? (
                     filteredTasks?.map(project =>
-                      project.tasks.map(task => {
-                        const isCompletedTask = task.resources.find(
+                      project?.tasks?.map(task => {
+                        const isCompletedTask = task?.resources?.find(
                           ({ userID }) => userID === props.userId,
                         )?.completedTask;
                         return (


### PR DESCRIPTION
# Description
User profile page is crashing at certain actions including array methods: .map and .find.


## Main changes explained:
- Adds more optional chaining to prevent the array methods from breaking in instances of null or undefined data.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→user profile page
6. verify page can load well

