### PR TITLE
kaushik_people-status_rehireable_by_default

### DIFF
--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -28,7 +28,7 @@ import { getPeopleReportData } from './selectors';
 import { PeopleTasksPieChart } from './components';
 import ToggleSwitch from '../../UserProfile/UserProfileEdit/ToggleSwitch';
 import { Checkbox } from '../../common/Checkbox';
-import {updateRehireableStatus} from '../../../actions/userManagement'
+import { updateRehireableStatus } from '../../../actions/userManagement'
 
 class PeopleReport extends Component {
   constructor(props) {
@@ -47,7 +47,7 @@ class PeopleReport extends Component {
       // eslint-disable-next-line react/no-unused-state
       isAssigned: '',
       isActive: '',
-      isRehireable: false,
+      isRehireable: true,
       // eslint-disable-next-line react/no-unused-state
       priority: '',
       // eslint-disable-next-line react/no-unused-state
@@ -441,10 +441,10 @@ class PeopleReport extends Component {
         >
           <div className={`report-stats ${darkMode ? 'text-light' : ''}`}>
             <p>
-              <Link to={`/userProfile/${_id}`} 
-                    title="View Profile" 
-                    className={darkMode ? 'text-light font-weight-bold' : ''}
-                    style={{fontSize: "24px"}}>
+              <Link to={`/userProfile/${_id}`}
+                title="View Profile"
+                className={darkMode ? 'text-light font-weight-bold' : ''}
+                style={{ fontSize: "24px" }}>
                 {firstName} {lastName}
               </Link>
             </p>
@@ -452,16 +452,16 @@ class PeopleReport extends Component {
             <p>Title: {jobTitle}</p>
 
             {/* {endDate ? ( */}
-              <div className="rehireable">
-                <Checkbox
-                  value={isRehireable}
-                  onChange={() => this.setRehireable(!isRehireable)}
-                  label="Rehireable"
-                  darkMode={darkMode}
-                  backgroundColorCN={darkMode ? "bg-yinmn-blue" : ""}
-                  textColorCN={darkMode ? "text-light" : ""}
-                />
-              </div>
+            <div className="rehireable">
+              <Checkbox
+                value={isRehireable}
+                onChange={() => this.setRehireable(!isRehireable)}
+                label="Rehireable"
+                darkMode={darkMode}
+                backgroundColorCN={darkMode ? "bg-yinmn-blue" : ""}
+                textColorCN={darkMode ? "text-light" : ""}
+              />
+            </div>
             {/* ) : (
               ''
             )} */}
@@ -516,7 +516,7 @@ class PeopleReport extends Component {
     return (
       <div className={`container-people-wrapper ${darkMode ? 'bg-oxford-blue' : ''}`}>
         <ReportPage renderProfile={renderProfileInfo} darkMode={darkMode}>
-          <div className={`people-report-time-logs-wrapper ${tangibleHoursReportedThisWeek === 0 ? "auto-width-report-time-logs-wrapper": ""}`}>
+          <div className={`people-report-time-logs-wrapper ${tangibleHoursReportedThisWeek === 0 ? "auto-width-report-time-logs-wrapper" : ""}`}>
             <ReportPage.ReportBlock
               firstColor="#ff5e82"
               secondColor="#e25cb2"
@@ -561,10 +561,10 @@ class PeopleReport extends Component {
             </ReportPage.ReportBlock>
           </div>
 
-          <PeopleTasksPieChart darkMode={darkMode}/>
+          <PeopleTasksPieChart darkMode={darkMode} />
           <div className="mobile-people-table">
             <ReportPage.ReportBlock darkMode={darkMode}>
-              <div className={`intro_date ${darkMode? 'text-light' : ''}`}>
+              <div className={`intro_date ${darkMode ? 'text-light' : ''}`}>
                 <h4>Tasks contributed</h4>
               </div>
 
@@ -580,7 +580,7 @@ class PeopleReport extends Component {
                     timeEntries={timeEntries}
                   />
                   <div className="visualizationDiv">
-                    <TimeEntriesViz timeEntries={timeEntries} fromDate={fromDate} toDate={toDate} darkMode={darkMode}/>
+                    <TimeEntriesViz timeEntries={timeEntries} fromDate={fromDate} toDate={toDate} darkMode={darkMode} />
                   </div>
                   <div className="visualizationDiv">
                     <InfringementsViz
@@ -599,7 +599,7 @@ class PeopleReport extends Component {
                       />
                     </div>
                     <div className="BadgeSummaryPreviewDiv">
-                      <BadgeSummaryPreview badges={userProfile.badgeCollection} darkMode={darkMode}/>
+                      <BadgeSummaryPreview badges={userProfile.badgeCollection} darkMode={darkMode} />
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/144624017/35ea98c7-9ba8-4b5d-a9e4-7241069152e2)

## Related PRS (if any):
This frontend PR is related to the dev backend PR.
…

## Main changes explained:
- isRehireable value is set to true by default in the backend, during creation
- In peopleReport.jsx, I've changed isRehireable to default true, to deal with edge cases
- This way when the constructor is used, the default value will be true
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local to run this PR locally
3. Clear site data/cache
4. log as admin/Owner user
5. Check the if the value of isRehireable is set to true everywhere
6. Only way its set to false is if done the by user.
7. Check in dashboard -> user profile -> top of the page
8. Check in  Dashboard -> reports -> reports -> people -> click on any person's name -> check isRehireable value


## Screenshots or videos of changes:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/144624017/6648d673-72f3-4791-8d66-2e3f004a0dbc)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/144624017/f99a497d-220e-417d-98b6-ee54fe6f29b0)

## Note:
After some tracing, I found that this value is created as true by default inside the mongoose schema itself. So if it is being set to false, its solely due to user intervention. This PR is prevent that edge case.
