### PR TITLE
XiaoW_Hotfix of refresh cause app to return to dashboard

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -130,7 +130,7 @@ const Timelog = props => {
   const { userId = authUser.userid } = useParams();
 
   const checkSessionStorage = () => JSON.parse(sessionStorage.getItem('viewingUser')) ?? false;
-  const [viewingUser, setViewingUser] = useState(checkSessionStorage);
+  const [viewingUser, setViewingUser] = useState(checkSessionStorage());
   const [displayUserId, setDisplayUserId] = useState(
     viewingUser ? viewingUser.userId : userId,
   );

--- a/src/store.js
+++ b/src/store.js
@@ -1,8 +1,6 @@
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 import { persistStore, persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage'; // defaults to localStorage for web
-import storageSession from 'redux-persist/lib/storage/session';
-import concatenateReducers from 'redux-concatenate-reducers';
 
 import thunk from 'redux-thunk';
 import { localReducers, sessionReducers } from './reducers';
@@ -13,58 +11,27 @@ const devTools = window.__REDUX_DEVTOOLS_EXTENSION__
   ? window.__REDUX_DEVTOOLS_EXTENSION__()
   : f => f;
 
-const localPersistReducer = persistReducer(
-  {
-    key: 'root',
-    storage,
-    blacklist: ['auth', 'errors', ...Object.keys(sessionReducers)],
-  },
-  combineReducers(localReducers),
-);
+export const rootReducers = combineReducers({
+  ...localReducers,
+  ...sessionReducers,
+});
 
-const sessionPersistReducer = persistReducer(
-  {
-    key: 'root',
-    storage: storageSession,
-    blacklist: [...Object.keys(localReducers)],
-  },
-  combineReducers(sessionReducers),
-);
-
-const filteredReducer = reducer => {
-  return (state, action) => {
-    let knownKeys = Object.keys(reducer(undefined, { type: '@@FILTER/INIT' }));
-    let filteredState = state;
-    if (knownKeys.length && state !== undefined) {
-      filteredState = knownKeys.reduce(
-        (current, key) => Object.assign(current, { [key]: state[key] }),
-        {},
-      );
-    }
-    const newState = reducer(filteredState, action);
-    let nextState = state;
-    if (newState !== filteredState) {
-      knownKeys = Object.keys(newState);
-      nextState = {
-        ...state,
-        ...newState,
-      };
-    }
-    return nextState;
-  };
+const persistConfig = {
+  key: 'root',
+  storage,
+  blacklist: ['auth', 'errors', ...Object.keys(sessionReducers)],
 };
 
-export const rootReducers = concatenateReducers([
-  filteredReducer(sessionPersistReducer),
-  filteredReducer(localPersistReducer),
-]);
+const localPersistReducer = persistReducer(persistConfig, rootReducers);
+
+const store = createStore(
+  localPersistReducer,
+  initialState,
+  compose(applyMiddleware(...middleware), devTools),
+);
+
+const persistor = persistStore(store);
 
 export default () => {
-  const store = createStore(
-    rootReducers,
-    initialState,
-    compose(applyMiddleware(...middleware), devTools),
-  );
-  const persistor = persistStore(store);
   return { store, persistor };
-};
+}


### PR DESCRIPTION
This bug is caused by states in store not persisted correctly. Since sessionStorage only apply to one tab, and to have both localStorage and sessionStorage under root will cause an unexpected keys warning, so this PR remove sessionStorage as one of the persistor and the reducers under sessionStorage will just use redux default store, which behaves similar like sessionStorage.