### PR TITLE
Hoang fix hours inputs in task modal

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -443,12 +443,12 @@ function EditTaskModal(props) {
                 )}
               </tr>
               <tr>
-                <td scope="col" data-tip="Hours - Best-case">
+                <td scope="col">
                   Hours
                 </td>
-                <td scope="col" data-tip="Hours - Best-case" className="w-100">
+                <td scope="col" className="w-100">
                   <div className="py-2 flex-responsive">
-                    <label htmlFor="bestCase" className={`text-nowrap mr-2 w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
+                    <label htmlFor="bestCase" className={`text-nowrap w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
                       Best-case
                     </label>
                     {ReadOnlySectionWrapper(
@@ -460,20 +460,20 @@ function EditTaskModal(props) {
                         onChange={e => setHoursBest(e.target.value)}
                         onBlur={() => calHoursEstimate()}
                         id="bestCase"
-                        className="w-25"
+                        className="m-auto"
                       />,
                       editable,
                       hoursBest,
                       {componentOnly:true}
                     )}
-                    <div className="warning">
-                      {hoursWarning
-                        ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
-                        : ''}
-                    </div>
+                  </div>
+                  <div className="warning">
+                    {hoursWarning
+                      ? 'The number of hours must be less than other cases'
+                      : ''}
                   </div>
                   <div className="py-2 flex-responsive">
-                    <label htmlFor="worstCase" className={`text-nowrap mr-2 w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
+                    <label htmlFor="worstCase" className={`text-nowrap w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
                       Worst-case
                     </label>
                     {ReadOnlySectionWrapper(
@@ -484,20 +484,20 @@ function EditTaskModal(props) {
                         value={hoursWorst}
                         onChange={e => setHoursWorst(e.target.value)}
                         onBlur={() => calHoursEstimate('hoursWorst')}
-                        className="w-25"
+                        className="m-auto"
                       />,
                       editable,
                       hoursWorst,
                       {componentOnly:true}
                     )}
-                    <div className="warning">
-                      {hoursWarning
-                        ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
-                        : ''}
-                    </div>
+                  </div>
+                  <div className="warning">
+                    {hoursWarning
+                      ? 'The number of hours must be higher than other cases'
+                      : ''}
                   </div>
                   <div className="py-2 flex-responsive">
-                    <label htmlFor="mostCase" className={`text-nowrap mr-2 w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
+                    <label htmlFor="mostCase" className={`text-nowrap w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
                       Most-case
                     </label>
                     {ReadOnlySectionWrapper(
@@ -508,20 +508,20 @@ function EditTaskModal(props) {
                         value={hoursMost}
                         onChange={e => setHoursMost(e.target.value)}
                         onBlur={() => calHoursEstimate('hoursMost')}
-                        className="w-25"
+                        className="m-auto"
                       />,
                       editable,
                       hoursMost,
                       {componentOnly:true}
                     )}
-                    <div className="warning">
-                      {hoursWarning
-                        ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
-                        : ''}
-                    </div>
+                  </div>
+                  <div className="warning">
+                    {hoursWarning
+                      ? 'The number of hours must range between best and worst cases'
+                      : ''}
                   </div>
                   <div className="py-2 flex-responsive">
-                    <label htmlFor="Estimated" className={`text-nowrap mr-2 w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
+                    <label htmlFor="Estimated" className={`text-nowrap w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
                       Estimated
                     </label>
                     {ReadOnlySectionWrapper(
@@ -531,7 +531,7 @@ function EditTaskModal(props) {
                         max="500"
                         value={hoursEstimate}
                         onChange={e => setHoursEstimate(e.target.value)}
-                        className="w-25"
+                        className="m-auto"
                       />,
                       editable,
                       hoursEstimate,


### PR DESCRIPTION
# Description
### Updated on June 16, 2024

Latest commits on `development` branch fixed the validation text's position in `AddTaskModal`, but not in `EditTaskModal`. This PR aims to resolve the problem in the Edit modal.

<img width="1800" alt="Screenshot 2024-06-16 at 3 11 09 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/62eb7219-0fcc-48a0-8eb2-3d16de3353f6">
<img width="1800" alt="Screenshot 2024-06-16 at 3 10 52 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/95428e2a-3280-4fee-b660-4c0c07d2121f">


---


The validation text alignments problem was encountered in https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2075#pullrequestreview-1964909284. 

<img width="743" alt="Screenshot 2024-04-09 at 10 02 54 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/fc77e775-4542-468e-a108-30fd57b884e7">


## Related PRS (if any):
Latest backend's development branch.
…

## Main changes explained:
- Group each label and corresponding input field inside a `div` tag and place validation text next to it.
- Remove "Hours - " prefixes for clarity.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user, or any other role that has permission to view/add projects.
5. go to dashboard→ Project→ pick a project→ WBS -> select a WBS
6. click "Add task"
  6.1. Enter any number that is greater than "Best case" input in the "Most-case" input.
  6.2. Verify that the validation text appears below the label-input group for each hour type on both desktop and mobile view.
7. pick a task and click "Edit"→"Edit"
  7.1. Follow the same procedure in 6.1 and 6.2 and verify.

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/81fb8b16-572b-45e4-82ae-532f2dd75bcd


## Note:
N/A
