### PR TITLE
Leo fix prop type  warnings in update password and reset password popup

### DIFF
--- a/src/components/UpdatePassword/UpdatePassword.jsx
+++ b/src/components/UpdatePassword/UpdatePassword.jsx
@@ -16,7 +16,7 @@ class UpdatePassword extends Form {
     errors: {},
     showPassword: { currentpassword: false, newpassword: false, confirmnewpassword: false }
   };
-  
+
   togglePasswordVisibility = (field) => {
     this.setState(prevState => ({
       showPassword: {
@@ -25,9 +25,9 @@ class UpdatePassword extends Form {
       }
     }));
   }
-  
 
-  componentDidMount() {}
+
+  componentDidMount() { }
 
   componentDidUpdate(prevProps) {
     if (prevProps.errors.error !== this.props.errors.error) {
@@ -97,35 +97,35 @@ class UpdatePassword extends Form {
 
   render() {
     return (
-        <div className="container mt-5">
-            <h2 className="text-2xl font-bold mb-5">Change Password</h2>
-            <form className="col-md-6 xs-12" onSubmit={e => this.handleSubmit(e)}>
-                <div className="mb-4">
-                    <div className="flex justify-between items-center">
-                        <label htmlFor="currentpassword" className="text-sm font-medium text-gray-700 mr-2">Current Password:</label>
-                    </div>
-                    {this.renderInput({ name: 'currentpassword', type: this.state.showPassword.currentpassword ? 'text' : 'password' })}
-                </div>
+      <div className="container mt-5">
+        <h2 className="text-2xl font-bold mb-5">Change Password</h2>
+        <form className="col-md-6 xs-12" onSubmit={e => this.handleSubmit(e)}>
+          <div className="mb-4">
+            <div className="flex justify-between items-center">
+              <label htmlFor="currentpassword" className="text-sm font-medium text-gray-700 mr-2">Current Password:</label>
+            </div>
+            {this.renderInput({ name: 'currentpassword', type: this.state.showPassword.currentpassword ? 'text' : 'password', label: 'Current Password' })}
+          </div>
 
-                <div className="mb-4">
-                    <div className="flex justify-between items-center">
-                        <label htmlFor="newpassword" className="text-sm font-medium text-gray-700 mr-2">New Password:</label>
-                    </div>
-                    {this.renderInput({ name: 'newpassword', type: this.state.showPassword.newpassword ? 'text' : 'password' })}
-                </div>
+          <div className="mb-4">
+            <div className="flex justify-between items-center">
+              <label htmlFor="newpassword" className="text-sm font-medium text-gray-700 mr-2">New Password:</label>
+            </div>
+            {this.renderInput({ name: 'newpassword', type: this.state.showPassword.newpassword ? 'text' : 'password', label: 'New Password' })}
+          </div>
 
-                <div className="mb-4">
-                    <div className="flex justify-between items-center">
-                        <label htmlFor="confirmnewpassword" className="text-sm font-medium text-gray-700 mr-2">Confirm Password:</label>
-                    </div>
-                    {this.renderInput({ name: 'confirmnewpassword', type: this.state.showPassword.confirmnewpassword ? 'text' : 'password' })}
-                </div>
+          <div className="mb-4">
+            <div className="flex justify-between items-center">
+              <label htmlFor="confirmnewpassword" className="text-sm font-medium text-gray-700 mr-2">Confirm Password:</label>
+            </div>
+            {this.renderInput({ name: 'confirmnewpassword', type: this.state.showPassword.confirmnewpassword ? 'text' : 'password', label: 'Confirm Password' })}
+          </div>
 
-                {this.renderButton('Submit')}
-            </form>
-        </div>
+          {this.renderButton('Submit')}
+        </form>
+      </div>
     );
-}
+  }
 
 }
 

--- a/src/components/UserManagement/ResetPasswordPopup.jsx
+++ b/src/components/UserManagement/ResetPasswordPopup.jsx
@@ -33,7 +33,7 @@ const ResetPasswordPopup = React.memo(props => {
     setError('');
   }, [props.open]);
 
-    const togglePasswordVisibility = (field) => {
+  const togglePasswordVisibility = (field) => {
     setShowPassword(prevState => ({
       ...prevState,
       [field]: !prevState[field]
@@ -63,13 +63,14 @@ const ResetPasswordPopup = React.memo(props => {
       <ModalBody>
         <Form>
           <div className="flex justify-between items-center mb-2">
-              <Label className="mr-2" for="newpassword">New Password</Label>
+            <Label className="mr-2" for="newpassword">New Password</Label>
           </div>
           <Input
             autoFocus
             type={showPassword.newPassword ? 'text' : 'password'}
             name="newpassword"
             id="newpassword"
+            label="New Password"
             value={newPassword.password}
             onChange={event => {
               const value = event.target.value;
@@ -84,14 +85,15 @@ const ResetPasswordPopup = React.memo(props => {
               }
             }}
           />
-          
+
           <div className="flex justify-between items-center mt-4 mb-2">
-              <Label className="mr-2" for="confirmpassword">Confirm Password</Label>
+            <Label className="mr-2" for="confirmpassword">Confirm Password</Label>
           </div>
           <Input
             type={showPassword.confirmPassword ? 'text' : 'password'}
             name="confirmpassword"
             id="confirmpassword"
+            label="Confirm Password"
             value={confirmPassword.password}
             onChange={event => {
               onConfirmPasswordChange({
@@ -117,7 +119,7 @@ const ResetPasswordPopup = React.memo(props => {
         </Button>
       </ModalFooter>
     </Modal>
-);
+  );
 });
 
 export default ResetPasswordPopup;


### PR DESCRIPTION
# Description
![螢幕擷取畫面 2024-04-10 013142](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/fae806c8-b137-4525-864d-fc82d7d0ae19)
![螢幕擷取畫面 2024-04-10 013206](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/66289d92-bf80-4e2f-967e-4287a066ced9)

Fixes # (bug list priority high/medium/low x.y.z)
Or Implements # (WBS) 

## Related PRS (if any):
This frontend PR is related to the #XXX backend PR.
To test this backend PR you need to checkout the #XXX frontend PR.
…

## Main changes explained:
- Delete file A for removing unused components …
- Update file B for including new pattern …
- Create file C for introducing new components …
…

## How to test:
1. check into current branch
2. do npm install and run npm test UpdatePassword.test.js
3. run npm test ResetPasswordPopup.test.js
4. verify all tests passed without the error mentioned in the Description


## Screenshots or videos of changes:
![螢幕擷取畫面 2024-04-10 024522](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/5ee19487-c5a5-4cff-8f69-c05f8ff36f67)
![螢幕擷取畫面 2024-04-10 024457](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/122568562/156f55fc-55cd-4186-814b-7aeec072ce63)


