### PR TITLE
Nahiyan_dark mode on taskeditsuggestions

### DIFF
--- a/src/components/TaskEditSuggestions/Components/TaskEditSuggestionRow.jsx
+++ b/src/components/TaskEditSuggestions/Components/TaskEditSuggestionRow.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 export const TaskEditSuggestionRow = ({
   taskEditSuggestion,
   handleToggleTaskEditSuggestionModal,
+  darkMode,
 }) => {
   const handleButtonClick = (event) => {
     event.stopPropagation(); // This stops the click event from bubbling up to the parent <tr>
@@ -12,7 +13,7 @@ export const TaskEditSuggestionRow = ({
   };
 
   return (
-    <table>
+    <table className={darkMode ? 'text-light' : ''}>
       <tbody>
         <tr onClick={() => handleToggleTaskEditSuggestionModal(taskEditSuggestion)}>
           <td>{datetimeToDate(taskEditSuggestion.dateSuggested)}</td>

--- a/src/components/TaskEditSuggestions/TaskEditSuggestions.jsx
+++ b/src/components/TaskEditSuggestions/TaskEditSuggestions.jsx
@@ -17,7 +17,9 @@ export const TaskEditSuggestions = () => {
     userSortDirection,
     dateSuggestedSortDirection,
     userRole,
+    darkMode
   } = useSelector(getTaskEditSuggestionsData);
+  
 
   const dispatch = useDispatch();
 
@@ -37,42 +39,45 @@ export const TaskEditSuggestions = () => {
   };
 
   return (
-    <Container>
-      <h1 className="mt-3">Task Edit Suggestions</h1>
-      {/* {isUserPermitted ? <h1>Task Edit Suggestions</h1> : <h1>{userRole} is not permitted to view this</h1>} */}
-      {isLoading && <Loading />}
-      {!isLoading && taskEditSuggestions && (
-        <div style={{ overflowX: 'auto' }}>
-          <Table>
-            <thead>
-              <tr>
-                <th onClick={() => dispatch(toggleDateSuggestedSortDirection())}>
-                  Date Suggested <SortArrow sortDirection={dateSuggestedSortDirection} />
-                </th>
-                <th onClick={() => dispatch(toggleUserSortDirection())}>
-                  User <SortArrow sortDirection={userSortDirection} />
-                </th>
-                <th>Task</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {taskEditSuggestions.map(taskEditSuggestion => (
-                <TaskEditSuggestionRow
-                  key={taskEditSuggestion._id}
-                  taskEditSuggestion={taskEditSuggestion}
-                  handleToggleTaskEditSuggestionModal={handleToggleTaskEditSuggestionModal}
-                />
-              ))}
-            </tbody>
-          </Table>
-        </div>
-      )}
-      <TaskEditSuggestionsModal
-        isTaskEditSuggestionModalOpen={isTaskEditSuggestionModalOpen}
-        taskEditSuggestion={currentTaskEditSuggestion}
-        handleToggleTaskEditSuggestionModal={handleToggleTaskEditSuggestionModal}
-      />
-    </Container>
+    <div className={darkMode ? 'bg-oxford-blue text-light' : ''} style={{minHeight: "100%"}}>
+      <Container>
+        <h1 className="pt-3">Task Edit Suggestions</h1>
+        {/* {isUserPermitted ? <h1>Task Edit Suggestions</h1> : <h1>{userRole} is not permitted to view this</h1>} */}
+        {isLoading && <Loading />}
+        {!isLoading && taskEditSuggestions && (
+          <div style={{ overflowX: 'auto' }}>
+            <Table>
+              <thead className={darkMode ? 'text-light' : ''}>
+                <tr>
+                  <th onClick={() => dispatch(toggleDateSuggestedSortDirection())}>
+                    Date Suggested <SortArrow sortDirection={dateSuggestedSortDirection} />
+                  </th>
+                  <th onClick={() => dispatch(toggleUserSortDirection())}>
+                    User <SortArrow sortDirection={userSortDirection} />
+                  </th>
+                  <th>Task</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {taskEditSuggestions.map(taskEditSuggestion => (
+                  <TaskEditSuggestionRow
+                    key={taskEditSuggestion._id}
+                    taskEditSuggestion={taskEditSuggestion}
+                    handleToggleTaskEditSuggestionModal={handleToggleTaskEditSuggestionModal}
+                    darkMode={darkMode}
+                  />
+                ))}
+              </tbody>
+            </Table>
+          </div>
+        )}
+        <TaskEditSuggestionsModal
+          isTaskEditSuggestionModalOpen={isTaskEditSuggestionModalOpen}
+          taskEditSuggestion={currentTaskEditSuggestion}
+          handleToggleTaskEditSuggestionModal={handleToggleTaskEditSuggestionModal}
+        />
+      </Container>
+    </div>
   );
 };

--- a/src/components/TaskEditSuggestions/__tests__/TaskEditSuggestions.test.js
+++ b/src/components/TaskEditSuggestions/__tests__/TaskEditSuggestions.test.js
@@ -6,6 +6,7 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { toggleDateSuggestedSortDirection, toggleUserSortDirection } from '../actions';
 import { waitFor } from '@testing-library/react';
+import { themeMock } from '__tests__/mockStates';
 
 
 describe('TaskEditSuggestions', () => {
@@ -41,6 +42,7 @@ describe('TaskEditSuggestions', () => {
       userSortDirection: 'asc',
       dateSuggestedSortDirection: 'asc',
     },
+    theme: themeMock,
   };
   const mockStore = configureStore();
   let store, mockDispatch;
@@ -128,6 +130,7 @@ describe('TaskEditSuggestions loading', () => {
       userSortDirection: 'asc',
       dateSuggestedSortDirection: 'asc',
     },
+    theme: themeMock,
   };
   const mockStore = configureStore();
   let store, mockDispatch;

--- a/src/components/TaskEditSuggestions/__tests__/selectors.test.js
+++ b/src/components/TaskEditSuggestions/__tests__/selectors.test.js
@@ -1,3 +1,4 @@
+import { themeMock } from '__tests__/mockStates';
 import { getTaskEditSuggestionsData } from '../selectors'; 
 
 describe('getTaskEditSuggestionsData', () => {
@@ -15,6 +16,7 @@ describe('getTaskEditSuggestionsData', () => {
         userSortDirection: 'asc',
         dateSuggestedSortDirection: 'desc',
       },
+      theme: themeMock,
     };
 
     // Define the expected result
@@ -24,6 +26,7 @@ describe('getTaskEditSuggestionsData', () => {
       taskEditSuggestions: [{ id: 1, suggestion: 'Edit suggestion 1' }],
       userSortDirection: 'asc',
       dateSuggestedSortDirection: 'desc',
+      darkMode: true,
     };
 
     // Call the function with the mock state

--- a/src/components/TaskEditSuggestions/selectors.js
+++ b/src/components/TaskEditSuggestions/selectors.js
@@ -5,5 +5,6 @@ export const getTaskEditSuggestionsData = state => {
     taskEditSuggestions: state.taskEditSuggestions.taskEditSuggestions,
     userSortDirection: state.taskEditSuggestions.userSortDirection,
     dateSuggestedSortDirection: state.taskEditSuggestions.dateSuggestedSortDirection,
+    darkMode: state.theme.darkMode,
   };
 };

--- a/src/components/TeamMemberTasks/FollowUpInfoModal.jsx
+++ b/src/components/TeamMemberTasks/FollowUpInfoModal.jsx
@@ -1,12 +1,15 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faInfo } from '@fortawesome/free-solid-svg-icons';
 import './FollowUpInfoModal.css';
+import { useSelector } from 'react-redux';
 
 const FollowUpInfoModal = () => {
+  const darkMode = useSelector(state => state.theme.darkMode)
+
   return (
     <div className="followup-tooltip-container">
       <button className="followup-tooltip-button">
-        <FontAwesomeIcon icon={faInfo} />
+        <FontAwesomeIcon icon={faInfo} style={{color: darkMode ? 'silver' : 'black'}}/>
         <div className="followup-tooltip">
           <div className='mb-3'>
             This checkbox allows you to track follow-ups. By clicking it, you indicate that you have

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -138,7 +138,7 @@ const TeamMemberTask = React.memo(
                 <i
                   className="fa fa-clock-o"
                   aria-hidden="true"
-                  style={{ fontSize: 24, cursor: 'pointer', color: darkMode ? 'white' : 'black' }}
+                  style={{ fontSize: 24, cursor: 'pointer', color: darkMode ? 'lightgray' : 'black' }}
                   title="Click to see user's timelog"
                 />
               </Link>
@@ -307,7 +307,7 @@ const TeamMemberTask = React.memo(
                 {canTruncate && (
                   <tr key="truncate-button-row" className="task-break">
                     <td className="task-align">
-                      <button type="button" onClick={handleTruncateTasksButtonClick}>
+                      <button type="button" onClick={handleTruncateTasksButtonClick} className={darkMode ? 'text-light' : ''}>
                         {isTruncated ? `Show All (${activeTasks.length}) Tasks` : 'Truncate Tasks'}
                       </button>
                     </td>

--- a/src/components/TeamMemberTasks/TeamMemberTaskIconsInfo.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTaskIconsInfo.jsx
@@ -27,7 +27,7 @@ const TeamMemberTaskInfo = React.memo(() => {
             icon={faInfoCircle}
             title="Click this icon to learn about the task icons"
             onClick={handleModalOpen}
-            color={darkMode ? 'grey' : ''}
+            color={darkMode ? 'lightgray' : ''}
         />
         <Modal backdropClassName="task-info-modal-backdrop" isOpen={infoTaskIconModal} toggle={toggleInfoTaskIconModal}>
             <ModalHeader toggle={toggleInfoTaskIconModal}>

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -333,7 +333,7 @@ const TeamMemberTasks = React.memo(props => {
                       </th>
                       <th className="team-member-tasks-headers team-clocks team-clocks-header">
                         <FontAwesomeIcon 
-                          style={{color: darkMode ? 'grey' : ''}} 
+                          style={{color: darkMode ? 'lightgray' : ''}} 
                           icon={faClock} 
                           title="Weekly Committed Hours" />
                         /

--- a/src/components/common/Clipboard/CopyToClipboard.jsx
+++ b/src/components/common/Clipboard/CopyToClipboard.jsx
@@ -16,7 +16,7 @@ const CopyToClipboard = ({ writeText, message }) => {
     <FontAwesomeIcon 
       className="copy-to-clipboard" 
       icon={faCopy} onClick={handleCopyToClipboard} 
-      color={darkMode ? 'grey' : ''}
+      color={darkMode ? 'lightgray' : ''}
     />
   );
 };


### PR DESCRIPTION
# Description
Implemented dark mode for taskeditsuggestions page.

## Related PRS (if any):
This frontend PR is related to the dev backend

## Main changes explained:
- Implemented dark mode for taskeditsuggestions page
- Made little tweaks to the timelog component

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ [taskeditsuggestions](http://localhost:3000/taskeditsuggestions)
6. verify dark mode is working

## Screenshots or videos of changes:
![Screenshot 2024-04-24 190706](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/5e319e4d-b2ad-47fd-abbf-7bd78b3330c2)
![Screenshot 2024-04-24 190817](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/c4a0e13f-b078-47b9-b25b-81eaddff6512)

