### PR TITLE
Peterson fix when adding team to profile save changes becomes disabled for other tabs

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
@@ -55,7 +55,7 @@ const TeamsTab = props => {
   const onSelectAssignTeam = team => {
     if (userProfile._id) {
       addTeamMember(team._id, userProfile._id, userProfile.firstName, userProfile.lastName);
-      if (!isTeamSaved) isTeamSaved(true);
+      if (isTeamSaved) isTeamSaved(false);
     }
     onAssignTeam(team);
     setRenderedOn(Date.now());

--- a/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
@@ -31,11 +31,11 @@ const TeamsTab = props => {
   const [removedTeams, setRemovedTeams] = useState([]);
 
   useEffect(() => {
-    if(saved && removedTeams.length > 0){
+    if (saved && removedTeams.length > 0) {
       removedTeams.forEach(teamId => {
         deleteTeamMember(teamId, userProfile._id);
         setRemovedTeams([]);
-      })
+      });
     }
   }, [saved]);
 
@@ -49,13 +49,13 @@ const TeamsTab = props => {
   const onSelectDeleteTeam = teamId => {
     setRemovedTeams([...removedTeams, teamId]);
     onDeleteTeam(teamId);
-    if(isTeamSaved) isTeamSaved(false);
+    if (isTeamSaved) isTeamSaved(false);
   };
 
   const onSelectAssignTeam = team => {
-    if(userProfile._id){
+    if (userProfile._id) {
       addTeamMember(team._id, userProfile._id, userProfile.firstName, userProfile.lastName);
-      if(isTeamSaved) isTeamSaved(true);
+      if (!isTeamSaved) isTeamSaved(true);
     }
     onAssignTeam(team);
     setRenderedOn(Date.now());


### PR DESCRIPTION
# Description
In the user profile page and the teams tab, when the button named 'Assign Team' is pressed, a modal opens containing an input to select or create a new team, and two buttons: one to close the modal and another to add the user to a team. When the user's own account is added to a team, it causes the 'Save Changes' button to be disabled in all other tabs, even when the user makes changes to fields like first name, last name, and others. This pull request has been opened to fix the bug.

## Related PRS (if any):
None
…

## Main changes explained:
The component TeamsTab.jsx has been modified to fix the bug.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4.Log in as an administrator or owner
5. go to view profile→ teams
6. Click the button named 'Assign Team' and a modal will open.
7. Select a team to add your user.
8. Check if the button 'Save Changes' is enabled in all the tabs.

## Screenshots or videos of changes:
![Before my fix](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73541319/97e4a421-a045-44df-8103-cc5ad4f5ea7b)
![After my fix](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73541319/10322a97-b5fa-47d3-8c98-594bdf1c11d4)

## Note:
None