### PR TITLE
Sucheta - (New) Improve add task modal format

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -322,16 +322,16 @@ function AddTaskModal(props) {
         <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
           <div className="table table-bordered responsive">
             <div>
-              <div className="m-0 border d-flex align-items-center">
-                <span className="p-1 " data-tip="WBS ID" style={{width: "30%"}}>
+              <div className="add_new_task_form-group">
+                <span className="add_new_task_form-label" data-tip="WBS ID">
                   WBS #
                 </span>
 
-                <span className="border-left flex-grow-1 p-2">{newTaskNum}</span>
+                <span className="add_new_task_form-input_area">{newTaskNum}</span>
               </div>
-              <div className="m-0 border d-flex align-items-center" >
-                <span className="p-1" style={{width: "30%"}}>Task Name</span>
-                <span className="border-left p-1 flex-grow-1">
+              <div className="add_new_task_form-group" >
+                <span className="add_new_task_form-label">Task Name</span>
+                <span className="add_new_task_form-input_area">
                   {/* Fix Task-name formatting - by Sucheta */}
                   <textarea
                     type="text"
@@ -343,9 +343,9 @@ function AddTaskModal(props) {
                   />
                 </span>
               </div >
-              <div className='m-0 border d-flex align-items-center'>
-                <span className="p-1" style={{width: "30%"}} >Priority</span>
-                <span className='border-left p-1 flex-grow-1'>
+              <div className='add_new_task_form-group'>
+                <span className="add_new_task_form-label" >Priority</span>
+                <span className='add_new_task_form-input_area'>
                   <select id="priority" onChange={e => setPriority(e.target.value)} ref={priorityRef}>
                     <option value="Primary">Primary</option>
                     <option value="Secondary">Secondary</option>
@@ -353,9 +353,9 @@ function AddTaskModal(props) {
                   </select>
                 </span>
               </div>
-              <div className="m-0 border d-flex align-items-center">
-                <span className="p-1" style={{width: "30%"}}>Resources</span>
-                <span className="border-left p-1" style={{width: "70%"}}>
+              <div className="add_new_task_form-group">
+                <span className="add_new_task_form-label">Resources</span>
+                <span className="add_new_task_form-input_area">
                     <TagsSearch
                       placeholder="Add resources"
                       members={allMembers.filter(user=>user.isActive)}
@@ -367,9 +367,9 @@ function AddTaskModal(props) {
                   
                 </span>
               </div>
-              <div className="m-0 border d-flex align-items-center">
-                <span className="p-1" style={{width: "30%"}}>Assigned</span>
-                <span className="border-left p-1">
+              <div className="add_new_task_form-group">
+                <span className="add_new_task_form-label" >Assigned</span>
+                <span className="add_new_task_form-input_area">
                   <div className="flex-row d-inline align-items-center" >
                     <div className="form-check form-check-inline">
                       <input
@@ -402,9 +402,9 @@ function AddTaskModal(props) {
                   </div>
                 </span>
               </div>
-              <div className="m-0 d-flex border align-items-center">
-                <span className= "p-1" style={{width: "30%"}}>Status</span>
-                <span className="p-1 border-left" style={{width: "70%"}}>
+              <div className="add_new_task_form-group">
+                <span className= 'add_new_task_form-label'>Status</span>
+                <span className="add_new_task_form-input_area">
                  <div className="d-flex align-items-center flex-wrap"> 
                   <span className="form-check form-check-inline mr-5">
                       <input
@@ -469,11 +469,11 @@ function AddTaskModal(props) {
                  </div>
                 </span>
               </div>
-              <div className="d-flex align-items-center">
-                <span className="p-1" style={{width: "30%"}}>
+              <div className="add_new_task_form-group">
+                <span className="add_new_task_form-label">
                   Hours
                 </span>
-                <span className="p-1 border-left" style={{width: "70%"}}>
+                <span className="add_new_task_form-input_area">
                   <div className="py-2 flex-responsive">
                     <label htmlFor="bestCase" className="text-nowrap mr-3 w-25 mr-auto" style={{ fontWeight: 'normal' }}>
                       Best-case
@@ -552,8 +552,8 @@ function AddTaskModal(props) {
                 </span>
               </div>
               <div className="d-flex border align-items-center" >
-                <span className="p-1" style={{width: "30%"}}>Links</span>
-                <span className="p-1 border-left" style={{width: "70%"}}>
+                <span className="add_new_task_form-label">Links</span>
+                <span className="add_new_task_form-input_area">
                   <div className="d-flex flex-row">
                     <input
                       type="text"
@@ -588,8 +588,8 @@ function AddTaskModal(props) {
                 </span>
               </div>
               <div className="d-flex border align-items-center">
-                <span  className= "p-1" style={{width: "30%"}}>Category</span>
-                <span  className="p-1 border-left" style={{width: "70%"}}>
+                <span  className= "add_new_task_form-label">Category</span>
+                <span  className="add_new_task_form-input_area">
                   <select value={category} onChange={e => setCategory(e.target.value)}>
                     {categoryOptions.map(cla => (
                       <option value={cla.value} key={cla.value}>

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -510,6 +510,7 @@ function AddTaskModal(props) {
                     />
                     
                   </div>
+                        {/* Moved warning outside of the parent div so that the input field does not get affected , now the warnings should appear in a new line - Sucheta*/}
                   <div className="warning">
                       {hoursWarning
                         ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -488,11 +488,12 @@ function AddTaskModal(props) {
                       id="bestCase"
                       className="w-50 ml-2"
                     />
-                    <div className="warning">
+                    
+                  </div>
+                  <div className="warning">
                       {hoursWarning
                         ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
                         : ''}
-                    </div>
                   </div>
                   <div className="py-2 flex-responsive">
                     <label htmlFor="worstCase" className={`text-nowrap mr-2 w-25 mr-auto ${fontColor}`} style={{ fontWeight: 'normal' }}>
@@ -507,12 +508,13 @@ function AddTaskModal(props) {
                       onBlur={() => calHoursEstimate('hoursWorst')}
                       className="w-50 ml-2"
                     />
-                    <div className="warning">
+                    
+                  </div>
+                  <div className="warning">
                       {hoursWarning
                         ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
                         : ''}
                     </div>
-                  </div>
                   <div className="py-2 flex-responsive">
                     <label htmlFor="mostCase" className={`text-nowrap mr-2 w-25 mr-auto ${fontColor}`} style={{ fontWeight: 'normal' }}>
                       Most-case
@@ -526,12 +528,13 @@ function AddTaskModal(props) {
                       onBlur={() => calHoursEstimate('hoursMost')}
                       className="w-50 ml-2"
                     />
-                    <div className="warning">
+                    
+                  </div>
+                  <div className="warning">
                       {hoursWarning
                         ? 'Hours - Best-case < Hours - Most-case < Hours - Most-case'
                         : ''}
                     </div>
-                  </div>
                   <div className="py-2 flex-responsive">
                     <label htmlFor="Estimated" className={`text-nowrap mr-2 w-25 mr-auto ${fontColor}`} style={{ fontWeight: 'normal' }}>
                       Estimated

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -39,7 +39,8 @@ function AddTaskModal(props) {
     if (props.taskId) {
       return tasks.find(({ _id }) => _id === props.taskId).category;
     } 
-      return allProjects.projects.find(({ _id }) => _id === props.projectId).category;
+  
+    return allProjects.projects.find(({ _id }) => _id === props.projectId);
       
   }, []);
   const [taskName, setTaskName] = useState('');

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -39,7 +39,6 @@ function AddTaskModal(props) {
     if (props.taskId) {
       return tasks.find(({ _id }) => _id === props.taskId).category;
     } 
-  
     return allProjects.projects.find(({ _id }) => _id === props.projectId);
       
   }, []);

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -322,14 +322,14 @@ function AddTaskModal(props) {
         <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
           <div className="table table-bordered responsive">
             <div>
-              <div className="m-0 border d-flex">
-                <span className="border p-2 " data-tip="WBS ID" style={{width: "30%"}}>
+              <div className="m-0 border d-flex align-items-center">
+                <span className="p-1 " data-tip="WBS ID" style={{width: "30%"}}>
                   WBS #
                 </span>
 
                 <span className="border-left flex-grow-1 p-2">{newTaskNum}</span>
               </div>
-              <div className="m-0 border d-flex" >
+              <div className="m-0 border d-flex align-items-center" >
                 <span className="p-1" style={{width: "30%"}}>Task Name</span>
                 <span className="border-left p-1 flex-grow-1">
                   {/* Fix Task-name formatting - by Sucheta */}
@@ -343,7 +343,7 @@ function AddTaskModal(props) {
                   />
                 </span>
               </div >
-              <div className='m-0 border d-flex'>
+              <div className='m-0 border d-flex align-items-center'>
                 <span className="p-1" style={{width: "30%"}} >Priority</span>
                 <span className='border-left p-1 flex-grow-1'>
                   <select id="priority" onChange={e => setPriority(e.target.value)} ref={priorityRef}>
@@ -367,7 +367,7 @@ function AddTaskModal(props) {
                   
                 </span>
               </div>
-              <div className="m-0 border d-flex">
+              <div className="m-0 border d-flex align-items-center">
                 <span className="p-1" style={{width: "30%"}}>Assigned</span>
                 <span className="border-left p-1">
                   <div className="flex-row d-inline align-items-center" >
@@ -402,10 +402,10 @@ function AddTaskModal(props) {
                   </div>
                 </span>
               </div>
-              <div className="m-0 d-flex border">
+              <div className="m-0 d-flex border align-items-center">
                 <span className= "p-1" style={{width: "30%"}}>Status</span>
                 <span className="p-1 border-left" style={{width: "70%"}}>
-                 <div className="d-flex align-items-center"> 
+                 <div className="d-flex align-items-center flex-wrap"> 
                   <span className="form-check form-check-inline mr-5">
                       <input
                         className="form-check-input"
@@ -435,7 +435,7 @@ function AddTaskModal(props) {
                       </label>
                   </span>
                  </div>
-                 <div className="d-flex align-items-center">
+                 <div className="d-flex align-items-center flex-wrap">
                   <span className="form-check form-check-inline mr-5">
                         <input
                           className="form-check-input"
@@ -469,7 +469,7 @@ function AddTaskModal(props) {
                  </div>
                 </span>
               </div>
-              <div className="d-flex">
+              <div className="d-flex align-items-center">
                 <span className="p-1" style={{width: "30%"}}>
                   Hours
                 </span>
@@ -547,7 +547,7 @@ function AddTaskModal(props) {
                   </div>
                 </span>
               </div>
-              <div className="d-flex border" >
+              <div className="d-flex border align-items-center" >
                 <span className="p-1" style={{width: "30%"}}>Links</span>
                 <span className="p-1 border-left" style={{width: "70%"}}>
                   <div className="d-flex flex-row">
@@ -583,7 +583,7 @@ function AddTaskModal(props) {
                   </div>
                 </span>
               </div>
-              <div className="d-flex border">
+              <div className="d-flex border align-items-center">
                 <span  className= "p-1" style={{width: "30%"}}>Category</span>
                 <span  className="p-1 border-left" style={{width: "70%"}}>
                   <select value={category} onChange={e => setCategory(e.target.value)}>
@@ -595,8 +595,8 @@ function AddTaskModal(props) {
                   </select>
                 </span>
               </div>
-              <tr className='w-100'>
-                <td scope="col" colSpan="3">
+              <div >
+                <div scope="col" colSpan="2" className='border p-1' >
                   Why this Task is Important
                   <Editor
                     tinymceScriptSrc="/tinymce/tinymce.min.js"
@@ -607,10 +607,10 @@ function AddTaskModal(props) {
                     value={whyInfo}
                     onEditorChange={content => setWhyInfo(content)}
                   />
-                </td>
-              </tr>
-              <tr>
-                <td scope="col" colSpan="2">
+                </div>
+              </div>
+              <div>
+                <div scope="col" colSpan="2" className="border p-1">
                   Design Intent
                   <Editor
                     tinymceScriptSrc="/tinymce/tinymce.min.js"
@@ -621,10 +621,10 @@ function AddTaskModal(props) {
                     value={intentInfo}
                     onEditorChange={content => setIntentInfo(content)}
                   />
-                </td>
-              </tr>
-              <tr>
-                <td scope="col" colSpan="2">
+                </div>
+              </div>
+              <div>
+                <div scope="col" colSpan="2" className="border p-1"> 
                   Endstate
                   <Editor
                     tinymceScriptSrc="/tinymce/tinymce.min.js"
@@ -635,11 +635,11 @@ function AddTaskModal(props) {
                     value={endstateInfo}
                     onEditorChange={content => setEndstateInfo(content)}
                   />
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Start Date</td>
-                <td scope="col">
+                </div>
+              </div>
+              <div className="d-flex border">
+                <span scope="col" style={{width: "30%"}} className="p-1">Start Date</span>
+                <span scope="col" className="border-left p-1">
                   <div>
                     <DayPickerInput
                       format={FORMAT}
@@ -652,11 +652,11 @@ function AddTaskModal(props) {
                       {dateWarning ? DUE_DATE_MUST_GREATER_THAN_START_DATE : ''}
                     </div>
                   </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">End Date</td>
-                <td scope="col">
+                </span>
+              </div>
+              <div className="d-flex border align-items-center">
+                <span scope="col" style={{width: "30%"}} className="p-1">End Date</span>
+                <span scope="col" className='border-left p-1'>
                   <DayPickerInput
                     format={FORMAT}
                     formatDate={formatDate}
@@ -667,8 +667,8 @@ function AddTaskModal(props) {
                   <div className="warning">
                     {dateWarning ? DUE_DATE_MUST_GREATER_THAN_START_DATE : ''}
                   </div>
-                </td>
-              </tr>
+                </span>
+              </div>
             </div>
           </div>
         </ModalBody>

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Row, Col } from 'reactstrap';
 import { connect } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
@@ -320,17 +320,19 @@ function AddTaskModal(props) {
           </button>
         </ModalHeader>
         <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
-          <table className={`table table-bordered responsive ${fontColor}`}>
-            <tbody>
-              <tr>
-                <td scope="col" data-tip="WBS ID">
+          <div className="table table-bordered responsive">
+            <div>
+              <div className="m-0 border d-flex">
+                <span className="border p-2 " data-tip="WBS ID" style={{width: "30%"}}>
                   WBS #
-                </td>
-                <td scope="col">{newTaskNum}</td>
-              </tr>
-              <tr>
-                <td scope="col">Task Name</td>
-                <td scope="col">
+                </span>
+
+                <span className="border-left flex-grow-1 p-2">{newTaskNum}</span>
+              </div>
+              <div className="m-0 border d-flex" >
+                <span className="p-1" style={{width: "30%"}}>Task Name</span>
+                <span className="border-left p-1 flex-grow-1">
+                  {/* Fix Task-name formatting - by Sucheta */}
                   <textarea
                     type="text"
                     rows="2"
@@ -339,22 +341,21 @@ function AddTaskModal(props) {
                     onKeyPress={e => setTaskName(e.target.value)}
                     value={taskName}
                   />
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Priority</td>
-                <td scope="col">
+                </span>
+              </div >
+              <div className='m-0 border d-flex'>
+                <span className="p-1" style={{width: "30%"}} >Priority</span>
+                <span className='border-left p-1 flex-grow-1'>
                   <select id="priority" onChange={e => setPriority(e.target.value)} ref={priorityRef}>
                     <option value="Primary">Primary</option>
                     <option value="Secondary">Secondary</option>
                     <option value="Tertiary">Tertiary</option>
                   </select>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Resources</td>
-                <td scope="col">
-                  <div>
+                </span>
+              </div>
+              <div className="m-0 border d-flex align-items-center">
+                <span className="p-1" style={{width: "30%"}}>Resources</span>
+                <span className="border-left p-1" style={{width: "70%"}}>
                     <TagsSearch
                       placeholder="Add resources"
                       members={allMembers.filter(user=>user.isActive)}
@@ -363,12 +364,12 @@ function AddTaskModal(props) {
                       resourceItems={resourceItems}
                       disableInput={false}
                     />
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Assigned</td>
-                <td scope="col">
+                  
+                </span>
+              </div>
+              <div className="m-0 border d-flex">
+                <span className="p-1" style={{width: "30%"}}>Assigned</span>
+                <span className="border-left p-1">
                   <div className="flex-row d-inline align-items-center" >
                     <div className="form-check form-check-inline">
                       <input
@@ -399,13 +400,13 @@ function AddTaskModal(props) {
                       </label>
                     </div>
                   </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Status</td>
-                <td scope="col">
-                  <div className="flex-row  d-inline align-items-center" >
-                    <div className="form-check form-check-inline">
+                </span>
+              </div>
+              <div className="m-0 d-flex border">
+                <span className= "p-1" style={{width: "30%"}}>Status</span>
+                <span className="p-1 border-left" style={{width: "70%"}}>
+                 <div className="d-flex align-items-center"> 
+                  <span className="form-check form-check-inline mr-5">
                       <input
                         className="form-check-input"
                         type="radio"
@@ -418,8 +419,8 @@ function AddTaskModal(props) {
                       <label className={`form-check-label ${fontColor}`} htmlFor="active">
                         Active
                       </label>
-                    </div>
-                    <div className="form-check form-check-inline">
+                    </span>
+                  <span className="form-check">
                       <input
                         className="form-check-input"
                         type="radio"
@@ -432,22 +433,25 @@ function AddTaskModal(props) {
                       <label className={`form-check-label ${fontColor}`} htmlFor="notStarted">
                         Not Started
                       </label>
-                    </div>
-                    <div className="form-check form-check-inline">
-                      <input
-                        className="form-check-input"
-                        type="radio"
-                        id="paused"
-                        name="status"
-                        value="Paused"
-                        checked={status === 'Paused'}
-                        onChange={(e) => setStatus(e.target.value)}
-                      />
-                      <label className={`form-check-label ${fontColor}`} htmlFor="paused">
-                        Paused
-                      </label>
-                    </div>
-                    <div className="form-check form-check-inline">
+                  </span>
+                 </div>
+                 <div className="d-flex align-items-center">
+                  <span className="form-check form-check-inline mr-5">
+                        <input
+                          className="form-check-input"
+                          type="radio"
+                          id="paused"
+                          name="status"
+                          value="Paused"
+                          checked={status === 'Paused'}
+                          onChange={(e) => setStatus(e.target.value)}
+                        />
+                        <label className="form-check-label" htmlFor="paused">
+                          Paused
+                        </label>
+                    
+                  </span>
+                  <span className="form-check form-check-inline">
                       <input
                         className="form-check-input"
                         type="radio"
@@ -460,17 +464,18 @@ function AddTaskModal(props) {
                       <label className={`form-check-label ${fontColor}`} htmlFor="complete">
                         Complete
                       </label>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col" className="w-100">
+                   
+                  </span>
+                 </div>
+                </span>
+              </div>
+              <div className="d-flex">
+                <span className="p-1" style={{width: "30%"}}>
                   Hours
-                </td>
-                <td scope="col" className="w-100">
+                </span>
+                <span className="p-1 border-left" style={{width: "70%"}}>
                   <div className="py-2 flex-responsive">
-                    <label htmlFor="bestCase" className={`text-nowrap mr-2 w-25 mr-auto ${fontColor}`} style={{ fontWeight: 'normal' }}>
+                    <label htmlFor="bestCase" className="text-nowrap mr-3 w-25 mr-auto" style={{ fontWeight: 'normal' }}>
                       Best-case
                     </label>
                     <input
@@ -481,7 +486,7 @@ function AddTaskModal(props) {
                       onChange={e => setHoursBest(e.target.value)}
                       onBlur={() => calHoursEstimate()}
                       id="bestCase"
-                      className="w-25"
+                      className="w-50 ml-2"
                     />
                     <div className="warning">
                       {hoursWarning
@@ -500,7 +505,7 @@ function AddTaskModal(props) {
                       value={hoursWorst}
                       onChange={e => setHoursWorst(e.target.value)}
                       onBlur={() => calHoursEstimate('hoursWorst')}
-                      className="w-25"
+                      className="w-50 ml-2"
                     />
                     <div className="warning">
                       {hoursWarning
@@ -519,7 +524,7 @@ function AddTaskModal(props) {
                       value={hoursMost}
                       onChange={e => setHoursMost(e.target.value)}
                       onBlur={() => calHoursEstimate('hoursMost')}
-                      className="w-25"
+                      className="w-50 ml-2"
                     />
                     <div className="warning">
                       {hoursWarning
@@ -537,14 +542,14 @@ function AddTaskModal(props) {
                       max="500"
                       value={hoursEstimate}
                       onChange={e => setHoursEstimate(e.target.value)}
-                      className="w-25"
+                      className="w-50 ml-2"
                     />
                   </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Links</td>
-                <td scope="col">
+                </span>
+              </div>
+              <div className="d-flex border" >
+                <span className="p-1" style={{width: "30%"}}>Links</span>
+                <span className="p-1 border-left" style={{width: "70%"}}>
                   <div className="d-flex flex-row">
                     <input
                       type="text"
@@ -576,11 +581,11 @@ function AddTaskModal(props) {
                       ) : null,
                     )}
                   </div>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col">Category</td>
-                <td scope="col">
+                </span>
+              </div>
+              <div className="d-flex border">
+                <span  className= "p-1" style={{width: "30%"}}>Category</span>
+                <span  className="p-1 border-left" style={{width: "70%"}}>
                   <select value={category} onChange={e => setCategory(e.target.value)}>
                     {categoryOptions.map(cla => (
                       <option value={cla.value} key={cla.value}>
@@ -588,10 +593,10 @@ function AddTaskModal(props) {
                       </option>
                     ))}
                   </select>
-                </td>
-              </tr>
-              <tr>
-                <td scope="col" colSpan="2">
+                </span>
+              </div>
+              <tr className='w-100'>
+                <td scope="col" colSpan="3">
                   Why this Task is Important
                   <Editor
                     tinymceScriptSrc="/tinymce/tinymce.min.js"
@@ -664,8 +669,8 @@ function AddTaskModal(props) {
                   </div>
                 </td>
               </tr>
-            </tbody>
-          </table>
+            </div>
+          </div>
         </ModalBody>
         <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
           <Button color="primary" onClick={addNewTask} disabled={taskName === '' || hoursWarning || isLoading} style={darkMode ? boxStyleDark : boxStyle}>

--- a/src/components/Projects/WBS/WBSDetail/wbs.css
+++ b/src/components/Projects/WBS/WBSDetail/wbs.css
@@ -193,3 +193,24 @@
 
   }
 }
+
+
+.add_new_task_form-group{
+  width: 100%;
+  padding: 0;
+  display: flex;
+  border: .01em solid #cdcbcb;
+}
+
+.add_new_task_form-label{
+  width: 30%;
+  padding: .5em .25em;
+  margin-left: .25em;
+}
+.add_new_task_form-input_area{
+  width: 70%;
+  padding: 0;
+  margin: .25em;
+  border-left: 1px solid #bbb;
+  padding-left: .25em;
+}


### PR DESCRIPTION
# Description
(PRIORITY HIGH) Jae: Improve “Add New Task” modal format
- Make Task Name box bigger
- Fix Status Section so everything fits on 2 lines
- Fix hours input width so up to a 4-digit number will show
- [Video clarification](https://www.loom.com/share/80b70f2750ad4f00abee0d6fdeeca4f9?sid=8f6037a8-169b-4b97-bf79-39051f93fea3)

## Related PRS (if any):
None

## Main changes explained:
- Changed html tags in `AddTaskModal.jsx` , from `<tr>` to `<div>` and `<td>` to `<span>` for the form labels and input fields
- Adds css classes to the style the `<div>` and `<span>` elements.


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ Projects → WBS -> Tasks -> Add Task
6. The input fields now take more space than the labels.

## Screenshots or videos of changes:
Before the change: 

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/2482fa39-6d7c-4078-ab7f-b2fab529aa2c

After the change: 


https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/c30ffe4b-0314-4db0-bedc-07e6784eeedf





## Note:
Extended version of
- [PR2167](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2167)
This PR resolved a bug , please refer to the picture below:
<img width="416" alt="Screenshot 2024-04-26 at 1 36 24 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/101291283/4b423b82-68db-4fae-8008-9c5499534a05">
- [PR2198](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2198), implemented style classes as suggested in the code reviews.
PLEASE NOTE: This PR does not change or debug any functionality issues related to this modal. This PR only fixes the css format.
This PR has a change in `AddTaskModal.jsx` on line 41
(Extended version: [PR2284](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2284))