### PR TITLE
Shiwani Role Permissions unit test

### DIFF
--- a/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
+++ b/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
@@ -1,0 +1,198 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act, wait } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import RolePermissions from '../RolePermissions';
+import thunk from 'redux-thunk';
+import mockAdminState from '__tests__/mockAdminState';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import axios from 'axios';
+import { toast } from 'react-toastify';
+
+const mockStore = configureStore([thunk]);
+let store;
+beforeEach(() => {
+  store = mockStore({
+    auth: {
+      user: {
+        permissions: {
+          frontPermissions: [],
+          backPermissions: [],
+        },
+        role: 'Owner',
+      },
+      permissions: {
+        frontPermissions: [],
+        backPermissions: [],
+      },
+    },
+    role: mockAdminState.role,
+    userProfile: { role: 'Owner' },
+    rolePreset: { presets: mockAdminState.role.roles[5].permissions },
+  });
+});
+
+afterEach(() => {
+  store.clearActions();
+});
+
+const roleName = 'Owner';
+const roleId = 'abc123';
+
+jest.mock('axios');
+jest.mock('react-toastify', () => ({
+  ...jest.requireActual('react-toastify'),
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const flushAllPromises = () => new Promise(setImmediate);
+
+describe('RolePermissions component', () => {
+  it('check if role name is displaying properly', () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+    render(
+      <Provider store={store}>
+        <RolePermissions
+          userRole={store.getState().userProfile.role}
+          role={roleName}
+          roleId={roleId}
+          header={`${roleName} Permissions:`}
+          permissions={mockAdminState.role.roles[5].permissions}
+        />
+      </Provider>,
+    );
+    expect(screen.getByText('Role Name: Owner')).toBeInTheDocument();
+  });
+  it('check if permission list header is displaying as expected', () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+    render(
+      <Provider store={store}>
+        <RolePermissions
+          userRole={store.getState().userProfile.role}
+          role={roleName}
+          roleId={roleId}
+          header={`${roleName} Permissions:`}
+          permissions={mockAdminState.role.roles[5].permissions}
+        />
+      </Provider>,
+    );
+    expect(screen.getByText('Permission List')).toBeInTheDocument();
+  });
+  it('check if presets option do not show when the role is not Owner', () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+
+    const store = mockStore({
+      auth: {
+        user: {
+          permissions: {
+            frontPermissions: [],
+            backPermissions: [],
+          },
+          role: 'Manager',
+        },
+        permissions: {
+          frontPermissions: [],
+          backPermissions: [],
+        },
+      },
+      role: mockAdminState.role,
+      userProfile: { role: 'Manager' },
+      rolePreset: { presets: mockAdminState.role.roles[3].permissions },
+    });
+
+    const roleName = 'Manager';
+    const roleId = 'def123';
+
+    render(
+      <Provider store={store}>
+        <RolePermissions
+          userRole={store.getState().userProfile.role}
+          role={roleName}
+          roleId={roleId}
+          header={`${roleName} Permissions:`}
+          permissions={mockAdminState.role.roles[5].permissions}
+        />
+      </Provider>,
+    );
+    expect(screen.queryByText('Create New Preset')).not.toBeInTheDocument();
+  });
+  it('check if clicking on Create New Preset displays toast success message when the post request is successful', async () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+
+    axios.post.mockResolvedValue({
+      status: 201,
+      data: { newPreset: 'New Preset 1' },
+    });
+
+    render(
+      <Provider store={store}>
+        <RolePermissions
+          userRole={store.getState().userProfile.role}
+          role={roleName}
+          roleId={roleId}
+          header={`${roleName} Permissions:`}
+          permissions={mockAdminState.role.roles[5].permissions}
+        />
+      </Provider>,
+    );
+
+    const createNewPresetElement = screen.getByText('Create New Preset');
+    fireEvent.click(createNewPresetElement);
+    await waitFor(() => {});
+    expect(toast.success).toHaveBeenCalledWith('Preset created successfully');
+  });
+  it('check if clicking on Create New Preset displays toast error message when the post request fails', async () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+
+    axios.post.mockRejectedValue({
+      status: 500,
+    });
+
+    render(
+      <Provider store={store}>
+        <RolePermissions
+          userRole={store.getState().userProfile.role}
+          role={roleName}
+          roleId={roleId}
+          header={`${roleName} Permissions:`}
+          permissions={mockAdminState.role.roles[5].permissions}
+        />
+      </Provider>,
+    );
+
+    const createNewPresetElement = screen.getByText('Create New Preset');
+    fireEvent.click(createNewPresetElement);
+    await waitFor(() => {});
+    expect(toast.error).toHaveBeenCalledWith('Error creating preset');
+  });
+  it('', async () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+
+    render(
+      <Provider store={store}>
+        <RolePermissions
+          userRole={store.getState().userProfile.role}
+          role={roleName}
+          roleId={roleId}
+          header={`${roleName} Permissions:`}
+          permissions={mockAdminState.role.roles[5].permissions}
+        />
+      </Provider>,
+    );
+  });
+});

