### PR TITLE
Peizhou - Fix the profile image formatting error

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -777,6 +777,7 @@ function UserProfile(props) {
                 alt="Profile Picture"
                 roundedCircle
                 className="profilePicture bg-white"
+                style={profilePic ? {} : { width: '240px', height: '240px' }}
               />
               {canEdit ? (
                 <div className="image-button file btn btn-lg btn-primary" style={darkMode ? boxStyleDark : boxStyle}>

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -44,11 +44,6 @@
   text-align: center;
 }
 
-.profile-img img {
-  width: 70%;
-  height: 100%;
-}
-
 .profile-img .file {
   position: relative;
   overflow: hidden;
@@ -183,8 +178,12 @@
 }
 
 .profilePicture {
-  width: 150px;
-  height: 150px;
+  display: flex;
+  max-width: 240px;
+  max-height: 240px;
+  width: auto;
+  height: auto;
+  margin: auto;
 }
 
 .whoSection {


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/95693786/3fa19a15-9597-4b15-9844-bfc0c7736fd4)

## Related PRS (if any):
This frontend PR is not related to any backend PR, please just check in to the development branch.

## Main changes explained:
- Fix the profile image formatting error, now, the user can upload a long image without affecting the entire page.

## How to test:
1. check into the current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log in
5. go to dashboard→ Profile
6. upload a long image as the profile image
7. verify that no matter what kind of image is uploaded, it will not affect the formatting of the entire page

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/95693786/9d08a613-d6e6-4371-b307-12c5504ba2ac

![my_PR_2](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/95693786/eaf3559d-649e-4c6d-9f07-74c01b728115)

## Note:
This PR is originally PR#2323, and it has 4 approvals already.
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/95693786/f0dfe33d-2f0f-4680-b28a-9f4fdfce0ad2)


