### PR TITLE
Chris_Weekly_Summaries_Report_Refresh_Button

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -23,6 +23,7 @@ import moment from 'moment';
 import 'moment-timezone';
 import { boxStyle, boxStyleDark } from 'styles';
 import EditableInfoModal from 'components/UserProfile/EditableModal/EditableInfoModal';
+import { toast } from 'react-toastify';
 import SkeletonLoading from '../common/SkeletonLoading';
 import { getWeeklySummariesReport } from '../../actions/weeklySummariesReport';
 import FormattedReport from './FormattedReport';
@@ -327,6 +328,34 @@ export class WeeklySummariesReport extends Component {
     return 0;
   };
 
+  handleRefresh = async () => {
+    this.setState({ loading: true });
+
+    try {
+      const res = await this.props.getWeeklySummariesReport();
+      const summaries = res?.data ?? this.props.summaries;
+
+      const summariesCopy = this.alphabetize(summaries);
+      const updatedSummaries = summariesCopy.map(summary => {
+        const promisedHoursByWeek = this.weekDates.map(weekDate =>
+          this.getPromisedHours(weekDate.toDate, summary.weeklycommittedHoursHistory),
+        );
+        return { ...summary, promisedHoursByWeek };
+      });
+
+      this.setState({
+        loading: false,
+        summaries: updatedSummaries,
+        filteredSummaries: updatedSummaries,
+      });
+
+      toast.success('Successfully Updated Weekly Summaries Report');
+    } catch (error) {
+      this.setState({ loading: false });
+      toast.error('Failed to update Weekly Summaries Report');
+    }
+  };
+
   toggleTab = tab => {
     const { activeTab } = this.state;
     if (activeTab !== tab) {
@@ -503,6 +532,7 @@ export class WeeklySummariesReport extends Component {
         </Container>
       );
     }
+
     return (
       <Container
         fluid
@@ -517,6 +547,15 @@ export class WeeklySummariesReport extends Component {
             <h3 className="mt-3 mb-5">
               <div className="d-flex align-items-center">
                 <span className="mr-2">Weekly Summaries Reports page</span>
+                <i
+                  data-toggle="tooltip"
+                  data-placement="right"
+                  title="Click to refresh the report"
+                  style={{ fontSize: 24, cursor: 'pointer' }}
+                  aria-hidden="true"
+                  className={`fa fa-refresh ${this.state.loading ? 'animation' : ''} mr-2`}
+                  onClick={this.handleRefresh}
+                />
                 <EditableInfoModal
                   areaName="WeeklySummariesReport"
                   areaTitle="Weekly Summaries Report"


### PR DESCRIPTION
# Description
![Screenshot 2024-06-04 at 1 28 59 AM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/5c4ec347-4adc-47c0-9d04-568ffe66a6cd)

## Related PRS (if any):
This frontend pr is not related to any backend pr, please just check-in to the development branch.

## Main changes explained:
- Added the icon of the refresh button
- Implemented the handleRefresh function to retrieve the newest summaries

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Links → Reports → Weekly Summaries Reports
6. verify the refresh button is clickable
7. verify the data is refreshed with a pop up showing "Successfully Updated Weekly Summaries Report"

## Screenshots or videos of changes:
There is a newly added refresh button
![Screenshot 2024-06-04 at 1 35 10 AM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/4da5d2fe-9747-45b6-a013-ab18207dd001)
After clicking the button and wait for a little bit, it's going to show the message and the data is refreshed
![Screenshot 2024-06-04 at 1 35 39 AM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/3ad7415f-96c4-416f-b5c3-ca7ce74499dc)

