### PR TITLE
Nathalia remove note from editable modals

### DIFF
--- a/src/components/UserProfile/EditableModal/EditableInfoModal.jsx
+++ b/src/components/UserProfile/EditableModal/EditableInfoModal.jsx
@@ -257,14 +257,6 @@ export class EditableInfoModal extends Component {
                     dangerouslySetInnerHTML={{ __html: infoContent }}
                     onClick={() => this.handleEdit(true)} />
                 }
-                {isPermissionPage && CanEdit &&
-                  (
-                    <div style={{ paddingLeft: '20px' }}>
-                      <p>Click above to edit this content. (Note: Only works on Permissions Management Page)</p>
-                    </div>
-
-                  )
-                }
               </ModalBody>
               <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
                 <Row className='no-gutters'>


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69649453/503d74f0-73ac-445a-bacb-3c8dc862d8c4)

## Related PRS (if any):
This frontend PR is related to the dev backend PR.

## Main changes explained:
- Deleted the condition related to showing the note.

## How to test:
1. Check into current branch.
2. Do `npm install` and `npm run start:local` to run this PR locally.
3. Clear site data/cache.
4. Log as owner user.
5. Verify that all editable info modals on all pages do not display the following message at the bottom: “(Note: Only works on Permissions Management Page)."

## Screenshots or videos of changes:
Before:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69649453/cfabbb0b-ff68-4af9-9dab-070727c68d5f



After:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69649453/ac530f6c-6658-47b6-9430-775f0ce50580


## Note:
...