### PR TITLE
Nahiyan_Dark mode for Permissions Management Modals

### DIFF
--- a/src/components/PermissionsManagement/NewRolePopUp.jsx
+++ b/src/components/PermissionsManagement/NewRolePopUp.jsx
@@ -3,11 +3,11 @@ import { FormCheck } from 'react-bootstrap';
 import { Alert, Button, Form, FormGroup, Input, Label } from 'reactstrap';
 import { toast } from 'react-toastify';
 import { connect } from 'react-redux';
-import { boxStyle } from 'styles';
+import { boxStyle, boxStyleDark } from 'styles';
 import { addNewRole, getAllRoles } from '../../actions/role';
 import PermissionList from './PermissionList';
 
-function CreateNewRolePopup({ toggle, addNewRole, roleNames }) {
+function CreateNewRolePopup({ toggle, addNewRole, roleNames, darkMode }) {
   const [permissionsChecked, setPermissionsChecked] = useState([]);
   const [newRoleName, setNewRoleName] = useState('');
   const [isValidRole, setIsValidRole] = useState(true);
@@ -75,7 +75,7 @@ function CreateNewRolePopup({ toggle, addNewRole, roleNames }) {
   return (
     <Form id="createRole" onSubmit={handleSubmit}>
       <FormGroup>
-        <Label>Role Name:</Label>
+        <Label className={darkMode ? 'text-light' : ''}>Role Name:</Label>
         <Input
           placeholder="Please enter a new role name"
           value={newRoleName}
@@ -91,21 +91,22 @@ function CreateNewRolePopup({ toggle, addNewRole, roleNames }) {
       </FormGroup>
 
       <FormGroup>
-        <Label>Permissions:</Label>
+        <Label className={darkMode ? 'text-light' : ''}>Permissions:</Label>
         <PermissionList
           rolePermissions={permissionsChecked}
           editable={true}
           setPermissions={setPermissionsChecked}
+          darkMode={darkMode}
         />
       </FormGroup>
-      <Button type="submit" id="createRole" color="primary" size="lg" block style={boxStyle}>
+      <Button type="submit" id="createRole" color="primary" size="lg" block style={darkMode ? boxStyleDark : boxStyle}>
         Create
       </Button>
     </Form>
   );
 }
 
-const mapStateToProps = state => ({ roles: state.role.roles });
+const mapStateToProps = state => ({ roles: state.role.roles, darkMode: state.theme.darkMode });
 
 const mapDispatchToProps = dispatch => ({
   getAllRoles: () => dispatch(getAllRoles()),

--- a/src/components/PermissionsManagement/PermissionListItem.jsx
+++ b/src/components/PermissionsManagement/PermissionListItem.jsx
@@ -5,6 +5,7 @@ import { boxStyle, boxStyleDark } from 'styles';
 import PermissionList from './PermissionList';
 import hasPermission from '../../utils/permissions';
 import './UserRoleTab.css';
+import '../Header/DarkMode.css'
 
 
 
@@ -77,10 +78,9 @@ const PermissionListItem = (props) => {
 
   return (
     <>
-      <li className="user-role-tab__permissions" key={permission} data-testid={permission}>
+      <li className="user-role-tab__permissions pr-2" key={permission} data-testid={permission}>
         <p
           style={{
-
             color: isCategory ?
               howManySubpermsInRole === 'All' ? 'green' :
               howManySubpermsInRole === 'Some' ? (darkMode ? 'white' : 'black') : 'red'
@@ -88,6 +88,7 @@ const PermissionListItem = (props) => {
 
             fontSize: isCategory && '20px',
             textIndent: 50 * depth + 'px',
+            textShadow: darkMode ? "0.5px 0.5px 2px black" : ""
           }}
         >
           {label}
@@ -170,10 +171,11 @@ const PermissionListItem = (props) => {
         isOpen={infoRoleModal}
         toggle={toggleInfoRoleModal}
         id="#modal2-body_new-role--padding"
+        className={darkMode ? 'text-light dark-mode' : ''}
       >
-        <ModalHeader toggle={toggleInfoRoleModal}>Permission Info</ModalHeader>
-        <ModalBody>{modalContent}</ModalBody>
-        <ModalFooter>
+        <ModalHeader toggle={toggleInfoRoleModal} className={darkMode ? 'bg-space-cadet' : ''}>Permission Info</ModalHeader>
+        <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>{modalContent}</ModalBody>
+        <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
           <Button onClick={toggleInfoRoleModal} color="secondary" className="float-left">
             {' '}
             Ok{' '}

--- a/src/components/PermissionsManagement/PermissionsManagement.jsx
+++ b/src/components/PermissionsManagement/PermissionsManagement.jsx
@@ -8,6 +8,7 @@ import { updateUserProfile, getUserProfile } from 'actions/userProfile';
 import { getAllUserProfile } from 'actions/userManagement';
 import { useHistory } from 'react-router-dom';
 import { boxStyle, boxStyleDark } from 'styles';
+import '../Header/DarkMode.css'
 import EditableInfoModal from 'components/UserProfile/EditableModal/EditableInfoModal';
 import UserPermissionsPopUp from './UserPermissionsPopUp';
 import { getAllRoles } from '../../actions/role';
@@ -87,6 +88,7 @@ function PermissionsManagement({ getAllRoles, roles, auth, getUserRole, userProf
                       areaName={`${roleName}` + 'Info'}
                       areaTitle={`${roleName}` + ' User Role'}
                       fontSize={18}
+                      darkMode={darkMode}
                       isPermissionPage
                     />
                   </div>
@@ -123,14 +125,15 @@ function PermissionsManagement({ getAllRoles, roles, auth, getUserRole, userProf
           )}
         </div>
         <div className="permissions-management--flex">
-          <Modal isOpen={isNewRolePopUpOpen} toggle={togglePopUpNewRole} id="modal-content__new-role">
+          <Modal isOpen={isNewRolePopUpOpen} toggle={togglePopUpNewRole} id="modal-content__new-role" className={darkMode ? 'text-light dark-mode' : ''}>
             <ModalHeader
               toggle={togglePopUpNewRole}
               cssModule={{ 'modal-title': 'w-100 text-center my-auto' }}
+              className={darkMode ? 'bg-space-cadet' : ''}
             >
               Create New Role
             </ModalHeader>
-            <ModalBody id="modal-body_new-role--padding">
+            <ModalBody id="modal-body_new-role--padding" className={darkMode ? 'bg-yinmn-blue' : ''}>
               <CreateNewRolePopup toggle={togglePopUpNewRole} roleNames={roleNames} />
             </ModalBody>
           </Modal>
@@ -138,14 +141,16 @@ function PermissionsManagement({ getAllRoles, roles, auth, getUserRole, userProf
             isOpen={isUserPermissionsOpen}
             toggle={togglePopUpUserPermissions}
             id="modal-content__new-role"
+            className={darkMode ? 'text-light dark-mode' : ''}
           >
             <ModalHeader
               toggle={togglePopUpUserPermissions}
               cssModule={{ 'modal-title': 'w-100 text-center my-auto' }}
+              className={darkMode ? 'bg-space-cadet' : ''}
             >
               Manage User Permissions
             </ModalHeader>
-            <ModalBody id="modal-body_new-role--padding">
+            <ModalBody id="modal-body_new-role--padding"  className={darkMode ? 'bg-yinmn-blue' : ''}>
               <UserPermissionsPopUp toggle={togglePopUpUserPermissions} />
             </ModalBody>
           </Modal>

--- a/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
+++ b/src/components/PermissionsManagement/UserPermissionsPopUp.jsx
@@ -8,10 +8,10 @@ import PermissionList from './PermissionList';
 import './PermissionsManagement.css';
 import axios from 'axios';
 import { ENDPOINTS } from 'utils/URL';
-import { boxStyle } from 'styles';
+import { boxStyle, boxStyleDark } from 'styles';
 import { cantUpdateDevAdminDetails } from '../../utils/permissions';
 
-const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles, authUser }) => {
+const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles, authUser, darkMode }) => {
 
   const [searchText, onInputChange] = useState('');
   const [actualUserProfile, setActualUserProfile] = useState();
@@ -99,7 +99,7 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles, aut
             setToDefault();
           }}
           disabled={actualUserProfile ? false : true}
-          style={boxStyle}
+          style={darkMode ? boxStyleDark : boxStyle}
         >
           Reset to Default
         </Button>
@@ -174,6 +174,7 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles, aut
             immutablePermissions={actualUserRolePermission}
             editable={!!actualUserProfile}
             setPermissions={setUserPermissions}
+            darkMode={darkMode}
           />
         </ul>
       </div>
@@ -183,7 +184,7 @@ const UserPermissionsPopUp = ({ allUserProfiles, toggle, getAllUsers, roles, aut
         color="primary"
         size="lg"
         block
-        style={{ ...boxStyle, marginTop: '1rem' }}
+        style={darkMode ? { ...boxStyleDark, marginTop: '1rem' } : {...boxStyle, marginTop: '1rem'}}
       >
         Submit
       </Button>
@@ -197,6 +198,7 @@ const mapStateToProps = state => ({
   roles: state.role.roles,
   allUserProfiles: state.allUserProfiles.userProfiles,
   permissionsUser: state.auth.permissions,
+  darkMode: state.theme.darkMode,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/PermissionsManagement/__tests__/NewRolePopUp.test.js
+++ b/src/components/PermissionsManagement/__tests__/NewRolePopUp.test.js
@@ -4,6 +4,7 @@ import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import CreateNewRolePopup from '../NewRolePopUp'
+import { themeMock } from '__tests__/mockStates';
 
 const mockTogglePopUpNewRole = jest.fn()
 const mockAddNewRole = jest.fn()
@@ -23,7 +24,8 @@ const middlewares = [thunk]
 const mockStore = configureStore(middlewares)
 const store = mockStore({
   auth: mockAuth,
-  role: [mockRoleNames]
+  role: [mockRoleNames],
+  theme: themeMock,
 })
 
 const renderComponent = () => {

--- a/src/components/PermissionsManagement/__tests__/UserPermissionsPopup.test.js
+++ b/src/components/PermissionsManagement/__tests__/UserPermissionsPopup.test.js
@@ -8,6 +8,7 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { toast } from 'react-toastify';
 import axios from 'axios';
+import { themeMock } from '__tests__/mockStates';
 
 const mockStore = configureStore([thunk]);
 let store;
@@ -58,6 +59,7 @@ beforeEach(() => {
         },
       ],
     },
+    theme: themeMock,
   });
 });
 

--- a/src/components/UserProfile/EditableModal/EditableInfoModal.jsx
+++ b/src/components/UserProfile/EditableModal/EditableInfoModal.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import {
   Button,
   Modal,
+  ModalHeader,
   ModalBody,
   ModalFooter,
-  ModalHeader,
   Row,
   Col,
 } from 'reactstrap';
@@ -14,7 +14,7 @@ import { Editor } from '@tinymce/tinymce-react';
 import { toast } from 'react-toastify';
 import { connect } from 'react-redux';
 import { getInfoCollections, addInfoCollection, updateInfoCollection, deleteInfoCollectionById } from '../../../actions/information';
-import { boxStyle } from 'styles';
+import { boxStyle, boxStyleDark } from 'styles';
 
 // New RichTextEditor component
 const RichTextEditor = ({ disabled, value, onEditorChange }) => (
@@ -228,6 +228,8 @@ export class EditableInfoModal extends Component {
       isPermissionPage,
     } = this.state;
 
+     const darkMode = this.props.darkMode;
+
     return (
       (CanRead) && (
         <div>
@@ -241,9 +243,9 @@ export class EditableInfoModal extends Component {
             onClick={() => this.setState({ editableModalOpen: true })}
           />
           {editableModalOpen && (
-            <Modal isOpen={editableModalOpen} toggle={this.toggleEditableModal} size="lg">
-              <ModalHeader>Welcome to the {this.props.areaTitle} Information Page!</ModalHeader>
-              <ModalBody>
+            <Modal isOpen={editableModalOpen} toggle={this.toggleEditableModal} size="lg" className={darkMode ? 'text-light' : ''}>
+              <ModalHeader className={darkMode ? 'bg-space-cadet' : ''}>Welcome to the {this.props.areaTitle} Information Page!</ModalHeader>
+              <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
                 {this.state.editing
                   ? <RichTextEditor
                     disabled={!this.state.editing}
@@ -264,7 +266,7 @@ export class EditableInfoModal extends Component {
                   )
                 }
               </ModalBody>
-              <ModalFooter>
+              <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
                 <Row className='no-gutters'>
                   {(this.state.editing) &&
                     (
@@ -284,13 +286,13 @@ export class EditableInfoModal extends Component {
                         <Button
                           className='saveBtn'
                           onClick={this.handleSave}
-                          style={boxStyle}>Save</Button>
+                          style={darkMode ? boxStyleDark : boxStyle}>Save</Button>
                       </Col>)
                   }
                   <Col
                     md={3}
                   >
-                    <Button onClick={this.handleClose} style={boxStyle}>Close</Button>
+                    <Button onClick={this.handleClose} style={darkMode ? boxStyleDark : boxStyle}>Close</Button>
                   </Col>
                 </Row>
               </ModalFooter>


### PR DESCRIPTION
# Description
Implemented dark mode on all modals that can be found on the Permissions Management page

## Related PRS (if any):
This frontend PR is related to the dev backend.

## Main changes explained:
- Dark mode for all modals on the Permissions Management page

## How to test:
1. check into the current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ Other Links → Permissions Management 
6. verify that all modals on the Permissions Management page are working properly

## Screenshots or videos of changes:
![Screenshot 2024-05-20 131139](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/1e2f42a0-9257-46b5-b597-6acde7156f6e)
![Screenshot 2024-05-20 131208](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/bd00a13f-8aea-4f34-bfe3-ba3412aa09ed)
