### PR TITLE
Peizhou_fix the profile image format error

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -777,6 +777,7 @@ function UserProfile(props) {
                 alt="Profile Picture"
                 roundedCircle
                 className="profilePicture bg-white"
+                style={profilePic ? {} : { width: '240px', height: '240px' }}
               />
               {canEdit ? (
                 <div className="image-button file btn btn-lg btn-primary" style={darkMode ? boxStyleDark : boxStyle}>

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -44,11 +44,6 @@
   text-align: center;
 }
 
-.profile-img img {
-  width: 70%;
-  height: 100%;
-}
-
 .profile-img .file {
   position: relative;
   overflow: hidden;
@@ -183,8 +178,12 @@
 }
 
 .profilePicture {
-  width: 150px;
-  height: 150px;
+  display: flex;
+  max-width: 240px;
+  max-height: 240px;
+  width: auto;
+  height: auto;
+  margin: auto;
 }
 
 .whoSection {


### PR DESCRIPTION
# Description
![Capture](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/95693786/ff00cd72-85df-49e6-bc80-6810d9947e91)

## Related PRS (if any):
This frontend PR is not related to any backend PR, please just check in to the development branch.

## Main changes explained:
- Fix the profile image formatting error, now, the user can upload a long image without affecting the entire page.

## How to test:
1. check into the current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in
5. go to dashboard→ Profile
6. upload a long image as the profile image
7. verify that no matter what kind of image is uploaded, it will not affect the formatting of the entire page

## Screenshots or videos of changes:
Screenshot:
![my_PR_2](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/95693786/4f3b6585-133d-432a-9d58-8971bf533021)
Video:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/95693786/b41cb800-5773-4078-9bff-7e8b961ca605




