### PR TITLE
hot fix blue square issue

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/QuickSetupCodes.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupCodes.jsx
@@ -1,6 +1,6 @@
 function QuickSetupCodes({ titles, setShowAssignModal, setTitleOnClick }) {
   return (
-    <div className="blueSquares mt-3">
+    <div className="blueSquares mt-3" id="qsc-outer-wrapper">
       {titles.map((title) => (
         <div
           key={title._id}

--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.css
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.css
@@ -4,26 +4,34 @@
     margin: 5px;
   }
   
-  #wrapper{
+ #qsc-outer-wrapper #wrapper{
     position: relative;
   }
 
-  #wrapper .title {
+  #qsc-outer-wrapper  #wrapper .title {
     position: absolute;
-    color: white;
+    color: #ddd;
     top:30px;
     left: 30px;
+    /* height: 2rem;
+    width: 150px; */
     display: none;
     white-space: nowrap;
     z-index: 10;
+    background-color: #555;
+    border-radius: 2px;
+    padding: 0.5rem 1rem;
   }
   
-  #wrapper:hover .title {
-    display: inline-block;
-    visibility: visible;
+  #qsc-outer-wrapper  #wrapper:hover .title {
+    cursor: pointer;
+    display: block;
   }
+
+
 .setup-title-name{
     max-height: 30px;
+
 }
 
 .qsm-modal-required{


### PR DESCRIPTION
# Description
Fix the issue of broken blue square message.
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/113729159/d04e6c47-4a71-44e6-8281-e43cd47c0751)

## Main changes explained:
- Change css conflicts for #wrapper for Quick setup modal files and other files
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→  View profile→
6. hover your mouse on the blue squares and short codes. The pop-up hovering windows should look like the following image.
## Screenshots or videos of changes:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/113729159/8675b40c-54f1-4f72-8629-dfd1e3e809ec)

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/113729159/9dd23efe-81c7-48bd-993a-4be4a45ce35c)



