### PR TITLE
Malav delete time entry own

### DIFF
--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -242,6 +242,18 @@ export const permissionLabels = [
     description: 'Category for all permissions related to timelog management',
     subperms: [
       {
+        label: 'Timelog Management (Own)',
+        description: 'Category for all permissions related to timelog management',
+        subperms: [
+          {
+            label: 'Delete Time Entry (Own)',
+            key: 'deleteTimeEntryOwn',
+            description:
+              'Gives the user permission to Delete time entry from others users "Dashboard" -> "Leaderboard" -> "Dot By the side of user\'s name" -> "Current Time Log" -> "Trash button on bottom right"',
+          },
+        ]
+      },
+      {
         label: 'Timelog Management (Others)',
         description: 'Category for all permissions related to timelog management',
         subperms: [
@@ -259,7 +271,7 @@ export const permissionLabels = [
           },
           {
             label: 'Delete Time Entry (Others)',
-            key: 'deleteTimeEntry',
+            key: 'deleteTimeEntryOthers',
             description:
               'Gives the user permission to Delete time entry from others users "Dashboard" -> "Leaderboard" -> "Dot By the side of user\'s name" -> "Current Time Log" -> "Trash button on bottom right"',
           },

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -411,6 +411,7 @@ const TeamMemberTasks = React.memo(props => {
                             <tr className="table-row" key={timeEntry._id}>
                               <td colSpan={6} style={{ padding: 0 }}>
                                 <TimeEntry
+                                  isOwnTask={false}
                                   from="TaskTab"
                                   data={timeEntry}
                                   displayYear

--- a/src/components/Timelog/DeleteModal.jsx
+++ b/src/components/Timelog/DeleteModal.jsx
@@ -10,10 +10,9 @@ import { ENDPOINTS } from 'utils/URL';
 import axios from 'axios';
 import {toast} from 'react-toastify';
 
-const DeleteModal = ({ timeEntry, projectCategory, taskClassification }) => {
+const DeleteModal = ({ timeEntry, projectCategory, taskClassification,userProfile}) => {
   const [isOpen, setOpen] = useState(false);
   const dispatch = useDispatch();
-
   const toggle = () => setOpen(isOpen => !isOpen);
 
   const deleteEntry = async event => {
@@ -29,7 +28,12 @@ const DeleteModal = ({ timeEntry, projectCategory, taskClassification }) => {
 
       fixDiscrepancy(userProfile);
 
-      const deleteTimeStatus = await dispatch(deleteTimeEntry(timeEntry));
+      const deleteTimeStatus = await dispatch(deleteTimeEntry({...timeEntry,role:userProfile?.role}));
+      if(deleteTimeStatus == 403)
+      {
+        throw new Error ('Unauthorized to perform the action');
+      }
+      
       if (deleteTimeStatus != 200){
         throw new Error ('error occurred while dispatching delete time entry action');
       }

--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -32,7 +32,7 @@ import checkNegativeNumber from 'utils/checkNegativeHours';
 
 const TimeEntry = (props) => {
   // props from parent
-  const { from, data, displayYear, timeEntryUserProfile, displayUserProjects, displayUserTasks, tab } = props
+  const { from, data, displayYear,isOwnTask,timeEntryUserProfile, displayUserProjects, displayUserTasks, tab } = props
   // props from store
   const { authUser } = props;
 
@@ -81,12 +81,16 @@ const TimeEntry = (props) => {
     //permission to edit any time entry on their own time logs tab
     || dispatch(hasPermission('editTimeEntry')) 
 
-  //permission to Delete time entry from other user's Dashboard
-  const canDelete = dispatch(hasPermission('deleteTimeEntryOthers')) ||
-    //permission to delete any time entry on their own time logs tab
-    dispatch(hasPermission('deleteTimeEntry')) ||
-    //default permission: delete own sameday tangible entry
-    isAuthUserAndSameDayEntry;
+  //permission to Delete any time entry from other user's Dashboard
+  const canDeleteOther = (dispatch(hasPermission('deleteTimeEntryOthers')) && !isOwnTask);
+
+  //permission to delete any time entry on their own time logs tab
+  const canDeleteOwn=(dispatch(hasPermission('deleteTimeEntryOwn')) && isOwnTask);
+
+  // condition for allowing delete in delete model
+  //default permission: delete own sameday tangible entry = isAuthUserAndSameDayEntry
+  const canDelete = canDeleteOther || canDeleteOwn || isAuthUserAndSameDayEntry;
+
 
   const toggleTangibility = () => {
     //Update intangible hours property in userprofile
@@ -218,8 +222,11 @@ const TimeEntry = (props) => {
                     <FontAwesomeIcon icon={faEdit} size="lg" onClick={toggle} />
                   </button>
               )}
-              {canDelete && from === 'WeeklyTab' && (
+              
+              { canDelete && from === 'WeeklyTab' && (
+                
                 <button className='text-primary'>
+                  
                   <DeleteModal
                     timeEntry={data}
                     userProfile={timeEntryUserProfile}
@@ -227,7 +234,7 @@ const TimeEntry = (props) => {
                     taskClassification={taskClassification}
                   />
                 </button>
-              )}
+              ) }
             </div>
           </Col>
         </Row>

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -186,6 +186,7 @@ const Timelog = props => {
        *  */ 
       <TimeEntry
         from='WeeklyTab'
+        isOwnTask={authUser.userid == displayUserId}
         data={entry}
         displayYear
         key={entry._id}
@@ -196,7 +197,7 @@ const Timelog = props => {
       />
     ));
   };
-
+       
   const loadAsyncData = async userId => {
     //load the timelog data
     setTimeLogState({ ...timeLogState, isTimeEntriesLoading: true });


### PR DESCRIPTION
# Description
This PR enables the user with the Delete Time Entry (Own) permission to be able to delete it's own any time entry  via their dashboard.

## Related PRS (if any):
This frontend PR is related to the dev backend PR.


## Main changes explained:
- Added conditional logic so that the user with the permission can delete the any time entry of it's own.


## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Other Links -> Permissions Management -> Manage User Permissions -> Choose a USER without Delete Time Entry (Own) permission under Timelog Management -> click on Add -> Scroll down then submit
6. Make sure USER doesn't have DELETE_TIME_ENTRY_OTHERS Permission.
7. verify that the user who was given the permission is now able to see  delete button in any of time entry log on  dashboard and able delete it.

## Screenshots or videos of changes:
![1](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/61341363/b3efe5cd-adf4-42f0-ba5b-16d4baaa686e)
![2](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/61341363/db6fd5ac-c4a6-4b88-8559-dd95d4e9eacc)
![3](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/61341363/cde10146-84c9-4be6-b750-7806c3fb2826)

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/61341363/6eb67fc0-9e6f-4d8c-886b-b6ce6d526e64



## Note:

