### PR TITLE
Yao - New Add less-than-minimum hours logged colors on Weekly Summaries Reports page

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -181,6 +181,17 @@ function EmailsList({ summaries, auth }) {
   return null;
 }
 
+function getTextColorForHoursLogged(hoursLogged, promisedHours) {
+  const percentage = (hoursLogged / promisedHours) * 100;
+
+  if (percentage < 50) {
+    return 'red';
+  } else if (percentage < 100) {
+    return '#0B6623';
+  }
+  return 'black';
+}
+
 function ReportDetails({
   summary,
   weekIndex,
@@ -243,15 +254,29 @@ function ReportDetails({
             </ListGroupItem>
             <ListGroupItem darkMode={darkMode}>
               {hoursLogged < summary.promisedHoursByWeek[weekIndex] && (
-                <p style={{ color: 'red' }}>
-                  Hours logged: {''}
-                  {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
+                <p
+                  style={{
+                    color: getTextColorForHoursLogged(
+                      hoursLogged,
+                      summary.promisedHoursByWeek[weekIndex],
+                    ),
+                    fontWeight: 'bold',
+                  }}
+                >
+                  Hours logged: {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
                 </p>
               )}
               {hoursLogged >= summary.promisedHoursByWeek[weekIndex] && (
-                <p>
-                  Hours logged: {''}
-                  {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
+                <p
+                  style={{
+                    color: getTextColorForHoursLogged(
+                      hoursLogged,
+                      summary.promisedHoursByWeek[weekIndex],
+                    ),
+                    fontWeight: 'bold',
+                  }}
+                >
+                  Hours logged: {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
                 </p>
               )}
             </ListGroupItem>

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -186,7 +186,8 @@ function getTextColorForHoursLogged(hoursLogged, promisedHours) {
 
   if (percentage < 50) {
     return 'red';
-  } else if (percentage < 100) {
+  }
+  if (percentage < 100) {
     return '#0B6623';
   }
   return 'black';

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -253,32 +253,17 @@ function ReportDetails({
               />
             </ListGroupItem>
             <ListGroupItem darkMode={darkMode}>
-              {hoursLogged < summary.promisedHoursByWeek[weekIndex] && (
-                <p
-                  style={{
-                    color: getTextColorForHoursLogged(
-                      hoursLogged,
-                      summary.promisedHoursByWeek[weekIndex],
-                    ),
-                    fontWeight: 'bold',
-                  }}
-                >
-                  Hours logged: {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
-                </p>
-              )}
-              {hoursLogged >= summary.promisedHoursByWeek[weekIndex] && (
-                <p
-                  style={{
-                    color: getTextColorForHoursLogged(
-                      hoursLogged,
-                      summary.promisedHoursByWeek[weekIndex],
-                    ),
-                    fontWeight: 'bold',
-                  }}
-                >
-                  Hours logged: {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
-                </p>
-              )}
+              <p
+                style={{
+                  color: getTextColorForHoursLogged(
+                    hoursLogged,
+                    summary.promisedHoursByWeek[weekIndex],
+                  ),
+                  fontWeight: 'bold',
+                }}
+              >
+                Hours logged: {hoursLogged.toFixed(2)} / {summary.promisedHoursByWeek[weekIndex]}
+              </p>
             </ListGroupItem>
             <ListGroupItem darkMode={darkMode}>
               <WeeklySummaryMessage summary={summary} weekIndex={weekIndex} />


### PR DESCRIPTION
# Description
### To fix the conflict on [PR 1990](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1990), and the commit error on [PR 2188](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2188) created this new PR. All the coed logic is same with PR 1990, and have some slight change to align with the recent PRs. 

Add less-than-minimum hours logged colors on Weekly Summaries Reports page (WIP Yao)
Other Links → Reports → Weekly Summaries Reports
If someone has done less than 49% of their hours, the whole Hours Logged row and hours should be red
If someone has done between 50-99% of their hours, the whole Hours Logged row and hours should be bright green
This is needed so it is clear to the Admins who these people are. Red people don’t get credited for their work for the week. Green and black people do. 

## Main changes explained:
- Add different text color for different hours logged.
- For less then 49% hours logged display as red, for 50 - 99% display as green, for 100% display as black. 

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as any user
5. go to dashboard→ Report→ Weekly summary report
6. use a Owner account to add different Tangible Time Entry
7. test the color display correctly 

## Screenshots or videos of changes:
### less then 49% hours logged:
<img width="397" alt="Screenshot 2024-02-24 at 11 56 22 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/137429365/0b0bc923-4ef1-4d84-817d-d19dbe7f6cd4">

### 50 - 99% hours logged:
<img width="379" alt="Screenshot 2024-02-24 at 11 57 26 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/137429365/22698792-12bd-46d5-947f-ddc787e2ac2c">

### 100% hours logged:
<img width="406" alt="Screenshot 2024-02-24 at 11 55 58 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/137429365/fee2424a-f1f7-440b-9c21-47e5835740ee">

