### PR TITLE
Shrada Reports UI fix buttons and graph

### DIFF
--- a/src/components/Reports/TotalReport/TotalReport.css
+++ b/src/components/Reports/TotalReport/TotalReport.css
@@ -50,3 +50,9 @@
 .team_table{
     border-collapse: collapse;
 }
+
+@media screen and (max-width: 550px) {
+    .total-container{
+        padding: 15px 15px;
+    }
+}

--- a/src/components/Reports/reportsPage.css
+++ b/src/components/Reports/reportsPage.css
@@ -128,8 +128,8 @@
 
 .total-report-item {
   display: flex;
-  flex-direction: row;
-  margin: 0px 25px 0px 0px;
+  flex-wrap: nowrap;
+  justify-content: space-between;
 }
 
 .lost-time-container {
@@ -141,8 +141,8 @@
 
 .lost-time-item {
   display: flex;
-  flex-direction: row;
-  margin: 0px 25px 0px 0px;
+  flex-wrap: nowrap;
+  justify-content: space-between;
 }
 
 .type-container {
@@ -173,6 +173,10 @@
   .container-component-category {
     width: 500px;
     padding: 16px;
+  }
+
+  .category-container {
+    margin-top: 20px;
   }
 
   .card-category-item {


### PR DESCRIPTION
# Description
<img width="680" alt="Screenshot 2024-06-28 at 8 56 32 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/56028645/234ddaca-4c17-403f-9c3c-fdb348068bb2">

## Related PRS (if any):
This frontend PR is related to the development backend.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Repots
6. verify the six buttons at the bottom appear in a square shape between 1100px and 1350px.
7. verify the increased top margin to the Projects/People/Teams table when 1350px and below.
8. verify the total project/people/team report graph goes out of view when 550px and below.

## Screenshots or videos of changes:
<img width="478" alt="Screenshot 2024-06-28 at 1 29 49 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/56028645/cd8f7606-94b3-4d40-a89d-9872dc02e430">
<img width="515" alt="Screenshot 2024-06-28 at 9 07 15 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/56028645/0fc0ce1f-e512-43e1-9109-9ccf943bfab8">
<img width="515" alt="Screenshot 2024-06-28 at 9 08 36 PM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/56028645/6a9e051f-8fa0-4b5a-8e3a-13b70a59369c">



