### PR TITLE
added red text and removed conosle.log in roleInfoModal

### DIFF
--- a/src/components/UserProfile/EditableModal/roleInfoModal.jsx
+++ b/src/components/UserProfile/EditableModal/roleInfoModal.jsx
@@ -1,56 +1,46 @@
 import React, { useState } from 'react';
-import {
-  Button,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
- } from 'reactstrap';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 
-const RoleInfoModal = ({info}) => {
-  console.log("showing information")
-  console.log(info)
-    const [isOpen, setOpen] = useState(false);
-    const {infoContent, CanRead} = {...info};
-    const handleMouseOver = () => {
-      setOpen(true);
-    }
+const RoleInfoModal = ({ info }) => {
+  const [isOpen, setOpen] = useState(false);
+  const { infoContent, CanRead } = { ...info };
+  const handleMouseOver = () => {
+    setOpen(true);
+  };
 
-    const handleClose = () => {
-      setOpen(false);
-    }
-    if(CanRead){
-      return (<span>
+  const handleClose = () => {
+    setOpen(false);
+  };
+  if (CanRead) {
+    return (
+      <span>
         <i
           data-toggle="tooltip"
           data-placement="right"
           title="Click for user class information"
-          style={{ fontSize: 24, cursor: 'pointer', color: '#00CCFF', marginLeft: '5px'}}
+          style={{ fontSize: 24, cursor: 'pointer', color: '#00CCFF', marginLeft: '5px' }}
           aria-hidden="true"
           className="fa fa-info-circle"
           onClick={handleMouseOver}
         />
         {isOpen && (
           <Modal isOpen={isOpen} size="lg">
-          <ModalHeader>Welcome to Information Page!</ModalHeader>
-          <ModalBody>
-           <div
-              style={{ paddingLeft: '20px' }}
-              dangerouslySetInnerHTML={{ __html: infoContent }}/>
-          </ModalBody>
-          <ModalFooter>
-          <Button onClick={handleClose}>Close</Button>
-          </ModalFooter>
+            <ModalHeader>Welcome to Information Page!</ModalHeader>
+            <ModalBody>
+              <div
+                style={{ paddingLeft: '20px' }}
+                dangerouslySetInnerHTML={{ __html: infoContent }}
+              />
+            </ModalBody>
+            <ModalFooter>
+              <Button onClick={handleClose}>Close</Button>
+            </ModalFooter>
           </Modal>
         )}
-      </span>)
-    }
-    return (
-        <>
-        </>
-
-    )
-}
+      </span>
+    );
+  }
+  return <></>;
+};
 
 export default RoleInfoModal;
-;

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -226,17 +226,17 @@ function ReportDetails({
               />
             </ListGroupItem>
             <ListGroupItem>
-              <b style={{ color: textColors[summary?.weeklySummaryOption] || textColors.Default }}>
-                Hours logged:
-              </b>
-              {hoursLogged >= summary.promisedHoursByWeek[weekIndex] ? (
-                <p>
+              {hoursLogged < summary.promisedHoursByWeek[weekIndex] && (
+                <p style={{ color: 'red' }}>
+                  Hours logged: {''}
                   {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
                 </p>
-              ) : (
-                <span className="ml-2">
+              )}
+              {hoursLogged >= summary.promisedHoursByWeek[weekIndex] && (
+                <p>
+                  Hours logged: {''}
                   {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
-                </span>
+                </p>
               )}
             </ListGroupItem>
             <ListGroupItem>

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.css
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.css
@@ -124,3 +124,7 @@
 .custom-control-label {
   margin-left: 8px;
 }
+
+.hours-not-fulfilled {
+  color: red;
+}


### PR DESCRIPTION
# Description

<img width="779" alt="Screenshot 2023-09-26 at 8 01 08 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/22454953/8df32e5f-f41c-4860-896e-4d77eb6177bc">
In short if hours haven't been fulfilled the text should be color red. Just like the "not provided" text



## Main changes explained:
Added a css class to weeklysummariesreport.css called hoursNotFulfilledwith color red.
If the hours aren't fulfilled the styling is added


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user or owner
4. go to dashboard→ reports → weekly reports
5. All user's who haven't fulfilled their hours should be red.

## Screenshots or videos of changes:
<img width="1621" alt="Screenshot 2023-09-26 at 8 13 31 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/22454953/7607ca8f-af3f-4fcf-b7e4-e4da78ee340e">

## Note:

this is a repost of the original repo. As the original, wouldn't pass the tests, since, the changes were very minimal I redid the changes. 

PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1343


There is one user who's text doesn't become red. Because it has default styling. I am unsure why it has default styling since, I adjusted the jsx. 

<img width="1438" alt="Screenshot 2023-09-26 at 8 13 11 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/22454953/c22bb507-2c12-4d4f-946a-9fb0149ffc3f">
