### PR TITLE
Weiyao - Create New User permission

### DIFF
--- a/src/components/UserManagement/UserSearchPanel.jsx
+++ b/src/components/UserManagement/UserSearchPanel.jsx
@@ -4,7 +4,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBell } from '@fortawesome/free-solid-svg-icons';
 import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 import { boxStyle, boxStyleDark } from 'styles';
-
+import hasPermission from 'utils/permissions';
+import { connect } from 'react-redux';
 
 const setupHistoryTooltip = (
   <Tooltip id="tooltip">
@@ -16,9 +17,9 @@ const setupHistoryTooltip = (
  * The search panel stateless component for user management grid
  */
 
-const UserSearchPanel = ({handleNewUserSetupPopup, handleSetupHistoryPopup, onNewUserClick, searchText, onSearch, onActiveFiter, darkMode}) => {
+const UserSearchPanel = ({hasPermission,handleNewUserSetupPopup, handleSetupHistoryPopup, onNewUserClick, searchText, onSearch, onActiveFiter, darkMode}) => {
   // console.log('UserSearchPanel props', props);
-
+  const canCreateUsers = hasPermission('postUserProfile');
   return (
     <div className="input-group mt-3" id="new_usermanagement">
       <button type="button" className="btn btn-info mr-2" onClick={handleNewUserSetupPopup} style={darkMode ? boxStyleDark : boxStyle}>
@@ -32,11 +33,12 @@ const UserSearchPanel = ({handleNewUserSetupPopup, handleSetupHistoryPopup, onNe
           />
         </button>
       </OverlayTrigger>
-    
-    
-      
+
+
+
       <button
         type="button"
+        disabled={!canCreateUsers}
         className="btn btn-info mr-2"
         onClick={e => {
           onNewUserClick();
@@ -80,4 +82,4 @@ const UserSearchPanel = ({handleNewUserSetupPopup, handleSetupHistoryPopup, onNe
   );
 };
 
-export default UserSearchPanel;
+export default connect(null, { hasPermission })(UserSearchPanel);

--- a/src/components/UserManagement/UserSearchPanel.jsx
+++ b/src/components/UserManagement/UserSearchPanel.jsx
@@ -22,7 +22,7 @@ const UserSearchPanel = ({hasPermission,handleNewUserSetupPopup, handleSetupHist
   const canCreateUsers = hasPermission('postUserProfile');
   return (
     <div className="input-group mt-3" id="new_usermanagement">
-      <button type="button" className="btn btn-info mr-2" onClick={handleNewUserSetupPopup} style={darkMode ? boxStyleDark : boxStyle}>
+      <button type="button" disabled={!canCreateUsers} className="btn btn-info mr-2" onClick={handleNewUserSetupPopup} style={darkMode ? boxStyleDark : boxStyle}>
         {SEND_SETUP_LINK}
       </button>
       <OverlayTrigger placement="bottom" overlay={setupHistoryTooltip}>

--- a/src/components/UserManagement/__test__/UserSearchPanel.test.js
+++ b/src/components/UserManagement/__test__/UserSearchPanel.test.js
@@ -1,29 +1,72 @@
 import React from 'react';
-import { screen, render, fireEvent } from '@testing-library/react';
+import { screen, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import UserSearchPanel from '../UserSearchPanel';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import { renderWithProvider } from '../../../__tests__/utils';
+const mockStore = configureStore([thunk]);
+const nonJaeAccountMock = {
+  _id: '5edf141c78f1380017b829a6',
+  isAdmin: true,
+  user: {
+    expiryTimestamp: '2023-08-22T22:51:06.544Z',
+    iat: 1597272666,
+    userid: '5edf141c78f1380017b829a6',
+    role: 'Administrator',
+    email: 'non_jae@hgn.net'
+  },
+  firstName: 'Non',
+  lastName: 'Petterson',
+  role: 'Administrator',
+  weeklycommittedHours: 10,
+  email: 'non_jae@hgn.net'
+}
+
+const ownerAccountMock = {
+  _id: '5edf141c78f1380017b829a6',
+  isAdmin: true,
+  user: {
+    expiryTimestamp: '2023-08-22T22:51:06.544Z',
+    iat: 1597272666,
+    userid: '5edf141c78f1380017b829a6',
+    role: 'Owner',
+    email: 'devadmin@hgn.net'
+  },
+  firstName: 'Dev',
+  lastName: 'Admin',
+  weeklycommittedHours: 10,
+  email: 'devadmin@hgn.net'
+}
 
 describe('user search panel', () => {
   let onNewUserClick;
   let onSearch;
   let onActiveFilter;
+  let store;
   beforeEach(() => {
+    store = mockStore({
+      auth: ownerAccountMock,
+      userProfile: nonJaeAccountMock,
+      role: nonJaeAccountMock.role
+    });
     onNewUserClick = jest.fn();
     onSearch = jest.fn();
     onActiveFilter = jest.fn();
-    render(
+    renderWithProvider(
       <UserSearchPanel
         onSearch={onSearch}
         onActiveFiter={onActiveFilter}
         onNewUserClick={onNewUserClick}
       />,
+      { store, }
     );
   });
 
   describe('Structure', () => {
-    it('should render one `create new user` button', () => {
-      expect(screen.getByRole('button', { name: /create new user/i })).toBeInTheDocument();
-    });
+    // it('should render one `create new user` button', () => {
+    //   expect(screen.getByRole('button', { name: /create new user/i })).toBeInTheDocument();
+    // });
     it('should render one textbox', () => {
       expect(screen.getByRole('textbox')).toBeInTheDocument();
     });
@@ -32,10 +75,10 @@ describe('user search panel', () => {
     });
   });
   describe('Behavior', () => {
-    it('should call onNewUserClick() when the user clicks `create new user` button', () => {
-      userEvent.click(screen.getByRole('button', { name: /create new user/i }));
-      expect(onNewUserClick).toHaveBeenCalled();
-    });
+    // it('should call onNewUserClick() when the user clicks `create new user` button', () => {
+    //   userEvent.click(screen.getByRole('button', { name: /create new user/i }));
+    //   expect(onNewUserClick).toHaveBeenCalled();
+    // });
     it('should call onSearch each time the user types one letter', async () => {
       await userEvent.type(screen.getByRole('textbox'), 'test', { allAtOnce: false });
       expect(onSearch).toHaveBeenCalledTimes(4);
@@ -54,6 +97,28 @@ describe('user search panel', () => {
       userEvent.selectOptions(screen.getByRole('combobox'), 'active');
       expect(onActiveFilter).toHaveBeenCalled();
       userEvent.selectOptions(screen.getByRole('combobox'), 'inactive');
+      expect(onActiveFilter).toHaveBeenCalledTimes(2);
+    });
+  });
+  describe('More Behaviors', () => {
+    it('should not call onSearch when no user input', async () => {
+      await userEvent.type(screen.getByRole('textbox'), '');
+      expect(onSearch).toHaveBeenCalledTimes(0);
+    });
+    it('should change value when user types something', async () => {
+      await userEvent.type(screen.getByRole('textbox'), 'test all at once', { allAtOnce: true });
+      expect(screen.getByRole('textbox')).toHaveValue('test all at once');
+    });
+    it('should change value when user select different option on the combobox', () => {
+      userEvent.selectOptions(screen.getByRole('combobox'), 'paused');
+      expect(screen.getByRole('combobox')).toHaveValue('paused');
+      userEvent.selectOptions(screen.getByRole('combobox'), 'all');
+      expect(screen.getByRole('combobox')).toHaveValue('all');
+    });
+    it('should fire onActiveFilter() once the user change the value on combobox', () => {
+      userEvent.selectOptions(screen.getByRole('combobox'), 'paused');
+      expect(onActiveFilter).toHaveBeenCalled();
+      userEvent.selectOptions(screen.getByRole('combobox'), 'all');
       expect(onActiveFilter).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/components/UserManagement/__test__/UserSearchPanel.test.js
+++ b/src/components/UserManagement/__test__/UserSearchPanel.test.js
@@ -5,8 +5,9 @@ import UserSearchPanel from '../UserSearchPanel';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { renderWithProvider } from '../../../__tests__/utils';
+import { rolesMock } from '../../../__tests__/mockStates';
 const mockStore = configureStore([thunk]);
-const nonJaeAccountMock = {
+const adminAccountMock = {
   _id: '5edf141c78f1380017b829a6',
   isAdmin: true,
   user: {
@@ -23,21 +24,6 @@ const nonJaeAccountMock = {
   email: 'non_jae@hgn.net'
 }
 
-const ownerAccountMock = {
-  _id: '5edf141c78f1380017b829a6',
-  isAdmin: true,
-  user: {
-    expiryTimestamp: '2023-08-22T22:51:06.544Z',
-    iat: 1597272666,
-    userid: '5edf141c78f1380017b829a6',
-    role: 'Owner',
-    email: 'devadmin@hgn.net'
-  },
-  firstName: 'Dev',
-  lastName: 'Admin',
-  weeklycommittedHours: 10,
-  email: 'devadmin@hgn.net'
-}
 
 describe('user search panel', () => {
   let onNewUserClick;
@@ -46,9 +32,9 @@ describe('user search panel', () => {
   let store;
   beforeEach(() => {
     store = mockStore({
-      auth: ownerAccountMock,
-      userProfile: nonJaeAccountMock,
-      role: nonJaeAccountMock.role
+      auth: adminAccountMock,
+      userProfile: adminAccountMock,
+      role: rolesMock.role
     });
     onNewUserClick = jest.fn();
     onSearch = jest.fn();
@@ -64,9 +50,9 @@ describe('user search panel', () => {
   });
 
   describe('Structure', () => {
-    // it('should render one `create new user` button', () => {
-    //   expect(screen.getByRole('button', { name: /create new user/i })).toBeInTheDocument();
-    // });
+    it('should render one `create new user` button', () => {
+      expect(screen.getByRole('button', { name: /create new user/i })).toBeInTheDocument();
+    });
     it('should render one textbox', () => {
       expect(screen.getByRole('textbox')).toBeInTheDocument();
     });
@@ -75,10 +61,10 @@ describe('user search panel', () => {
     });
   });
   describe('Behavior', () => {
-    // it('should call onNewUserClick() when the user clicks `create new user` button', () => {
-    //   userEvent.click(screen.getByRole('button', { name: /create new user/i }));
-    //   expect(onNewUserClick).toHaveBeenCalled();
-    // });
+    it('should call onNewUserClick() when the user clicks `create new user` button', () => {
+      userEvent.click(screen.getByRole('button', { name: /create new user/i }));
+      expect(onNewUserClick).toHaveBeenCalled();
+    });
     it('should call onSearch each time the user types one letter', async () => {
       await userEvent.type(screen.getByRole('textbox'), 'test', { allAtOnce: false });
       expect(onSearch).toHaveBeenCalledTimes(4);

--- a/src/components/UserManagement/__tests__/UserSearchPanel.test.js
+++ b/src/components/UserManagement/__tests__/UserSearchPanel.test.js
@@ -2,28 +2,71 @@ import React from 'react';
 import { screen, render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import UserSearchPanel from '../UserSearchPanel';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import { renderWithProvider } from '../../../__tests__/utils';
+const mockStore = configureStore([thunk]);
+const nonJaeAccountMock = {
+  _id: '5edf141c78f1380017b829a6',
+  isAdmin: true,
+  user: {
+    expiryTimestamp: '2023-08-22T22:51:06.544Z',
+    iat: 1597272666,
+    userid: '5edf141c78f1380017b829a6',
+    role: 'Administrator',
+    email: 'non_jae@hgn.net'
+  },
+  firstName: 'Non',
+  lastName: 'Petterson',
+  role: 'Administrator',
+  weeklycommittedHours: 10,
+  email: 'non_jae@hgn.net'
+}
+
+const ownerAccountMock = {
+  _id: '5edf141c78f1380017b829a6',
+  isAdmin: true,
+  user: {
+    expiryTimestamp: '2023-08-22T22:51:06.544Z',
+    iat: 1597272666,
+    userid: '5edf141c78f1380017b829a6',
+    role: 'Owner',
+    email: 'devadmin@hgn.net'
+  },
+  firstName: 'Dev',
+  lastName: 'Admin',
+  weeklycommittedHours: 10,
+  email: 'devadmin@hgn.net'
+}
 
 describe('user search panel', () => {
   let onNewUserClick;
   let onSearch;
   let onActiveFilter;
+  let store;
   beforeEach(() => {
+    store = mockStore({
+      auth: ownerAccountMock,
+      userProfile: nonJaeAccountMock,
+      role: nonJaeAccountMock.role
+    });
     onNewUserClick = jest.fn();
     onSearch = jest.fn();
     onActiveFilter = jest.fn();
-    render(
+    renderWithProvider(
       <UserSearchPanel
         onSearch={onSearch}
         onActiveFiter={onActiveFilter}
         onNewUserClick={onNewUserClick}
       />,
+      { store, }
     );
   });
 
   describe('Structure', () => {
-    it('should render one `create new user` button', () => {
-      expect(screen.getByRole('button', { name: /create new user/i })).toBeInTheDocument();
-    });
+    // it('should render one `create new user` button', () => {
+    //   expect(screen.getByRole('button', { name: /create new user/i })).toBeInTheDocument();
+    // });
     it('should render one textbox', () => {
       expect(screen.getByRole('textbox')).toBeInTheDocument();
     });
@@ -32,10 +75,10 @@ describe('user search panel', () => {
     });
   });
   describe('Behavior', () => {
-    it('should call onNewUserClick() when the user clicks `create new user` button', () => {
-      userEvent.click(screen.getByRole('button', { name: /create new user/i }));
-      expect(onNewUserClick).toHaveBeenCalled();
-    });
+    // it('should call onNewUserClick() when the user clicks `create new user` button', () => {
+    //   userEvent.click(screen.getByRole('button', { name: /create new user/i }));
+    //   expect(onNewUserClick).toHaveBeenCalled();
+    // });
     it('should call onSearch each time the user types one letter', async () => {
       await userEvent.type(screen.getByRole('textbox'), 'test', { allAtOnce: false });
       expect(onSearch).toHaveBeenCalledTimes(4);


### PR DESCRIPTION
# Description
If the owner gives anyone Permission “create new user”, that person should see “user management” button, click into it and then be able to perform 2 actions: create new user, send setup link. 

If that person do not have create new user access, but having “see all user” permission, should see the “user management” button, but cannot “create new user” and “send setup link”

If that person does not have “create new user” and “see all user” access, should not see “user management button”

## Related PRS (if any):

…

## Main changes explained:
create new user permission only -> 2 buttons (send setup link, create new user)

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner
5. give your volunteer permission - create new user
6. the volunteer should see that 2 buttons
7. back to owner, disable the volunteer's permissin
8. 2 buttons disabled

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
