### PR TITLE
Shengwei_Hotfix_Timer_Issue

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -54,7 +54,7 @@ const TimeEntryForm = props => {
   /*---------------- variables -------------- */
   // props from parent
   const { from, sendStop, edit, data, toggle, isOpen, tab, userProfile } = props;
-
+  debugger
   // props from store
   const { authUser } = props;
 
@@ -495,7 +495,7 @@ const TimeEntryForm = props => {
                 id="dateOfWork"
                 value={formValues.dateOfWork}
                 onChange={handleInputChange}
-                min={userProfile?.isFirstTimelog === true ? moment().toISOString().split('T')[0] : userProfile?.startDate.split('T')[0]} 
+                // min={userProfile?.isFirstTimelog === true ? moment().toISOString().split('T')[0] : userProfile?.startDate ? userProfile?.startDate.split('T')[0] : null} 
                 disabled={!canEditTimeEntry}
               />
               {'dateOfWork' in errors && (

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -54,7 +54,6 @@ const TimeEntryForm = props => {
   /*---------------- variables -------------- */
   // props from parent
   const { from, sendStop, edit, data, toggle, isOpen, tab, userProfile } = props;
-  debugger
   // props from store
   const { authUser } = props;
 


### PR DESCRIPTION
# Description
[Issue demo](https://www.loom.com/share/2841284838c1420bac3e60ef31920dee)

## Related PRS (if any):

## Main changes explained:
- Remove min validation for date input in timeEntryForm.jsx. This is due to UserProfile is not set in the global redux store hence it leads to an can't read undefine error on min={... userProfile?.startDate.split()}

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Click on stop timer icon and verify it works

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
