### PR TITLE
Nahiyan_Dark mode on Teams page modals

### DIFF
--- a/src/components/Header/DarkMode.css
+++ b/src/components/Header/DarkMode.css
@@ -9,3 +9,13 @@
 .dark-mode-button .icon {
   font-size: 34px;
 }
+
+.dark-mode .close {
+  color: white;
+  opacity: 1; 
+}
+
+.dark-mode .close:hover {
+  color: #f0f0f0;
+  opacity: 1; 
+}

--- a/src/components/Header/DarkModeButton.jsx
+++ b/src/components/Header/DarkModeButton.jsx
@@ -1,6 +1,6 @@
 import {useState} from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import './DarkModeButton.css';
+import './DarkMode.css';
 import { Tooltip } from 'reactstrap';
 
 const DarkModeButton = () => {

--- a/src/components/Teams/CreateNewTeamPopup.jsx
+++ b/src/components/Teams/CreateNewTeamPopup.jsx
@@ -1,8 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Input, Alert } from 'reactstrap';
-import { boxStyle } from 'styles';
+import { boxStyle, boxStyleDark } from 'styles';
+import '../Header/DarkMode.css'
 
 export const CreateNewTeamPopup = React.memo(props => {
+  const darkMode = useSelector(state => state.theme.darkMode)
+
   const [newTeam, setNewName] = useState('');
   const closePopup = () => {
     props.onClose();
@@ -12,12 +16,12 @@ export const CreateNewTeamPopup = React.memo(props => {
     setNewName(props.teamName);
   }, [props.open, props.teamName]);
   return (
-    <Modal autoFocus={false} isOpen={props.open} toggle={closePopup}>
-      <ModalHeader toggle={closePopup}>
+    <Modal autoFocus={false} isOpen={props.open} toggle={closePopup} className={darkMode ? 'dark-mode text-light' : ''}>
+      <ModalHeader toggle={closePopup} className={darkMode ? 'bg-space-cadet' : ''}>
         {props.isEdit ? 'Update Team Name' : 'Create New Team'}
       </ModalHeader>
-      <ModalBody style={{ textAlign: 'start' }}>
-        <label>Name of the Team</label>
+      <ModalBody style={{ textAlign: 'start' }} className={darkMode ? 'bg-yinmn-blue' : ''}>
+        <label className={darkMode ? 'text-light' : ''}>Name of the Team</label>
         <Input
           autoFocus
           id="teamName"
@@ -31,8 +35,8 @@ export const CreateNewTeamPopup = React.memo(props => {
         />
         {isValidTeam === false ? <Alert color="danger">Please enter a team name.</Alert> : <></>}
       </ModalBody>
-      <ModalFooter>
-        <Button color="secondary" onClick={closePopup} style={boxStyle}>
+      <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
+        <Button color="secondary" onClick={closePopup} style={darkMode ? boxStyleDark : boxStyle}>
           Close
         </Button>
         <Button
@@ -44,7 +48,7 @@ export const CreateNewTeamPopup = React.memo(props => {
               onValidation(false);
             }
           }}
-          style={boxStyle}
+          style={darkMode ? boxStyleDark : boxStyle}
         >
           OK
         </Button>

--- a/src/components/Teams/DeleteTeamPopup.jsx
+++ b/src/components/Teams/DeleteTeamPopup.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
-import { boxStyle } from 'styles';
-import { connect } from 'react-redux';
+import { boxStyle, boxStyleDark } from 'styles';
+import '../Header/DarkMode.css'
+import { connect, useSelector } from 'react-redux';
 import hasPermission from 'utils/permissions';
 
 export const DeleteTeamPopup = React.memo(props => {
+  const darkMode = useSelector(state => state.theme.darkMode);
+
   const closePopup = () => {
     props.onClose();
   };
@@ -12,15 +15,15 @@ export const DeleteTeamPopup = React.memo(props => {
   const canPutTeam = props.hasPermission('putTeam');
 
   return (
-    <Modal isOpen={props.open} toggle={closePopup}>
-      <ModalHeader toggle={closePopup}>Delete</ModalHeader>
-      <ModalBody style={{ textAlign: 'center' }}>
+    <Modal isOpen={props.open} toggle={closePopup} className={darkMode ? 'dark-mode text-light' : ''}>
+      <ModalHeader toggle={closePopup} className={darkMode ? 'bg-space-cadet' : ''}>Delete</ModalHeader>
+      <ModalBody style={{ textAlign: 'center' }} className={darkMode ? 'bg-yinmn-blue' : ''}>
         <span>
           {`Are you sure you want to delete the team with name "${props.selectedTeamName}"?
           This action cannot be undone. Switch this team to "Inactive" if you'd like to keep it in the system.`}
         </span>
       </ModalBody>
-      <ModalFooter>
+      <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
         {(canDeleteTeam || canPutTeam) && (
           <>
             <Button
@@ -28,7 +31,7 @@ export const DeleteTeamPopup = React.memo(props => {
             onClick={async () => {
               await props.onDeleteClick(props.selectedTeamId);
             }}
-            style={boxStyle}
+            style={darkMode ? boxStyleDark : boxStyle}
             >
               Confirm
             </Button>
@@ -37,7 +40,7 @@ export const DeleteTeamPopup = React.memo(props => {
               onClick={async () => {
                 await props.onSetInactiveClick(props.selectedTeamName, props.selectedTeamId, false, props.selectedTeamCode);
               }}
-              style={boxStyle}
+              style={darkMode ? boxStyleDark : boxStyle}
             >
               Set Inactive
             </Button>
@@ -48,7 +51,7 @@ export const DeleteTeamPopup = React.memo(props => {
             Unauthorized Action
           </>
         )}
-        <Button color="primary" onClick={closePopup} style={boxStyle}>
+        <Button color="primary" onClick={closePopup} style={darkMode ? boxStyleDark : boxStyle}>
           Close
         </Button>
       </ModalFooter>

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -2,13 +2,16 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Container, Alert } from 'reactstrap';
 import MembersAutoComplete from './MembersAutoComplete';
 import hasPermission from 'utils/permissions';
-import { boxStyle } from 'styles';
+import { boxStyle, boxStyleDark } from 'styles';
+import '../Header/DarkMode.css'
 import moment from 'moment';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSort, faSortUp, faSortDown } from '@fortawesome/free-solid-svg-icons';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 
 export const TeamMembersPopup = React.memo(props => {
+  const darkMode = useSelector(state => state.theme.darkMode);
+
   const closePopup = () => {
     props.onClose();
     setSortOrder(0)
@@ -136,9 +139,9 @@ export const TeamMembersPopup = React.memo(props => {
 
   return (
     <Container fluid>
-      <Modal isOpen={props.open} toggle={closePopup} autoFocus={false} size='lg'>
-        <ModalHeader toggle={closePopup}>{`Members of ${props.selectedTeamName}`}</ModalHeader>
-        <ModalBody style={{ textAlign: 'center' }}>
+      <Modal isOpen={props.open} toggle={closePopup} autoFocus={false} size='lg' className={darkMode ? 'dark-mode text-light' : ''}>
+        <ModalHeader className={darkMode ? 'bg-space-cadet' : ''} toggle={closePopup}>{`Members of ${props.selectedTeamName}`}</ModalHeader>
+        <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''} style={{ textAlign: 'center' }}>
           {canAssignTeamToUsers && (
             <div className="input-group-prepend" style={{ marginBottom: '10px' }}>
               <MembersAutoComplete
@@ -148,7 +151,7 @@ export const TeamMembersPopup = React.memo(props => {
                 searchText={searchText}
                 setSearchText={setSearchText}
               />
-              <Button color="primary" onClick={onAddUser} style={boxStyle}>
+              <Button color="primary" onClick={onAddUser} style={darkMode ? boxStyleDark : boxStyle}>
                 Add
               </Button>
             </div>
@@ -162,9 +165,9 @@ export const TeamMembersPopup = React.memo(props => {
             <></>
           )}
 
-          <table className="table table-bordered table-responsive-sm">
+          <table className={`table table-bordered table-responsive-sm ${darkMode ? 'text-light' : ''}`}>
             <thead>
-              <tr>
+              <tr className={darkMode ? 'bg-space-cadet' : ''}>
                 <th>Active</th>
                 <th>#</th>
                 <th>User Name</th>
@@ -175,7 +178,7 @@ export const TeamMembersPopup = React.memo(props => {
             <tbody>
               {props.members.teamMembers.length > 0 &&
                 memberList.toSorted().map((user, index) => {
-                  return (<tr key={`team_member_${index}`}>
+                  return (<tr key={`team_member_${index}`} className={darkMode ? 'bg-yinmn-blue' : ''}>
                     <td>
                       <span className={user.isActive ? "isActive" : "isNotActive"}>
                         <i className="fa fa-circle" aria-hidden="true" />
@@ -190,7 +193,7 @@ export const TeamMembersPopup = React.memo(props => {
                         <Button
                           color="danger"
                           onClick={() => props.onDeleteClick(`${user._id}`)}
-                          style={boxStyle}
+                          style={darkMode ? boxStyleDark : boxStyle}
                         >
                           Delete
                         </Button>
@@ -202,8 +205,8 @@ export const TeamMembersPopup = React.memo(props => {
             </tbody>
           </table>
         </ModalBody>
-        <ModalFooter>
-          <Button color="secondary" onClick={closePopup} style={boxStyle}>
+        <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
+          <Button color="secondary" onClick={closePopup} style={darkMode ? boxStyleDark : boxStyle}>
             Close
           </Button>
         </ModalFooter>

--- a/src/components/Teams/TeamStatusPopup.jsx
+++ b/src/components/Teams/TeamStatusPopup.jsx
@@ -1,19 +1,23 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Input } from 'reactstrap';
+import { boxStyle, boxStyleDark } from 'styles';
 
 export const TeamStatusPopup = React.memo(props => {
+  const darkMode = useSelector(state => state.theme.darkMode);
+
   const closePopup = () => {
     props.onClose();
   };
 
   return (
-    <Modal isOpen={props.open} toggle={closePopup}>
-      <ModalHeader toggle={closePopup}>Status Popup</ModalHeader>
-      <ModalBody style={{ textAlign: 'center' }}>
+    <Modal isOpen={props.open} toggle={closePopup} className={darkMode ? 'dark-mode text-light' : ''}>
+      <ModalHeader toggle={closePopup} className={darkMode ? 'bg-space-cadet' : ''}>Status Popup</ModalHeader>
+      <ModalBody style={{ textAlign: 'center' }} className={darkMode ? 'bg-yinmn-blue' : ''}>
         <span>{`Are you sure you want to change the status of this team ${props.selectedTeamName}`}</span>
         <br />
       </ModalBody>
-      <ModalFooter>
+      <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
         <Button
           color="danger"
           onClick={async () => {
@@ -24,10 +28,11 @@ export const TeamStatusPopup = React.memo(props => {
               props.selectedTeamCode,
             );
           }}
+          style={darkMode ? boxStyleDark : boxStyle}
         >
           Confirm
         </Button>
-        <Button color="primary" onClick={closePopup}>
+        <Button color="primary" onClick={closePopup} style={darkMode ? boxStyleDark : boxStyle}>
           Close
         </Button>
       </ModalFooter>

--- a/src/components/Teams/__tests__/DeleteTeamPopup.test.js
+++ b/src/components/Teams/__tests__/DeleteTeamPopup.test.js
@@ -4,7 +4,7 @@ import { screen, fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../__tests__/utils';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { authMock, userProfileMock, rolesMock } from '../../../__tests__/mockStates';
+import { authMock, userProfileMock, rolesMock, themeMock } from '../../../__tests__/mockStates';
 
 const mock = jest.fn();
 const mockStore = configureStore([thunk]);
@@ -25,6 +25,7 @@ beforeEach(() => {
     auth: authMock,
     userProfile: userProfileMock,
     role: rolesMock.role,
+    theme: themeMock,
     ...defaultProps,
   });
 });

--- a/src/components/Teams/__tests__/TeamMembersPopup.test.js
+++ b/src/components/Teams/__tests__/TeamMembersPopup.test.js
@@ -1,7 +1,7 @@
 import configureStore from 'redux-mock-store';
 import TeamMembersPopup from 'components/Teams/TeamMembersPopup';
 import thunk from 'redux-thunk';
-import { authMock, userProfileMock, rolesMock } from '../../../__tests__/mockStates';
+import { authMock, userProfileMock, rolesMock, themeMock } from '../../../__tests__/mockStates';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
@@ -17,6 +17,7 @@ const renderComponent = props => {
     auth: authMock,
     userProfile: userProfileMock,
     role: rolesMock.role,
+    theme: themeMock,
     ...props,
   });
 


### PR DESCRIPTION
# Description
Implemented dark mode on all modals that can be found in the Teams page

## Related PRS (if any):
This frontend PR is related to the dev backend.

## Main changes explained:
- Dark mode for all modals on the Teams page

## How to test:
1. check into the current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ Other Links → Teams
6. verify that all modals on the Teams page are working properly

## Screenshots or videos of changes:
![Screenshot 2024-05-17 111848](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/d5baf6fd-d4cb-4586-aa39-b253d581205d)
![Screenshot 2024-05-17 111912](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/65afd52c-4969-4afa-a2b4-a912c3c7d875)
