### PR TITLE
Nathan prevent deleting own account

### DIFF
--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -35,8 +35,8 @@ const UserTableData = React.memo(props => {
   const checkPermissionsOnOwner = () => {
     const recordEmail = props.user.email;
     const loginUserEmail = props.authEmail;
-    
-    return (props.user.role === 'Owner' && !canAddDeleteEditOwners) 
+
+    return (props.user.role === 'Owner' && !canAddDeleteEditOwners)
       || cantUpdateDevAdminDetails(recordEmail, loginUserEmail);
   };
 
@@ -164,7 +164,7 @@ const UserTableData = React.memo(props => {
           : ''}
       </td>
       <td>{props.user.createdDate ? formatDate(props.user.createdDate) : 'N/A'}</td>
-      
+
        <td className="email_cell">
       {props.user.endDate ? formatDate(props.user.endDate) : 'N/A'}
         <FontAwesomeIcon
@@ -186,6 +186,7 @@ const UserTableData = React.memo(props => {
                 props.onDeleteClick(props.user, 'archive');
               }}
               style={boxStyle}
+              disabled={props.auth?.user.userid === props.user._id}
             >
               {DELETE}
             </button>
@@ -199,4 +200,8 @@ const UserTableData = React.memo(props => {
   );
 });
 
-export default connect(null, { hasPermission })(UserTableData);
+const mapStateToProps = state => ({
+  auth: state.auth,
+});
+
+export default connect(mapStateToProps, { hasPermission })(UserTableData);

--- a/src/components/UserManagement/__test__/UserTableData.test.js
+++ b/src/components/UserManagement/__test__/UserTableData.test.js
@@ -9,12 +9,12 @@ import configureStore from 'redux-mock-store';
 
 const mockStore = configureStore([thunk]);
 const jaeAccountMock = {
-  _id: '5edf141c78f1380017b829a6',
+  _id: '1',
   isAdmin: true,
   user: {
     expiryTimestamp: '2023-08-22T22:51:06.544Z',
     iat: 1597272666,
-    userid: '5edf141c78f1380017b829a6',
+    userid: '1',
     role: 'Administrator',
     email: 'devadmin@hgn.net'
   },
@@ -25,12 +25,12 @@ const jaeAccountMock = {
   weeklycommittedHours: 10,
 }
 const nonJaeAccountMock = {
-  _id: '5edf141c78f1380017b829a6',
+  _id: '2',
   isAdmin: true,
   user: {
     expiryTimestamp: '2023-08-22T22:51:06.544Z',
     iat: 1597272666,
-    userid: '5edf141c78f1380017b829a6',
+    userid: '2',
     role: 'Administrator',
     email: 'non_jae@hgn.net'
   },
@@ -42,12 +42,12 @@ const nonJaeAccountMock = {
 }
 
 const ownerAccountMock = {
-  _id: '5edf141c78f1380017b829a6',
+  _id: '3',
   isAdmin: true,
   user: {
     expiryTimestamp: '2023-08-22T22:51:06.544Z',
     iat: 1597272666,
-    userid: '5edf141c78f1380017b829a6',
+    userid: '3',
     role: 'Owner',
     email: 'devadmin@hgn.net'
   },
@@ -82,7 +82,6 @@ describe('User Table Data: Non-Jae related Account', () => {
             onActiveInactiveClick={onActiveInactiveClick}
             onPauseResumeClick={onPauseResumeClick}
             onDeleteClick={onDeleteClick}
-            userId={nonJaeAccountMock._id}
           />
         </tbody>
       </table>,
@@ -175,7 +174,6 @@ describe('User Table Data: Jae protected account record and login as Jae related
             onActiveInactiveClick={onActiveInactiveClick}
             onPauseResumeClick={onPauseResumeClick}
             onDeleteClick={onDeleteClick}
-            userId={jaeAccountMock._id}
           />
         </tbody>
       </table>,


### PR DESCRIPTION
# Description
Adds a check to prevent a user from deleting itself

## Related PRS (if any):
This frontend PR is related to the [#889](https://github.com/OneCommunityGlobal/HGNRest/pull/889) backend PR.


## Main changes explained:
- Disable the delete button in User Management when it's for your account



## Related PRS (if any):
To test this backend PR you need to checkout the #XXX frontend PR.

## Main changes explained:
- Added check in `deleteUserProfile()`

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other LInks→ User Management
6. verify you can't delete the account you're logged into


