### PR TITLE
Huijie fix times on timelog and profile page don't match

### DIFF
--- a/src/components/Timelog/EffortBar.jsx
+++ b/src/components/Timelog/EffortBar.jsx
@@ -13,8 +13,9 @@ const EffortBar = ({ activeTab, projectsSelected }) => {
         (projectsSelected.includes('all') || projectsSelected.includes(entry.projectId)),
     );
 
-    const reducer = (total, entry) => Number((total + parseInt(entry.hours) + parseInt(entry.minutes) / 60).toFixed(2));
-    return filteredData.reduce(reducer, 0);
+    const reducer = (total, entry) => total + parseInt(entry.hours) + parseInt(entry.minutes) / 60;
+    const total = filteredData.reduce(reducer, 0);
+    return Number(total.toFixed(2));
   };
 
   const tangibleTime = calculateTotalTime(data, true);

--- a/src/components/Timelog/EffortBar.jsx
+++ b/src/components/Timelog/EffortBar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-const EffortBar = ({ activeTab, projectsSelected, userProfile }) => {
+const EffortBar = ({ activeTab, projectsSelected }) => {
   const data = useSelector(state =>
     activeTab === 4 ? state.timeEntries.period : state.timeEntries.weeks[activeTab - 1],
   );
@@ -17,10 +17,8 @@ const EffortBar = ({ activeTab, projectsSelected, userProfile }) => {
     return filteredData.reduce(reducer, 0);
   };
 
-  // const tangibleTime = calculateTotalTime(data, true);
-  // const intangibleTime = calculateTotalTime(data, false);
-  const { totalIntangibleHrs: intangibleTime, hoursByCategory } = userProfile;
-  const tangibleTime = Object.values(hoursByCategory).reduce((sum, value) => sum + value, 0);
+  const tangibleTime = calculateTotalTime(data, true);
+  const intangibleTime = calculateTotalTime(data, false);
   const totalTime = tangibleTime + intangibleTime;
 
   return (

--- a/src/components/Timelog/EffortBar.jsx
+++ b/src/components/Timelog/EffortBar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-const EffortBar = ({ activeTab, projectsSelected }) => {
+const EffortBar = ({ activeTab, projectsSelected, userProfile }) => {
   const data = useSelector(state =>
     activeTab === 4 ? state.timeEntries.period : state.timeEntries.weeks[activeTab - 1],
   );
@@ -17,8 +17,10 @@ const EffortBar = ({ activeTab, projectsSelected }) => {
     return filteredData.reduce(reducer, 0);
   };
 
-  const tangibleTime = calculateTotalTime(data, true);
-  const intangibleTime = calculateTotalTime(data, false);
+  // const tangibleTime = calculateTotalTime(data, true);
+  // const intangibleTime = calculateTotalTime(data, false);
+  const { totalIntangibleHrs: intangibleTime, hoursByCategory } = userProfile;
+  const tangibleTime = Object.values(hoursByCategory).reduce((sum, value) => sum + value, 0);
   const totalTime = tangibleTime + intangibleTime;
 
   return (

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -769,6 +769,7 @@ const Timelog = props => {
                       <></>
                     ) : (
                       <EffortBar
+                        userProfile={displayUserProfile}
                         activeTab={timeLogState.activeTab}
                         projectsSelected={timeLogState.projectsSelected}
                         roles={roles}

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -769,7 +769,6 @@ const Timelog = props => {
                       <></>
                     ) : (
                       <EffortBar
-                        userProfile={displayUserProfile}
                         activeTab={timeLogState.activeTab}
                         projectsSelected={timeLogState.projectsSelected}
                         roles={roles}


### PR DESCRIPTION
# Description
<img width="805" alt="description" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/91745551/54a270b1-6073-4cf3-afd0-c9bacfdb817f">
On the timelog page, the total hours are currently calculated by rounding up each time entry before adding them together, which can lead to differences from the profile page. This PR changes the calculation to first add up the entries and then round up the final result.
Please review backend PR [1004](https://github.com/OneCommunityGlobal/HGNRest/pull/1004) for more details, as most of the code changes are on the backend. Thank you!

## Related PRS (if any):
This frontend PR is related to the backend PR 1004.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log in as any user
5. follow the detailed instructions on backend PR 1004 to test the functionality. Thank you!

## After the code changes:
<img width="900" alt="6" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/91745551/a56d3839-6187-4185-8b63-4e3ae67cf1e0">

