### PR TITLE
Imran fix permission access profile of project members

### DIFF
--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -157,10 +157,10 @@ export const permissionLabels = [
           'Gives the user permission to edit the category or the status of any Project. "Other Links" -> "Projects"',
       },
       {
-        label: 'Find User in Project',
+        label: 'See User in Project',
         key: 'getProjectMembers',
         description:
-          'Gives the user permission to find any user on the project members page. "Other Links" -> "Projects" -> "Members" -> "Find user input" ',
+          'Gives the user permission to access the profile of any user directly from the projects members page. "Other Links" -> "Projects" -> "Members"',
       },
       {
         label: 'Assign Project to Users',

--- a/src/components/Projects/Members/Member/Member.jsx
+++ b/src/components/Projects/Members/Member/Member.jsx
@@ -12,9 +12,9 @@ import PropTypes from 'prop-types';
 
 const Member = props => {
   const {darkMode} = props;
-  const canGetUserProfiles = props.hasPermission('getUserProfiles');
-  //const canAssignProjectToUsers = props.hasPermission('assignProjectToUsers');
+  const canGetProjectMembers = props.hasPermission('getProjectMembers');
   const canUnassignUserInProject = props.hasPermission('unassignUserInProject');
+ 
   return (
     <React.Fragment>
       <tr className={`members__tr ${darkMode ? 'bg-yinmn-blue' : ''}`}>
@@ -22,7 +22,7 @@ const Member = props => {
           <div>{typeof props.index === 'number' ? props.index + 1 : null}</div>
         </th>
         <td className="members__name">
-          {canGetUserProfiles ? (
+          {canGetProjectMembers ? (
             <a href={`/userprofile/${props.uid}`} className={darkMode ? 'text-azure' : ''}>{props.fullName}</a>
           ) : (
             props.fullName

--- a/src/components/Projects/Members/Members.jsx
+++ b/src/components/Projects/Members/Members.jsx
@@ -28,7 +28,6 @@ const Members = props => {
   const [membersList, setMembersList] = useState(props.state.projectMembers.members);
   const [lastTimeoutId, setLastTimeoutId] = useState(null);
 
-  const canGetProjectMembers = props.hasPermission('getProjectMembers');
   const canAssignProjectToUsers = props.hasPermission('assignProjectToUsers');
   const canUnassignUserInProject = props.hasPermission('unassignUserInProject');
 
@@ -95,7 +94,7 @@ const Members = props => {
               <div id="member_project__name">PROJECTS {props.projectId}</div>
             </ol>
           </nav>
-          {canGetProjectMembers ? (
+          {canAssignProjectToUsers ? (
             <div className="input-group" id="new_project">
               <div className="input-group-prepend">
                 <span className="input-group-text">Find user</span>
@@ -195,7 +194,7 @@ const Members = props => {
               {displayedMembers.map((member, i) => (
                 <Member
                   index={i}
-                  key={member._id}
+                  key={member._id ?? i}
                   projectId={projectId}
                   uid={member._id}
                   fullName={member.firstName + ' ' + member.lastName}


### PR DESCRIPTION
# Description
Gives the user permission to access the profile of any user directly from the projects members page.

## Related PRS (if any):
This frontend PR is related to the [#953](https://github.com/OneCommunityGlobal/HGNRest/pull/953) backend PR.


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in as admin user
5. go to Other Links -> Permissions Management -> Project Management-> Choose a user without "See User in Project" permission -> add "See User in Project" -> Scroll down then submit
6. login as the user given permission and go to "Other Links" -> "Projects" -> "Members"
7. verify that the user who was given the permission is now able to click the members name and navigated to their profile.
8. verify for users without the "See User in Project" that their are not able to click the members name and navigated to their profile

## Screenshots or videos of changes:
Give User the "See User in Project" Project.
![Step 1](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/87269725/a2a0ed23-bb4f-4d37-ab58-39366d000b88)

User with "See User in Project" can navigate to member profile
![Step 2](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/87269725/6501dc0a-e2ea-4a04-9e1f-8c2f1024f436)


User without "See User in Project" can't navigate to member profile
![Step 3](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/87269725/5ea3a3e4-bae8-4171-a0da-ba6f17014e43)



## Note:
Include the information the reviewers need to know.
