### PR TITLE
Ramakrishnaupdated warning msg for incorrect teamcode saving

### DIFF
--- a/src/components/Reports/TeamTable.jsx
+++ b/src/components/Reports/TeamTable.jsx
@@ -54,7 +54,7 @@ function TeamTable({ allTeams, auth, hasPermission, darkMode }) {
                 invalid={hasError}
               />
               <FormFeedback>
-              The code format must be A-AAAAA or A12AAAA.
+                 NOT SAVED! The code must be between 5 and 7 characters long
               </FormFeedback>
             </FormGroup>
           </div>

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -825,7 +825,7 @@ function UserProfile(props) {
               </Alert>
             ) : null}
             {!codeValid ? (
-              <Alert color="danger">The code format should be A-AAAAA or AA1AAAA.</Alert>
+              <Alert color="danger">NOT SAVED! The code must be between 5 and 7 characters long</Alert>
             ) : null}
             <div className="profile-head">
               <h5 className={`mr-2 ${darkMode ? 'text-light' : ''}`}>{`${firstName} ${lastName}`}</h5>

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -402,7 +402,7 @@ function TeamCodeRow({ canEditTeamCode, summary, handleTeamCodeChange }) {
       </div>
       {hasError ? (
         <Alert className="code-alert" color="danger">
-          NOT SAVED! The code format must be A-AAA1A or AAA2AAA.
+          NOT SAVED! The code must be between 5 and 7 characters long.
         </Alert>
       ) : null}
     </>


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/64008831/980c88bf-0b93-43d0-923d-b16956364aa7)


## Related PRS (if any):
Please use latest development backend branch
…

## Main changes explained:
- Updated warning messages for teamcode changes in formatted.jsx,userprofile.jsx, Teamtable.jsx
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user or any user who has permission to edit teamcodes
5. go to dashboard→ Weekly summaries Report 
6. Here Try to change any teamcode with incorrect value (eg assign any teamcode with less then 5 value).
7. Now observing the latest warning message i.e "NOT SAVED! The code must be between 5 and 7 characters long"

## Screenshots or videos of changes:
Before change:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/64008831/e7c373d8-ddc0-4759-b8df-0bdae8fb31fb)
After Change:
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/64008831/1c92e413-f378-41c9-8645-ea05205f840f)


## Note:
For some users while changing teamcode we will get 500 api status error those errors are not related to this changes please ignore.
