### PR TITLE
Aaryaneil PieChartInfoDetail unit test

### DIFF
--- a/src/components/Reports/TeamReport/components/__tests__/PieChartInfoDetail.test.js
+++ b/src/components/Reports/TeamReport/components/__tests__/PieChartInfoDetail.test.js
@@ -21,4 +21,32 @@ describe('PieChartInfoDetail Component', () => {
     const legendSquare = container.querySelector('.pie-chart-legend-color-square');
     expect(legendSquare).toHaveStyle('background-color: #ff0000');
   });
+
+  test('test_render_keyName_and_value_with_darkMode', () => {
+    const { getByText } = render(<PieChartInfoDetail keyName="Test Key" value="123" color="#000000" darkMode={true} />);
+    expect(getByText('Test Key')).toBeInTheDocument();
+    expect(getByText('123')).toBeInTheDocument();
+    expect(getByText('Test Key')).toHaveClass('text-light');
+    expect(getByText('123')).toHaveClass('text-light');
+  });
+
+  test('test_render_with_specific_margin_styles', () => {
+    const { getByText } = render(<PieChartInfoDetail keyName="Test Key" value="123" color="#000000" darkMode={false} />);
+    const valueElement = getByText('123');
+    expect(valueElement).toHaveStyle('margin-top: 16px');
+    expect(valueElement).toHaveStyle('margin-left: 120px');
+  });
+
+  test('test_render_with_different_color_and_darkMode_combinations', () => {
+    const { getByText } = render(<PieChartInfoDetail keyName="Test Key" value="123" color="#00ff00" darkMode={true} />);
+    expect(getByText('Test Key')).toBeInTheDocument();
+    expect(getByText('123')).toBeInTheDocument();
+    expect(getByText('Test Key')).toHaveClass('text-light');
+    expect(getByText('123')).toHaveClass('text-light');
+  });
+
+  test('test_apply_special_key_class_when_keyName_is_Special', () => {
+    const { getByText } = render(<PieChartInfoDetail keyName="Special" value="123" color="#000000" darkMode={false} />);
+    expect(getByText('Special')).toHaveClass('pie-chart-info-key');
+  });
 });

--- a/src/components/Reports/TeamReport/components/__tests__/PieChartInfoDetail.test.js
+++ b/src/components/Reports/TeamReport/components/__tests__/PieChartInfoDetail.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import PieChartInfoDetail from '../PieChartInfoDetail';
+
+describe('PieChartInfoDetail Component', () => {
+  test('test_render_keyName_and_value', () => {
+    const { getByText } = render(<PieChartInfoDetail keyName="Test Key" value="123" color="#000000" darkMode={false} />);
+    expect(getByText('Test Key')).toBeInTheDocument();
+    expect(getByText('123')).toBeInTheDocument();
+  });
+
+  test('test_apply_darkMode_class', () => {
+    const { getByText } = render(<PieChartInfoDetail keyName="Test Key" value="123" color="#000000" darkMode={true} />);
+    expect(getByText('Test Key')).toHaveClass('text-light');
+    expect(getByText('123')).toHaveClass('text-light');
+  });
+
+  test('test_apply_legend_square_color', () => {
+    const { container } = render(<PieChartInfoDetail keyName="Test Key" value="123" color="#ff0000" darkMode={false} />);
+    const legendSquare = container.querySelector('.pie-chart-legend-color-square');
+    expect(legendSquare).toHaveStyle('background-color: #ff0000');
+  });
+});


### PR DESCRIPTION
# Description
Added unit tests to check for PieChartInfoDetail functionality.

## Main changes explained:

Added test cases to check the following:

1. Test Render Key Name and Value
2. Test Apply Dark Mode Class
3. Test Apply Legend Square Color
4. Test Render Key Name and Value with Dark Mode
5. Test Render with Specific Margin Styles
6. Test Render with Different Color and Dark Mode Combinations
7. Test Apply Special Key Class when Key Name is Special


## How to test:
1. check into current branch
2. do `npm install` and `npm test PieChartInfoDetail.test.js`

## Screenshots or videos of changes:
<img width="1552" alt="Screenshot 2024-06-30 at 1 24 58 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/39597927/eeedb2e9-fc48-4425-97a6-a02ffd82f9b8">

