### PR TITLE
Youyou click profile icon open in new tab

### DIFF
--- a/src/components/UserManagement/ProfileNavDot.jsx
+++ b/src/components/UserManagement/ProfileNavDot.jsx
@@ -1,14 +1,14 @@
 import { React } from 'react';
 import { useHistory } from 'react-router';
 
-// pass userId of an account to navigate to user profile onClick of icon
+// pass userId of an account to navigate to user profile onClick of icon and open in new tab
 export const ProfileNavDot = ({ userId }) => {
   const history = useHistory();
   return (
     <span
       style={{ fontSize: '1.5rem' }}
       onClick={() => {
-        history.push(`/userprofile/${userId}`);
+        window.open(`/userprofile/${userId}`, '_blank', 'noopener,noreferrer');
       }}
       title="Click here to go to the user's profile."
     >

--- a/src/components/UserManagement/ProfileNavDot.jsx
+++ b/src/components/UserManagement/ProfileNavDot.jsx
@@ -1,15 +1,27 @@
 import { React } from 'react';
 import { useHistory } from 'react-router';
 
-// pass userId of an account to navigate to user profile onClick of icon and open in new tab
+// pass userId of an account to navigate to user profile onClick of icon and open in new tab if Command or Control key is pressed
 export const ProfileNavDot = ({ userId }) => {
   const history = useHistory();
+
+  const handleClick = (event) => {
+    const url = `/userprofile/${userId}`;
+
+    // Check if Command key (metaKey) or Control key (ctrlKey) is pressed
+    if (event.metaKey || event.ctrlKey) {
+      // Open the URL in a new tab
+      window.open(url, '_blank', 'noopener,noreferrer');
+    } else {
+      // Navigate to the URL in the current tab
+      history.push(url);
+    }
+  };
+
   return (
     <span
-      style={{ fontSize: '1.5rem' }}
-      onClick={() => {
-        window.open(`/userprofile/${userId}`, '_blank', 'noopener,noreferrer');
-      }}
+      style={{ fontSize: '1.5rem', cursor: 'pointer' }}
+      onClick={handleClick}
       title="Click here to go to the user's profile."
     >
       <i className="fa fa-user"/>


### PR DESCRIPTION

# Description

Give ability to command (mac)/control (PC) + click profile icon from Dashboard->Tasks and Timelogs panel

## Related PRS (if any):

This frontend PR is not related to the other backend PR. Use Development backend branch.

## Main changes explained:

- Updated onClick event in ProfileNavDot.jsx to open in new tab if command (mac)/control (PC) + click profile icon. Otherwise, open in current tab.

## How to test:

1. Check into current branch
2. Do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. Log as any user
5. Go to Dashboard. Find the panel Tasks and Timelogs. Find the profile icon to its right. 
6. command (mac)/control (PC) + click profile icon: check if it opens user profile page in new tab.
7. Directly click profile icon: check if it opens in current tab.

## Screenshots or videos of changes:
![691-ezgif com-video-to-gif-converter](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/66922622/0ef6f901-c818-4d22-8bde-c1b3283ce13c)


## Note:
N/A