### PR TITLE
add run lint in the husky stage

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run lint
+npm run test


### PR DESCRIPTION
# Description
This PR is adding a new stage in husky. So when you commit your changes, it will run `npm run test` after `npm run lint`. This could prevent the codes of broken Unit Tests to be pushed and merged into our repo.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. make sure everything is working fine

## Screenshots or videos of changes:
Below image is result from terminal when you do "git commit":
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/5071040/6e5f0f7f-ed32-4674-99d8-46b0a9e14c01)
