### PR TITLE
Sucheta- Hotfix Add Eye icon to reveal/hide input value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4905,6 +4905,15 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -8794,6 +8803,12 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -19707,6 +19722,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -20332,6 +20348,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/src/components/WeeklySummariesReport/PasswordInputModal.jsx
+++ b/src/components/WeeklySummariesReport/PasswordInputModal.jsx
@@ -42,7 +42,7 @@ export default function PasswordInputModal({
     setPasswordField(event.target.value);
   };
 
-  const revealPassword = e => {
+  const revealPassword = () => {
     setShowPassword(prev => !prev);
   };
 

--- a/src/components/WeeklySummariesReport/PasswordInputModal.jsx
+++ b/src/components/WeeklySummariesReport/PasswordInputModal.jsx
@@ -10,6 +10,8 @@ import {
   Input,
   FormGroup,
 } from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEyeSlash, faEye } from '@fortawesome/free-solid-svg-icons';
 import { boxStyle } from 'styles';
 import axios from 'axios';
 import { toast } from 'react-toastify';
@@ -34,10 +36,16 @@ export default function PasswordInputModal({
     passwordMatchErr: '',
   });
   const [passwordField, setPasswordField] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
 
   const onChangeFunc = event => {
     setPasswordField(event.target.value);
   };
+
+  const revealPassword = e => {
+    setShowPassword(prev => !prev);
+  };
+
   const authorizeWeeklySummariesButton = async () => {
     const url = ENDPOINTS.AUTHORIZE_WEEKLY_SUMMARY_REPORTS();
     try {
@@ -84,12 +92,25 @@ export default function PasswordInputModal({
           <FormGroup>
             <Input
               autoFocus
-              type="password"
+              type={showPassword ? 'text' : 'password'}
               name="passwordField"
               id="passwordField"
               value={passwordField}
               onChange={onChangeFunc}
             />
+            {showPassword ? (
+              <FontAwesomeIcon
+                icon={faEyeSlash}
+                onClick={revealPassword}
+                style={{ color: '#666a70', position: 'absolute', top: '26px', right: '32px' }}
+              />
+            ) : (
+              <FontAwesomeIcon
+                icon={faEye}
+                onClick={revealPassword}
+                style={{ color: '#666a70', position: 'absolute', top: '26px', right: '32px' }}
+              />
+            )}
           </FormGroup>
         </ModalBody>
         <ModalFooter>


### PR DESCRIPTION
# Description
The WeeklySummaryRecipient button opens a password modal that checks for authorized users. The user must be able to see the input value by clicking the `eye` icon and hide with a click on `eyeSlash` icon.

## Related PRS (if any):
Continuation of [PR2124](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2124)

## Main changes explained:
- Imported `faEye`  and `faEyeSlash` icon from Fontawesome.
- Added an onClick toggle function to the icons
- Additional state to determine whether to show the input value or hide it.

## How to test:
1. check into the current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as Owner(Authorized) user
5. go to Reports→ Weekly Summaries Report → Weekly Summary Report Recipients → Enter password…
6. verify if function `revealPassword` works as intended.


## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/45dc02d3-f3b7-4a71-ab8b-0d7dd7f27968



## Note:
Include the information the reviewers need to know.
