### PR TITLE
Chris_teamMemberTasks_reducer_unittest

### DIFF
--- a/src/components/TeamMemberTasks/__tests__/reducer.test.js
+++ b/src/components/TeamMemberTasks/__tests__/reducer.test.js
@@ -1,0 +1,105 @@
+import { teamMemberTasksReducer } from '../reducer';
+describe('teamMemberTasksReducer', () => {
+  const initialState = {
+    isLoading: false,
+    usersWithTasks: [],
+    usersWithTimeEntries: [],
+  };
+
+  it('should return the initial state when no action is provided', () => {
+    expect(teamMemberTasksReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should handle FETCH_TEAM_MEMBERS_DATA_BEGIN', () => {
+    const action = { type: 'FETCH_TEAM_MEMBERS_DATA_BEGIN' };
+    const expectedState = { ...initialState, isLoading: true };
+    expect(teamMemberTasksReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle FETCH_TEAM_MEMBERS_DATA_ERROR', () => {
+    const action = { type: 'FETCH_TEAM_MEMBERS_DATA_ERROR' };
+    const expectedState = { ...initialState, isLoading: false };
+    expect(teamMemberTasksReducer({ ...initialState, isLoading: true }, action)).toEqual(expectedState);
+  });
+
+  it('should handle FETCH_TEAM_MEMBERS_TASK_SUCCESS', () => {
+    const action = {
+      type: 'FETCH_TEAM_MEMBERS_TASK_SUCCESS',
+      payload: { usersWithTasks: [{ id: 1, name: 'John Doe' }] },
+    };
+    const expectedState = { ...initialState, isLoading: false, usersWithTasks: [{ id: 1, name: 'John Doe' }] };
+    expect(teamMemberTasksReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle FETCH_TEAM_MEMBERS_TIMEENTRIES_SUCCESS', () => {
+    const action = {
+      type: 'FETCH_TEAM_MEMBERS_TIMEENTRIES_SUCCESS',
+      payload: { usersWithTimeEntries: [{ _id: 1, hours: 10 }] },
+    };
+    const expectedState = { ...initialState, isLoading: false, usersWithTimeEntries: [{ _id: 1, hours: 10 }] };
+    expect(teamMemberTasksReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle UPDATE_TEAM_MEMBERS_TIMEENTRY_SUCCESS', () => {
+    const action = {
+      type: 'UPDATE_TEAM_MEMBERS_TIMEENTRY_SUCCESS',
+      payload: { _id: 1, hours: 15 },
+    };
+    const initialStateWithEntries = {
+      ...initialState,
+      usersWithTimeEntries: [{ _id: 1, hours: 10 }],
+    };
+    const expectedState = {
+      ...initialState,
+      usersWithTimeEntries: [{ _id: 1, hours: 15 }],
+    };
+    expect(teamMemberTasksReducer(initialStateWithEntries, action)).toEqual(expectedState);
+  });
+
+  it('should handle DELETE_TASK_NOTIFICATION_SUCCESS', () => {
+    const action = {
+      type: 'DELETE_TASK_NOTIFICATION_SUCCESS',
+      payload: {
+        userId: 1,
+        taskId: 1,
+        taskNotificationId: 1,
+      },
+    };
+    const initialStateWithTasks = {
+      ...initialState,
+      usersWithTasks: [
+        {
+          personId: 1,
+          tasks: [
+            {
+              _id: 1,
+              taskNotifications: [{ _id: 1 }, { _id: 2 }],
+            },
+          ],
+        },
+      ],
+    };
+    const expectedState = {
+      ...initialState,
+      usersWithTasks: [
+        {
+          personId: 1,
+          tasks: [
+            {
+              _id: 1,
+              taskNotifications: [{ _id: 2 }],
+            },
+          ],
+        },
+      ],
+      isLoading: false,
+    };
+    expect(teamMemberTasksReducer(initialStateWithTasks, action)).toEqual(expectedState);
+  });
+
+  it('should handle DELETE_TASK_NOTIFICATION_BEGIN', () => {
+    const action = { type: 'DELETE_TASK_NOTIFICATION_BEGIN' };
+    const expectedState = { ...initialState, isLoading: true };
+    expect(teamMemberTasksReducer(initialState, action)).toEqual(expectedState);
+  });
+});


### PR DESCRIPTION
# Description
This is a unit test for the src/components/TeamMemberTasks/reducer.js

## Main changes explained:
- fetchTeamMembersDataBegin: Ensures the action to begin fetching team members' data is handled correctly by setting isLoading to true.
- fetchTeamMembersDataError: Ensures the action for handling errors while fetching team members' data is handled correctly by setting isLoading to false.
- fetchTeamMembersTaskSuccess: Ensures the action for successfully fetching team members' tasks is handled correctly by updating usersWithTasks with the payload data and setting isLoading to false.
- fetchTeamMembersTimeEntriesSuccess: Ensures the action for successfully fetching team members' time entries is handled correctly by updating usersWithTimeEntries with the payload data and setting isLoading to false.
- updateTeamMembersTimeEntrySuccess: Ensures the action for successfully updating a team member's time entry is handled correctly by updating the specific entry in usersWithTimeEntries with the payload data.
- deleteTaskNotificationBegin: Ensures the action to begin deleting a task notification is handled correctly by setting isLoading to true.
- deleteTaskNotificationSuccess: Ensures the action for successfully deleting a task notification is handled correctly by updating usersWithTasks to remove the specified task notification and setting isLoading to false.

## How to test:
- check into current branch
- do `npm test src/components/TeamMemberTasks/__tests__/reducer.test.js`
- check if all the test cases pass as expected without any warnings or errors

## Screenshots or videos of changes:
![Screenshot 2024-06-16 at 11 58 22 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/df7e6873-25c2-496b-997d-cbc833e960c9)

