### PR TITLE
Sucheta - Adds user's ability to check entered password to reveal the weeklySummaryRecipient for Authorized users only

### DIFF
--- a/src/components/WeeklySummariesReport/PasswordInputModal.jsx
+++ b/src/components/WeeklySummariesReport/PasswordInputModal.jsx
@@ -53,7 +53,7 @@ export default function PasswordInputModal({
             dispatch(authorizeWeeklySummaries(response.data.message));
             checkForValidPwd(true);
             toast.success('Authorization successful! Please wait to see Recipients table!');
-            setAuthpassword(response.data.password);
+            setAuthpassword(`${response.data.password}`);
             setSummaryRecepientsPopup(true);
             onClose();
           }

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -215,6 +215,8 @@ export class WeeklySummariesReport extends Component {
         open={this.state.summaryRecepientsPopupOpen}
         onClose={this.onSummaryRecepientsPopupClose}
         summaries={this.props.summaries}
+        password={this.state.weeklyRecipientAuthPass}
+        authEmailWeeklySummaryRecipient={this.props.authEmailWeeklySummaryRecipient}
       />
     );
   };
@@ -419,8 +421,8 @@ export class WeeklySummariesReport extends Component {
     const { error } = this.props;
     const hasPermissionToFilter = role === 'Owner' || role === 'Administrator';
     const { authEmailWeeklySummaryRecipient } = this.props;
-    const authorizedUser1 = process.env.REACT_APP_JAE;
-    const authorizedUser2 = process.env.REACT_APP_SARA;
+    const authorizedUser1 = 'jae@onecommunityglobal.org';
+    const authorizedUser2 = 'sucheta.prtester@test.com'; // To test please include your email here
 
     if (error) {
       return (

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -422,7 +422,7 @@ export class WeeklySummariesReport extends Component {
     const hasPermissionToFilter = role === 'Owner' || role === 'Administrator';
     const { authEmailWeeklySummaryRecipient } = this.props;
     const authorizedUser1 = 'jae@onecommunityglobal.org';
-    const authorizedUser2 = 'sucheta.prtester@test.com'; // To test please include your email here
+    const authorizedUser2 = 'sucheta_mu@test.com'; // To test please include your email here
 
     if (error) {
       return (

--- a/src/components/WeeklySummariesReport/WeeklySummaryRecepientsPopup.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummaryRecepientsPopup.jsx
@@ -5,6 +5,8 @@ import { toast } from 'react-toastify';
 // import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import moment from 'moment';
 import { useDispatch } from 'react-redux';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import MembersAutoComplete from '../Teams/MembersAutoComplete';
 import {
   getSummaryRecipients,
@@ -17,12 +19,13 @@ import {
 
 const WeeklySummaryRecipientsPopup = React.memo(props => {
   const dispatch = useDispatch();
-
-  const { open, onClose, summaries } = props;
+  const { open, onClose, summaries, password, authEmailWeeklySummaryRecipient } = props;
 
   const [searchText, setSearchText] = useState('');
   const [selectedUser, setSelectedUser] = useState(undefined);
   const [isValidUser, setIsValidUser] = useState(true);
+  const [infoModalOpen, setInfoModalOpen] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   // The below states keeps a track of the list of Weekly Summary Report Recipients - sucheta
   const [recipients, setRecipients] = useState([]);
   const [updatedRecipients, setUpdatedRecipients] = useState(false);
@@ -83,10 +86,47 @@ const WeeklySummaryRecipientsPopup = React.memo(props => {
       toast.error('Could not delete recipient at this time! Please try again');
     }
   };
+
+  // Function open info modal
+  const openInfo = () => {
+    setInfoModalOpen(prev => !prev);
+    setShowPassword(false);
+  };
+
   return (
     <Container fluid>
       <Modal isOpen={open} toggle={closePopup} autoFocus={false} size="lg">
-        <ModalHeader toggle={closePopup}>Recipients of Weekly summaries</ModalHeader>
+        <ModalHeader toggle={closePopup}>
+          Recipients of Weekly summaries
+          <FontAwesomeIcon
+            icon={faInfoCircle}
+            className="ml-2"
+            style={{ color: '#74C0FC', cursor: 'pointer' }}
+            onClick={openInfo}
+          />
+          {infoModalOpen && (
+            <div className="mt-3">
+              <span style={{ fontSize: '.8em' }}>
+                Authoried User: {authEmailWeeklySummaryRecipient}
+              </span>
+              <section>
+                <span className="mr-3" style={{ fontSize: '.8em' }}>
+                  Password: {showPassword ? password : ''}
+                </span>
+                {!showPassword && (
+                  <Button onClick={() => setShowPassword(true)} style={boxStyle}>
+                    Reveal{' '}
+                  </Button>
+                )}
+                {showPassword && (
+                  <Button onClick={() => setShowPassword(false)} style={boxStyle}>
+                    Hide
+                  </Button>
+                )}
+              </section>
+            </div>
+          )}
+        </ModalHeader>
         <ModalBody style={{ textAlign: 'center' }}>
           <div className="input-group-prepend" style={{ marginBottom: '10px' }}>
             <MembersAutoComplete


### PR DESCRIPTION
# Description
The feature implemented in this PR reveals the user password in the `weeklySummaryRecepients` table for the convenience of the user only if the user is an authorized user.

## Related PRS (if any):
This frontend PR is related to the [#861](https://github.com/OneCommunityGlobal/HGNRest/pull/861) backend PR.

…

## Main changes explained:
- Adds infoCircle icon to the Modal Header on `WeeklySummaryRececipentsPopup.jsx`
- `Onclick`  reveals and hides the user password , only in case of an authorized user.

…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Include the user email with owner's access on `WeeklySummaryReport.jxs` 
<img width="795" alt="Screenshot 2024-04-07 at 5 41 10 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/f3fb0af1-e8ba-40ae-8eff-7c889f6a7b93">
5. log as OWNER user
6. go to Reports→ WeeklySummaryReports
7. Check if the `WeeklySummaryRecepients` button renders
8. Enter your user account password
9. Once authenticated, the user should now see an info icon , on click reveals or hides user password


## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/59be5109-45ff-4628-8ee6-de5b8cb34fae



## Note:
Please note this feature can only be accessed by authorized users, hence please include the email that has OWNER rights both in the Frontend and Backend code .
