### PR TITLE
Kyrene - Allow volunteers, admin and owners to click task and navigate to task page

### DIFF
--- a/src/utils/routePermissions.js
+++ b/src/utils/routePermissions.js
@@ -49,6 +49,7 @@ export const RoutePermissions = {
     'updateTask',
     'deleteTask',
     'resolveTask',
-    'putReviewStatus'
+    'putReviewStatus',
+    'suggestTask'
   ]
 };


### PR DESCRIPTION
…ructure key to allow volunteers to open /wbs/tasks/taskId route

# Description
- This bug is to fix the ability for members to open their tasks from the landing page under Tasks tab. 

![Screenshot 2024-06-07 at 3 52 37 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/129882345/bd5606e9-0895-4cf7-92f0-0e5248438ebb)

[Video of bug](https://drive.google.com/file/d/1zNa7cRoKpSLFoa6L_5ZRGlMZbUQV1LmF/view)


## Related PRS (if any):
This frontend PR is related to the #1458.

…

## Main changes explained:
-Added 'suggestTask' to the 'workBreakdownStructure' key in the routePermissions.js to grant permission to access the protected route /wbs/tasks/:taskId, which includes the Task and its suggest task page.
…

## How to test:
1. check into current branch: [Kyrene_fix_bug_opening_task_page]
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as volunteer user
5. go to dashboard→  'Tasks and Timelogs' table on landing page > Tasks tab → under Tasks(s)→  click blue text for task description…
(if there are no tasks you must create one for your volunteer account using an owner or admin account. how to video below)
7. verify you can click on the task link as a volunteer, admin and owner

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/129882345/04519abe-02a6-42ed-9e49-c8d629661668



## Screenshots or videos of changes:
- Final desired functionality:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/129882345/fe64bccf-b952-4d2b-ab09-881091535eed


## Note:
Include the information the reviewers need to know.
