### PR TITLE
Sucheta- Refactor WeeklySummaryRecipient Button Functionality

### DIFF
--- a/src/components/WeeklySummariesReport/PasswordInputModal.jsx
+++ b/src/components/WeeklySummariesReport/PasswordInputModal.jsx
@@ -26,6 +26,8 @@ export default function PasswordInputModal({
   checkForValidPwd,
   isValidPwd,
   setSummaryRecepientsPopup,
+  setAuthpassword,
+  authEmailWeeklySummaryRecipient,
 }) {
   const [state, dispatch] = useReducer(weeklySummaryRecipientsReducer, {
     passwordMatch: '',
@@ -39,21 +41,24 @@ export default function PasswordInputModal({
   const authorizeWeeklySummariesButton = async () => {
     const url = ENDPOINTS.AUTHORIZE_WEEKLY_SUMMARY_REPORTS();
     try {
-      await axios.post(url, { currentPassword: passwordField }).then(response => {
-        // console.log(response);
-        if (response.status !== 200) {
-          dispatch(authorizeWeeklySummariesReportError('Incorrect Password! Unauthorised User!'));
-          checkForValidPwd(false);
-          setSummaryRecepientsPopup(false);
-        } else {
-          dispatch(authorizeWeeklySummaries(response.data.message));
-          checkForValidPwd(true);
-          toast.success('Authorization successful! Please wait to see Recipients table!');
-          setSummaryRecepientsPopup(true);
-        }
-      });
+      await axios
+        .post(url, { currentPassword: passwordField, currentUser: authEmailWeeklySummaryRecipient })
+        .then(response => {
+          // console.log(response);
+          if (response.status !== 200) {
+            dispatch(authorizeWeeklySummariesReportError('Incorrect Password! Unauthorised User!'));
+            checkForValidPwd(false);
+            setSummaryRecepientsPopup(false);
+          } else {
+            dispatch(authorizeWeeklySummaries(response.data.message));
+            checkForValidPwd(true);
+            toast.success('Authorization successful! Please wait to see Recipients table!');
+            setAuthpassword(response.data.password);
+            setSummaryRecepientsPopup(true);
+            onClose();
+          }
+        });
     } catch (error) {
-      // console.log('error:', error);
       checkForValidPwd(false);
       dispatch(authorizeWeeklySummariesReportError('Incorrect Password! Unauthorised User!'));
       throw Error(error);
@@ -63,9 +68,8 @@ export default function PasswordInputModal({
   const onSubmit = () => {
     setPasswordField('');
     authorizeWeeklySummariesButton(passwordField);
-
-    onClose();
   };
+
   return (
     <Container fluid>
       <Modal isOpen={open} toggle={onClose} autoFocus={false} size="lg">

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -70,7 +70,7 @@ export class WeeklySummariesReport extends Component {
       auth: [],
       selectedOverTime: false,
       selectedBioStatus: false,
-      weeklyRecipientAuthPass: '',
+      // weeklyRecipientAuthPass: '',
     };
   }
 
@@ -251,10 +251,16 @@ export class WeeklySummariesReport extends Component {
   };
 
   onClickRecepients = () => {
-    this.setState({
-      passwordModalOpen: true,
-    });
-    this.checkForValidPwd(true);
+    if (this.state.weeklyRecipientAuthPass) {
+      this.setState({
+        summaryRecepientsPopupOpen: true,
+      });
+    } else {
+      this.setState({
+        passwordModalOpen: true,
+      });
+      this.checkForValidPwd(true);
+    }
   };
 
   /**

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -70,6 +70,7 @@ export class WeeklySummariesReport extends Component {
       auth: [],
       selectedOverTime: false,
       selectedBioStatus: false,
+      weeklyRecipientAuthPass: '',
     };
   }
 
@@ -236,8 +237,17 @@ export class WeeklySummariesReport extends Component {
         checkForValidPwd={this.checkForValidPwd}
         isValidPwd={this.state.isValidPwd}
         setSummaryRecepientsPopup={this.setSummaryRecepientsPopup}
+        setAuthpassword={this.setAuthpassword}
+        authEmailWeeklySummaryRecipient={this.props.authEmailWeeklySummaryRecipient}
       />
     );
+  };
+
+  // Authorization for the weeklySummary Recipients is required once
+  setAuthpassword = authPass => {
+    this.setState({
+      weeklyRecipientAuthPass: authPass,
+    });
   };
 
   onClickRecepients = () => {
@@ -402,6 +412,9 @@ export class WeeklySummariesReport extends Component {
     } = this.state;
     const { error } = this.props;
     const hasPermissionToFilter = role === 'Owner' || role === 'Administrator';
+    const { authEmailWeeklySummaryRecipient } = this.props;
+    const authorizedUser1 = process.env.REACT_APP_JAE;
+    const authorizedUser2 = process.env.REACT_APP_SARA;
 
     if (error) {
       return (
@@ -445,17 +458,20 @@ export class WeeklySummariesReport extends Component {
             </h3>
           </Col>
         </Row>
-        <Row className="d-flex justify-content-center mb-3">
-          <Button
-            color="primary"
-            className="permissions-management__button"
-            type="button"
-            onClick={() => this.onClickRecepients()}
-            style={boxStyle}
-          >
-            Weekly Summary Report Recipients
-          </Button>
-        </Row>
+        {(authEmailWeeklySummaryRecipient === authorizedUser1 ||
+          authEmailWeeklySummaryRecipient === authorizedUser2) && (
+          <Row className="d-flex justify-content-center mb-3">
+            <Button
+              color="primary"
+              className="permissions-management__button"
+              type="button"
+              onClick={() => this.onClickRecepients()}
+              style={boxStyle}
+            >
+              Weekly Summary Report Recipients
+            </Button>
+          </Row>
+        )}
         <Row style={{ marginBottom: '10px' }}>
           <Col lg={{ size: 5, offset: 1 }} xs={{ size: 5, offset: 1 }}>
             Select Team Code
@@ -608,6 +624,7 @@ const mapStateToProps = state => ({
   infoCollections: state.infoCollections.infos,
   role: state.userProfile.role,
   auth: state.auth,
+  authEmailWeeklySummaryRecipient: state.userProfile.email, // capturing the user email through Redux store - Sucheta
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/WeeklySummariesReport/WeeklySummaryRecepientsPopup.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummaryRecepientsPopup.jsx
@@ -115,7 +115,9 @@ const WeeklySummaryRecipientsPopup = React.memo(props => {
                   <tr key={`recipient_name_${index}`}>
                     <td>{index + 1}</td>
                     <td>{`${user.firstName} ${user.lastName}`}</td>
-                    <td>{moment(user.createdDate).format('MMM-DD-YY')}</td>
+                    <td>
+                      {moment(user.permissionGrantedToGetWeeklySummaryReport).format('MMM-DD-YY')}
+                    </td>
                     <td>
                       <Button
                         color="danger"

--- a/src/components/WeeklySummariesReport/WeeklySummaryRecepientsPopup.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummaryRecepientsPopup.jsx
@@ -38,7 +38,7 @@ const WeeklySummaryRecipientsPopup = React.memo(props => {
       }
     };
     getRecipients();
-  }, [updatedRecipients]);
+  }, [open, updatedRecipients]);
 
   const closePopup = () => {
     onClose();
@@ -60,6 +60,7 @@ const WeeklySummaryRecipientsPopup = React.memo(props => {
         }
         toast.success('Added new recipient.');
         setRecipients(prevState => [...prevState, selectedUser]);
+        setUpdatedRecipients(prevState => !prevState);
         setSearchText('');
       } catch (error) {
         toast.error('Could not add recipient');


### PR DESCRIPTION
# Description
(PRIORITY HIGH) Jae: Create a Weekly Summaries Reports recipient button for Owners(WIP SUCHETA)
- Place the Button somewhere on the top of the Other Links → Reports → Weekly Summaries Reports page
- The authorized user's email will be saved in the environment variables to secure them from being exposed.
- The `WeeklySummaryRecipients` button will render dynamically i.e if the user is an authorized user.
- Make it password-protected with the same password as the [jae@onecommunityglobal.org](mailto:jae@onecommunityglobal.org) account
- Redundancy of the authorization process now has been removed. The password needs to be entered once for Authorization.
- Have it show an editable list of who is currently receiving the report.
- The Table will show when the recipients were added instead of showing the account `created` date.
- Needs final update to my password before being merged

## Related PRS (if any):
This frontend PR is related to the [#792](https://github.com/OneCommunityGlobal/HGNRest/pull/792) backend PR.

…

## Main changes explained:
- Renders the `WeeklySummaryRecipients` button only when authorized users are logged in.
- User only needs to enter password once for added security
- Both authorized users should see the same recipients list.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as Owner(authorized user only) user
5. go to dashboard→ Tasks→ task→…
6. verify if the account is authorized to view the `WeeklySummaryRecipients` - button.
7. 
## Screenshots or videos of changes:

## Note:
Please add 2 emails to these 2 env variables before testing. This allows only the verified user to be able to access the weeklySummaryRecipients :
REACT_APP_JAE="yourEmailHere"
REACT_APP_SARA="yourEmailHere" 