### PR TITLE
Nathan seeUsersInDashboard Permission

### DIFF
--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -354,6 +354,11 @@ export const permissionLabels = [
         description:
           'Gives the user permission to edit 4-digit team codes on profile page and weekly summaries report page.',
       },
+      {
+        label: 'See All Users in Dashboard and Leaderboard',
+        key: 'seeUsersInDashboard',
+        description: 'Lets the user see all users in the dashboard as if they were on the same team. Requires "See All Users" to function',
+      },
     ],
   },
 ];


### PR DESCRIPTION
# Description
Adds a permission `seeUsersInDashboard` to replace the role-based logic for allowing admins, owners, and core team members to see all users in the leaderboard and task list on the dashboard.

2-Minute Video of Jae describing what's needed here: https://www.loom.com/share/1deb6fcb7772465eae2cfdd1acbebde6?sid=89c685da-9f46-4e3f-bb4a-c8af670ce5c7 

## Related PRS (if any):
This frontend PR is related to the [#839](https://github.com/OneCommunityGlobal/HGNRest/pull/839) backend PR.

## Main changes explained:
- adds permission to PermissionConst

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→see all users in leaderboard and task list

