### PR TITLE
fix invalid date in the blue square description

### DIFF
--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -44,7 +44,7 @@ const BlueSquare = props => {
                     <div className="title">{formatDate(blueSquare.date)}</div>
                     {blueSquare.description !== undefined && (
                       <div className="summary">
-                        {blueSquare.createdDate !== undefined
+                        {blueSquare.createdDate !== undefined && blueSquare.createdDate !== null
                           ? `${formatCreatedDate(blueSquare.createdDate)}: ${blueSquare.description}`
                           : blueSquare.description}
                       </div>


### PR DESCRIPTION
# Description

This pull request resolves the issue of the invalid date in the blue square description.

## Screenshots:

### Before:
![Screenshot 2024-03-21 205233](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/49083865/365433ca-d5e8-42f2-b440-885299ed820f)
### After:
![Screenshot 2024-03-21 205111](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/49083865/50ba8918-e86e-49d6-a38c-a2994bcf771b)
