### PR TITLE
Chris_ignore_spaces_inputs_user_management_search

### DIFF
--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -486,7 +486,7 @@ class UserManagement extends React.PureComponent {
    */
   onFirstNameSearch = searchText => {
     this.setState({
-      firstNameSearchText: searchText,
+      firstNameSearchText: searchText.trim(),
       selectedPage: 1,
     });
   };
@@ -496,7 +496,7 @@ class UserManagement extends React.PureComponent {
    */
   onLastNameSearch = searchText => {
     this.setState({
-      lastNameSearchText: searchText,
+      lastNameSearchText: searchText.trim(),
       selectedPage: 1,
     });
   };
@@ -516,7 +516,7 @@ class UserManagement extends React.PureComponent {
    */
   onEmailSearch = searchText => {
     this.setState({
-      emailSearchText: searchText,
+      emailSearchText: searchText.trim(),
       selectedPage: 1,
     });
   };
@@ -526,7 +526,7 @@ class UserManagement extends React.PureComponent {
    */
   onWeeklyHrsSearch = searchText => {
     this.setState({
-      weeklyHrsSearchText: searchText,
+      weeklyHrsSearchText: searchText.trim(),
       selectedPage: 1,
     });
   };
@@ -555,7 +555,7 @@ class UserManagement extends React.PureComponent {
    */
   onWildCardSearch = searchText => {
     this.setState({
-      wildCardSearchText: searchText,
+      wildCardSearchText: searchText.trim(),
       selectedPage: 1,
     });
   };

--- a/src/components/UserManagement/UserTableSearchHeader.jsx
+++ b/src/components/UserManagement/UserTableSearchHeader.jsx
@@ -33,16 +33,16 @@ const UserTableSearchHeader = React.memo((props) => {
     <tr className={darkMode ? 'bg-yinmn-blue text-light' : ''}>
       <td id="user_active"></td>
       <td id="user_first">
-        <TextSearchBox id={'firts_name_search'} searchCallback={onFirstNameSearch} />
+        <TextSearchBox id={'firts_name_search'} searchCallback={onFirstNameSearch} placeholder=" Search First Name"/>
       </td>
       <td id="user_last_name">
-        <TextSearchBox id={'last_name_search'} searchCallback={onLastNameSearch} />
+        <TextSearchBox id={'last_name_search'} searchCallback={onLastNameSearch} placeholder=" Search Last Name"/>
       </td>
       <td id="user_role">
         <DropDownSearchBox id={'role_search'} items={props.roles} searchCallback={onRoleSearch} />
       </td>
       <td id="user_email" >
-        <TextSearchBox id={'email_search'} searchCallback={onEmailSearch} style={{ width:'100%' }}/>
+        <TextSearchBox id={'email_search'} searchCallback={onEmailSearch} style={{ width:'100%' }} placeholder=" Search Email"/>
       </td>
       <td id="user_hrs" style= {{ display: 'flex' }}>
         <TextSearchBox


### PR DESCRIPTION
# Description
<img width="761" alt="Screenshot 2024-06-10 at 10 47 13 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/a6c4f814-3f9b-45d8-a915-d56aab19c43d">
The search for the User Management search should ignore the starting and trailing spaces

## Related PRS (if any):
Not related to any backend prs. For the backend please just check in to the development branch

## Main changes explained:
Ignored the starting and trailing spaces for the following searchbox and the headers
- firstNameSearchText
- lastNameSearchText
- emailSearchText
- weeklyHrsSearchText
- wildCardSearchText

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Admin Login → Other Links → User Management
6. For the SearchBox enter:    ChrisAdmin
7. For the FirstName enter:   Chris  
8. For the LastName enter:     Chen  
9. For the Email enter:     chrischen  
10. For the Weekly Committed Hours enter:   5   
(For the test, you can use your own test cases, just add some starting and trailing spaces to them 

## Screenshots or videos of changes:
[The original problem recorded by Jae](https://www.loom.com/share/965d643e027b437f9116d18602504020?sid=e4a4700b-453e-46a6-b63d-4ce0bf660036)

This is my fixture of problem
For the TextBox, it's not allowing spaces anyway
<img width="1696" alt="Screenshot 2024-06-10 at 11 17 07 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/2fb1600d-2ff3-40d0-8468-e37b90558f14">
For the first name, you can see the search results with the spaces
<img width="1696" alt="Screenshot 2024-06-10 at 11 17 34 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/5c2874cc-374c-450b-b8c1-f5294edc24ef">
For the last name, you can see the search results with the spaces
<img width="1696" alt="Screenshot 2024-06-10 at 11 17 54 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/d8c9cdb9-d92f-41b8-9176-66f38084098c">
For the email, you can see the search results with the spaces
<img width="1696" alt="Screenshot 2024-06-10 at 11 18 16 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/b05b04c6-8100-46b4-96aa-a50fd76e5d23">
For the Weekly Committed Hours, you can see the search results with the spaces
<img width="1696" alt="Screenshot 2024-06-10 at 11 18 36 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/4764423c-db21-4615-8787-5e508c160056">

## Note:
For the search box, it's automatically voiding the starting and trailing spaces, but for other text boxes in the headers, it does not ignore the spaces. The main goal of this PR is to be able to bring up the search results with the spaces.
