### PR TITLE
Hoang fix viewing other dashboard

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 // import { getUserProfile } from '../../actions/userProfile'
 import { ENDPOINTS } from 'utils/URL';
 import axios from 'axios';
 import { getHeaderData } from '../../actions/authActions';
 import { getAllRoles } from '../../actions/role';
+import { getWeeklySummaries } from 'actions/weeklySummaries';
 import { Link } from 'react-router-dom';
 import { connect, useDispatch } from 'react-redux';
 import Timer from '../Timer/Timer';
@@ -68,46 +69,51 @@ export function Header(props) {
   const [displayUserId, setDisplayUserId] = useState(user.userid);
   const [popup, setPopup] = useState(false);
   const [isAuthUser, setIsAuthUser] = useState(true);
+
+  const ALLOWED_ROLES_TO_INTERACT = useMemo(() => ['Owner', 'Administrator'], []);
+  const canInteractWithViewingUser = useMemo(
+    () => ALLOWED_ROLES_TO_INTERACT.includes(props.auth.user.role), [ALLOWED_ROLES_TO_INTERACT, props.auth.user.role])
+
   // Reports
-  const canGetReports = props.hasPermission('getReports');
-  const canGetWeeklySummaries = props.hasPermission('getWeeklySummaries');
+  const canGetReports = props.hasPermission('getReports', !isAuthUser && canInteractWithViewingUser);
+  const canGetWeeklySummaries = props.hasPermission('getWeeklySummaries', !isAuthUser && canInteractWithViewingUser);
   // Users
-  const canAccessUserManagement = props.hasPermission('postUserProfile')
-    || props.hasPermission('deleteUserProfile')
-    || props.hasPermission('changeUserStatus')
-    || props.hasPermission('getUserProfiles');
+  const canAccessUserManagement = props.hasPermission('postUserProfile', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('deleteUserProfile', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('changeUserStatus', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('getUserProfiles', !isAuthUser && canInteractWithViewingUser);
 
   // Badges
-  const canAccessBadgeManagement = props.hasPermission('seeBadges')
-    || props.hasPermission('createBadges')
-    || props.hasPermission('updateBadges')
-    || props.hasPermission('deleteBadges');
+  const canAccessBadgeManagement = props.hasPermission('seeBadges', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('createBadges', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('updateBadges', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('deleteBadges', !isAuthUser && canInteractWithViewingUser);
   // Projects
-  const canAccessProjects = props.hasPermission('postProject')
-    || props.hasPermission('deleteProject')
-    || props.hasPermission('putProject')
-    || props.hasPermission('getProjectMembers')
-    || props.hasPermission('assignProjectToUsers')
-    || props.hasPermission('postWbs')
-    || props.hasPermission('deleteWbs')
-    || props.hasPermission('postTask')
-    || props.hasPermission('updateTask')
-    || props.hasPermission('deleteTask');
+  const canAccessProjects = props.hasPermission('postProject', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('deleteProject', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('putProject', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('getProjectMembers', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('assignProjectToUsers', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('postWbs', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('deleteWbs', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('postTask', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('updateTask', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('deleteTask', !isAuthUser && canInteractWithViewingUser);
   // Tasks
-  const canUpdateTask = props.hasPermission('updateTask');
+  const canUpdateTask = props.hasPermission('updateTask', !isAuthUser && canInteractWithViewingUser);
   // Teams
-  const canAccessTeams = props.hasPermission('postTeam')
-    || props.hasPermission('putTeam')
-    || props.hasPermission('deleteTeam')
-    || props.hasPermission('assignTeamToUsers');
+  const canAccessTeams = props.hasPermission('postTeam', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('putTeam', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('deleteTeam', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('assignTeamToUsers', !isAuthUser && canInteractWithViewingUser);
   // Popups
-  const canAccessPopups = props.hasPermission('createPopup')
-    || props.hasPermission('updatePopup');
+  const canAccessPopups = props.hasPermission('createPopup', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('updatePopup', !isAuthUser && canInteractWithViewingUser);
   // Permissions
-  const canAccessPermissionsManagement = props.hasPermission('postRole')
-    || props.hasPermission('putRole')
-    || props.hasPermission('deleteRole')
-    || props.hasPermission('putUserProfilePermissions')
+  const canAccessPermissionsManagement = props.hasPermission('postRole', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('putRole', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('deleteRole', !isAuthUser && canInteractWithViewingUser)
+    || props.hasPermission('putUserProfilePermissions', !isAuthUser && canInteractWithViewingUser)
 
   const userId = user.userid;
   const [isModalVisible, setModalVisible] = useState(false);
@@ -187,6 +193,7 @@ export function Header(props) {
     setPopup(false);
     sessionStorage.removeItem('viewingUser');
     window.dispatchEvent(new Event('storage'));
+    props.getWeeklySummaries(user.userid)
   }
 
   const closeModal = () => {
@@ -481,4 +488,5 @@ export default connect(mapStateToProps, {
   getHeaderData,
   getAllRoles,
   hasPermission,
+  getWeeklySummaries
 })(Header);

--- a/src/components/LeaderBoard/LeaderBoard.container.jsx
+++ b/src/components/LeaderBoard/LeaderBoard.container.jsx
@@ -5,6 +5,7 @@ import Leaderboard from './Leaderboard';
 import { getcolor, getprogress, getProgressValue } from '../../utils/effortColors';
 import { getMouseoverText } from '../../actions/mouseoverTextAction';
 import { showTimeOffRequestModal } from '../../actions/timeOffRequestAction';
+import { getWeeklySummaries } from '../../actions/weeklySummaries';
 
 const mapStateToProps = state => {
   let leaderBoardData = get(state, 'leaderBoardData', []);
@@ -73,4 +74,5 @@ export default connect(mapStateToProps, {
   getOrgData,
   getMouseoverText,
   showTimeOffRequestModal,
+  getWeeklySummaries,
 })(Leaderboard);

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -78,6 +78,7 @@ function LeaderBoard({
   allRequests,
   showTimeOffRequestModal,
   darkMode,
+  getWeeklySummaries,
 }) {
   const userId = displayUserId;
   const hasSummaryIndicatorPermission = hasPermission('seeSummaryIndicator'); // ??? this permission doesn't exist?
@@ -203,6 +204,7 @@ function LeaderBoard({
   const dashboardClose = () => setIsDashboardOpen(false);
 
   const showDashboard = item => {
+    getWeeklySummaries(item.personId);
     dispatch(getUserProfile(item.personId)).then(user => {
       const { _id, role, firstName, lastName, profilePic, email } = user;
       const viewingUser = {

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -382,10 +382,10 @@ const SummaryBar = props => {
       loadUserProfile();
       getUserTasks();
     } else {
-      setUserProfile(userProfile);
+      setUserProfile(authUser);
       setTasks(displayUserTask.length);
     }
-  }, [displayUserId]);
+  }, [isAuthUser]);
 
   useEffect(() => {
     if (summaryBarData && displayUserProfile !== undefined) {
@@ -423,7 +423,8 @@ const SummaryBar = props => {
                 </font>
                 <CardTitle className={`align-middle ${darkMode ? 'text-light' : 'text-dark'}`} tag="h3">
                   <div className='font-weight-bold'>
-                    {userProfile?.firstName ||displayUserProfile.firstName + ' '}
+                    {userProfile?.firstName || displayUserProfile.firstName}
+                    {' '}
                     {userProfile?.lastName || displayUserProfile.lastName}
                   </div>
                 </CardTitle>

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -325,7 +325,7 @@ const TeamMemberTasks = React.memo(props => {
 
     if (usersWithTasks.length > 0) {
       usersWithTasks.forEach(user => {
-        const teamNames = user.teams.map(team => team.teamName);
+        const teamNames = user.teams?.map(team => team.teamName) ?? [];
         const code = user.teamCode || 'noCodeLabel';
         const color = user.weeklySummaryOption || 'noColorLabel';
 

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -74,12 +74,14 @@ const TimeEntryForm = props => {
   // props from store
   const { authUser } = props;
 
+  const viewingUser = JSON.parse(sessionStorage.getItem('viewingUser') ?? '{}'); 
+
   const initialFormValues = Object.assign(
     {
       dateOfWork: moment()
         .tz('America/Los_Angeles')
         .format('YYYY-MM-DD'),
-      personId: authUser.userid,
+      personId: viewingUser.userId ?? authUser.userid,
       projectId: '',
       wbsId: '',
       taskId: '',
@@ -92,7 +94,9 @@ const TimeEntryForm = props => {
     data,
   );
 
-  const timeEntryUserId = from === 'Timer' ? authUser.userid : data.personId;
+  const timeEntryUserId = from === 'Timer' 
+    ? (viewingUser.userId ?? authUser.userid)
+    : data.personId;
 
   const {
     dateOfWork: initialDateOfWork,
@@ -471,7 +475,7 @@ const TimeEntryForm = props => {
     if (isOpen) {
       loadAsyncData(timeEntryUserId);
     }
-  }, [isOpen]);
+  }, [isOpen, timeEntryUserId]);
 
   useEffect(() => {
     setFormValues({ ...formValues, ...data})
@@ -492,7 +496,7 @@ const TimeEntryForm = props => {
             ) : (
               <span style={{ color: 'orange' }}>Intangible </span>
             )}
-            Time Entry{' '}
+            Time Entry{viewingUser.userId ? ` for ${viewingUser.firstName} ${viewingUser.lastName} ` : ' '}
             <i
               className="fa fa-info-circle"
               data-tip

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -14,6 +14,7 @@ import {
 } from 'react-icons/fa';
 import { toast } from 'react-toastify';
 import cs from 'classnames';
+import { connect } from 'react-redux';
 import css from './Timer.module.css';
 import '../Header/DarkMode.css';
 import { ENDPOINTS } from '../../utils/URL';
@@ -22,7 +23,7 @@ import TimeEntryForm from '../Timelog/TimeEntryForm';
 import Countdown from './Countdown';
 import TimerStatus from './TimerStatus';
 
-export default function Timer({ darkMode }) {
+function Timer({ authUser, darkMode }) {
   /**
    *  Because the websocket can not be closed when internet is cut off (lost server connection),
    *  the readyState will be stuck at OPEN, so here we need to use a custom readyState to
@@ -52,7 +53,7 @@ export default function Timer({ darkMode }) {
    * }
    */
 
-  const { sendMessage, lastJsonMessage, getWebSocket } = useWebSocket(
+  const { sendMessage, sendJsonMessage, lastJsonMessage, getWebSocket } = useWebSocket(
     ENDPOINTS.TIMER_SERVICE,
     WSoptions,
   );
@@ -63,11 +64,12 @@ export default function Timer({ darkMode }) {
     PAUSE_TIMER: 'PAUSE_TIMER',
     STOP_TIMER: 'STOP_TIMER',
     CLEAR_TIMER: 'CLEAR_TIMER',
-    SET_GOAL: 'SET_GOAL=',
-    ADD_GOAL: 'ADD_TO_GOAL=',
-    REMOVE_GOAL: 'REMOVE_FROM_GOAL=',
+    GET_TIMER: 'GET_TIMER',
+    SET_GOAL: 'SET_GOAL',
+    ADD_GOAL: 'ADD_TO_GOAL',
+    REMOVE_GOAL: 'REMOVE_FROM_GOAL',
     ACK_FORCED: 'ACK_FORCED',
-    START_CHIME: 'START_CHIME=',
+    START_CHIME: 'START_CHIME',
     HEARTBEAT: 'ping',
   };
 
@@ -85,6 +87,8 @@ export default function Timer({ darkMode }) {
   const MAX_HOURS = 5;
   const MIN_MINS = 1;
 
+  const ALLOWED_ROLES_TO_INTERACT = useMemo(() => ['Owner', 'Administrator'], []);
+
   const [message, setMessage] = useState(defaultMessage);
   const { time, paused, started, goal, startAt } = message;
 
@@ -96,6 +100,7 @@ export default function Timer({ darkMode }) {
   const [timeIsOverModalOpen, setTimeIsOverModalIsOpen] = useState(false);
   const [remaining, setRemaining] = useState(time);
   const [logTimer, setLogTimer] = useState({ hours: 0, minutes: 0 });
+  const [viewingUserId, setViewingUserId] = useState(null);
   const isWSOpenRef = useRef(0);
   const timeIsOverAudioRef = useRef(null);
   const forcedPausedAudioRef = useRef(null);
@@ -105,6 +110,7 @@ export default function Timer({ darkMode }) {
   const logMinutes = timeToLog.minutes();
 
   const sendMessageNoQueue = useCallback(msg => sendMessage(msg, false), [sendMessage]);
+  const sendJsonMessageNoQueue = useCallback(msg => sendJsonMessage(msg, false), [sendMessage]);
 
   const wsMessageHandler = useMemo(
     () => ({
@@ -122,17 +128,101 @@ export default function Timer({ darkMode }) {
     [sendMessageNoQueue],
   );
 
+  useEffect(() => {
+    const handleStorageEvent = () => {
+      const sessionStorageData = JSON.parse(window.sessionStorage.getItem('viewingUser'));
+      if (sessionStorageData) {
+        setViewingUserId(sessionStorageData.userId);
+      } else {
+        setViewingUserId(null);
+      }
+    };
+
+    // Set the initial state when the component mounts
+    handleStorageEvent();
+
+    // Add the event listener
+    window.addEventListener('storage', handleStorageEvent);
+
+    // Clean up the event listener when the component unmounts
+    return () => {
+      window.removeEventListener('storage', handleStorageEvent);
+    };
+  }, []);
+
+  // control whether buttons should be clickable
+  const isButtonDisabled = useMemo(
+    () => viewingUserId && !ALLOWED_ROLES_TO_INTERACT.includes(authUser?.role),
+    [viewingUserId, authUser],
+  );
+  // control whether to send GET_TIMER message to avoid message overriding
+  const isInitialJsonMessageReceived = useMemo(() => !!lastJsonMessage, [lastJsonMessage]);
+
+  const wsJsonMessageHandler = useMemo(() => {
+    if (viewingUserId == null) {
+      return {
+        sendStart: () => sendJsonMessageNoQueue({ action: action.START_TIMER }),
+        sendPause: () => sendJsonMessageNoQueue({ action: action.PAUSE_TIMER }),
+        sendClear: () => sendJsonMessageNoQueue({ action: action.CLEAR_TIMER }),
+        sendStop: () => sendJsonMessageNoQueue({ action: action.STOP_TIMER }),
+        sendAckForced: () => sendJsonMessageNoQueue({ action: action.ACK_FORCED }),
+        sendGetTimer: () => sendJsonMessageNoQueue({ action: action.GET_TIMER }),
+        sendStartChime: state =>
+          sendJsonMessageNoQueue({ action: action.START_CHIME, value: state }),
+        sendSetGoal: timerGoal =>
+          sendJsonMessageNoQueue({ action: action.SET_GOAL, value: timerGoal }),
+        sendAddGoal: duration =>
+          sendJsonMessageNoQueue({ action: action.ADD_GOAL, value: duration }),
+        sendRemoveGoal: duration =>
+          sendJsonMessageNoQueue({ action: action.REMOVE_GOAL, value: duration }),
+        sendHeartbeat: () => sendJsonMessageNoQueue({ action: action.HEARTBEAT }),
+      };
+    }
+    return {
+      sendStart: () =>
+        sendJsonMessageNoQueue({ action: action.START_TIMER, userId: viewingUserId }),
+      sendPause: () =>
+        sendJsonMessageNoQueue({ action: action.PAUSE_TIMER, userId: viewingUserId }),
+      sendClear: () =>
+        sendJsonMessageNoQueue({ action: action.CLEAR_TIMER, userId: viewingUserId }),
+      sendStop: () => sendJsonMessageNoQueue({ action: action.STOP_TIMER, userId: viewingUserId }),
+      sendAckForced: () =>
+        sendJsonMessageNoQueue({ action: action.ACK_FORCED, userId: viewingUserId }),
+      sendGetTimer: () =>
+        sendJsonMessageNoQueue({ action: action.GET_TIMER, userId: viewingUserId }),
+      sendStartChime: state =>
+        sendJsonMessageNoQueue({ action: action.START_CHIME, userId: viewingUserId, value: state }),
+      sendSetGoal: timerGoal =>
+        sendJsonMessageNoQueue({
+          action: action.SET_GOAL,
+          userId: viewingUserId,
+          value: timerGoal,
+        }),
+      sendAddGoal: duration =>
+        sendJsonMessageNoQueue({ action: action.ADD_GOAL, userId: viewingUserId, value: duration }),
+      sendRemoveGoal: duration =>
+        sendJsonMessageNoQueue({
+          action: action.REMOVE_GOAL,
+          userId: viewingUserId,
+          value: duration,
+        }),
+      sendHeartbeat: () =>
+        sendJsonMessageNoQueue({ action: action.HEARTBEAT, userId: viewingUserId }),
+    };
+  }, [sendJsonMessageNoQueue, viewingUserId]);
+
   const {
     sendStart,
     sendPause,
     sendClear,
     sendStop,
     sendAckForced,
+    sendGetTimer,
     sendStartChime,
     sendAddGoal,
     sendRemoveGoal,
     sendHeartbeat,
-  } = wsMessageHandler;
+  } = wsJsonMessageHandler;
 
   const toggleLogTimeModal = () => {
     setLogTimeEntryModal(modal => !modal);
@@ -317,6 +407,13 @@ export default function Timer({ darkMode }) {
     }
   }, [inacModal]);
 
+  useEffect(() => {
+    // If initial json message is null, do nothing
+    if (!isInitialJsonMessageReceived) return;
+
+    sendGetTimer();
+  }, [isInitialJsonMessageReceived, viewingUserId]);
+
   const fontColor = darkMode ? 'text-light' : '';
   const headerBg = darkMode ? 'bg-space-cadet' : '';
   const bodyBg = darkMode ? 'bg-yinmn-blue' : '';
@@ -325,12 +422,13 @@ export default function Timer({ darkMode }) {
     <div className={css.timerContainer}>
       <button
         type="button"
+        disabled={isButtonDisabled}
         onClick={toggleTimer}
         className={css.btnDiv}
         aria-label="Open timer dropdown"
       >
         <BsAlarmFill
-          className={cs(css.transitionColor, css.btn)}
+          className={cs(css.transitionColor, isButtonDisabled ? css.btnDisabled : css.btn)}
           fontSize="2rem"
           title="Open timer dropdown"
         />
@@ -342,7 +440,12 @@ export default function Timer({ darkMode }) {
           <Progress bar value={100 * (remaining / goal)} color="primary" animated={running} />
         </Progress>
         {customReadyState === ReadyState.OPEN ? (
-          <button type="button" className={css.preview} onClick={toggleTimer}>
+          <button
+            type="button"
+            disabled={isButtonDisabled}
+            className={cs(css.preview, isButtonDisabled && css.btnDisabled)}
+            onClick={toggleTimer}
+          >
             {moment.utc(remaining).format('HH:mm:ss')}
           </button>
         ) : (
@@ -353,6 +456,7 @@ export default function Timer({ darkMode }) {
         <div className={css.btns}>
           <button
             type="button"
+            disabled={isButtonDisabled}
             onClick={() => {
               handleAddButton(15);
             }}
@@ -360,33 +464,53 @@ export default function Timer({ darkMode }) {
             aria-label="Add 15min"
           >
             <FaPlusCircle
-              className={cs(css.transitionColor, checkBtnAvail(15) ? css.btn : css.btnDisabled)}
+              className={cs(
+                isButtonDisabled ? css.btnDisabled : css.transitionColor,
+                checkBtnAvail(15) ? css.btn : css.btnDisabled,
+              )}
               fontSize="1.5rem"
             />
           </button>
           <button
             type="button"
+            disabled={isButtonDisabled}
             onClick={() => handleSubtractButton(15)}
             title="Subtract 15min"
             aria-label="Subtract 15min"
           >
             <FaMinusCircle
-              className={cs(css.transitionColor, checkBtnAvail(-15) ? css.btn : css.btnDisabled)}
+              className={cs(
+                isButtonDisabled ? css.btnDisabled : css.transitionColor,
+                checkBtnAvail(-15) ? css.btn : css.btnDisabled,
+              )}
               fontSize="1.5rem"
             />
           </button>
           {!started || paused ? (
-            <button type="button" onClick={handleStartButton} aria-label="Start timer">
+            <button
+              type="button"
+              disabled={isButtonDisabled}
+              onClick={handleStartButton}
+              aria-label="Start timer"
+            >
               <FaPlayCircle
-                className={cs(css.transitionColor, remaining !== 0 ? css.btn : css.btnDisabled)}
+                className={cs(
+                  isButtonDisabled ? css.btnDisabled : css.transitionColor,
+                  remaining !== 0 ? css.btn : css.btnDisabled,
+                )}
                 fontSize="1.5rem"
                 title="Start timer"
               />
             </button>
           ) : (
-            <button type="button" onClick={sendPause} aria-label="Pause timer">
+            <button
+              type="button"
+              disabled={isButtonDisabled}
+              onClick={sendPause}
+              aria-label="Pause timer"
+            >
               <FaPauseCircle
-                className={cs(css.btn, css.transitionColor)}
+                className={cs(css.btn, isButtonDisabled ? css.btnDisabled : css.transitionColor)}
                 fontSize="1.5rem"
                 title="Pause timer"
               />
@@ -394,14 +518,15 @@ export default function Timer({ darkMode }) {
           )}
           <button
             type="button"
+            disabled={!started || isButtonDisabled}
             onClick={handleStopButton}
-            disable={`${!started}`}
             title="Stop timer and log time"
             aria-label="Stop timer and log time"
           >
             <FaStopCircle
               className={cs(
                 css.transitionColor,
+                isButtonDisabled && css.btnDisabled,
                 started && goal - remaining >= 60000 ? css.btn : css.btnDisabled,
               )}
               fontSize="1.5rem"
@@ -409,11 +534,15 @@ export default function Timer({ darkMode }) {
           </button>
           <button
             type="button"
+            disabled={isButtonDisabled}
             onClick={() => setConfirmationResetModal(true)}
             title="Reset timer"
             aria-label="Reset timer"
           >
-            <FaUndoAlt className={cs(css.transitionColor, css.btn)} fontSize="1.3rem" />
+            <FaUndoAlt
+              className={cs(css.transitionColor, isButtonDisabled && css.btnDisabled, css.btn)}
+              fontSize="1.3rem"
+            />
           </button>
         </div>
       )}
@@ -562,3 +691,10 @@ export default function Timer({ darkMode }) {
     </div>
   );
 }
+
+const mapStateToProps = state => ({
+  authUser: state.auth.user,
+  userProfile: state.userProfile,
+});
+
+export default connect(mapStateToProps, {})(Timer);

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -1,10 +1,18 @@
 
-const hasPermission = (action) => {
+/**
+ * 
+ * @param {string} action 
+ * @param {boolean} viewingUser indicate whether to check authUser or other user. Default to `false` 
+ * @returns 
+ */
+const hasPermission = (action, viewingUser = false) => {
   return (dispatch, getState) => {
     const state = getState();
     const rolePermissions = state.role.roles;
-    const userRole = state.auth.user.role;
-    const userPermissions = state.auth.user.permissions?.frontPermissions;
+    const userRole = viewingUser ? state.userProfile.role : state.auth.user.role;
+    const userPermissions = viewingUser 
+      ? state.userProfile.permissions?.frontPermissions 
+      : state.auth.user.permissions?.frontPermissions;
 
     if (userRole && rolePermissions && rolePermissions.length != 0) {
       const roleIndex = rolePermissions?.findIndex(({ roleName }) => roleName === userRole);


### PR DESCRIPTION
# Description
<img width="754" alt="Screenshot 2024-05-16 at 4 02 56 PM" src="https://github.com/OneCommunityGlobal/HGNRest/assets/35129229/8342f882-bd24-4ce2-9365-96613c501f63">

[Video](https://drive.google.com/file/d/1ceJH_zhxNswWvk4Qxa_-05rpBOBi79_l/view?usp=sharing) of Weekly Summary  Report issue

## Related PRS (if any):
This frontend PR is related to the https://github.com/OneCommunityGlobal/HGNRest/pull/949 backend PR.
…

## Main changes explained:
- Update websocket contract to send JSON message.
- Implement new `GET_TIMER` websocket contract to get other person's timer data.
- Add owner/admin-only interaction to timer component, lower roles like Volunteer/Manager cannot interact with other's timer.
- Allow owner/admin to submit time entry on behalf of others.
- Fix fetching weekly summary data on changing dashboard view (see video in the description for reference).


## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. All videos below show an Admin role account on the left and a Volunteer role account on the right. Verify that:
  - 5.1. Admin role can interact with the Volunteer role's timer. They can add/remove time, start/pause, and reset timer in real time.

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/873f639a-ef56-4f5c-a538-8cdeec69598a

  - 5.2. Volunteer role cannot interact with the Admin role's timer. All timer's buttons are disabled.

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/fd4edb18-ac1c-4787-84ab-86720c011cef

  - 5.3. Admin role's nav items on the right should reflect what lower role sees, with limited permissions to access different routes.


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/5915089a-5733-4215-afe3-e17dcbd24825


  - 5.4. Volunteer role's nav items on the right should reflect what lower role sees, with limited permissions to access different routes.

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/fa4922df-43a4-41a9-98e8-68f464336678



  - 5.5. Admin role's nav items on the right should reflect what higher role sees, with every permissions to access different routes.


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/7b4fb1ef-4dfd-414f-8b49-e09f582d0baa

  - 5.6. Admin role can submit time entry on behalf of other user.
 

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/e9967bd6-4182-4c30-9d1f-51b79f25a78d


  - 5.7. Fetching weekly summary data on changing dashboard view properly.

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/49472b31-1c45-4e27-a706-db02dde1a7c2

## Note:
There is a limit that if user A is viewing user B's dashboard, B's interaction with their timer doesn't reflect to A in real-time, but A's interaction with B's timer will be real-time interaction.
