### PR TITLE
Sucheta - Improve Format of Add New Task modal

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -493,6 +493,7 @@ function AddTaskModal(props) {
                     />
                     
                   </div>
+                        {/* Moved warning outside of the parent div so that the input field does not get affected , now the warnings should appear in a new line - Sucheta*/}
                   <div className="warning">
                       {hoursWarning
                         ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -471,11 +471,12 @@ function AddTaskModal(props) {
                       id="bestCase"
                       className="w-50 ml-2"
                     />
-                    <div className="warning">
+                    
+                  </div>
+                  <div className="warning">
                       {hoursWarning
                         ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
                         : ''}
-                    </div>
                   </div>
                   <div className="py-2 flex-responsive">
                     <label htmlFor="worstCase" className="text-nowrap mr-2  w-25 mr-auto" style={{ fontWeight: 'normal' }}>
@@ -490,12 +491,13 @@ function AddTaskModal(props) {
                       onBlur={() => calHoursEstimate('hoursWorst')}
                       className="w-50 ml-2"
                     />
-                    <div className="warning">
+                    
+                  </div>
+                  <div className="warning">
                       {hoursWarning
                         ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
                         : ''}
                     </div>
-                  </div>
                   <div className="py-2 flex-responsive">
                     <label htmlFor="mostCase" className="text-nowrap mr-2 w-25 mr-auto" style={{ fontWeight: 'normal' }}>
                       Most-case
@@ -509,12 +511,13 @@ function AddTaskModal(props) {
                       onBlur={() => calHoursEstimate('hoursMost')}
                       className="w-50 ml-2"
                     />
-                    <div className="warning">
+                    
+                  </div>
+                  <div className="warning">
                       {hoursWarning
                         ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
                         : ''}
                     </div>
-                  </div>
                   <div className="py-2 flex-responsive">
                     <label htmlFor="Estimated" className="text-nowrap mr-2 w-25 mr-auto" style={{ fontWeight: 'normal' }}>
                       Estimated

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -305,14 +305,14 @@ function AddTaskModal(props) {
         <ModalBody>
           <div className="table table-bordered responsive">
             <div>
-              <div className="m-0 border d-flex">
-                <span className="border p-2 " data-tip="WBS ID" style={{width: "30%"}}>
+              <div className="m-0 border d-flex align-items-center">
+                <span className="p-1 " data-tip="WBS ID" style={{width: "30%"}}>
                   WBS #
                 </span>
 
                 <span className="border-left flex-grow-1 p-2">{newTaskNum}</span>
               </div>
-              <div className="m-0 border d-flex" >
+              <div className="m-0 border d-flex align-items-center" >
                 <span className="p-1" style={{width: "30%"}}>Task Name</span>
                 <span className="border-left p-1 flex-grow-1">
                   {/* Fix Task-name formatting - by Sucheta */}
@@ -326,7 +326,7 @@ function AddTaskModal(props) {
                   />
                 </span>
               </div >
-              <div className='m-0 border d-flex'>
+              <div className='m-0 border d-flex align-items-center'>
                 <span className="p-1" style={{width: "30%"}} >Priority</span>
                 <span className='border-left p-1 flex-grow-1'>
                   <select id="priority" onChange={e => setPriority(e.target.value)} ref={priorityRef}>
@@ -350,7 +350,7 @@ function AddTaskModal(props) {
                   
                 </span>
               </div>
-              <div className="m-0 border d-flex">
+              <div className="m-0 border d-flex align-items-center">
                 <span className="p-1" style={{width: "30%"}}>Assigned</span>
                 <span className="border-left p-1">
                   <div className="flex-row d-inline align-items-center" >
@@ -385,10 +385,10 @@ function AddTaskModal(props) {
                   </div>
                 </span>
               </div>
-              <div className="m-0 d-flex border">
+              <div className="m-0 d-flex border align-items-center">
                 <span className= "p-1" style={{width: "30%"}}>Status</span>
                 <span className="p-1 border-left" style={{width: "70%"}}>
-                 <div className="d-flex align-items-center"> 
+                 <div className="d-flex align-items-center flex-wrap"> 
                   <span className="form-check form-check-inline mr-5">
                       <input
                         className="form-check-input"
@@ -418,7 +418,7 @@ function AddTaskModal(props) {
                       </label>
                   </span>
                  </div>
-                 <div className="d-flex align-items-center">
+                 <div className="d-flex align-items-center flex-wrap">
                   <span className="form-check form-check-inline mr-5">
                         <input
                           className="form-check-input"
@@ -452,7 +452,7 @@ function AddTaskModal(props) {
                  </div>
                 </span>
               </div>
-              <div className="d-flex">
+              <div className="d-flex align-items-center">
                 <span className="p-1" style={{width: "30%"}}>
                   Hours
                 </span>
@@ -530,7 +530,7 @@ function AddTaskModal(props) {
                   </div>
                 </span>
               </div>
-              <div className="d-flex border" >
+              <div className="d-flex border align-items-center" >
                 <span className="p-1" style={{width: "30%"}}>Links</span>
                 <span className="p-1 border-left" style={{width: "70%"}}>
                   <div className="d-flex flex-row">
@@ -566,7 +566,7 @@ function AddTaskModal(props) {
                   </div>
                 </span>
               </div>
-              <div className="d-flex border">
+              <div className="d-flex border align-items-center">
                 <span  className= "p-1" style={{width: "30%"}}>Category</span>
                 <span  className="p-1 border-left" style={{width: "70%"}}>
                   <select value={category} onChange={e => setCategory(e.target.value)}>
@@ -578,8 +578,8 @@ function AddTaskModal(props) {
                   </select>
                 </span>
               </div>
-              <tr className='w-100'>
-                <td scope="col" colSpan="3">
+              <div >
+                <div scope="col" colSpan="2" className='border p-1' >
                   Why this Task is Important
                   <Editor
                     init={{
@@ -599,10 +599,10 @@ function AddTaskModal(props) {
                     value={whyInfo}
                     onEditorChange={content => setWhyInfo(content)}
                   />
-                </td>
-              </tr>
-              <tr>
-                <td scope="col" colSpan="2">
+                </div>
+              </div>
+              <div>
+                <div scope="col" colSpan="2" className="border p-1">
                   Design Intent
                   <Editor
                     init={{
@@ -622,10 +622,10 @@ function AddTaskModal(props) {
                     value={intentInfo}
                     onEditorChange={content => setIntentInfo(content)}
                   />
-                </td>
-              </tr>
-              <tr>
-                <td scope="col" colSpan="2">
+                </div>
+              </div>
+              <div>
+                <div scope="col" colSpan="2" className="border p-1"> 
                   Endstate
                   <Editor
                     init={{
@@ -645,11 +645,11 @@ function AddTaskModal(props) {
                     value={endstateInfo}
                     onEditorChange={content => setEndstateInfo(content)}
                   />
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Start Date</td>
-                <td scope="col">
+                </div>
+              </div>
+              <div className="d-flex border">
+                <span scope="col" style={{width: "30%"}} className="p-1">Start Date</span>
+                <span scope="col" className="border-left p-1">
                   <div>
                     <DayPickerInput
                       format={FORMAT}
@@ -662,11 +662,11 @@ function AddTaskModal(props) {
                       {dateWarning ? DUE_DATE_MUST_GREATER_THAN_START_DATE : ''}
                     </div>
                   </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">End Date</td>
-                <td scope="col">
+                </span>
+              </div>
+              <div className="d-flex border align-items-center">
+                <span scope="col" style={{width: "30%"}} className="p-1">End Date</span>
+                <span scope="col" className='border-left p-1'>
                   <DayPickerInput
                     format={FORMAT}
                     formatDate={formatDate}
@@ -677,8 +677,8 @@ function AddTaskModal(props) {
                   <div className="warning">
                     {dateWarning ? DUE_DATE_MUST_GREATER_THAN_START_DATE : ''}
                   </div>
-                </td>
-              </tr>
+                </span>
+              </div>
             </div>
           </div>
         </ModalBody>

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Row, Col } from 'reactstrap';
 import { connect } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
@@ -303,17 +303,18 @@ function AddTaskModal(props) {
           </button>
         </ModalHeader>
         <ModalBody>
-          <table className="table table-bordered responsive">
-            <tbody>
-              <tr>
-                <td scope="col" data-tip="WBS ID">
+          <div className="table table-bordered responsive">
+            <div>
+              <div className="m-0 border d-flex">
+                <span className="border p-2 " data-tip="WBS ID" style={{width: "30%"}}>
                   WBS #
-                </td>
-                <td scope="col">{newTaskNum}</td>
-              </tr>
-              <tr>
-                <td scope="col">Task Name</td>
-                <td scope="col">
+                </span>
+
+                <span className="border-left flex-grow-1 p-2">{newTaskNum}</span>
+              </div>
+              <div className="m-0 border d-flex" >
+                <span className="p-1" style={{width: "30%"}}>Task Name</span>
+                <span className="border-left p-1 flex-grow-1">
                   {/* Fix Task-name formatting - by Sucheta */}
                   <textarea
                     type="text"
@@ -323,22 +324,21 @@ function AddTaskModal(props) {
                     onKeyPress={e => setTaskName(e.target.value)}
                     value={taskName}
                   />
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Priority</td>
-                <td scope="col">
+                </span>
+              </div >
+              <div className='m-0 border d-flex'>
+                <span className="p-1" style={{width: "30%"}} >Priority</span>
+                <span className='border-left p-1 flex-grow-1'>
                   <select id="priority" onChange={e => setPriority(e.target.value)} ref={priorityRef}>
                     <option value="Primary">Primary</option>
                     <option value="Secondary">Secondary</option>
                     <option value="Tertiary">Tertiary</option>
                   </select>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Resources</td>
-                <td scope="col">
-                  <div>
+                </span>
+              </div>
+              <div className="m-0 border d-flex align-items-center">
+                <span className="p-1" style={{width: "30%"}}>Resources</span>
+                <span className="border-left p-1" style={{width: "70%"}}>
                     <TagsSearch
                       placeholder="Add resources"
                       members={allMembers.filter(user=>user.isActive)}
@@ -347,12 +347,12 @@ function AddTaskModal(props) {
                       resourceItems={resourceItems}
                       disableInput={false}
                     />
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Assigned</td>
-                <td scope="col">
+                  
+                </span>
+              </div>
+              <div className="m-0 border d-flex">
+                <span className="p-1" style={{width: "30%"}}>Assigned</span>
+                <span className="border-left p-1">
                   <div className="flex-row d-inline align-items-center" >
                     <div className="form-check form-check-inline">
                       <input
@@ -383,13 +383,13 @@ function AddTaskModal(props) {
                       </label>
                     </div>
                   </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Status</td>
-                <td scope="col">
-                  <div className="flex-row  d-inline align-items-center" >
-                    <div className="form-check form-check-inline">
+                </span>
+              </div>
+              <div className="m-0 d-flex border">
+                <span className= "p-1" style={{width: "30%"}}>Status</span>
+                <span className="p-1 border-left" style={{width: "70%"}}>
+                 <div className="d-flex align-items-center"> 
+                  <span className="form-check form-check-inline mr-5">
                       <input
                         className="form-check-input"
                         type="radio"
@@ -402,8 +402,8 @@ function AddTaskModal(props) {
                       <label className="form-check-label" htmlFor="active">
                         Active
                       </label>
-                    </div>
-                    <div className="form-check form-check-inline">
+                    </span>
+                  <span className="form-check">
                       <input
                         className="form-check-input"
                         type="radio"
@@ -416,22 +416,25 @@ function AddTaskModal(props) {
                       <label className="form-check-label" htmlFor="notStarted">
                         Not Started
                       </label>
-                    </div>
-                    <div className="form-check form-check-inline">
-                      <input
-                        className="form-check-input"
-                        type="radio"
-                        id="paused"
-                        name="status"
-                        value="Paused"
-                        checked={status === 'Paused'}
-                        onChange={(e) => setStatus(e.target.value)}
-                      />
-                      <label className="form-check-label" htmlFor="paused">
-                        Paused
-                      </label>
-                    </div>
-                    <div className="form-check form-check-inline">
+                  </span>
+                 </div>
+                 <div className="d-flex align-items-center">
+                  <span className="form-check form-check-inline mr-5">
+                        <input
+                          className="form-check-input"
+                          type="radio"
+                          id="paused"
+                          name="status"
+                          value="Paused"
+                          checked={status === 'Paused'}
+                          onChange={(e) => setStatus(e.target.value)}
+                        />
+                        <label className="form-check-label" htmlFor="paused">
+                          Paused
+                        </label>
+                    
+                  </span>
+                  <span className="form-check form-check-inline">
                       <input
                         className="form-check-input"
                         type="radio"
@@ -444,17 +447,18 @@ function AddTaskModal(props) {
                       <label className="form-check-label" htmlFor="complete">
                         Complete
                       </label>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col" className="w-100">
+                   
+                  </span>
+                 </div>
+                </span>
+              </div>
+              <div className="d-flex">
+                <span className="p-1" style={{width: "30%"}}>
                   Hours
-                </td>
-                <td scope="col" className="w-100">
+                </span>
+                <span className="p-1 border-left" style={{width: "70%"}}>
                   <div className="py-2 flex-responsive">
-                    <label htmlFor="bestCase" className="text-nowrap mr-2 w-25 mr-auto" style={{ fontWeight: 'normal' }}>
+                    <label htmlFor="bestCase" className="text-nowrap mr-3 w-25 mr-auto" style={{ fontWeight: 'normal' }}>
                       Best-case
                     </label>
                     <input
@@ -465,7 +469,7 @@ function AddTaskModal(props) {
                       onChange={e => setHoursBest(e.target.value)}
                       onBlur={() => calHoursEstimate()}
                       id="bestCase"
-                      className="w-25"
+                      className="w-50 ml-2"
                     />
                     <div className="warning">
                       {hoursWarning
@@ -484,7 +488,7 @@ function AddTaskModal(props) {
                       value={hoursWorst}
                       onChange={e => setHoursWorst(e.target.value)}
                       onBlur={() => calHoursEstimate('hoursWorst')}
-                      className="w-25"
+                      className="w-50 ml-2"
                     />
                     <div className="warning">
                       {hoursWarning
@@ -503,7 +507,7 @@ function AddTaskModal(props) {
                       value={hoursMost}
                       onChange={e => setHoursMost(e.target.value)}
                       onBlur={() => calHoursEstimate('hoursMost')}
-                      className="w-25"
+                      className="w-50 ml-2"
                     />
                     <div className="warning">
                       {hoursWarning
@@ -521,14 +525,14 @@ function AddTaskModal(props) {
                       max="500"
                       value={hoursEstimate}
                       onChange={e => setHoursEstimate(e.target.value)}
-                      className="w-25"
+                      className="w-50 ml-2"
                     />
                   </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Links</td>
-                <td scope="col">
+                </span>
+              </div>
+              <div className="d-flex border" >
+                <span className="p-1" style={{width: "30%"}}>Links</span>
+                <span className="p-1 border-left" style={{width: "70%"}}>
                   <div className="d-flex flex-row">
                     <input
                       type="text"
@@ -560,11 +564,11 @@ function AddTaskModal(props) {
                       ) : null,
                     )}
                   </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Category</td>
-                <td scope="col">
+                </span>
+              </div>
+              <div className="d-flex border">
+                <span  className= "p-1" style={{width: "30%"}}>Category</span>
+                <span  className="p-1 border-left" style={{width: "70%"}}>
                   <select value={category} onChange={e => setCategory(e.target.value)}>
                     {categoryOptions.map(cla => (
                       <option value={cla.value} key={cla.value}>
@@ -572,10 +576,10 @@ function AddTaskModal(props) {
                       </option>
                     ))}
                   </select>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col" colSpan="2">
+                </span>
+              </div>
+              <tr className='w-100'>
+                <td scope="col" colSpan="3">
                   Why this Task is Important
                   <Editor
                     init={{
@@ -675,8 +679,8 @@ function AddTaskModal(props) {
                   </div>
                 </td>
               </tr>
-            </tbody>
-          </table>
+            </div>
+          </div>
         </ModalBody>
         <ModalFooter>
           <Button color="primary" onClick={addNewTask} disabled={taskName === '' || hoursWarning || isLoading} style={boxStyle}>


### PR DESCRIPTION
# Description
(PRIORITY HIGH) Jae: Improve “Add New Task” modal format
- Make Task Name box bigger
- Fix Status Section so everything fits on 2 lines
- Fix hours input width so up to a 4-digit number will show
- [Video clarification](https://www.loom.com/share/80b70f2750ad4f00abee0d6fdeeca4f9?sid=8f6037a8-169b-4b97-bf79-39051f93fea3)

## Related PRS (if any):
None

## Main changes explained:
- Changed html tags in `AddTaskModal.jsx` , from `<tr>` to `<div>` and `<td>` to `<span>` for the form labels and input fields


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ Projects → WBS -> Tasks -> Add Task
6. The input fields now take more space than the labels.

## Screenshots or videos of changes:
Before the change: 

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/2482fa39-6d7c-4078-ab7f-b2fab529aa2c

After the change: 

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/91fc9ee0-bc4a-40bc-8eeb-cc519e70eaef



## Note:
Extended version of [PR2167](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2167)
This PR resolved a bug , please refer to the picture below:
<img width="416" alt="Screenshot 2024-04-26 at 1 36 24 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/4b423b82-68db-4fae-8008-9c5499534a05">

