### PR TITLE
Masasa_Fixed the value of end dates

### DIFF
--- a/src/components/Reports/PeopleTable.js
+++ b/src/components/Reports/PeopleTable.js
@@ -48,7 +48,7 @@ function PeopleTable({ userProfiles, darkMode }) {
             {moment(person.createdDate).format('MM-DD-YY')}
           </td>
           <td className={`hide-mobile-start-end ${darkMode ? 'text-light' : ''}`} style={{ width: '110px' }}>
-            {moment(person.endDate).format('MM-DD-YY') || 'N/A'}
+          {person.endDate ? moment(person.endDate).format('MM-DD-YY') : 'N/A'}
           </td>
         </tr>
       ));


### PR DESCRIPTION
# Description

<img width="800" alt="Screenshot 2024-04-20 at 11 23 07 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73863365/29793fb3-5694-4898-8ee4-da3d46ed653a">


## Related PRS (if any):
This frontend PR is not related to any backend PR.
This is a redo of PR https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1852

## Main changes explained:
Added a check in case the person object has no end date and in which case the end date would be 'N/A'…
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ People→…
6. verify that the end dates for people who are not ended yet are N/A
## Screenshots or videos of changes:
<img width="678" alt="Screenshot 2024-04-20 at 11 13 53 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73863365/e07154c5-053d-4389-929c-9799cd6d40c0">

<img width="1202" alt="Screenshot 2024-04-20 at 11 26 35 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73863365/9a11a31e-9c0d-43b1-80ef-4013e81a0933">


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73863365/4a6474bb-4e1d-4192-aa88-12113b799fc0


