### PR TITLE
Nahiyan_Fix table header for mobile display

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.css
+++ b/src/components/LeaderBoard/Leaderboard.css
@@ -14,11 +14,11 @@
     display: relative;
   }
 
-  thead th {
+  .leaderboard thead th {
     position: sticky;
     top: 0;
-    background-color: aliceblue;
-    border-top: 1px solid #dee2e6;
+    background-color: #1c2541;
+    border-top: 10px solid #dee2e6;
     border-top-width: 1px;
     border-top-style: solid;
     border-top-color: rgb(222, 226, 230);


### PR DESCRIPTION
# Description
Created a fix for all table headers in dark mode. Previously, the background of all table headers would change to light mode.

## Related PRS (if any):
This frontend PR is related to the dev backend

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ Leaderboard
6. verify that in dark mode, the table header when smaller than 544px doesn't convert back to light mode
7. Another place to check is user management table and reports table

## Screenshots or videos of changes:
Before: 
![Screenshot 2024-06-17 102749](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/224a954c-6632-4ddd-9b8d-f0702b8c4ddb)

After:
![Screenshot 2024-06-17 102812](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/1c9e9fc1-802e-46f0-a280-6a114e90319e)
