### PR TITLE
Jay unit tests for SetUpFinalDayPopUp

### DIFF
--- a/src/components/UserManagement/__tests__/SetUpFinalDayButton.test.js
+++ b/src/components/UserManagement/__tests__/SetUpFinalDayButton.test.js
@@ -1,30 +1,32 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import userEvent from '@testing-library/user-event';
 import configureStore from 'redux-mock-store';
 import { themeMock } from '__tests__/mockStates';
 import { Provider } from 'react-redux';
+import axios from 'axios';
 import SetUpFinalDayButton from '../SetUpFinalDayButton';
 import { SET_FINAL_DAY, CANCEL } from '../../../languages/en/ui';
-import { updateUserFinalDayStatus } from '../../../actions/userManagement.js';
-import axios from 'axios';
+// import { updateUserFinalDayStatus } from '../../../actions/userManagement.js';
 
-jest.mock('react-toastify');
-jest.mock('axios', () => {
-  return {
-    patch: jest.fn(() => Promise.resolve({ data: { status: 200 } })),
-  };
+jest.mock('axios');
+
+const mockToastSuccess = jest.fn();
+
+beforeAll(() => {
+  jest.mock('react-toastify', () => ({
+    toast: { success: mockToastSuccess },
+  }));
 });
-const mockStore = configureStore([]);
+
+const mockStore = configureStore();
 
 // const userProfileUrl = ENDPOINTS.USER_PROFILE(mockState.auth.user.userid);
 
 describe('SetUpFinalDayButton', () => {
+  const store = mockStore({
+    theme: themeMock,
+  });
   let renderSetUpFinalDayButton = props => {
-    const store = mockStore({
-      theme: themeMock,
-    });
-
     render(
       <Provider store={store}>
         <SetUpFinalDayButton {...props} />
@@ -61,35 +63,34 @@ describe('SetUpFinalDayButton', () => {
   describe('onFinalDayClick tests', () => {
     let props;
 
-    // it('If isSet is true, then an alert will apear', async () => {
-    //   renderSetUpFinalDayButton(props);
-    //   fireEvent.click(screen.getByText(CANCEL));
+    it('If isSet is true, then an alert will appear', async () => {
+      renderSetUpFinalDayButton(props);
+      const mockedResponse = { data: { status: 200 } };
+      axios.patch.mockResolvedValue(mockedResponse);
 
-    //   // expect(await screen.findByRole('dialog')).toBeInTheDocument();
-    //   await waitFor(
-    //     async () =>
-    //       expect(
-    //         await screen.findByText("This user's final day has been deleted."),
-    //       ).toBeInTheDocument(),
-    //     { timeout: 1000 },
-    //   );
-    // });
+      const message = "This user's final day has been deleted.";
+
+      const cancelFinalDayButton = screen.getByText(CANCEL);
+      fireEvent.click(cancelFinalDayButton);
+      waitFor(() => {
+        expect(mockToastSuccess).toHaveBeenCalledWith(message);
+      });
+    });
 
     it('If isSet is false then SetUpFinalDayPopUp will be present', async () => {
-      console.log(axios.patch('', {}));
       props.userProfile.endDate = undefined;
 
       renderSetUpFinalDayButton(props);
       fireEvent.click(screen.getByText(SET_FINAL_DAY));
-      await waitFor(async () =>
-        expect(await screen.findByText('Set Your Final Day')).toBeInTheDocument(),
-      );
+      const setYourFinalDayElement = await screen.findByText('Set Your Final Day');
+      await waitFor(() => expect(setYourFinalDayElement).toBeInTheDocument());
     });
 
     beforeEach(() => {
       props = {
         userProfile: {
-          endDate: 'mockEndDate',
+          endDate: '20210311',
+          _id: '1',
         },
         loadUserProfile: jest.fn().mockReturnValueOnce(200),
         isBigBtn: true,

--- a/src/components/UserManagement/__tests__/SetUpFinalDayButton.test.js
+++ b/src/components/UserManagement/__tests__/SetUpFinalDayButton.test.js
@@ -1,0 +1,100 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import configureStore from 'redux-mock-store';
+import { themeMock } from '__tests__/mockStates';
+import { Provider } from 'react-redux';
+import SetUpFinalDayButton from '../SetUpFinalDayButton';
+import { SET_FINAL_DAY, CANCEL } from '../../../languages/en/ui';
+import { updateUserFinalDayStatus } from '../../../actions/userManagement.js';
+import axios from 'axios';
+
+jest.mock('react-toastify');
+jest.mock('axios', () => {
+  return {
+    patch: jest.fn(() => Promise.resolve({ data: { status: 200 } })),
+  };
+});
+const mockStore = configureStore([]);
+
+// const userProfileUrl = ENDPOINTS.USER_PROFILE(mockState.auth.user.userid);
+
+describe('SetUpFinalDayButton', () => {
+  let renderSetUpFinalDayButton = props => {
+    const store = mockStore({
+      theme: themeMock,
+    });
+
+    render(
+      <Provider store={store}>
+        <SetUpFinalDayButton {...props} />
+      </Provider>,
+    );
+  };
+
+  describe('useEffect tests', () => {
+    let props;
+
+    it(`If user profile end date is not set, then button text is ${SET_FINAL_DAY}`, () => {
+      props.userProfile.endDate = undefined;
+      renderSetUpFinalDayButton(props);
+      expect(screen.getByText(SET_FINAL_DAY)).toBeInTheDocument();
+    });
+
+    it(`If user profile end date is set, then button text is ${CANCEL}`, () => {
+      renderSetUpFinalDayButton(props);
+      expect(screen.getByText(CANCEL)).toBeInTheDocument();
+    });
+
+    beforeEach(() => {
+      props = {
+        userProfile: {
+          endDate: 'mockEndDate',
+        },
+        loadUserProfile: jest.fn(),
+        isBigBtn: true,
+        darkMode: themeMock.darkMode,
+      };
+    });
+  });
+
+  describe('onFinalDayClick tests', () => {
+    let props;
+
+    // it('If isSet is true, then an alert will apear', async () => {
+    //   renderSetUpFinalDayButton(props);
+    //   fireEvent.click(screen.getByText(CANCEL));
+
+    //   // expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    //   await waitFor(
+    //     async () =>
+    //       expect(
+    //         await screen.findByText("This user's final day has been deleted."),
+    //       ).toBeInTheDocument(),
+    //     { timeout: 1000 },
+    //   );
+    // });
+
+    it('If isSet is false then SetUpFinalDayPopUp will be present', async () => {
+      console.log(axios.patch('', {}));
+      props.userProfile.endDate = undefined;
+
+      renderSetUpFinalDayButton(props);
+      fireEvent.click(screen.getByText(SET_FINAL_DAY));
+      await waitFor(async () =>
+        expect(await screen.findByText('Set Your Final Day')).toBeInTheDocument(),
+      );
+    });
+
+    beforeEach(() => {
+      props = {
+        userProfile: {
+          endDate: 'mockEndDate',
+        },
+        loadUserProfile: jest.fn().mockReturnValueOnce(200),
+        isBigBtn: true,
+        darkMode: themeMock.darkMode,
+      };
+    });
+  });
+});

--- a/src/components/UserManagement/__tests__/SetUpFinalDayButton.test.js
+++ b/src/components/UserManagement/__tests__/SetUpFinalDayButton.test.js
@@ -40,11 +40,15 @@ describe('SetUpFinalDayButton', () => {
     it(`If user profile end date is not set, then button text is ${SET_FINAL_DAY}`, () => {
       props.userProfile.endDate = undefined;
       renderSetUpFinalDayButton(props);
+
+      // Renders with SET_FINAL_DAY text
       expect(screen.getByText(SET_FINAL_DAY)).toBeInTheDocument();
     });
 
     it(`If user profile end date is set, then button text is ${CANCEL}`, () => {
       renderSetUpFinalDayButton(props);
+
+      // Renders with CANCEL text
       expect(screen.getByText(CANCEL)).toBeInTheDocument();
     });
 
@@ -60,20 +64,21 @@ describe('SetUpFinalDayButton', () => {
     });
   });
 
-  describe('onFinalDayClick tests', () => {
+  describe('onFinalDayClick tests ', () => {
     let props;
 
-    it('If isSet is true, then an alert will appear', async () => {
+    const finalDayDeletedMessage = "This user's final day has been deleted.";
+    it(`If isSet is true, then an alert will appear with message: ${finalDayDeletedMessage}`, async () => {
       renderSetUpFinalDayButton(props);
       const mockedResponse = { data: { status: 200 } };
       axios.patch.mockResolvedValue(mockedResponse);
 
-      const message = "This user's final day has been deleted.";
-
       const cancelFinalDayButton = screen.getByText(CANCEL);
       fireEvent.click(cancelFinalDayButton);
+
+      // Clicking CANCEL button calls final day deleted toast
       waitFor(() => {
-        expect(mockToastSuccess).toHaveBeenCalledWith(message);
+        expect(mockToastSuccess).toHaveBeenCalledWith(finalDayDeletedMessage);
       });
     });
 
@@ -83,7 +88,46 @@ describe('SetUpFinalDayButton', () => {
       renderSetUpFinalDayButton(props);
       fireEvent.click(screen.getByText(SET_FINAL_DAY));
       const setYourFinalDayElement = await screen.findByText('Set Your Final Day');
+
+      // Clicking SET_FINAL_DAY button causes popup to appear
       await waitFor(() => expect(setYourFinalDayElement).toBeInTheDocument());
+    });
+
+    it('setUpFinalDayPopupClose should close SetUpFinalDayPopUp', async () => {
+      props.userProfile.endDate = undefined;
+
+      renderSetUpFinalDayButton(props);
+      fireEvent.click(screen.getByText(SET_FINAL_DAY));
+      const setYourFinalDayElement = await screen.findByText('Set Your Final Day');
+      // Popup is open
+      await waitFor(() => expect(setYourFinalDayElement).toBeInTheDocument());
+
+      const closeFinalDayPopup = screen.getByText('Close');
+      fireEvent.click(closeFinalDayPopup);
+
+      // Clicking close on popup closes it (popup uses function defined in button element)
+      await waitFor(() => expect(setYourFinalDayElement).not.toBeInTheDocument());
+    });
+
+    const finalDaySetMessage = "This user's final day has been set.";
+    it(`When deactiveUser is called by child component, popup should close and alert will appear with following text: ${finalDaySetMessage}`, async () => {
+      props.userProfile.endDate = undefined;
+
+      renderSetUpFinalDayButton(props);
+      fireEvent.click(screen.getByText(SET_FINAL_DAY));
+      // Popup is open
+      const setYourFinalDayElement = await screen.findByText('Set Your Final Day');
+      await waitFor(() => expect(setYourFinalDayElement).toBeInTheDocument());
+
+      const dateInput = screen.getByTestId('date-input');
+      fireEvent.change(dateInput, { target: { value: '12-07-2019' } });
+      const saveFinalDayPopup = screen.getByText('Save');
+      fireEvent.click(saveFinalDayPopup);
+
+      // When final day is set, expect toast to be called with appropriate message
+      waitFor(() => {
+        expect(mockToastSuccess).toHaveBeenCalledWith(finalDaySetMessage);
+      });
     });
 
     beforeEach(() => {


### PR DESCRIPTION
# Description
Implements unit tests for `/src/components/UserManagement/SetUpFinalDayPopUp.jsx`

## Related PRS (if any):
This is not related to any other PRs
…

## Main changes explained:
- Create file SetUpFinalDayButton.test.js which contains unit tests for component SetUpFinalDayButton.jsx
- Tests for the following cases:

On render:
1. If user profile end date is not set, then button text is Set Final Day
2. If user profile end date is set, then button text is Delete Final Day

When button is clicked:
1. If the user has an endDate, then an alert will appear with message: This user's final day has been deleted.
2. If the user has no endDate, SetUpFinalDayPopUp will be open

For code coverage:
1. setUpFinalDayPopupClose should close SetUpFinalDayPopUp 
2. When deactiveUser is called by child component, popup should close and alert will appear with following text: This user's final day has been set.

## How to test:
1. check into current branch
4. run npm test -- SetUpFinalDayButton.test.js
5. verify that all tests pass and accomplish 100% code coverage

## Screenshots or videos of changes:
<img width="574" alt="SetUpFinalDayButton all tests working and full code coverage" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71467346/ad4166f1-0b28-4ba9-ad59-feee5c5bf867">