### PR TITLE
Remove TinyMCE cloud script from /public/index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,10 +11,6 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="stylesheet" href="%PUBLIC_URL%/index.css" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <script
-      src="https://cdn.tiny.cloud/1/1rsz7lmakcvzg8trwjy91zht48pj4oubz8jrdyqxbbr63pvs/tinymce/5/tinymce.min.js"
-      referrerpolicy="origin"
-    ></script>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
# Description
**Remove a static TinyMCE cloud resource reference in the application. One line code is deleted.**

## Main changes explained:
- Update file public/index.html, removing TinyMCE cloud script reference.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Verify that all editors work as expected


## Screenshots or videos of changes:
<img width="710" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69882989/dc400e7d-a2d6-4363-9c50-e9fb3493bc7e">

## Note:
Include the information the reviewers need to know.
