### PR TITLE
Imran hide remove button on wbs task when no permission

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/ControllerRow/ControllerRow.jsx
+++ b/src/components/Projects/WBS/WBSDetail/ControllerRow/ControllerRow.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import {
   Button,
@@ -110,8 +110,9 @@ function ControllerRow (props) {
           load={props.load}
           setIsLoading={props.setIsLoading}
         />
-        {canDeleteTask ? (
+        
           <>
+          {canDeleteTask && (
             <Button
               color="danger"
               size="sm"
@@ -121,6 +122,7 @@ function ControllerRow (props) {
             >
               Remove
             </Button>
+            )}
 
             <Dropdown
               direction="up"
@@ -154,9 +156,9 @@ function ControllerRow (props) {
               {isCopied ? 'Copied' : 'Copy'}
             </Button>
           </>
-        ) : null}
+        
         <ModalDelete
-          isOpen={modalDelete}
+          isOpen={canDeleteTask && modalDelete}
           closeModal={() => {
             setModalDelete(false);
           }}

--- a/src/reducers/allTasksReducer.js
+++ b/src/reducers/allTasksReducer.js
@@ -124,7 +124,6 @@ export const taskReducer = (allTasks = allTasksInital, action) => {
       };
     case types.COPY_TASK:
       const copiedTask = allTasks.taskItems.find(item => item._id === action.taskId);
-      console.log(copiedTask);
       return { ...allTasks, copiedTask };
     case types.ADD_NEW_TASK_ERROR:
       const error = action.err;


### PR DESCRIPTION
# Description
This PR is related to  [Permission Management Fixes](https://docs.google.com/spreadsheets/d/1TfiJY9OLDZuyP2UgF0C1wI9tOSLKbS9MiJFH6n1Dsao/edit#gid=0). It enables users with deleteTask permission to interact with the remove button and delete a task on any WBS. "Other Links" -> "Projects" -> "WBS Button" -> "Choose any WBS" -> "Edit" -> "Remove"

## Related PRS (if any):
This frontend PR is related to the development backend PR.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Other Links -> Permissions Management -> Manage User Permissions ->Project Management -> Work Breakdown Structures-> Tasks -> Choose a user without a "Delete Task" -> add the permission for this user -> Scroll down then submit
6. log into the account that was just granted permission and go to "Other Links" -> "Projects" -> "WBS Button" -> "Choose any WBS" -> "Edit" -> "Remove" to test the permission you just added.

## Screenshots or videos of changes:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/87269725/a5547b5f-0623-483e-8c5a-7e69e9f223a8