--- a/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
+++ b/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
@@ -60,6 +60,8 @@ jest.mock('react-toastify', () => ({
   },
 }));
 
+const flushAllPromises = () => new Promise(setImmediate);
+
 const renderComponent = (newStore, history, newRoleName, newRoleId) => {
   return render(
     <Router history={history}>
@@ -204,27 +206,25 @@ describe('RolePermissions component', () => {
     fireEvent.click(deleteRole);
     expect(screen.getByText(`Delete ${roleName} Role`)).toBeInTheDocument();
   });
-  it('check delete role modal', () => {
+  it('check if delete role modal content displays as expected', () => {
     axios.get.mockResolvedValue({
       data: {},
     });
 
     const history = createMemoryHistory();
-    const { container } = renderComponent(store, history, roleName, roleId);
+    renderComponent(store, history, roleName, roleId);
     const deleteRole = screen.getByText('Delete Role');
     fireEvent.click(deleteRole);
 
     const modalElement = screen.getByRole('dialog');
     const modalDialog = modalElement.querySelector('.modal-dialog');
     const modalContent = modalDialog.querySelector('.modal-content');
-    const modalHeader = modalContent.querySelector('.modal-header');
     const modalBody = modalContent.querySelector('.modal-body');
-    //console.log(modalBody.outerHTML);
 
     expect(screen.getByText(`Delete ${roleName} Role`)).toBeInTheDocument();
-    //expect(screen.getByText(`/Are you sure you want to delete/`)).toBeInTheDocument();
+    expect(modalBody.textContent).toBe('Are you sure you want to delete Owner role?');
   });
-  it('check edit role modal', async () => {
+  it('check if edit role modal content displays as expected', async () => {
     axios.get.mockResolvedValue({
       data: {},
     });

--- a/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
+++ b/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
@@ -149,8 +149,9 @@ describe('RolePermissions component', () => {
 
     const createNewPresetElement = screen.getByText('Create New Preset');
     fireEvent.click(createNewPresetElement);
-    await waitFor(() => {});
-    expect(toast.success).toHaveBeenCalledWith('Preset created successfully');
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Preset created successfully');
+    });
   });
   it('check if clicking on Create New Preset displays toast error message when the post request fails', async () => {
     axios.get.mockResolvedValue({
@@ -166,8 +167,9 @@ describe('RolePermissions component', () => {
 
     const createNewPresetElement = screen.getByText('Create New Preset');
     fireEvent.click(createNewPresetElement);
-    await waitFor(() => {});
-    expect(toast.error).toHaveBeenCalledWith('Error creating preset');
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Error creating preset');
+    });
   });
   it('check if clicking on Load Presets opens modal', async () => {
     axios.get.mockResolvedValue({
@@ -190,9 +192,10 @@ describe('RolePermissions component', () => {
 
     const saveButton = screen.getByText('Save');
     fireEvent.click(saveButton);
-    await waitFor(() => {});
-    expect(toast.success).toHaveBeenCalledWith('Role updated successfully');
-    expect(history.location.pathname).toBe('/permissionsmanagement');
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Role updated successfully');
+      expect(history.location.pathname).toBe('/permissionsmanagement');
+    });
   });
 
   it('check delete role button works as expected', async () => {

--- a/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
+++ b/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, act, wait } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import RolePermissions from '../RolePermissions';
 import thunk from 'redux-thunk';

--- a/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
+++ b/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
@@ -8,6 +8,8 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import axios from 'axios';
 import { toast } from 'react-toastify';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 const mockStore = configureStore([thunk]);
 let store;
@@ -67,6 +69,33 @@ describe('RolePermissions component', () => {
       </Provider>,
     );
     expect(screen.getByText('Role Name: Owner')).toBeInTheDocument();
+  });
+  it('check edit role modal', async () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+    const { container } = render(
+      <Provider store={store}>
+        <RolePermissions
+          userRole={store.getState().userProfile.role}
+          role={roleName}
+          roleId={roleId}
+          header={`${roleName} Permissions:`}
+          permissions={mockAdminState.role.roles[5].permissions}
+        />
+      </Provider>,
+    );
+    const editRoleIcon = container.querySelector('.user-role-tab__icon.edit-icon');
+    fireEvent.click(editRoleIcon);
+    expect(screen.queryByText('Edit Role Name')).toBeInTheDocument();
+    expect(screen.queryByText('New Role Name')).toBeInTheDocument();
+    const modalElement = screen.getByRole('dialog');
+    const modalDialog = modalElement.querySelector('.modal-dialog');
+    const modalContent = modalDialog.querySelector('.modal-content');
+    const modalBody = modalContent.querySelector('.modal-body');
+    const searchBox = modalBody.querySelector('[name="editRoleName"]');
+    fireEvent.change(searchBox, { target: { value: 'manager' } });
+    expect(searchBox.value).toBe('manager');
   });
   it('check if permission list header is displaying as expected', () => {
     axios.get.mockResolvedValue({
@@ -178,7 +207,7 @@ describe('RolePermissions component', () => {
     await waitFor(() => {});
     expect(toast.error).toHaveBeenCalledWith('Error creating preset');
   });
-  it('', async () => {
+  it('check if clicking on Load Presets opens modal', async () => {
     axios.get.mockResolvedValue({
       data: {},
     });
@@ -194,5 +223,84 @@ describe('RolePermissions component', () => {
         />
       </Provider>,
     );
+    const loadPresetButton = screen.getByText('Load Presets');
+    fireEvent.click(loadPresetButton);
+    expect(screen.queryByText('Role Presets')).toBeInTheDocument();
+  });
+  it('check save button toast success message', async () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+    const history = createMemoryHistory();
+
+    render(
+      <Router history={history}>
+        <Provider store={store}>
+          <RolePermissions
+            userRole={store.getState().userProfile.role}
+            role={roleName}
+            roleId={roleId}
+            header={`${roleName} Permissions:`}
+            permissions={mockAdminState.role.roles[5].permissions}
+          />
+        </Provider>
+      </Router>,
+    );
+    const saveButton = screen.getByText('Save');
+    fireEvent.click(saveButton);
+    await waitFor(() => {});
+    expect(toast.success).toHaveBeenCalledWith('Role updated successfully');
+    expect(history.location.pathname).toBe('/permissionsmanagement');
+  });
+  it('check save button toast success message', async () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+    const history = createMemoryHistory();
+
+    render(
+      <Router history={history}>
+        <Provider store={store}>
+          <RolePermissions
+            userRole={store.getState().userProfile.role}
+            role={roleName}
+            roleId={roleId}
+            header={`${roleName} Permissions:`}
+            permissions={mockAdminState.role.roles[5].permissions}
+          />
+        </Provider>
+      </Router>,
+    );
+  });
+  it('check delete role button modal', async () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+    const history = createMemoryHistory();
+
+    render(
+      <Router history={history}>
+        <Provider store={store}>
+          <RolePermissions
+            userRole={store.getState().userProfile.role}
+            role={roleName}
+            roleId={roleId}
+            header={`${roleName} Permissions:`}
+            permissions={mockAdminState.role.roles[5].permissions}
+          />
+        </Provider>
+      </Router>,
+    );
+    const deleteRole = screen.getByText('Delete Role');
+    fireEvent.click(deleteRole);
+    expect(screen.queryByText(`Delete ${roleName} Role`)).toBeInTheDocument();
+    expect(
+      screen.queryByText(`Are you sure you want to delete ${roleName} role?`),
+    ).toBeInTheDocument();
+    const modalElement = screen.getByRole('dialog');
+    const modalDialog = modalElement.querySelector('.modal-dialog');
+    const modalContent = modalDialog.querySelector('.modal-content');
+    const modalHeader = modalContent.querySelector('.modal-header');
+    const modalBody = modalContent.querySelector('.modal-body');
   });
 });

--- a/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
+++ b/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
@@ -50,68 +50,37 @@ jest.mock('react-toastify', () => ({
   },
 }));
 
-const flushAllPromises = () => new Promise(setImmediate);
+const renderComponent = (newStore, history, newRoleName, newRoleId) => {
+  return render(
+    <Router history={history}>
+      <Provider store={newStore}>
+        <RolePermissions
+          userRole={newStore.getState().userProfile.role}
+          role={newRoleName}
+          roleId={newRoleId}
+          header={`${newRoleName} Permissions:`}
+          permissions={mockAdminState.role.roles[5].permissions}
+        />
+      </Provider>
+    </Router>,
+  );
+};
 
 describe('RolePermissions component', () => {
   it('check if role name is displaying properly', () => {
     axios.get.mockResolvedValue({
       data: {},
     });
-    render(
-      <Provider store={store}>
-        <RolePermissions
-          userRole={store.getState().userProfile.role}
-          role={roleName}
-          roleId={roleId}
-          header={`${roleName} Permissions:`}
-          permissions={mockAdminState.role.roles[5].permissions}
-        />
-      </Provider>,
-    );
+    const history = createMemoryHistory();
+    renderComponent(store, history, roleName, roleId);
     expect(screen.getByText('Role Name: Owner')).toBeInTheDocument();
-  });
-  it('check edit role modal', async () => {
-    axios.get.mockResolvedValue({
-      data: {},
-    });
-    const { container } = render(
-      <Provider store={store}>
-        <RolePermissions
-          userRole={store.getState().userProfile.role}
-          role={roleName}
-          roleId={roleId}
-          header={`${roleName} Permissions:`}
-          permissions={mockAdminState.role.roles[5].permissions}
-        />
-      </Provider>,
-    );
-    const editRoleIcon = container.querySelector('.user-role-tab__icon.edit-icon');
-    fireEvent.click(editRoleIcon);
-    expect(screen.queryByText('Edit Role Name')).toBeInTheDocument();
-    expect(screen.queryByText('New Role Name')).toBeInTheDocument();
-    const modalElement = screen.getByRole('dialog');
-    const modalDialog = modalElement.querySelector('.modal-dialog');
-    const modalContent = modalDialog.querySelector('.modal-content');
-    const modalBody = modalContent.querySelector('.modal-body');
-    const searchBox = modalBody.querySelector('[name="editRoleName"]');
-    fireEvent.change(searchBox, { target: { value: 'manager' } });
-    expect(searchBox.value).toBe('manager');
   });
   it('check if permission list header is displaying as expected', () => {
     axios.get.mockResolvedValue({
       data: {},
     });
-    render(
-      <Provider store={store}>
-        <RolePermissions
-          userRole={store.getState().userProfile.role}
-          role={roleName}
-          roleId={roleId}
-          header={`${roleName} Permissions:`}
-          permissions={mockAdminState.role.roles[5].permissions}
-        />
-      </Provider>,
-    );
+    const history = createMemoryHistory();
+    renderComponent(store, history, roleName, roleId);
     expect(screen.getByText('Permission List')).toBeInTheDocument();
   });
   it('check if presets option do not show when the role is not Owner', () => {
@@ -119,7 +88,7 @@ describe('RolePermissions component', () => {
       data: {},
     });
 
-    const store = mockStore({
+    const newStore = mockStore({
       auth: {
         user: {
           permissions: {
@@ -138,20 +107,10 @@ describe('RolePermissions component', () => {
       rolePreset: { presets: mockAdminState.role.roles[3].permissions },
     });
 
-    const roleName = 'Manager';
-    const roleId = 'def123';
-
-    render(
-      <Provider store={store}>
-        <RolePermissions
-          userRole={store.getState().userProfile.role}
-          role={roleName}
-          roleId={roleId}
-          header={`${roleName} Permissions:`}
-          permissions={mockAdminState.role.roles[5].permissions}
-        />
-      </Provider>,
-    );
+    const newRoleName = 'Manager';
+    const newRoleId = 'def123';
+    const history = createMemoryHistory();
+    renderComponent(newStore, history, newRoleName, newRoleId);
     expect(screen.queryByText('Create New Preset')).not.toBeInTheDocument();
   });
   it('check if clicking on Create New Preset displays toast success message when the post request is successful', async () => {
@@ -164,17 +123,8 @@ describe('RolePermissions component', () => {
       data: { newPreset: 'New Preset 1' },
     });
 
-    render(
-      <Provider store={store}>
-        <RolePermissions
-          userRole={store.getState().userProfile.role}
-          role={roleName}
-          roleId={roleId}
-          header={`${roleName} Permissions:`}
-          permissions={mockAdminState.role.roles[5].permissions}
-        />
-      </Provider>,
-    );
+    const history = createMemoryHistory();
+    renderComponent(store, history, roleName, roleId);
 
     const createNewPresetElement = screen.getByText('Create New Preset');
     fireEvent.click(createNewPresetElement);
@@ -190,17 +140,8 @@ describe('RolePermissions component', () => {
       status: 500,
     });
 
-    render(
-      <Provider store={store}>
-        <RolePermissions
-          userRole={store.getState().userProfile.role}
-          role={roleName}
-          roleId={roleId}
-          header={`${roleName} Permissions:`}
-          permissions={mockAdminState.role.roles[5].permissions}
-        />
-      </Provider>,
-    );
+    const history = createMemoryHistory();
+    renderComponent(store, history, roleName, roleId);
 
     const createNewPresetElement = screen.getByText('Create New Preset');
     fireEvent.click(createNewPresetElement);
@@ -212,17 +153,8 @@ describe('RolePermissions component', () => {
       data: {},
     });
 
-    render(
-      <Provider store={store}>
-        <RolePermissions
-          userRole={store.getState().userProfile.role}
-          role={roleName}
-          roleId={roleId}
-          header={`${roleName} Permissions:`}
-          permissions={mockAdminState.role.roles[5].permissions}
-        />
-      </Provider>,
-    );
+    const history = createMemoryHistory();
+    renderComponent(store, history, roleName, roleId);
     const loadPresetButton = screen.getByText('Load Presets');
     fireEvent.click(loadPresetButton);
     expect(screen.queryByText('Role Presets')).toBeInTheDocument();
@@ -231,76 +163,67 @@ describe('RolePermissions component', () => {
     axios.get.mockResolvedValue({
       data: {},
     });
-    const history = createMemoryHistory();
 
-    render(
-      <Router history={history}>
-        <Provider store={store}>
-          <RolePermissions
-            userRole={store.getState().userProfile.role}
-            role={roleName}
-            roleId={roleId}
-            header={`${roleName} Permissions:`}
-            permissions={mockAdminState.role.roles[5].permissions}
-          />
-        </Provider>
-      </Router>,
-    );
+    const history = createMemoryHistory();
+    renderComponent(store, history, roleName, roleId);
+
     const saveButton = screen.getByText('Save');
     fireEvent.click(saveButton);
     await waitFor(() => {});
     expect(toast.success).toHaveBeenCalledWith('Role updated successfully');
     expect(history.location.pathname).toBe('/permissionsmanagement');
   });
-  it('check save button toast success message', async () => {
+
+  it('check delete role button works as expected', async () => {
     axios.get.mockResolvedValue({
       data: {},
     });
-    const history = createMemoryHistory();
 
-    render(
-      <Router history={history}>
-        <Provider store={store}>
-          <RolePermissions
-            userRole={store.getState().userProfile.role}
-            role={roleName}
-            roleId={roleId}
-            header={`${roleName} Permissions:`}
-            permissions={mockAdminState.role.roles[5].permissions}
-          />
-        </Provider>
-      </Router>,
-    );
-  });
-  it('check delete role button modal', async () => {
-    axios.get.mockResolvedValue({
-      data: {},
-    });
     const history = createMemoryHistory();
-
-    render(
-      <Router history={history}>
-        <Provider store={store}>
-          <RolePermissions
-            userRole={store.getState().userProfile.role}
-            role={roleName}
-            roleId={roleId}
-            header={`${roleName} Permissions:`}
-            permissions={mockAdminState.role.roles[5].permissions}
-          />
-        </Provider>
-      </Router>,
-    );
+    renderComponent(store, history, roleName, roleId);
     const deleteRole = screen.getByText('Delete Role');
     fireEvent.click(deleteRole);
-    expect(screen.queryByText(`Delete ${roleName} Role`)).toBeInTheDocument();
-    expect(
-      screen.queryByText(`Are you sure you want to delete ${roleName} role?`),
-    ).toBeInTheDocument();
+    expect(screen.getByText(`Delete ${roleName} Role`)).toBeInTheDocument();
+  });
+  it('check delete role modal', () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+
+    const history = createMemoryHistory();
+    const { container } = renderComponent(store, history, roleName, roleId);
+    const deleteRole = screen.getByText('Delete Role');
+    fireEvent.click(deleteRole);
+
     const modalElement = screen.getByRole('dialog');
     const modalDialog = modalElement.querySelector('.modal-dialog');
     const modalContent = modalDialog.querySelector('.modal-content');
     const modalHeader = modalContent.querySelector('.modal-header');
     const modalBody = modalContent.querySelector('.modal-body');
+    console.log(modalBody.outerHTML);
+
+    expect(screen.getByText(`Delete ${roleName} Role`)).toBeInTheDocument();
+    expect(screen.getByText(`/Are you sure you want to delete/`)).toBeInTheDocument();
+  });
+  it('check edit role modal', async () => {
+    axios.get.mockResolvedValue({
+      data: {},
+    });
+    const history = createMemoryHistory();
+    const { container } = renderComponent(store, history, roleName, roleId);
+
+    const editRoleIcon = container.querySelector('.user-role-tab__icon.edit-icon');
+    expect(screen.queryByText('Edit Role Name')).not.toBeInTheDocument();
+    fireEvent.click(editRoleIcon);
+
+    const modalElement = screen.getByRole('dialog');
+    const modalDialog = modalElement.querySelector('.modal-dialog');
+    const modalContent = modalDialog.querySelector('.modal-content');
+    const modalBody = modalContent.querySelector('.modal-body');
+
+    expect(screen.queryByText('New Role Name')).toBeInTheDocument();
+    const searchBox = modalBody.querySelector('[name="editRoleName"]');
+    fireEvent.change(searchBox, { target: { value: 'manager' } });
+    expect(searchBox.value).toBe('manager');
   });
 });

--- a/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
+++ b/src/components/PermissionsManagement/__tests__/RolePermissions.test.js
@@ -13,6 +13,7 @@ import { createMemoryHistory } from 'history';
 
 const mockStore = configureStore([thunk]);
 let store;
+
 beforeEach(() => {
   store = mockStore({
     auth: {
@@ -30,7 +31,16 @@ beforeEach(() => {
     },
     role: mockAdminState.role,
     userProfile: { role: 'Owner' },
-    rolePreset: { presets: mockAdminState.role.roles[5].permissions },
+    rolePreset: {
+      presets: [
+        {
+          _id: 'preset123',
+          permissions: mockAdminState.role.roles[5].permissions,
+          roleName: 'Owner',
+          presetName: 'Preset name 1',
+        },
+      ],
+    },
   });
 });
 
@@ -104,7 +114,16 @@ describe('RolePermissions component', () => {
       },
       role: mockAdminState.role,
       userProfile: { role: 'Manager' },
-      rolePreset: { presets: mockAdminState.role.roles[3].permissions },
+      rolePreset: {
+        presets: [
+          {
+            _id: 'preset456',
+            permissions: mockAdminState.role.roles[3].permissions,
+            roleName: 'Manager',
+            presetName: 'Preset name 2',
+          },
+        ],
+      },
     });
 
     const newRoleName = 'Manager';
@@ -200,10 +219,10 @@ describe('RolePermissions component', () => {
     const modalContent = modalDialog.querySelector('.modal-content');
     const modalHeader = modalContent.querySelector('.modal-header');
     const modalBody = modalContent.querySelector('.modal-body');
-    console.log(modalBody.outerHTML);
+    //console.log(modalBody.outerHTML);
 
     expect(screen.getByText(`Delete ${roleName} Role`)).toBeInTheDocument();
-    expect(screen.getByText(`/Are you sure you want to delete/`)).toBeInTheDocument();
+    //expect(screen.getByText(`/Are you sure you want to delete/`)).toBeInTheDocument();
   });
   it('check edit role modal', async () => {
     axios.get.mockResolvedValue({


### PR DESCRIPTION
# Description
Unit test for `src/components/PermissionsManagement/RolePermissions.jsx`

## Main changes explained:
- Added 10 test cases: check if role name is displaying properly, check if permission list header is displaying as expected, check if presets option do not show when the role is not Owner, check if clicking on Create New Preset displays toast success message when the post request is successful, check if clicking on Create New Preset displays toast error message when the post request fails, check if clicking on Load Presets opens modal, check save button toast success message, check delete role button works as expected, check if delete role modal content displays as expected, check if edit role modal content displays as expected 

## How to test:
1. check into current branch
2. do `npm test src/components/PermissionsManagement/__tests__/RolePermissions.test.js` 
3. check if all the test cases pass without any error or warning


## Screenshots or videos of changes:
<img width="1151" alt="Screenshot 2024-04-11 at 2 09 10 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/78906820/745f0784-da99-4f69-b4e9-7ce9d2e7e872">

