### PR TITLE
XiaoW_Hotfix of disappearance of deletion icon of authorized users when viewing other's timeentry.

### DIFF
--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -127,12 +127,12 @@ const TimeEntry = (props) => {
     || dispatch(hasPermission('editTimeEntry'))) && !cantEditJaeRelatedRecord;
 
   //permission to Delete time entry from other user's Dashboard
-  const canDelete = (dispatch(hasPermission('deleteTimeEntryOthers')) ||
+  const canDelete = (dispatch(hasPermission('deleteTimeEntryOthers')) && !cantEditJaeRelatedRecord) ||
     //permission to delete any time entry on their own time logs tab
-    (isAuthUser && dispatch(hasPermission('deleteTimeEntry'))) ||
+    dispatch(hasPermission('deleteTimeEntry')) ||
     //default permission: delete own sameday tangible entry
-    isAuthUserAndSameDayEntry) && !cantEditJaeRelatedRecord;;
-
+    isAuthUserAndSameDayEntry;
+  
   const toggleTangibility = async () => {
     setIsProcessing(true);
     const newData = {


### PR DESCRIPTION
fix: move check of editting protected users to permission checks of deleting other's timeentry
