### PR TITLE
Nathalia make blue square description box bigger and auto-fit

### DIFF
--- a/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
@@ -125,6 +125,7 @@ const UserProfileModal = props => {
     } else if (event.target.id === 'summary') {
       setSummary(event.target.value);
       checkFields(dateStamp, summary);
+      adjustTextareaHeight(event.target);
     } else if (event.target.id === 'date') {
       setDateStamp(event.target.value);
       setSummaryFieldView(false);
@@ -141,6 +142,11 @@ const UserProfileModal = props => {
       setAddButton(true);
     }
   }
+
+  const adjustTextareaHeight = (textarea) => {
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  };
 
   const boxStyling = darkMode ? boxStyleDark : boxStyle;
   const fontColor = darkMode ? 'text-light' : '';
@@ -315,7 +321,14 @@ const UserProfileModal = props => {
 
             <FormGroup hidden={summaryFieldView}>
               <Label className={fontColor} for="report">Summary</Label>
-              <Input type="textarea" id="summary" onChange={handleChange} />
+              <Input 
+                type="textarea" 
+                id="summary" 
+                onChange={handleChange} 
+                value={summary} 
+                style={{ minHeight: '200px', overflow: 'hidden'}} 
+                onInput={e => adjustTextareaHeight(e.target)} 
+              />
             </FormGroup>
           </>
         )}
@@ -334,7 +347,14 @@ const UserProfileModal = props => {
             </FormGroup>
             <FormGroup>
               <Label className={fontColor} for="report">Summary</Label>
-              <Input type="textarea" onChange={e => setSummary(e.target.value)} value={summary} />
+              <Input 
+                type="textarea" 
+                id="summary" 
+                onChange={handleChange} 
+                value={summary} 
+                style={{ minHeight: '200px', overflow: 'hidden'}} // 4x taller than usual
+                onInput={e => adjustTextareaHeight(e.target)} // auto-adjust height
+              />
             </FormGroup>
           </>
         )}


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69649453/b6d253a6-8dae-4739-a05f-b679c3736db8)

## Related PRS (if any):
This frontend PR is related to the dev backend PR.

## Main changes explained:
- Created a function called adjustTextareaHeight which adjusts the height of the textarea dynamically based on its scroll height, ensuring it grows to fit the content as the user types.
- Set the minimum height of the textarea to 200 pixels to ensure it is taller by default, and added overflow hidden. 

## How to test:
1. Check into current branch.
2. Do `npm install` and `npm run start:local` to run this PR locally.
3. Clear site data/cache.
4. Log as admin/owner user.
6. Go to Dashboard→ User Profile→Blue Squares→Select a blue square (to edit or add a new one).
7. Ensure that the default height of the input field for the summary is 4x taller than before.
8. Add some text to the summary field and verify that the height of the field expands dynamically to fit the content.

## Screenshots or videos of changes:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69649453/f3121205-8543-4edb-b222-16249d0e0577

## Note:
...
