### PR TITLE
simplify and generalize getTimeEntriesForPeriod()

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -120,48 +120,16 @@ const TeamMemberTasks = React.memo(props => {
   };
 
   const getTimeEntriesForPeriod = async (selectedPeriod) => {
-    const oneDayAgo = moment()
+    if(isNaN(parseInt(selectedPeriod))) {
+      setTimeEntriesList([]);
+    } else {
+    const xDaysAgo = moment()
       .tz('America/Los_Angeles')
-      .subtract(1, 'days')
+      .subtract(parseInt(selectedPeriod), 'days')
       .format('YYYY-MM-DD');
 
-    const twoDaysAgo = moment()
-      .tz('America/Los_Angeles')
-      .subtract(2, 'days')
-      .format('YYYY-MM-DD');
-    
-    const threeDaysAgo = moment()
-      .tz('America/Los_Angeles')
-      .subtract(3, 'days')
-      .format('YYYY-MM-DD');
-
-    const fourDaysAgo = moment()
-      .tz('America/Los_Angeles')
-      .subtract(4, 'days')
-      .format('YYYY-MM-DD');
-
-    switch (selectedPeriod) {
-      case '1':
-        const oneDaysList = usersWithTimeEntries.filter(entry => moment(entry.dateOfWork).isAfter(oneDayAgo));
-        setTimeEntriesList(oneDaysList);
-        break;
-      case '2':
-        const twoDaysList = usersWithTimeEntries.filter(entry => moment(entry.dateOfWork).isAfter(twoDaysAgo));
-        setTimeEntriesList(twoDaysList);
-        break;
-      case '3':
-        const threeDaysList = usersWithTimeEntries.filter(entry => moment(entry.dateOfWork).isAfter(threeDaysAgo));
-        setTimeEntriesList(threeDaysList);
-        break;
-      case '4':
-        const fourDaysList = usersWithTimeEntries.filter(entry => moment(entry.dateOfWork).isAfter(fourDaysAgo));
-        setTimeEntriesList(fourDaysList);
-        break;
-      case '7':
-        setTimeEntriesList(usersWithTimeEntries);
-        break;
-      default:
-        setTimeEntriesList([]);
+      const xDaysList = usersWithTimeEntries.filter(entry => moment(entry.dateOfWork).isAfter(xDaysAgo));
+      setTimeEntriesList(xDaysList);
     }
 
     setFinishLoading(true);


### PR DESCRIPTION
# Description
Refactors getTimeEntriesForPeriod() to be more generalized and condensed logic.

## Main changes explained:
- Replace `oneDayAgo`, `twoDaysAgo`,... with `xDaysAgo`
- Remove switch statement for 1,2,3,4,7 inputs with one generalized statement
- Create file C for introducing new components …
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks and Timelogs
6. Try each of the "1 days", "2 days", ... buttons next to "Team Member Tasks"
7. verify the filter shows time entries from within those periods

## Screenshots or videos of changes:
Taken April 2nd:
7 days ago should show everything after March 26th:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/8c648b8e-6e7d-4314-9f6f-c10812507497)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/40c0d55c-455a-4614-8ba7-c08eb7510822)

4 days ago should show everything after March 29th:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/3f159d3d-5e6d-44b8-ab17-77499c0282ca)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/845cadb9-443a-4b3a-9bf0-2fc8a135e270)

Neither should show up with 1 day ago:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/8e92ad68-d3b3-417a-9672-6dfde01e4b4b)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/65aafff6-6581-4ae8-afe4-237c1752db6a)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/23086054/28b25631-84c2-4f39-9ca2-4235be81c8fe)