### PR TITLE
Jiayu Add WBS icon in userprofile page projects

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
@@ -6,6 +6,9 @@ import styles from './UserProjectsTable.css';
 import { boxStyle, boxStyleDark } from 'styles';
 import { useLocation } from 'react-router-dom';
 import { connect } from 'react-redux';
+import EditableInfoModal from 'components/UserProfile/EditableModal/EditableInfoModal';
+import { NavItem, UncontrolledTooltip } from 'reactstrap';
+import { Link } from 'react-router-dom';
 
 const UserProjectsTable = React.memo(props => {
   const {darkMode} = props;
@@ -15,6 +18,7 @@ const UserProjectsTable = React.memo(props => {
   const canUpdateTask = props.hasPermission('updateTask');
   const canDeleteProjects = props.hasPermission('deleteProject');
   const canDeleteTasks = props.hasPermission('deleteTask')
+  const canPostTask = props.hasPermission('postTask');
 
   const userProjects = props.userProjectsById;
   const userTasks = props.userTasks;
@@ -142,6 +146,21 @@ const UserProjectsTable = React.memo(props => {
                   <tr className={darkMode ? 'bg-space-cadet' : ''}>
                     <th className='table-header'>#</th>
                     <th>Project Name</th>
+                    {canPostTask && 
+                    <th style={{width: '100px'}}>
+                      <div className="d-flex align-items-center">
+                        <span className="mr-2">WBS</span>
+                          <EditableInfoModal
+                            areaName="ProjectTableHeaderWBS"
+                            areaTitle="WBS"
+                            fontSize={24}
+                            isPermissionPage={true}
+                            role={props.role}
+                            className="p-2" // Add Bootstrap padding class to the EditableInfoModal
+                            darkMode={darkMode}
+                          />
+                      </div>
+                    </th>}
                     {canAssignProjectToUsers ? <th style={{ width: '100px' }}>{}</th> : null}
                   </tr>
                 )}
@@ -152,6 +171,18 @@ const UserProjectsTable = React.memo(props => {
                     <tr key={project._id} className={darkMode ? 'bg-yinmn-blue' : ''}>
                       <td>{index + 1}</td>
                       <td>{project.projectName}</td>
+                      {props.role && canPostTask && (
+                        <td className='table-cell'>
+                          <NavItem tag={Link} to={`/project/wbs/${project._id}` } id={`wbs-tooltip-${project._id}`}>
+                            <button type="button" className="btn btn-outline-info" style={darkMode ? {} : boxStyle}>
+                              <i className="fa fa-tasks" aria-hidden="true"></i>
+                            </button>
+                          </NavItem>
+                          <UncontrolledTooltip placement="left" target={`wbs-tooltip-${project._id}`}>
+                            Click to access the Work Breakdown Structures &#40;WBSs&#41; for this project
+                          </UncontrolledTooltip>
+                        </td>
+                      )}
                       {props.edit && props.role && canDeleteProjects &&(
                         <td className='table-cell'>
                           <Button

--- a/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
@@ -156,7 +156,7 @@ const UserProjectsTable = React.memo(props => {
                             fontSize={24}
                             isPermissionPage={true}
                             role={props.role}
-                            className="p-2" // Add Bootstrap padding class to the EditableInfoModal
+                            className="p-2"
                             darkMode={darkMode}
                           />
                       </div>


### PR DESCRIPTION
# Description
<img width="707" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/58479595/c51d2721-6055-4c37-a54f-5089a8e8e205">

## Related PRS (if any):
Use the development branch of backend to test this PR.

## Main changes explained:
- Updated `UserProjectsTable.jsx` to include WBS icon for users with `postTask` permission.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user or user with `postTask` permission
5. go to dashboard→ Profile→ Projects tab
6. verify function “A” (feel free to include screenshot here)
7. verify that you can see and click the wbs icon to navigate to the wbs page according to the project
8. verify that you can see the mouseover text of the wbs icon when you hover on it

## Screenshots or videos of changes:
<img width="979" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/58479595/d9bd33d4-d932-4b6b-adf0-7341a868fb3e">

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/58479595/bfedfc82-3c93-4411-9a87-7a6be5465120)
