### PR TITLE
Needs new developer - Fix the design of the Projects/People/Teams page on the narrow screens 

### DIFF
--- a/src/components/Reports/Reports.jsx
+++ b/src/components/Reports/Reports.jsx
@@ -28,7 +28,7 @@ import { boxStyle, boxStyleDark } from 'styles';
 const DATE_PICKER_MIN_DATE = '01/01/2010';
 
 class ReportsPage extends Component {
-  
+
   constructor(props) {
     super(props);
     this.state = {
@@ -129,11 +129,11 @@ class ReportsPage extends Component {
       // Applying the search filters before creating each team table data element
       if (
         (project.projectName &&
-          searchWithAccent(project.projectName,this.state.teamNameSearchText) &&
+          searchWithAccent(project.projectName, this.state.teamNameSearchText) &&
           this.state.wildCardSearchText === '') ||
         // the wild card search, the search text can be match with any item
         (this.state.wildCardSearchText !== '' &&
-        searchWithAccent(project.projectName,this.state.wildCardSearchText))
+          searchWithAccent(project.projectName, this.state.wildCardSearchText))
       ) {
         return project;
       }
@@ -152,7 +152,7 @@ class ReportsPage extends Component {
           this.state.wildCardSearchText === '') ||
         // the wild card search, the search text can be match with any item
         (this.state.wildCardSearchText !== '' &&
-        searchWithAccent(team.teamName, this.state.wildCardSearchText))
+          searchWithAccent(team.teamName, this.state.wildCardSearchText))
       ) {
         return team;
       }
@@ -171,7 +171,7 @@ class ReportsPage extends Component {
           this.state.wildCardSearchText === '') ||
         // the wild card search, the search text can be match with any item
         (this.state.wildCardSearchText !== '' &&
-           searchWithAccent(userProfile.firstName, this.state.wildCardSearchText)) ||
+          searchWithAccent(userProfile.firstName, this.state.wildCardSearchText)) ||
         (this.state.wildCardSearchText !== '' &&
           userProfile.lastName &&
           searchWithAccent(userProfile.lastName, this.state.wildCardSearchText))
@@ -365,7 +365,7 @@ class ReportsPage extends Component {
       showAddTeamHistory: !prevState.showAddTeamHistory,
     }));
   }
