### PR TITLE
Chris_spinning_wheel_date_change_reports

### DIFF
--- a/src/components/Reports/TotalReport/TotalPeopleReport.jsx
+++ b/src/components/Reports/TotalReport/TotalPeopleReport.jsx
@@ -214,7 +214,7 @@ function TotalPeopleReport(props) {
       <div className={`total-container ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}>
         <div className={`total-title ${darkMode ? 'text-azure' : ''}`}>Total People Report</div>
         <div className="total-period">
-          In the period from {fromDate} to {toDate}:
+        In the period from {startDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })} to {endDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })}:
         </div>
         <div className="total-item">
           <div className="total-number">{allPeople.length}</div>

--- a/src/components/Reports/TotalReport/TotalPeopleReport.jsx
+++ b/src/components/Reports/TotalReport/TotalPeopleReport.jsx
@@ -12,6 +12,7 @@ function TotalPeopleReport(props) {
   const { startDate, endDate, userProfiles, darkMode } = props;
   const [dataLoading, setDataLoading] = useState(true);
   const [dataRefresh, setDataRefresh] = useState(false);
+  const [dataReady, setDataReady] = useState(false);
   const [showTotalPeopleTable, setShowTotalPeopleTable] = useState(false);
   const [allTimeEntries, setAllTimeEntries] = useState([]);
   const [allPeople, setAllPeople] = useState([]);
@@ -163,6 +164,7 @@ function TotalPeopleReport(props) {
   };
 
   useEffect(() => {
+    setDataReady(false);
     const controller = new AbortController();
     loadTimeEntriesForPeriod(controller).then(() => {
       setDataLoading(false);
@@ -180,6 +182,7 @@ function TotalPeopleReport(props) {
       setAllPeople(contributedUsers);
       checkPeriodForSummary();
       setDataRefresh(false);
+      setDataReady(true);
     }
   }, [dataRefresh]);
 
@@ -275,7 +278,7 @@ function TotalPeopleReport(props) {
 
   return (
     <div>
-      {dataLoading ? (
+      {!dataReady? (
         <Loading align="center" darkMode={darkMode}/>
       ) : (
         <div>

--- a/src/components/Reports/TotalReport/TotalPeopleReport.jsx
+++ b/src/components/Reports/TotalReport/TotalPeopleReport.jsx
@@ -10,8 +10,8 @@ import Loading from '../../common/Loading';
 
 function TotalPeopleReport(props) {
   const { startDate, endDate, userProfiles, darkMode } = props;
-  const [dataLoading, setDataLoading] = useState(true);
-  const [dataReady, setDataReady] = useState(false);
+  const [totalPeopleReportDataLoading, setTotalPeopleReportDataLoading] = useState(true);
+  const [totalPeopleReportDataReady, setTotalPeopleReportDataReady] = useState(false);
   const [showTotalPeopleTable, setShowTotalPeopleTable] = useState(false);
   const [allTimeEntries, setAllTimeEntries] = useState([]);
   const [allPeople, setAllPeople] = useState([]);
@@ -155,17 +155,17 @@ function TotalPeopleReport(props) {
   }, [endDate, startDate, generateBarData, summaryOfTimeRange]);
 
   useEffect(() => {
-    setDataReady(false);
+    setTotalPeopleReportDataReady(false);
     const controller = new AbortController();
     loadTimeEntriesForPeriod(controller).then(() => {
-      setDataLoading(false);
-      setDataReady(true);
+      setTotalPeopleReportDataLoading(false);
+      setTotalPeopleReportDataReady(true);
     });
     return () => controller.abort();
   }, [loadTimeEntriesForPeriod, startDate, endDate]);
 
   useEffect(() => {
-    if (!dataLoading && dataReady) {
+    if (!totalPeopleReportDataLoading && totalPeopleReportDataReady) {
       setShowMonthly(false);
       setShowYearly(false);
       const groupedUsers = Object.values(sumByUser(allTimeEntries, 'userId'));
@@ -173,7 +173,7 @@ function TotalPeopleReport(props) {
       setAllPeople(contributedUsers);
       checkPeriodForSummary();
     }
-  }, [dataLoading, dataReady, sumByUser, filterTenHourUser, allTimeEntries, checkPeriodForSummary]);
+  }, [totalPeopleReportDataLoading, totalPeopleReportDataReady, sumByUser, filterTenHourUser, allTimeEntries, checkPeriodForSummary]);
 
   const onClickTotalPeopleDetail = () => {
     setShowTotalPeopleTable(prevState => !prevState);
@@ -257,7 +257,7 @@ function TotalPeopleReport(props) {
 
   return (
     <div>
-      {!dataReady ? (
+      {!totalPeopleReportDataReady ? (
         <Loading align="center" darkMode={darkMode} />
       ) : (
         <div>

--- a/src/components/Reports/TotalReport/TotalProjectReport.jsx
+++ b/src/components/Reports/TotalReport/TotalProjectReport.jsx
@@ -198,7 +198,7 @@ function TotalProjectReport(props) {
       <div className={`total-container ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}>
         <div className={`total-title ${darkMode ? 'text-azure' : ''}`}>Total Project Report</div>
         <div className="total-period">
-          In the period from {fromDate} to {toDate}:
+        In the period from {startDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })} to {endDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })}:
         </div>
         <div className="total-item">
           <div className="total-number">{allProject.length}</div>

