### PR TITLE
Gayathri users enddate moreaccurate

### DIFF
--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -48,7 +48,6 @@ export const getTimeEntriesForPeriod = (userId, fromDate, toDate) => {
     .endOf('day')
     .format('YYYY-MM-DDTHH:mm:ss');
   const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate, toDate);
-  console.log(url);
   return async dispatch => {
     let loggedOut = false;
     const res = await axios.get(url).catch(error => {

--- a/src/actions/userManagement.js
+++ b/src/actions/userManagement.js
@@ -48,8 +48,8 @@ export const updateUserStatus = (user, status, reactivationDate) => {
         const lastEnddate = await dispatch(getTimeEndDateEntriesForPeriod(user._id, user.createdDate, userProfile.toDate));
         // If lastenddate is not "N/A", set endDate and userProfile.endDate
         if (lastEnddate !== "N/A") {
-          patchData.endDate = moment(lastEnddate).format('YYYY-MM-DD');
-          userProfile.endDate = moment(lastEnddate).format('YYYY-MM-DD');
+          patchData.endDate = moment(lastEnddate).format('YYYY-MM-DDTHH:mm:ss');
+          userProfile.endDate = moment(lastEnddate).format('YYYY-MM-DDTHH:mm:ss');
         } else {
           patchData.endDate = undefined;
           userProfile.endDate = undefined;

--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -17,7 +17,7 @@ import {
 import { getUserProjects } from '../../../actions/userProjects';
 import { getWeeklySummaries, updateWeeklySummaries } from '../../../actions/weeklySummaries';
 import 'react-input-range/lib/css/index.css';
-import { getTimeEntriesForPeriod } from '../../../actions/timeEntries';
+import { getTimeEntriesForPeriod, getTimeEndDateEntriesForPeriod } from '../../../actions/timeEntries';
 import InfringementsViz from '../InfringementsViz';
 import TimeEntriesViz from '../TimeEntriesViz';
 import BadgeSummaryViz from '../BadgeSummaryViz';
@@ -28,7 +28,7 @@ import { getPeopleReportData } from './selectors';
 import { PeopleTasksPieChart } from './components';
 import ToggleSwitch from '../../UserProfile/UserProfileEdit/ToggleSwitch';
 import { Checkbox } from '../../common/Checkbox';
-import {updateRehireableStatus} from '../../../actions/userManagement'
+import { updateRehireableStatus } from '../../../actions/userManagement'
 
 class PeopleReport extends Component {
   constructor(props) {
@@ -97,6 +97,7 @@ class PeopleReport extends Component {
       await this.props.getUserProjects(userId);
       await this.props.getWeeklySummaries(userId);
       await this.props.getTimeEntriesForPeriod(userId, fromDate, toDate);
+      await this.props.getTimeendDateEntriesForPeriod(userId, fromDate, toDate);
 
       const { userProfile, userTask, userProjects, timeEntries, auth } = this.props;
 
@@ -447,13 +448,13 @@ class PeopleReport extends Component {
             <p>Title: {jobTitle}</p>
 
             {/* {endDate ? ( */}
-              <div className="rehireable">
-                <Checkbox
-                  value={isRehireable}
-                  onChange={() => this.setRehireable(!isRehireable)}
-                  label="Rehireable"
-                />
-              </div>
+            <div className="rehireable">
+              <Checkbox
+                value={isRehireable}
+                onChange={() => this.setRehireable(!isRehireable)}
+                label="Rehireable"
+              />
+            </div>
             {/* ) : (
               ''
             )} */}
@@ -507,7 +508,7 @@ class PeopleReport extends Component {
     return (
       <div className="container-people-wrapper">
         <ReportPage renderProfile={renderProfileInfo}>
-          <div className={`people-report-time-logs-wrapper ${tangibleHoursReportedThisWeek === 0 ? "auto-width-report-time-logs-wrapper": ""}`}>
+          <div className={`people-report-time-logs-wrapper ${tangibleHoursReportedThisWeek === 0 ? "auto-width-report-time-logs-wrapper" : ""}`}>
             <ReportPage.ReportBlock
               firstColor="#ff5e82"
               secondColor="#e25cb2"
@@ -652,4 +653,6 @@ export default connect(getPeopleReportData, {
   getUserTasks,
   getUserProjects,
   getTimeEntriesForPeriod,
+  getTimeEndDateEntriesForPeriod,
+
 })(PeopleReport);

--- a/src/components/Reports/PeopleTable.js
+++ b/src/components/Reports/PeopleTable.js
@@ -1,6 +1,6 @@
 import '../Teams/Team.css';
 import { Link } from 'react-router-dom';
-import './reports.css';
+import './reports.css'
 import moment from 'moment';
 
 function PeopleTable({ userProfiles }) {
@@ -47,7 +47,7 @@ function PeopleTable({ userProfiles }) {
             {moment(person.createdDate).format('MM-DD-YY')}
           </td>
           <td className="hide-mobile-start-end" style={{ width: '110px' }}>
-            {moment(person.endDate).format('MM-DD-YY') || 'N/A'}
+            {person.isActive ? 'N/A' : moment(person.endDate).format('MM-DD-YY')}
           </td>
         </tr>
       ));

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -11,6 +11,8 @@ import { boxStyle } from 'styles';
 import { connect } from 'react-redux';
 import { formatDate } from 'utils/formatDate';
 import { cantUpdateDevAdminDetails } from 'utils/permissions';
+
+
 /**
  * The body row of the user table
  */
@@ -52,7 +54,7 @@ const UserTableData = React.memo(props => {
         />
       </td>
       <td className="email_cell">
-      <a href={`/userprofile/${props.user._id}`}>{props.user.firstName} </a>
+        <a href={`/userprofile/${props.user._id}`}>{props.user.firstName} </a>
         <FontAwesomeIcon
           className="copy_icon"
           icon={faCopy}
@@ -62,8 +64,8 @@ const UserTableData = React.memo(props => {
           }}
         />
       </td>
-       <td className="email_cell">
-       <a href={`/userprofile/${props.user._id}`}>{props.user.lastName}</a>
+      <td className="email_cell">
+        <a href={`/userprofile/${props.user._id}`}>{props.user.lastName}</a>
         <FontAwesomeIcon
           className="copy_icon"
           icon={faCopy}
@@ -91,7 +93,7 @@ const UserTableData = React.memo(props => {
           type="button"
           className={`btn btn-outline-${props.isActive ? 'warning' : 'success'} btn-sm`}
           onClick={e => {
-            if(cantUpdateDevAdminDetails(props.user.email , props.authEmail)){
+            if (cantUpdateDevAdminDetails(props.user.email, props.authEmail)) {
               alert('STOP! YOU SHOULDN’T BE TRYING TO CHANGE THIS. Please reconsider your choices.');
               return;
             }
@@ -108,9 +110,8 @@ const UserTableData = React.memo(props => {
       </td>
       <td className="centered-td">
         <button
-          className={`btn btn-outline-primary btn-sm${
-            props.timeOffRequests?.length > 0 ? ` time-off-request-btn-moved` : ''
-          }`}
+          className={`btn btn-outline-primary btn-sm${props.timeOffRequests?.length > 0 ? ` time-off-request-btn-moved` : ''
+            }`}
           onClick={e => props.onLogTimeOffClick(props.user)}
           id="requested-time-off-btn"
           style={boxStyle}
@@ -144,7 +145,7 @@ const UserTableData = React.memo(props => {
           type="button"
           className={`btn btn-outline-${props.isSet ? 'warning' : 'success'} btn-sm`}
           onClick={e => {
-            if(cantUpdateDevAdminDetails(props.user.email , props.authEmail)){
+            if (cantUpdateDevAdminDetails(props.user.email, props.authEmail)) {
               alert('STOP! YOU SHOULDN’T BE TRYING TO CHANGE THIS. Please reconsider your choices.');
               return;
             }
@@ -165,8 +166,9 @@ const UserTableData = React.memo(props => {
       </td>
       <td>{props.user.createdDate ? formatDate(props.user.createdDate) : 'N/A'}</td>
 
-       <td className="email_cell">
-      {props.user.endDate ? formatDate(props.user.endDate) : 'N/A'}
+      <td className="email_cell">
+        {props.user.endDate ? formatDate(props.user.endDate) : 'N/A'}
+
         <FontAwesomeIcon
           className="copy_icon"
           icon={faCopy}

--- a/src/components/UserProfile/UserProfile.container.jsx
+++ b/src/components/UserProfile/UserProfile.container.jsx
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { updateUserProfile, clearUserProfile } from 'actions/userProfile';
 import { updateTask } from 'actions/task';
-import { getTimeEntriesForWeek, getTimeEntriesForPeriod } from '../../actions/timeEntries';
+import { getTimeEntriesForWeek, getTimeEntriesForPeriod,getTimeEndDateEntriesForPeriod } from '../../actions/timeEntries';
 import { refreshToken } from '../../actions/authActions';
 import { getUserProjects } from '../../actions/userProjects';
 import UserProfile from './UserProfile';
@@ -23,6 +23,7 @@ export default connect(mapStateToProps, {
   updateUserProfile,
   getTimeEntriesForWeek,
   getTimeEntriesForPeriod,
+  getTimeEndDateEntriesForPeriod,
   getUserProjects,
   updateTask,
   refreshToken,


### PR DESCRIPTION
# Description
Make a user’s end date more accurate  
If a person stops working without notice, or is activated and deactivated at some point in the future, their end date is the day I deactivate them. This is not accurate. A person’s end date should be the last week they contributed hours. 
Making a person inactive should have the software check for the last week they contributed hours and set the last day of that week as their end date. 
This should be reflected in these 3 areas:
Profile Page
Reports → Reports → People → Their report page
Other Links → User Management page
I’d also like Owners/Admins to be able to edit a person’s last day from their Profile page


## Related PRS (if any):
To test this backend PR you need to checkout latest branch frontend PR.
…

## Main changes explained:
Implemented accurate end date calculation functionality in the Frontend and integrate it into the User Management and profile pages, as well as the People report's page. Thoroughly test the accuracy of the implementation..


## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin/ owner user
5. go to Other Links→ User Management Page 
6. Profile Pag
7. Reports → Reports → People → Their report page

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/163784958/bf9d619a-724d-44de-921e-7912caecb254

![dateAccurate-2](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/163784958/f8f65b16-47d8-45a6-9995-06509282a10a)
![dateAccurate-3](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/163784958/ac8bd65b-8444-453d-8701-4a8c6fa83a5a)
![dateAccurate-4](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/163784958/ed4da6a4-d726-402d-969f-9d6c660617ee)
![dateAccurate-5](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/163784958/442559a1-f7a2-4c3f-bbbc-b0c56954d37e)

## Note:
Include the information the reviewers need to know.
If the person has tasks assigned, you can see their end date; otherwise, you will see "N/A". The end date displays as Saturday of that week. You need to ensure that the user has both Tasks and Time Logs entries.