### PR TITLE
Christy fix weekly summary reports toggle and Weekly Summary Report Recipients button

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -632,7 +632,7 @@ const mapStateToProps = state => ({
   infoCollections: state.infoCollections.infos,
   role: state.auth.user.role,
   auth: state.auth,
-  authEmailWeeklySummaryRecipient: state.userProfile.email, // capturing the user email through Redux store - Sucheta
+  authEmailWeeklySummaryRecipient: state.auth.user.email, // capturing the user email through Redux store - Sucheta
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -630,7 +630,7 @@ const mapStateToProps = state => ({
   summaries: state.weeklySummariesReport.summaries,
   allBadgeData: state.badge.allBadgeData,
   infoCollections: state.infoCollections.infos,
-  role: state.userProfile.role,
+  role: state.auth.user.role,
   auth: state.auth,
   authEmailWeeklySummaryRecipient: state.userProfile.email, // capturing the user email through Redux store - Sucheta
 });


### PR DESCRIPTION
# Description
This pull request addresses an issue in the weeklysummaryreport.jsx component, where the role data was fetched from sessionStorage. This led to inconsistencies in displaying the `Filter by Over Hours` toggles and `Weekly Summary Report Recipients` button across multiple tabs.

## Related PRS (if any):
n/a
…

## Main changes explained:
- Update WeeklySummariesReport.jsx
…

## How to test:
1. check into current branch
2. do `npm install`  and run this PR locally
3. Clear site data/cache
4. log as Administrator/ Owner
5. go to dashboard→ Weekly Summaries Reports, the `Filter by Over Hours` toggles and `Weekly Summary Report Recipients` button are available
6. open a new tab from Weekly Summaries Reports. The toggle and the button should still be visible

## Screenshots or videos of changes:


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59427068/d239ef2d-d5c8-4d55-a7fe-037f04e8a876





## Note:


To test the display of the "Weekly Summary Report Recipients" button, add your email to the "authorizedUser2" field.

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59427068/1cf0fb39-237f-4a0d-838a-307858b7b5e3)

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/59427068/064300e5-ad7a-4d31-8a01-f3b9aa48c3d5)