### PR TITLE
Nahiyan_Fix Basic Information tab UI (Tablet View)

### DIFF
--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -20,13 +20,13 @@ import { toast } from 'react-toastify';
 
 
 const Name = props => {
-  const { userProfile, setUserProfile, formValid, setFormValid, canEdit } = props;
+  const { userProfile, setUserProfile, formValid, setFormValid, canEdit, desktopDisplay } = props;
   const { firstName, lastName } = userProfile;
 
   if (canEdit) {
     return (
       <>
-        <Col md="3">
+        <Col md={desktopDisplay ? '3' : ''}>
           <FormGroup>
             <Input
               type="text"
@@ -44,7 +44,7 @@ const Name = props => {
             <FormFeedback>First Name Can&apos;t be empty</FormFeedback>
           </FormGroup>
         </Col>
-        <Col md="3">
+        <Col md={desktopDisplay ? '3' : ''}>
           <FormGroup>
             <Input
               type="text"
@@ -69,20 +69,20 @@ const Name = props => {
   return (
     <>
       <Col>
-        <p>{`${firstName} ${lastName}`}</p>
+        <p className="text-right">{`${firstName} ${lastName}`}</p>
       </Col>
     </>
   );
 };
 
 const Title = props => {
-  const { userProfile, setUserProfile, canEdit } = props;
+  const { userProfile, setUserProfile, canEdit, desktopDisplay } = props;
   const { jobTitle } = userProfile;
 
   if (canEdit) {
     return (
       <>
-        <Col md="6">
+        <Col md={desktopDisplay ? '6' : ''}>
           <FormGroup>
             <Input
               type="text"
@@ -102,14 +102,14 @@ const Title = props => {
   return (
     <>
       <Col>
-        <p>{`${jobTitle}`}</p>
+        <p className='text-right'>{`${jobTitle}`}</p>
       </Col>
     </>
   );
 };
 
 const Email = props => {
-  const { userProfile, setUserProfile, formValid, setFormValid, canEdit } = props;
+  const { userProfile, setUserProfile, formValid, setFormValid, canEdit, desktopDisplay } = props;
   const { email, privacySettings, emailSubscriptions } = userProfile;
 
   const emailPattern = new RegExp(/^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$/i);
@@ -117,7 +117,7 @@ const Email = props => {
   if (canEdit) {
     return (
       <>
-        <Col md="6">
+        <Col md={desktopDisplay ? '6' : ''}>
           <FormGroup>
             <ToggleSwitch
               switchType="email"
@@ -153,7 +153,7 @@ const Email = props => {
     <>
       {privacySettings?.email && (
         <Col>
-          <p>{email}</p>
+          <p className='text-right'>{email}</p>
         </Col>
       )}
     </>
@@ -191,12 +191,12 @@ const formatPhoneNumber = str => {
   return str;
 };
 const Phone = props => {
-  const { userProfile, setUserProfile, handleUserProfile, canEdit } = props;
+  const { userProfile, setUserProfile, handleUserProfile, canEdit, desktopDisplay } = props;
   const { phoneNumber, privacySettings } = userProfile;
   if (canEdit) {
     return (
       <>
-        <Col md="6">
+        <Col md={desktopDisplay ? '6' : ''}>
           <FormGroup>
             <ToggleSwitch
               switchType="phone"
@@ -220,7 +220,7 @@ const Phone = props => {
     <>
       {privacySettings?.phoneNumber && (
         <Col>
-          <p>{formatPhoneNumber(phoneNumber)}</p>
+          <p className='text-right'>{formatPhoneNumber(phoneNumber)}</p>
         </Col>
       )}
     </>
@@ -228,7 +228,7 @@ const Phone = props => {
 };
 
 const TimeZoneDifference = props => {
-  const { isUserSelf, errorOccurred, setErrorOccurred } = props;
+  const { isUserSelf, errorOccurred, setErrorOccurred, desktopDisplay } = props;
   const [signedOffset, setSignedOffset] = useState('');
   const viewingTimeZone = props.userProfile.timeZone;
   const yourLocalTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -268,8 +268,8 @@ const TimeZoneDifference = props => {
   if (!isUserSelf) {
     return (
       <>
-        <Col md="7">
-          <p>{signedOffset} hours</p>
+        <Col md="6">
+          <p className='text-right'>{signedOffset} hours</p>
         </Col>
       </>
     );
@@ -277,8 +277,8 @@ const TimeZoneDifference = props => {
 
   return (
     <>
-      <Col md="7">
-        <p>This is your own profile page</p>
+      <Col md={desktopDisplay ? '6' : ''}>
+        <p className={desktopDisplay ? 'text-right' : 'text-left'}>This is your own profile page</p>
       </Col>
     </>
   );
@@ -377,6 +377,7 @@ const BasicInformationTab = props => {
         formValid={formValid}
         role={props.role}
         canEdit={canEdit}
+        desktopDisplay={desktopDisplay}
       />
     </>
   );
@@ -403,6 +404,7 @@ const BasicInformationTab = props => {
         formValid={formValid}
         role={props.role}
         canEdit={canEdit}
+        desktopDisplay={desktopDisplay}
       />
     </>
   );
@@ -430,6 +432,7 @@ const BasicInformationTab = props => {
         setFormValid={setFormValid}
         role={props.role}
         canEdit={canEdit}
+        desktopDisplay={desktopDisplay}
       />
     </>
   );
@@ -456,6 +459,7 @@ const BasicInformationTab = props => {
         formValid={formValid}
         role={props.role}
         canEdit={canEdit}
+        desktopDisplay={desktopDisplay}
       />
     </>
   );
@@ -571,7 +575,7 @@ const BasicInformationTab = props => {
             <Col className="cols">
               <Input onChange={handleLocation} value={userProfile.location.userProvided || ''} />
               <div>
-                <Button color="secondary" block size="sm" onClick={onClickGetTimeZone}>
+                <Button color="secondary" block size="sm" onClick={onClickGetTimeZone} className="mt-2">
                   Get Time Zone
                 </Button>
               </div>
@@ -604,7 +608,7 @@ const BasicInformationTab = props => {
 
   const timeZoneDifferenceComponent = (
     <>
-      <Col md={desktopDisplay ? '5' : null}>
+      <Col md={desktopDisplay ? '5' : ''}>
         <label>Difference in this Time Zone from Your Local</label>
       </Col>
       <TimeZoneDifference
@@ -615,14 +619,15 @@ const BasicInformationTab = props => {
         formValid={formValid}
         errorOccurred={errorOccurred}
         setErrorOccurred={setErrorOccurred}
+        desktopDisplay={desktopDisplay}
       />
     </>
   );
 
   const endDateComponent = (
     <>
-      <Col>
-        <Label>
+      <Col md={desktopDisplay ? '8' : ''} className="mr-5">
+        <Label className='mr-1'>
           {userProfile.endDate
             ? 'End Date ' + formatDate(userProfile.endDate)
             : 'End Date ' + 'N/A'}
@@ -637,7 +642,7 @@ const BasicInformationTab = props => {
         )}
       </Col>
       {desktopDisplay && canEdit && (
-        <Col md="6">
+        <Col>
           <SetUpFinalDayButton
             loadUserProfile={loadUserProfile}
             setUserProfile={setUserProfile}
@@ -653,10 +658,10 @@ const BasicInformationTab = props => {
     <>
       {desktopDisplay ? (
         <>
-          <Col>
+          <Col md="8" className="mr-5">
             <Label>Status</Label>
           </Col>
-          <Col md="6">
+          <Col>
             <Label>
               {userProfile.isActive
                 ? 'Active'
@@ -677,7 +682,7 @@ const BasicInformationTab = props => {
         </>
       ) : (
         <>
-          <Col style={{ alignItems: 'center', justifyContent: 'center' }}>
+          <Col md="9">
             <Label>Status</Label>
             <div>
               <Label style={{ fontWeight: 'normal' }}>

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -626,7 +626,7 @@ const BasicInformationTab = props => {
 
   const endDateComponent = (
     <>
-      <Col md={desktopDisplay ? '8' : ''} className="mr-5">
+      <Col md={desktopDisplay ? '8' : ''} className={desktopDisplay ? 'mr-5' : ''}>
         <Label className='mr-1'>
           {userProfile.endDate
             ? 'End Date ' + formatDate(userProfile.endDate)
@@ -682,7 +682,7 @@ const BasicInformationTab = props => {
         </>
       ) : (
         <>
-          <Col md="9">
+          <Col>
             <Label>Status</Label>
             <div>
               <Label style={{ fontWeight: 'normal' }}>


### PR DESCRIPTION
[](url)# Description
The Basic Information tab UI seems to break from the viewport of (768px - 1024px)
![Screenshot 2024-03-19 141434](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/84ba229c-eaaf-4e6a-af52-ea8a31205232)


## Related PRS (if any):
This frontend PR is related to the DEV backend

## Main changes explained:
- Added conditions to the column props so width changes for the desktop view

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as Owner and Volunteer user
5. go to dashboard→ User Profile → Basic Information Tab
6. verify that when making the viewport smaller than 1024px, the UI appears to be normal
7. verify the mobile and desktop view as well by adjusting the viewport width
8. Use both an owner account and a volunteer account to test this as there are edit and non edit versions of these fields

## Screenshots or videos of changes:
Before: 
![Screenshot 2024-03-21 132017](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/eeb1aa42-1571-4080-aeed-f0e79d993bdd)

After:
![Screenshot 2024-03-21 131956](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/8830ca62-cf42-4867-8cf9-b44d23d87e91)