-  
+
 
   render() {
     const darkMode = this.props.state.theme.darkMode;
@@ -404,53 +404,87 @@ class ReportsPage extends Component {
     return (
       <Container fluid className={`mb-5 container-component-wrapper ${isOxfordBlue}`}>
         <div className={`category-data-container ${isOxfordBlue} ${this.state.showPeople || this.state.showProjects || this.state.showTeams || this.state.showTotalProject || this.state.showTotalPeople || this.state.showTotalTeam || this.state.showAddTimeForm || this.state.showAddPersonHistory || this.state.showAddTeamHistory || this.state.showAddProjHistory ? '' : 'no-active-selection'}`}>
-        <div className="container-component-category">
-        <h2 className="mt-3 mb-5">
-          <div className="d-flex align-items-center">
-            <span className="mr-2">Reports Page</span>
-            <EditableInfoModal
-              areaName="ReportsPage"
-              areaTitle="Reports Page"
-              role={userRole}
-              fontSize={26}
-              isPermissionPage={true}
-              className="p-2" // Add Bootstrap padding class to the EditableInfoModal
-            />
-          </div>
-        </h2>
-          <div className={textColor}>
-            <p>Select a Category</p>
-          </div>
-          <div className="container-box-shadow">
-            <div className="category-container">
-              <button
-                className={`card-category-item ${this.state.showProjects ? 'selected' : ''} ${isYinmnBlue}`}
-                style={boxStyling}
-                onClick={this.showProjectTable}
-              >
-                <h3 className="card-category-item-title"> Projects</h3>
-                <h3 className="card-category-item-number">{this.state.projectSearchData.length} </h3>
-                <img src={projectsImage} alt="Image that representes the projects" />
-              </button>
-              <button
-                className={`card-category-item ${this.state.showPeople ? 'selected' : ''} ${isYinmnBlue}`}
-                style={boxStyling}
-                onClick={this.showPeopleTable}
-              >
-                <h3 className="card-category-item-title"> People </h3>
-                <h3 className="card-category-item-number">{this.state.peopleSearchData.length}</h3>
-                <img src={peopleImage} alt="Image that representes the people" />
-              </button>
-              <button
-                className={`card-category-item ${this.state.showTeams ? 'selected' : ''} ${isYinmnBlue}`}
-                style={boxStyling}
-                onClick={this.showTeamsTable}
-              >
-                <h3 className="card-category-item-title"> Teams </h3>
-                <h3 className="card-category-item-number">{this.state.teamSearchData?.length}</h3>
-                <img src={teamsImage} alt="Image that representes the teams" />
-              </button>
-              {/* <button style={{ margin: '5px' }} exact className="btn btn-info btn-bg mt-3" onClick={this.showProjectTable}>
+          <div className="container-component-category">
+            <h2 className="mt-3 mb-5">
+              <div className="d-flex align-items-center">
+                <span className="mr-2">Reports Page</span>
+                <EditableInfoModal
+                  areaName="ReportsPage"
+                  areaTitle="Reports Page"
+                  role={userRole}
+                  fontSize={26}
+                  isPermissionPage={true}
+                  className="p-2" // Add Bootstrap padding class to the EditableInfoModal
+                />
+              </div>
+            </h2>
+            <div className={textColor}>
+              <p>Select a Category</p>
+            </div>
+            <div className="container-box-shadow">
+              <div className="category-container">
+                <button
+                  className={`card-category-item ${this.state.showProjects ? 'selected' : ''} ${isYinmnBlue}`}
+                  style={boxStyling}
+                  onClick={() => {
+                    if (window.innerWidth > 900) {
+                      this.showProjectTable();
+                    } else {
+                      window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+                      // Wait for scrolling to complete before showing teams
+                      setTimeout(() => {
+                        this.showProjectTable();
+                      }); // Adjust the delay time as needed
+                    }
+                  }}
+                >
+                  <h3 className="card-category-item-title"> Projects</h3>
+                  <h3 className="card-category-item-number">{this.state.projectSearchData.length} </h3>
+                  <img src={projectsImage} alt="Image that representes the projects" />
+                </button>
+                <button
+                  className={`card-category-item ${this.state.showPeople ? 'selected' : ''} ${isYinmnBlue}`}
+                  style={boxStyling}
+                  onClick={() => {
+                    if (window.innerWidth > 900) {
+                      this.showPeopleTable();
+                    } else {
+                      window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+                      // Wait for scrolling to complete before showing teams
+                      setTimeout(() => {
+                        this.showPeopleTable();
+                      }); // Adjust the delay time as needed
+                    }
+                  }}
+                >
+                  <h3 className="card-category-item-title"> People </h3>
+                  <h3 className="card-category-item-number">{this.state.peopleSearchData.length}</h3>
+                  <img src={peopleImage} alt="Image that representes the people" />
+                </button>
+                <button
+                  className={`card-category-item ${this.state.showTeams ? 'selected' : ''} ${isYinmnBlue}`}
+                  style={boxStyling}
+                  onClick={() => {
+                    if (window.innerWidth > 900) {
+
+                      this.showTeamsTable();
+                    } else {
+
+
+                      // Wait for scrolling to complete before showing teams
+                      window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+                      setTimeout(() => {
+                        this.showTeamsTable();
+                      }); // Adjust the delay time as needed
+
+                    }
+                  }}
+                >
+                  <h3 className="card-category-item-title"> Teams </h3>
+                  <h3 className="card-category-item-number">{this.state.teamSearchData?.length}</h3>
+                  <img src={teamsImage} alt="Image that representes the teams" />
+                </button>
+                {/* <button style={{ margin: '5px' }} exact className="btn btn-info btn-bg mt-3" onClick={this.showProjectTable}>
                 <i className="fa fa-folder" aria-hidden="true" />
                 {' '}
                 Projects
@@ -471,332 +505,332 @@ class ReportsPage extends Component {
                 {' '}
                 {this.state.teamSearchData?.length}
               </button> */}
-            </div>
-            <div 
-              className={`mt-4 p-3 rounded-lg ${darkMode ? 'bg-yinmn-blue text-light' : 'bg-white'}`} 
-              style={darkMode ? boxStyleDark : boxStyle}>
-              <div>
-                <a>Select a Filter</a>
               </div>
-              <div>
-                <input
-                  name="radio"
-                  type="radio"
-                  style={{ margin: '8px 12px', marginLeft: 0 }}
-                  value="active"
-                  onChange={this.setActive}
-                />
-                Active
-                <input
-                  name="radio"
-                  type="radio"
-                  style={{ margin: '8px 12px' }}
-                  value="inactive"
-                  onChange={this.setInActive}
-                />
-                Inactive
-                <input
-                  name="radio"
-                  type="radio"
-                  style={{ margin: '8px 12px' }}
-                  value="all"
-                  onChange={this.setAll}
-                  defaultChecked
-                />
-                All
-              </div>
-              <div className="mt-4">
-                <ReportTableSearchPanel
-                  onSearch={this.onWildCardSearch}
-                  onCreateNewTeamClick={this.onCreateNewTeamShow}
-                />
-              </div>
-              <div className="date-picker-container">
-                <div id="task_startDate" className="date-picker-item">
-                  <label htmlFor="task_startDate" className={`date-picker-label ${textColor}`}>
-                    {' '}
-                    Start Date
-                  </label>
-                  <DatePicker
-                    selected={this.state.startDate}
-                    minDate={new Date(DATE_PICKER_MIN_DATE)}
-                    maxDate={new Date()}
-                    onChange={date => {
-                      if (date > new Date(DATE_PICKER_MIN_DATE) && date <= this.state.endDate) {
-                        this.setState({ startDate: date });
-                      }
-                    }}
-                    className="form-control"
-                    popperPlacement="top-start"
+              <div
+                className={`mt-4 p-3 rounded-lg ${darkMode ? 'bg-yinmn-blue text-light' : 'bg-white'}`}
+                style={darkMode ? boxStyleDark : boxStyle}>
+                <div>
+                  <a>Select a Filter</a>
+                </div>
+                <div>
+                  <input
+                    name="radio"
+                    type="radio"
+                    style={{ margin: '8px 12px', marginLeft: 0 }}
+                    value="active"
+                    onChange={this.setActive}
+                  />
+                  Active
+                  <input
+                    name="radio"
+                    type="radio"
+                    style={{ margin: '8px 12px' }}
+                    value="inactive"
+                    onChange={this.setInActive}
+                  />
+                  Inactive
+                  <input
+                    name="radio"
+                    type="radio"
+                    style={{ margin: '8px 12px' }}
+                    value="all"
+                    onChange={this.setAll}
+                    defaultChecked
+                  />
+                  All
+                </div>
+                <div className="mt-4">
+                  <ReportTableSearchPanel
+                    onSearch={this.onWildCardSearch}
+                    onCreateNewTeamClick={this.onCreateNewTeamShow}
                   />
                 </div>
-                <div id="task_EndDate" className="date-picker-item">
-                  <label htmlFor="task_EndDate" className={`date-picker-label ${textColor}`}>
-                    {' '}
-                    End Date
-                  </label>
-                  <DatePicker
-                    selected={this.state.endDate}
-                    maxDate={new Date()}
-                    minDate={new Date(DATE_PICKER_MIN_DATE)}
-                    onChange={date => {
-                      if (date >= this.state.startDate) {
-                        this.setState({ endDate: date });
-                      }
-                    }}
-                    className="form-control"
-                    popperPlacement="top"
-                  />
-                </div>
-              </div>
-              <div className="total-report-container">
-                <div className="total-report-item">
-                  <Button color="info" onClick={this.showTotalProject}>
-                    {this.state.showTotalProject
-                      ? 'Hide Total Project Report'
-                      : 'Show Total Project Report'}
-                  </Button>
-                  <div style={{ display: 'inline-block', marginLeft: 10 }}>
-                  <EditableInfoModal
-                    areaName="totalProjectReportInfoPoint"
-                    areaTitle="Total Project Report"
-                    role={userRole}
-                    fontSize={15}
-                    isPermissionPage={true}
-                  />
+                <div className="date-picker-container">
+                  <div id="task_startDate" className="date-picker-item">
+                    <label htmlFor="task_startDate" className={`date-picker-label ${textColor}`}>
+                      {' '}
+                      Start Date
+                    </label>
+                    <DatePicker
+                      selected={this.state.startDate}
+                      minDate={new Date(DATE_PICKER_MIN_DATE)}
+                      maxDate={new Date()}
+                      onChange={date => {
+                        if (date > new Date(DATE_PICKER_MIN_DATE) && date <= this.state.endDate) {
+                          this.setState({ startDate: date });
+                        }
+                      }}
+                      className="form-control"
+                      popperPlacement="top-start"
+                    />
+                  </div>
+                  <div id="task_EndDate" className="date-picker-item">
+                    <label htmlFor="task_EndDate" className={`date-picker-label ${textColor}`}>
+                      {' '}
+                      End Date
+                    </label>
+                    <DatePicker
+                      selected={this.state.endDate}
+                      maxDate={new Date()}
+                      minDate={new Date(DATE_PICKER_MIN_DATE)}
+                      onChange={date => {
+                        if (date >= this.state.startDate) {
+                          this.setState({ endDate: date });
+                        }
+                      }}
+                      className="form-control"
+                      popperPlacement="top"
+                    />
                   </div>
                 </div>
-                <div className="total-report-item">
-                  <Button color="info" onClick={this.showTotalPeople}>
-                    {this.state.showTotalPeople
-                      ? 'Hide Total People Report'
-                      : 'Show Total People Report'}
-                  </Button>
-                  <div style={{ display: 'inline-block', marginLeft: 10 }}>
-                  <EditableInfoModal
-                    areaName="totalPeopleReportInfoPoint"
-                    areaTitle="Total People Report"
-                    role={userRole}
-                    fontSize={15}
-                    isPermissionPage={true}
-                  />
-                  </div>
-                </div>
-                <div className="total-report-item">
-                  <Button color="info" onClick={this.showTotalTeam}>
-                    {this.state.showTotalTeam ? 'Hide Total Team Report' : 'Show Total Team Report'}
-                  </Button>
-                  <div style={{ display: 'inline-block', marginLeft: 10 }}>
-                  <EditableInfoModal
-                    areaName="totalTeamReportInfoPoint"
-                    areaTitle="Total Team Report"
-                    role={userRole}
-                    fontSize={15}
-                    isPermissionPage={true}
-                  />
-                  </div>
-                </div>
-              </div>
-              {myRole != 'Owner' && (
-                <div className='lost-time-container'>
-                  <div className='lost-time-item'>
-                    <Button color='info' onClick={this.showAddProjHistory}>
-                      {this.state.showAddProjHistory
-                        ? 'Hide Project Lost Time'
-                        : 'Show Project Lost Time'}
+                <div className="total-report-container">
+                  <div className="total-report-item">
+                    <Button color="info" onClick={this.showTotalProject}>
+                      {this.state.showTotalProject
+                        ? 'Hide Total Project Report'
+                        : 'Show Total Project Report'}
                     </Button>
                     <div style={{ display: 'inline-block', marginLeft: 10 }}>
                       <EditableInfoModal
-                        areaName="projectLostTimeInfoPoint"
-                        areaTitle="Project Lost Time"
-                        role={myRole}
+                        areaName="totalProjectReportInfoPoint"
+                        areaTitle="Total Project Report"
+                        role={userRole}
                         fontSize={15}
                         isPermissionPage={true}
                       />
                     </div>
                   </div>
-                  <div className='lost-time-item'>
-                    <Button color='info' onClick={this.showAddPersonHistory}>
-                      {this.state.showAddPersonHistory
-                        ? 'Hide Person Lost Time'
-                        : 'Show Person Lost Time'}
+                  <div className="total-report-item">
+                    <Button color="info" onClick={this.showTotalPeople}>
+                      {this.state.showTotalPeople
+                        ? 'Hide Total People Report'
+                        : 'Show Total People Report'}
                     </Button>
                     <div style={{ display: 'inline-block', marginLeft: 10 }}>
                       <EditableInfoModal
-                        areaName="personLostTimeInfoPoint"
-                        areaTitle="Person Lost Time"
-                        role={myRole}
+                        areaName="totalPeopleReportInfoPoint"
+                        areaTitle="Total People Report"
+                        role={userRole}
                         fontSize={15}
                         isPermissionPage={true}
                       />
                     </div>
                   </div>
-                  <div className='lost-time-item'>
-                    <Button color='info' onClick={this.showAddTeamHistory}>
-                      {this.state.showAddTeamHistory
-                        ? 'Hide Team Lost Time'
-                        : 'Show Team Lost Time'}
+                  <div className="total-report-item">
+                    <Button color="info" onClick={this.showTotalTeam}>
+                      {this.state.showTotalTeam ? 'Hide Total Team Report' : 'Show Total Team Report'}
                     </Button>
                     <div style={{ display: 'inline-block', marginLeft: 10 }}>
                       <EditableInfoModal
-                        areaName="teamLostTimeInfoPoint"
-                        areaTitle="Team Lost Time"
-                        role={myRole}
+                        areaName="totalTeamReportInfoPoint"
+                        areaTitle="Total Team Report"
+                        role={userRole}
                         fontSize={15}
                         isPermissionPage={true}
                       />
+                    </div>
+                  </div>
+                </div>
+                {myRole != 'Owner' && (
+                  <div className='lost-time-container'>
+                    <div className='lost-time-item'>
+                      <Button color='info' onClick={this.showAddProjHistory}>
+                        {this.state.showAddProjHistory
+                          ? 'Hide Project Lost Time'
+                          : 'Show Project Lost Time'}
+                      </Button>
+                      <div style={{ display: 'inline-block', marginLeft: 10 }}>
+                        <EditableInfoModal
+                          areaName="projectLostTimeInfoPoint"
+                          areaTitle="Project Lost Time"
+                          role={myRole}
+                          fontSize={15}
+                          isPermissionPage={true}
+                        />
+                      </div>
+                    </div>
+                    <div className='lost-time-item'>
+                      <Button color='info' onClick={this.showAddPersonHistory}>
+                        {this.state.showAddPersonHistory
+                          ? 'Hide Person Lost Time'
+                          : 'Show Person Lost Time'}
+                      </Button>
+                      <div style={{ display: 'inline-block', marginLeft: 10 }}>
+                        <EditableInfoModal
+                          areaName="personLostTimeInfoPoint"
+                          areaTitle="Person Lost Time"
+                          role={myRole}
+                          fontSize={15}
+                          isPermissionPage={true}
+                        />
+                      </div>
+                    </div>
+                    <div className='lost-time-item'>
+                      <Button color='info' onClick={this.showAddTeamHistory}>
+                        {this.state.showAddTeamHistory
+                          ? 'Hide Team Lost Time'
+                          : 'Show Team Lost Time'}
+                      </Button>
+                      <div style={{ display: 'inline-block', marginLeft: 10 }}>
+                        <EditableInfoModal
+                          areaName="teamLostTimeInfoPoint"
+                          areaTitle="Team Lost Time"
+                          role={myRole}
+                          fontSize={15}
+                          isPermissionPage={true}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+              {myRole === 'Owner' && (
+                <div
+                  className={`mt-4 p-3 rounded-lg ${darkMode ? 'bg-yinmn-blue' : 'bg-white'}`}
+                  style={darkMode ? boxStyleDark : boxStyle}
+                >
+                  <div className='lost-time-container'>
+                    <div className='lost-time-item'>
+                      <Button color='success' onClick={this.setAddTime} >
+                        Add Lost Time
+                      </Button>
+                      <div style={{ display: 'inline-block', marginLeft: 10 }}>
+                        <EditableInfoModal
+                          areaName="addLostTimeInfoPoint"
+                          areaTitle="Add Lost Time"
+                          role={myRole}
+                          fontSize={15}
+                          isPermissionPage={true}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div className='lost-time-container'>
+                    <div className='lost-time-item'>
+                      <Button color='info' onClick={this.showAddProjHistory}>
+                        {this.state.showAddProjHistory
+                          ? 'Hide Project Lost Time'
+                          : 'Show Project Lost Time'}
+                      </Button>
+                      <div style={{ display: 'inline-block', marginLeft: 10 }}>
+                        <EditableInfoModal
+                          areaName="projectLostTimeInfoPoint"
+                          areaTitle="Project Lost Time"
+                          role={myRole}
+                          fontSize={15}
+                          isPermissionPage={true}
+                        />
+                      </div>
+                    </div>
+                    <div className='lost-time-item'>
+                      <Button color='info' onClick={this.showAddPersonHistory}>
+                        {this.state.showAddPersonHistory
+                          ? 'Hide Person Lost Time'
+                          : 'Show Person Lost Time'}
+                      </Button>
+                      <div style={{ display: 'inline-block', marginLeft: 10 }}>
+                        <EditableInfoModal
+                          areaName="personLostTimeInfoPoint"
+                          areaTitle="Person Lost Time"
+                          role={myRole}
+                          fontSize={15}
+                          isPermissionPage={true}
+                        />
+                      </div>
+                    </div>
+                    <div className='lost-time-item'>
+                      <Button color='info' onClick={this.showAddTeamHistory}>
+                        {this.state.showAddTeamHistory
+                          ? 'Hide Team Lost Time'
+                          : 'Show Team Lost Time'}
+                      </Button>
+                      <div style={{ display: 'inline-block', marginLeft: 10 }}>
+                        <EditableInfoModal
+                          areaName="teamLostTimeInfoPoint"
+                          areaTitle="Team Lost Time"
+                          role={myRole}
+                          fontSize={15}
+                          isPermissionPage={true}
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
               )}
             </div>
-            {myRole === 'Owner' && (
-              <div 
-                className={`mt-4 p-3 rounded-lg ${darkMode ? 'bg-yinmn-blue' : 'bg-white'}`}
-                style={darkMode ? boxStyleDark : boxStyle}
-              >
-                <div className='lost-time-container'>
-                  <div className='lost-time-item'>
-                    <Button color='success' onClick={this.setAddTime} >
-                      Add Lost Time
-                    </Button>
-                    <div style={{ display: 'inline-block', marginLeft: 10 }}>
-                      <EditableInfoModal
-                        areaName="addLostTimeInfoPoint"
-                        areaTitle="Add Lost Time"
-                        role={myRole}
-                        fontSize={15}
-                        isPermissionPage={true}
-                      />
-                    </div>
-                  </div>
-                </div>
-                <div className='lost-time-container'>
-                  <div className='lost-time-item'>
-                    <Button color='info' onClick={this.showAddProjHistory}>
-                      {this.state.showAddProjHistory
-                        ? 'Hide Project Lost Time'
-                        : 'Show Project Lost Time'}
-                    </Button>
-                    <div style={{ display: 'inline-block', marginLeft: 10 }}>
-                      <EditableInfoModal
-                        areaName="projectLostTimeInfoPoint"
-                        areaTitle="Project Lost Time"
-                        role={myRole}
-                        fontSize={15}
-                        isPermissionPage={true}
-                      />
-                    </div>
-                  </div>
-                  <div className='lost-time-item'>
-                    <Button color='info' onClick={this.showAddPersonHistory}>
-                      {this.state.showAddPersonHistory
-                        ? 'Hide Person Lost Time'
-                        : 'Show Person Lost Time'}
-                    </Button>
-                    <div style={{ display: 'inline-block', marginLeft: 10 }}>
-                      <EditableInfoModal
-                        areaName="personLostTimeInfoPoint"
-                        areaTitle="Person Lost Time"
-                        role={myRole}
-                        fontSize={15}
-                        isPermissionPage={true}
-                      />
-                    </div>
-                  </div>
-                  <div className='lost-time-item'>
-                    <Button color='info' onClick={this.showAddTeamHistory}>
-                      {this.state.showAddTeamHistory
-                        ? 'Hide Team Lost Time'
-                        : 'Show Team Lost Time'}
-                    </Button>
-                    <div style={{ display: 'inline-block', marginLeft: 10 }}>
-                      <EditableInfoModal
-                        areaName="teamLostTimeInfoPoint"
-                        areaTitle="Team Lost Time"
-                        role={myRole}
-                        fontSize={15}
-                        isPermissionPage={true}
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
+          </div>
+          <div className="table-data-container mt-5">
+            {this.state.showPeople && <PeopleTable userProfiles={this.state.peopleSearchData} darkMode={darkMode} />}
+            {this.state.showProjects && <ProjectTable projects={this.state.projectSearchData} darkMode={darkMode} />}
+            {this.state.showTeams && <TeamTable allTeams={this.state.teamSearchData} darkMode={darkMode} />}
+            {this.state.showTotalProject && (
+              <TotalProjectReport
+                startDate={this.state.startDate}
+                endDate={this.state.endDate}
+                userProfiles={userProfiles}
+                projects={projects}
+                darkMode={darkMode}
+              />
             )}
-        </div>
-        </div>
-        <div className="table-data-container mt-5">
-          {this.state.showPeople && <PeopleTable userProfiles={this.state.peopleSearchData} darkMode={darkMode}/>}
-          {this.state.showProjects && <ProjectTable projects={this.state.projectSearchData} darkMode={darkMode}/>}
-          {this.state.showTeams && <TeamTable allTeams={this.state.teamSearchData} darkMode={darkMode}/>}
-          {this.state.showTotalProject && (
-            <TotalProjectReport
-              startDate={this.state.startDate}
-              endDate={this.state.endDate}
-              userProfiles={userProfiles}
-              projects={projects}
-              darkMode={darkMode}
-            />
-          )}
-          {this.state.showTotalPeople && (
-            <TotalPeopleReport
-              startDate={this.state.startDate}
-              endDate={this.state.endDate}
-              userProfiles={userProfiles}
-              darkMode={darkMode}
-            />
-          )}
-          {this.state.showTotalTeam && (
-            <TotalTeamReport
-              startDate={this.state.startDate}
-              endDate={this.state.endDate}
-              userProfiles={userProfiles}
-              allTeamsData={allTeams}
-              passTeamMemberList={this.setTeamMemberList}
-              savedTeamMemberList={this.state.teamMemberList}
-              darkMode={darkMode}
-            />
-          )}
-          {(this.state.showAddTimeForm && myRole === 'Owner') && 
-            <AddLostTime
-              isOpen = {this.state.showAddTimeForm}
-              toggle = {this.setAddTime}
-              projects = {projects}
-              teams = {allTeams}
-              users = {userProfiles}
-            />
-          }
-          {this.state.showAddPersonHistory && (
-            <LostTimeHistory
-              type={"person"}
-              isOpen={this.state.showAddPersonHistory}
-              startDate={this.state.startDate}
-              endDate={this.state.endDate}
-              allData = {userProfiles}
-              darkMode={darkMode}
-            />
-          )}
-          {this.state.showAddTeamHistory && (
-            <LostTimeHistory
-              type={"team"}
-              isOpen={this.state.showAddTeamHistory}
-              startDate={this.state.startDate}
-              endDate={this.state.endDate}
-              allData = {allTeams}
-              darkMode={darkMode}
-            />
-          )}
-          {this.state.showAddProjHistory && (
-            <LostTimeHistory
-              type={"project"}
-              isOpen={this.state.showAddProjHistory}
-              startDate={this.state.startDate}
-              endDate={this.state.endDate}
-              allData = {projects}
-              darkMode={darkMode}
-            />
-          )}
-        </div>
+            {this.state.showTotalPeople && (
+              <TotalPeopleReport
+                startDate={this.state.startDate}
+                endDate={this.state.endDate}
+                userProfiles={userProfiles}
+                darkMode={darkMode}
+              />
+            )}
+            {this.state.showTotalTeam && (
+              <TotalTeamReport
+                startDate={this.state.startDate}
+                endDate={this.state.endDate}
+                userProfiles={userProfiles}
+                allTeamsData={allTeams}
+                passTeamMemberList={this.setTeamMemberList}
+                savedTeamMemberList={this.state.teamMemberList}
+                darkMode={darkMode}
+              />
+            )}
+            {(this.state.showAddTimeForm && myRole === 'Owner') &&
+              <AddLostTime
+                isOpen={this.state.showAddTimeForm}
+                toggle={this.setAddTime}
+                projects={projects}
+                teams={allTeams}
+                users={userProfiles}
+              />
+            }
+            {this.state.showAddPersonHistory && (
+              <LostTimeHistory
+                type={"person"}
+                isOpen={this.state.showAddPersonHistory}
+                startDate={this.state.startDate}
+                endDate={this.state.endDate}
+                allData={userProfiles}
+                darkMode={darkMode}
+              />
+            )}
+            {this.state.showAddTeamHistory && (
+              <LostTimeHistory
+                type={"team"}
+                isOpen={this.state.showAddTeamHistory}
+                startDate={this.state.startDate}
+                endDate={this.state.endDate}
+                allData={allTeams}
+                darkMode={darkMode}
+              />
+            )}
+            {this.state.showAddProjHistory && (
+              <LostTimeHistory
+                type={"project"}
+                isOpen={this.state.showAddProjHistory}
+                startDate={this.state.startDate}
+                endDate={this.state.endDate}
+                allData={projects}
+                darkMode={darkMode}
+              />
+            )}
+          </div>
         </div>
       </Container>
     );


### PR DESCRIPTION
# Description
(PRIORITY LOW) Sushmitha: Fix the design of the Projects/People/Teams page on the narrow screens (WIP Gayathridevi)
Right now, users might not realize results have appeared without scrolling down. Make it more obvious that the search has produced results.
	A. go to Reports→ Reports → Projects/People/Teams
	B. Narrow the screen
C. Type any letter in the search bar
Do not change how it works on large screens

## Related PRS (if any):
This frontend PR is related to the #XXX backend PR.
To test this backend PR you need to checkout latest Backend.
…

## Main changes explained:
- Reports.jsx functionality added.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin /owner user
5. go to Reports→ Reports → Projects/People/Teams	
6. B. Narrow the screen
7.Type any letter in the search bar)  ( When you click  Projects/People/Teams scroll down to the result page)

## Screenshots or videos of changes:
Before changes
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/163784958/fd1fccad-7fd8-4ffb-ac3f-83b96c4ec07c)
After changes:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/163784958/c53461f4-219b-4564-9298-eede3374f51b)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/163784958/5df41772-f74f-4b3a-8d15-a0cd64141a6b)


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/163784958/216e9210-7dee-4ec3-99b4-78d9f7de9a6e


## Note:
When it is narrow screen it will automatically scroll down

