### PR TITLE
Tareq - Fix map component scrolling

### DIFF
--- a/src/components/TeamLocations/TeamLocations.css
+++ b/src/components/TeamLocations/TeamLocations.css
@@ -13,3 +13,7 @@
   overflow: hidden;
   max-height: 300px;
 }
+
+#map-container {
+  height: calc(100vh - 225px);
+}

--- a/src/components/TeamLocations/TeamLocations.jsx
+++ b/src/components/TeamLocations/TeamLocations.jsx
@@ -266,6 +266,7 @@ function TeamLocations() {
         ) : null}
       </div>
       <MapContainer
+        id='map-container'
         center={[51.505, -0.09]}
         maxBounds={[
           [-90, -225],


### PR DESCRIPTION
# Description
<img width="727" alt="Screenshot 2024-03-16 at 4 09 44 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/39747003/4d9478bc-4ab8-4734-ba6d-3394ab457de4">

## Related PRS (if any):
To test this PR, use the current Development backend.

## Main changes explained:
- Changed the CSS of the MapContainer so that it fits in the whole screen without needing to scroll.

## How to test:
1. check into the current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in as any user
5. go to dashboard → Reports → Team Locations
6. verify that the entire map fits in the viewport and that there is no scrolling. 
7. also verify on a smaller screen size (smaller window and mobile screen size)

## Screenshots or videos of changes:
### Before

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/39747003/4847ec44-d47b-461d-beeb-42287766b878



https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/39747003/6dd2c5dd-3cff-42bd-a6ab-1964b42456d9


### After

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/39747003/7ce1b3da-d4cb-45a7-b432-1d34d665e44f

<img width="1500" alt="Screenshot 2024-03-16 at 4 25 25 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/39747003/9b575913-dabe-4a15-8dc1-b8c1dda21d23">



