### PR TITLE
Meet change buttons and tasks colors in Tasks and Timelog component

### DIFF
--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -1,10 +1,11 @@
 export const orange = '#f26100';
 export const silverGray = '#e9e9e9';
 export const warningRed = '#B22222';
+
 export const hrsFilterBtnColorMap = {
-  1: '#eb8334', // lightbrown
-  2: '#DC143C', // red
-  3: '#6495ED', // blue
-  4: '#228B22', // green
+  1: '#228B22', // green
+  2: '#6495ED', // blue
+  3: '#eb8334', // lightbrown
+  4: '#DC143C', // red
   7: '#6a6a6a', // grey
 };


### PR DESCRIPTION
# Description
Please refer the image attached.
<img width="809" alt="description" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/67577022/4330426b-8978-481c-b628-870569550689">
 

## Related PRS (if any):
This frontend PR is related to the latest backend PR.

## Main changes explained:
- Changed the color mappings in src/constants/colors.js
- Mapped the values of 1 to Green, 2 to Blue, 3 to Lightbrown, and 4 to Red in hrsFilterBtnColorMap

## How to test:
1. Check into current branch
2. Do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log as owner user
5. Go to Tasks and Timelogs→ Tasks tab
6. Verify that buttons have the following colors: 1 days - Green, 2 days - Blue, 3 days - Lightbrown/Orange, and 4 days - Red
7. Go to Tasks and Timelogs→ Current Week Timelog tab
8. Verify that the same color mapping applies to tasks as well.

## Screenshots or videos of changes:
Before changes:
Buttons
<img width="814" alt="before button colors" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/67577022/3da84022-027e-4eb3-bf59-f35da304b600">
Tasks
<img width="814" alt="before task colors" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/67577022/af1f41ed-887b-4dc9-bee2-f2ed7e61308a">
After changes:
Buttons
<img width="814" alt="after button colors" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/67577022/aa8ba20c-600f-46c6-8443-b42ebc268bf2">
Tasks
<img width="796" alt="after tasks colors" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/67577022/6937f58d-0d58-4508-a722-fe3f6d7064ab">

## Note:
