### PR TITLE
Chris_fix_unspecified_category_wbs

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -37,11 +37,15 @@ function AddTaskModal(props) {
   // states from hooks
   const defaultCategory = useMemo(() => {
     if (props.taskId) {
-      return tasks.find(({ _id }) => _id === props.taskId).category;
-    } 
-    return allProjects.projects.find(({ _id }) => _id === props.projectId);
-      
-  }, []);
+      const task =  tasks.find(({ _id }) => _id === props.taskId);
+      return task.category? task.category : 'Unspecified';
+    } else if (props.projectId) {
+      const project = allProjects.projects.find(({ _id }) => _id === props.projectId);
+      return project.category? project.category : 'Unspecified';
+    }
+    return 'Unspecified';
+  }, [props.taskId, props.projectId, tasks, allProjects.projects]);
+
   const [taskName, setTaskName] = useState('');
   const [priority, setPriority] = useState('Primary');
   const [resourceItems, setResourceItems] = useState([]);


### PR DESCRIPTION
# Description
![Screenshot 2024-06-23 at 9 06 07 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/b655f968-30be-4718-a2cb-bd31364fc246)

## Related PRS (if any):
This frontend pr is not related to any backend pr, please just check in to the development branch.

## Main changes explained:
- For the default category, instead of returning the project itself, returned the project.category

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Other Links>Projects> Remember the Category like ‘Stewardship’, ‘Energy’, ‘Housing’, ‘Food’, and even ‘Unspecified’ > Click on the WBS tab on the same row
6. Choose a project and click on it’s name > Click on ‘Add Task’ > Check if the default word in Category selection matches the one in we’ve seen before

## Screenshots or videos of changes:

![Screenshot 2024-06-23 at 9 03 45 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/67433827-4e2d-4d04-9304-8be7886b6dca)
Before, the default display for category is always 'unspecified', but now it matches what the default project is
![Screenshot 2024-06-23 at 9 03 28 PM](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/114450390/4e2441a7-c82c-48bc-b09a-90d5af99079c)
