### PR TITLE
Roberto-hotfix-helps restore old logic to fix the userprofile tasks section to normal

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
@@ -40,10 +40,11 @@ const UserProjectsTable = React.memo(props => {
   const filterTasksByUserTaskSituation = situation => {
     if (sortedTasksByNumber) {
       return userProjects?.map(project => {
-        const tasks = [];
-        sortedTasksByNumber?.forEach(task => {
-          const isCompletedTask = task?.resources?.find(user => user.userID === props.userId)?.completedTask;
-          if (task?.projectId?.includes(project._id)) {
+        const filteredTasks = sortedTasksByNumber.filter(task => {
+          const isTaskForProject = task.projectId.includes(project._id);
+          const isCompletedTask = task.resources?.find(user => user.userID === props.userId)?.completedTask;
+  
+          if (isTaskForProject) {
             if (situation === 'active' && !isCompletedTask) {
               return true;
             } else if (situation === 'complete' && isCompletedTask) {
@@ -54,7 +55,7 @@ const UserProjectsTable = React.memo(props => {
           }
           return false;
         });
-
+  
         return { ...project, tasks: filteredTasks };
       });
     }

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -1409,7 +1409,7 @@ function UserProfile(props) {
                   </Button>
                 </Link>
               )}
-              {canEdit && (activeTab === '1' || activeTab === '2' || activeTab === '3') && (
+              {canEdit && (activeTab) && (
                 <>
                   <SaveButton
                     className="mr-1 btn-bottom"


### PR DESCRIPTION
# Description
https://www.loom.com/share/f7d8b48a4cca492dabdfc268d9079892?sid=c660f226-10fd-40e0-9db9-2d520cb7097f
from 0:21 to end

## Related PRS (if any):
use latest backend

## Main changes explained:
- Helps resolve logic that sorts and filters the tasks, filterTasksByUserTaskSituation function had been altered which broke some logic and caused the tasks to show projects instead. Helped revert the logic to the original way which resolved in proper display.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to user profile→ projects tab→ tasks
6. verify you can see the tasks properly on the page, filter through all, active, and completed. 
7. try editing them by adding or deleting back to user and make sure it works well.


## Note:
If you add or delete the tasks, watch the save changes button, don't refresh the page until the save changes button has become disabled or else the changes won't reflect. 