--- a/src/components/Reports/TotalReport/TotalProjectReport.jsx
+++ b/src/components/Reports/TotalReport/TotalProjectReport.jsx
@@ -11,6 +11,7 @@ import Loading from '../../common/Loading';
 function TotalProjectReport(props) {
   const [dataLoading, setDataLoading] = useState(true);
   const [dataRefresh, setDataRefresh] = useState(false);
+  const [dataReady, setDataReady] = useState(false);
   const [showTotalProjectTable, setShowTotalProjectTable] = useState(false);
   const [allTimeEntries, setAllTimeEntries] = useState([]);
   const [allProject, setAllProject] = useState([]);
@@ -174,6 +175,7 @@ function TotalProjectReport(props) {
   };
 
   useEffect(() => {
+    setDataReady(false);
     loadTimeEntriesForPeriod().then(() => {
       setDataLoading(false);
       setDataRefresh(true);
@@ -189,6 +191,7 @@ function TotalProjectReport(props) {
       setAllProject(contributedProjects);
       checkPeriodForSummary();
       setDataRefresh(false);
+      setDataReady(true);
     }
   }, [dataRefresh]);
 
@@ -287,7 +290,7 @@ function TotalProjectReport(props) {
 
   return (
     <div>
-      {dataLoading ? (
+      {!dataReady ? (
         <Loading align="center" darkMode={darkMode}/>
       ) : (
         <div>

--- a/src/components/Reports/TotalReport/TotalProjectReport.jsx
+++ b/src/components/Reports/TotalReport/TotalProjectReport.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import { ENDPOINTS } from 'utils/URL';
 import axios from 'axios';
 import './TotalReport.css';
@@ -9,6 +9,8 @@ import TotalReportBarGraph from './TotalReportBarGraph';
 import Loading from '../../common/Loading';
 
 function TotalProjectReport(props) {
+  const { startDate, endDate, userProfiles, projects, darkMode } = props;
+
   const [dataLoading, setDataLoading] = useState(true);
   const [dataRefresh, setDataRefresh] = useState(false);
   const [dataReady, setDataReady] = useState(false);
@@ -20,54 +22,40 @@ function TotalProjectReport(props) {
   const [showMonthly, setShowMonthly] = useState(false);
   const [showYearly, setShowYearly] = useState(false);
 
-  const { startDate, endDate, userProfiles, projects, darkMode } = props;
+  const fromDate = useMemo(() => startDate.toLocaleDateString('en-CA'), [startDate]);
+  const toDate = useMemo(() => endDate.toLocaleDateString('en-CA'), [endDate]);
+  const userList = useMemo(() => userProfiles.map(user => user._id), [userProfiles]);
+  const projectList = useMemo(() => projects.map(proj => proj._id), [projects]);
 
-  const fromDate = startDate.toLocaleDateString('en-CA');
-  const toDate = endDate.toLocaleDateString('en-CA');
+  const loadTimeEntriesForPeriod = useCallback(async () => {
+    try {
+      const url = ENDPOINTS.TIME_ENTRIES_REPORTS;
+      const timeEntries = await axios.post(url, { users: userList, fromDate, toDate }).then(res => res.data.map(entry => ({
+        projectId: entry.projectId,
+        projectName: entry.projectName,
+        hours: entry.hours,
+        minutes: entry.minutes,
+        isTangible: entry.isTangible,
+        date: entry.dateOfWork,
+      })));
 
-  const userList = userProfiles.map(user => user._id);
-  const projectList = projects.map(proj => proj._id);
+      const projUrl = ENDPOINTS.TIME_ENTRIES_LOST_PROJ_LIST;
+      const projTimeEntries = await axios.post(projUrl, { projects: projectList, fromDate, toDate }).then(res => res.data.map(entry => ({
+        projectId: entry.projectId,
+        projectName: entry.projectName,
+        hours: entry.hours,
+        minutes: entry.minutes,
+        isTangible: entry.isTangible,
+        date: entry.dateOfWork,
+      })));
 
-  const loadTimeEntriesForPeriod = async () => {
-    let url = ENDPOINTS.TIME_ENTRIES_REPORTS;
-    const timeEntries = await axios
-      .post(url, { users: userList, fromDate, toDate })
-      .then(res => {
-        return res.data.map(entry => {
-          return {
-            projectId: entry.projectId,
-            projectName: entry.projectName,
-            hours: entry.hours,
-            minutes: entry.minutes,
-            isTangible: entry.isTangible,
-            date: entry.dateOfWork,
-          };
-        });
-      })
-      .catch(err => {
-        // eslint-disable-next-line no-console
-        console.log(err.message);
-      });
+      setAllTimeEntries([...timeEntries, ...projTimeEntries]);
+    } catch (err) {
+      console.error("API error:", err.message);
+    }
+  }, [fromDate, toDate, userList, projectList]);
 
-    url = ENDPOINTS.TIME_ENTRIES_LOST_PROJ_LIST;
-    const projTimeEntries = await axios
-      .post(url, { projects: projectList, fromDate, toDate })
-      .then(res => {
-        return res.data.map(entry => {
-          return {
-            projectId: entry.projectId,
-            projectName: entry.projectName,
-            hours: entry.hours,
-            minutes: entry.minutes,
-            isTangible: entry.isTangible,
-            date: entry.dateOfWork,
-          };
-        });
-      });
-    setAllTimeEntries([...timeEntries, ...projTimeEntries]);
-  };
-
-  const sumByProject = (objectArray, property) => {
+  const sumByProject = useCallback((objectArray, property) => {
     return objectArray.reduce((acc, obj) => {
       const key = obj[property];
       if (!acc[key]) {
@@ -88,91 +76,68 @@ function TotalProjectReport(props) {
       acc[key].minutes += Number(obj.minutes);
       return acc;
     }, {});
-  };
+  }, []);
 
-  const groupByTimeRange = (objectArray, timeRange) => {
-    let range = 0;
-    if (timeRange === 'month') {
-      range = 7;
-    } else if (timeRange === 'year') {
-      range = 4;
-    } else {
-      // eslint-disable-next-line no-console
-      console.log('The time range should be month or year.');
-    }
+  const groupByTimeRange = useCallback((objectArray, timeRange) => {
+    const range = timeRange === 'month' ? 7 : 4;
     return objectArray.reduce((acc, obj) => {
       const key = obj.date.substring(0, range);
-      const month = acc[key] || [];
-      month.push(obj);
-      acc[key] = month;
+      acc[key] = acc[key] || [];
+      acc[key].push(obj);
       return acc;
     }, {});
-  };
-  const filterOneHourProject = projectTimeList => {
-    const filteredProjects = [];
-    projectTimeList.forEach(element => {
-      const allTimeLogged = element.hours + element.minutes / 60.0;
-      const allTangibleTimeLogged = element.tangibleHours + element.tangibleMinutes / 60.0;
-      if (allTimeLogged >= 1) {
-        filteredProjects.push({
-          projectId: element.projectId,
-          projectName: element.projectName,
-          totalTime: allTimeLogged.toFixed(2),
-          tangibleTime: allTangibleTimeLogged.toFixed(2),
-        });
-      }
-    });
-    return filteredProjects;
-  };
-  const summaryOfTimeRange = timeRange => {
+  }, []);
+
+  const filterOneHourProject = useCallback(projectTimeList => {
+    return projectTimeList
+      .filter(element => (element.hours + element.minutes / 60.0) >= 1)
+      .map(element => ({
+        projectId: element.projectId,
+        projectName: element.projectName,
+        totalTime: (element.hours + element.minutes / 60.0).toFixed(2),
+        tangibleTime: (element.tangibleHours + element.tangibleMinutes / 60.0).toFixed(2),
+      }));
+  }, []);
+
+  const summaryOfTimeRange = useCallback(timeRange => {
     const groupedEntries = Object.entries(groupByTimeRange(allTimeEntries, timeRange));
-    const summaryOfTime = [];
-    groupedEntries.forEach(element => {
-      const groupedProjectsOfTime = Object.values(sumByProject(element[1], 'projectId'));
-      const contributedProjectsOfTime = filterOneHourProject(groupedProjectsOfTime);
-      summaryOfTime.push({ timeRange: element[0], projectsOfTime: contributedProjectsOfTime });
+    return groupedEntries.map(([key, entries]) => {
+      const groupedProjectsOfTime = Object.values(sumByProject(entries, 'projectId'));
+      return { timeRange: key, projectsOfTime: filterOneHourProject(groupedProjectsOfTime) };
     });
-    return summaryOfTime;
-  };
-  const generateBarData = (groupedDate, isYear = false) => {
+  }, [allTimeEntries, groupByTimeRange, sumByProject, filterOneHourProject]);
+
+  const generateBarData = useCallback((groupedDate, isYear = false) => {
     if (isYear) {
       const startMonth = startDate.getMonth();
       const endMonth = endDate.getMonth();
-      const sumData = groupedDate.map(range => {
-        return {
-          label: range.timeRange,
-          value: range.projectsOfTime.length,
-          months: 12,
-        };
-      });
+      const sumData = groupedDate.map(range => ({
+        label: range.timeRange,
+        value: range.projectsOfTime.length,
+        months: 12,
+      }));
       if (sumData.length > 1) {
         sumData[0].months = 12 - startMonth;
         sumData[sumData.length - 1].months = endMonth + 1;
       }
       return sumData;
     }
-    const sumData = groupedDate.map(range => {
-      return {
-        label: range.timeRange,
-        value: range.projectsOfTime.length,
-      };
-    });
-    return sumData;
-  };
-  const checkPeriodForSummary = () => {
+    return groupedDate.map(range => ({
+      label: range.timeRange,
+      value: range.projectsOfTime.length,
+    }));
+  }, [startDate, endDate]);
+
+  const checkPeriodForSummary = useCallback(() => {
     const oneMonth = 1000 * 60 * 60 * 24 * 31;
     const diffDate = endDate - startDate;
     if (diffDate > oneMonth) {
       setProjectInMonth(generateBarData(summaryOfTimeRange('month')));
       setProjectInYear(generateBarData(summaryOfTimeRange('year'), true));
-      if (diffDate <= oneMonth * 12) {
-        setShowMonthly(true);
-      }
-      if (startDate.getFullYear() !== endDate.getFullYear()) {
-        setShowYearly(true);
-      }
+      if (diffDate <= oneMonth * 12) setShowMonthly(true);
+      if (startDate.getFullYear() !== endDate.getFullYear()) setShowYearly(true);
     }
-  };
+  }, [endDate, startDate, generateBarData, summaryOfTimeRange]);
 
   useEffect(() => {
     setDataReady(false);
@@ -180,63 +145,50 @@ function TotalProjectReport(props) {
       setDataLoading(false);
       setDataRefresh(true);
     });
-  }, [startDate, endDate]);
+  }, [loadTimeEntriesForPeriod, startDate, endDate]);
 
   useEffect(() => {
     if (!dataLoading && dataRefresh) {
       setShowMonthly(false);
       setShowYearly(false);
       const groupedProjects = Object.values(sumByProject(allTimeEntries, 'projectId'));
-      const contributedProjects = filterOneHourProject(groupedProjects);
-      setAllProject(contributedProjects);
+      setAllProject(filterOneHourProject(groupedProjects));
       checkPeriodForSummary();
       setDataRefresh(false);
       setDataReady(true);
     }
-  }, [dataRefresh]);
+  }, [dataLoading, dataRefresh, sumByProject, filterOneHourProject, allTimeEntries, checkPeriodForSummary]);
 
-  const onClickTotalProjectDetail = () => {
-    const showDetail = showTotalProjectTable;
-    setShowTotalProjectTable(!showDetail);
-  };
+  const onClickTotalProjectDetail = () => setShowTotalProjectTable(prevState => !prevState);
 
-  const totalProjectTable = totalProject => {
-    let ProjectList = [];
-    if (totalProject.length > 0) {
-      ProjectList = totalProject
-        .sort((a, b) => a.projectName.localeCompare(b.projectName))
-        .map((project, index) => (
+  const totalProjectTable = totalProject => (
+    <table className="table table-bordered table-responsive-sm">
+      <thead>
+        <tr>
+          <th scope="col" id="projects__order">#</th>
+          <th scope="col">Project Name</th>
+          <th scope="col">Total Logged Time (Hrs)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {totalProject.sort((a, b) => a.projectName.localeCompare(b.projectName)).map((project, index) => (
           <tr className="teams__tr" id={`tr_${project.projectId}`} key={project.projectId}>
             <th className="teams__order--input" scope="row">
               <div>{index + 1}</div>
             </th>
             <td>
               {project.projectId ? (
-                <Link to={`/projectReport/${project.projectId}`} className={darkMode ? 'text-light' : ''}>{project.projectName}</Link>
-              ) : (
-                'Unrecorded Project'
-              )}
+                <Link to={`/projectReport/${project.projectId}`} className={darkMode ? 'text-light' : ''}>
+                  {project.projectName}
+                </Link>
+              ) : 'Unrecorded Project'}
             </td>
             <td>{project.totalTime}</td>
           </tr>
-        ));
-    }
-
-    return (
-      <table className="table table-bordered table-responsive-sm">
-        <thead>
-          <tr>
-            <th scope="col" id="projects__order">
-              #
-            </th>
-            <th scope="col">Project Name</th>
-            <th scope="col">Total Logged Time (Hrs) </th>
-          </tr>
-        </thead>
-        <tbody>{ProjectList}</tbody>
-      </table>
-    );
-  };
+        ))}
+      </tbody>
+    </table>
+  );
 
   const totalProjectInfo = totalProject => {
     const totalTangibleTime = totalProject.reduce((acc, obj) => {

--- a/src/components/Reports/TotalReport/TotalProjectReport.jsx
+++ b/src/components/Reports/TotalReport/TotalProjectReport.jsx
@@ -7,13 +7,13 @@ import { Button } from 'reactstrap';
 import ReactTooltip from 'react-tooltip';
 import TotalReportBarGraph from './TotalReportBarGraph';
 import Loading from '../../common/Loading';
+import { set } from 'lodash';
 
 function TotalProjectReport(props) {
   const { startDate, endDate, userProfiles, projects, darkMode } = props;
 
-  const [dataLoading, setDataLoading] = useState(true);
-  const [dataRefresh, setDataRefresh] = useState(false);
-  const [dataReady, setDataReady] = useState(false);
+  const [totalProjectReportDataLoading, setTotalProjectReportDataLoading] = useState(true);
+  const [totalProjectReportDataReady, setTotalProjectReportDataReady] = useState(false);
   const [showTotalProjectTable, setShowTotalProjectTable] = useState(false);
   const [allTimeEntries, setAllTimeEntries] = useState([]);
   const [allProject, setAllProject] = useState([]);
@@ -139,25 +139,26 @@ function TotalProjectReport(props) {
     }
   }, [endDate, startDate, generateBarData, summaryOfTimeRange]);
 
+
   useEffect(() => {
-    setDataReady(false);
-    loadTimeEntriesForPeriod().then(() => {
-      setDataLoading(false);
-      setDataRefresh(true);
+    setTotalProjectReportDataReady(false);
+    const controller = new AbortController();
+    loadTimeEntriesForPeriod(controller).then(() => {
+      setTotalProjectReportDataLoading(false);
+      setTotalProjectReportDataReady(true);
     });
+    return () => controller.abort();
   }, [loadTimeEntriesForPeriod, startDate, endDate]);
 
   useEffect(() => {
-    if (!dataLoading && dataRefresh) {
+    if (!totalProjectReportDataLoading && totalProjectReportDataReady) {
       setShowMonthly(false);
       setShowYearly(false);
       const groupedProjects = Object.values(sumByProject(allTimeEntries, 'projectId'));
       setAllProject(filterOneHourProject(groupedProjects));
       checkPeriodForSummary();
-      setDataRefresh(false);
-      setDataReady(true);
     }
-  }, [dataLoading, dataRefresh, sumByProject, filterOneHourProject, allTimeEntries, checkPeriodForSummary]);
+  }, [totalProjectReportDataLoading,totalProjectReportDataReady,sumByProject, filterOneHourProject, allTimeEntries, checkPeriodForSummary]);
 
   const onClickTotalProjectDetail = () => setShowTotalProjectTable(prevState => !prevState);
 
@@ -242,7 +243,7 @@ function TotalProjectReport(props) {
 
   return (
     <div>
-      {!dataReady ? (
+      {!totalProjectReportDataReady ? (
         <Loading align="center" darkMode={darkMode}/>
       ) : (
         <div>

--- a/src/components/Reports/TotalReport/TotalTeamReport.jsx
+++ b/src/components/Reports/TotalReport/TotalTeamReport.jsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo} from 'react';
 import { useDispatch } from 'react-redux';
 import { ENDPOINTS } from 'utils/URL';
 import axios from 'axios';
@@ -28,11 +28,10 @@ function TotalTeamReport(props) {
   const [userNameList, setUserNameList] = useState({});
 
   const { startDate, endDate, userProfiles, allTeamsData, darkMode } = props;
-
-  const fromDate = startDate.toLocaleDateString('en-CA');
-  const toDate = endDate.toLocaleDateString('en-CA');
-  const userList = userProfiles.map(user => user._id);
-  const teamList = allTeamsData.map(team => team._id);
+  const fromDate = useMemo(() => startDate.toLocaleDateString('en-CA'), [startDate]);
+  const toDate = useMemo(() => endDate.toLocaleDateString('en-CA'), [endDate]);
+  const userList = useMemo(() => userProfiles.map(user => user._id), [userProfiles]);
+  const teamList = useMemo(() => allTeamsData.map(team => team._id), [allTeamsData]);
 
   const filterTeamByEndDate = (teams, endDateTime) => {
     const filteredTeams = teams

--- a/src/components/Reports/TotalReport/TotalTeamReport.jsx
+++ b/src/components/Reports/TotalReport/TotalTeamReport.jsx
@@ -411,7 +411,7 @@ function TotalTeamReport(props) {
       <div className={`total-container ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}>
         <div className={`total-title ${darkMode ? 'text-azure' : ''}`}>Total Team Report</div>
         <div className="total-period">
-          In the period from {fromDate} to {toDate}:
+         In the period from {startDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })} to {endDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })}:
         </div>
         <div className="total-item">
           <div className="total-number">{totalTeam.length}</div>


### PR DESCRIPTION
# Description
The issue with the original pr is that when the date is changed, there isn't an indicator to show that the data is retrieved or not. With the spinning wheels added, it's going to spin until the newest data is ready and graph is rerendered.

## Related PRS (if any):
This PR is a minor patch for the functionality implemented in [PR #2268](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2268).
No backend pr related, for the backend just check-in to the development branch 

## Main changes explained:
- Added the state for "dataReady" and "setDataReady" for the spinning wheel of the total people report
- Added the state for "dataReady" and "setDataReady" for the spinning wheel of the total project report

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Reports →Reports → Projects/People/Teams
6. Click on ‘Show Total Project Report’, ‘Show Total People Report’, and ‘Show Total Team Report’ one by one
7. Change the end date to last year or any date you would want to test, see if there is a spinning wheel on there before the new report is shown for the new date

## Screenshots or videos of changes:
Before, when changing the date for People Report and Project Report to a different date, the date would be refreshed to the new date but the new graph is lagged to render.
<img width="1391" alt="Screenshot 2024-05-29 at 11 58 00 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/32f76528-0e43-4b0f-a6e3-e52035df8b7a">
With the new spinning wheel, it's not going to show the graph until the new graph is ready with the updated date.
<img width="1391" alt="Screenshot 2024-05-29 at 11 42 30 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/bd4e34f6-baa8-4db4-8664-cb586bc3f98b">
