### PR TITLE
Nahiyan_Added dark mode to editor and user profile modals

### DIFF
--- a/src/components/Announcements/index.jsx
+++ b/src/components/Announcements/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './Announcements.css';
 import { useDispatch, useSelector } from 'react-redux';
 import { Editor } from '@tinymce/tinymce-react'; // Import Editor from TinyMCE
@@ -13,6 +13,73 @@ function Announcements() {
   const [headerContent, setHeaderContent] = useState('');
   const [emailSubject, setEmailSubject] = useState('');
   const [testEmail, setTestEmail] = useState('');
+  const [showEditor, setShowEditor] = useState(true); // State to control rendering of the editor
+
+  useEffect(() => {
+    // Toggle the showEditor state to force re-render when dark mode changes
+    setShowEditor(false);
+    setTimeout(() => setShowEditor(true), 0);
+  }, [darkMode]);
+
+  const editorInit = {
+    license_key: 'gpl',
+    selector: 'textarea#open-source-plugins',
+    height: 500,
+    menubar: false,
+    plugins: [
+      'advlist autolink lists link image paste',
+      'charmap print preview anchor help',
+      'searchreplace visualblocks code',
+      'insertdatetime media table paste wordcount',
+    ],
+    image_title: true,
+    automatic_uploads: true,
+    file_picker_callback(cb, value, meta) {
+      const input = document.createElement('input');
+      input.setAttribute('type', 'file');
+      input.setAttribute('accept', 'image/*');
+
+      /*
+        Note: In modern browsers input[type="file"] is functional without
+        even adding it to the DOM, but that might not be the case in some older
+        or quirky browsers like IE, so you might want to add it to the DOM
+        just in case, and visually hide it. And do not forget do remove it
+        once you do not need it anymore.
+      */
+
+      input.onchange = function() {
+        const file = this.files[0];
+
+        const reader = new FileReader();
+        reader.onload = function() {
+          /*
+            Note: Now we need to register the blob in TinyMCEs image blob
+            registry. In the next release this part hopefully won't be
+            necessary, as we are looking to handle it internally.
+          */
+          const id = `blobid${new Date().getTime()}`;
+          const { blobCache } = tinymce.activeEditor.editorUpload;
+          const base64 = reader.result.split(',')[1];
+          const blobInfo = blobCache.create(id, file, base64);
+          blobCache.add(blobInfo);
+
+          /* call the callback and populate the Title field with the file name */
+          cb(blobInfo.blobUri(), { title: file.name });
+        };
+        reader.readAsDataURL(file);
+      };
+
+      input.click();
+    },
+    a11y_advanced_options: true,
+    menubar: 'file insert edit view format tools',
+    toolbar:
+      'undo redo | formatselect | bold italic | blocks fontfamily fontsize | image \
+      alignleft aligncenter alignright | \
+      bullist numlist outdent indent | removeformat | help',
+    skin: darkMode ? 'oxide-dark' : 'oxide',
+    content_css: darkMode ? 'dark' : 'default',
+  }
 
   const handleEmailListChange = e => {
     const emails = e.target.value.split(',');
@@ -75,71 +142,15 @@ function Announcements() {
         <div className="editor">
           <h3>Weekly Progress Editor</h3>
           <br />
-          <Editor
+          {showEditor && <Editor
             tinymceScriptSrc="/tinymce/tinymce.min.js"
             id="email-editor"
             initialValue="<p>This is the initial content of the editor</p>"
-            init={{
-              license_key: 'gpl',
-              selector: 'textarea#open-source-plugins',
-              height: 500,
-              menubar: false,
-              plugins: [
-                'advlist autolink lists link image paste',
-                'charmap print preview anchor help',
-                'searchreplace visualblocks code',
-                'insertdatetime media table paste wordcount',
-              ],
-              image_title: true,
-              automatic_uploads: true,
-              file_picker_callback(cb, value, meta) {
-                const input = document.createElement('input');
-                input.setAttribute('type', 'file');
-                input.setAttribute('accept', 'image/*');
-
-                /*
-                  Note: In modern browsers input[type="file"] is functional without
-                  even adding it to the DOM, but that might not be the case in some older
-                  or quirky browsers like IE, so you might want to add it to the DOM
-                  just in case, and visually hide it. And do not forget do remove it
-                  once you do not need it anymore.
-                */
-
-                input.onchange = function() {
-                  const file = this.files[0];
-
-                  const reader = new FileReader();
-                  reader.onload = function() {
-                    /*
-                      Note: Now we need to register the blob in TinyMCEs image blob
-                      registry. In the next release this part hopefully won't be
-                      necessary, as we are looking to handle it internally.
-                    */
-                    const id = `blobid${new Date().getTime()}`;
-                    const { blobCache } = tinymce.activeEditor.editorUpload;
-                    const base64 = reader.result.split(',')[1];
-                    const blobInfo = blobCache.create(id, file, base64);
-                    blobCache.add(blobInfo);
-
-                    /* call the callback and populate the Title field with the file name */
-                    cb(blobInfo.blobUri(), { title: file.name });
-                  };
-                  reader.readAsDataURL(file);
-                };
-
-                input.click();
-              },
-              a11y_advanced_options: true,
-              menubar: 'file insert edit view format tools',
-              toolbar:
-                'undo redo | formatselect | bold italic | blocks fontfamily fontsize | image \
-                alignleft aligncenter alignright | \
-                bullist numlist outdent indent | removeformat | help',
-            }}
+            init={editorInit}
             onEditorChange={(content, editor) => {
               setEmailContent(content);
             }}
-          />
+          />}
           <button type="button" className="send-button" onClick={handleBroadcastEmails} style={darkMode ? boxStyleDark : boxStyle}>
             Broadcast Weekly Update
           </button>
@@ -167,12 +178,6 @@ function Announcements() {
           </div>
         </div>
       </div>
-      {/* <div className="email-content-preview-section">
-        <div className="email-content-preview-title">
-          <h3>Preview</h3>
-        </div>
-        <div className="email-content-preview" dangerouslySetInnerHTML={{ __html: emailContent }} />
-      </div> */}
     </div>
   );
 }

--- a/src/components/UserProfile/BlueSquaresTable/BlueSquaresTable.jsx
+++ b/src/components/UserProfile/BlueSquaresTable/BlueSquaresTable.jsx
@@ -16,6 +16,7 @@ const BlueSquaresTable = ({ userProfile ,canEdit, isPrivate , handleUserProfile 
               fontSize={20}
               isPermissionPage
               role={userProfile.role}
+              darkMode={darkMode}
             />
           </div>
         </div>

--- a/src/components/UserProfile/BluequareEmailBBCPopUp.jsx
+++ b/src/components/UserProfile/BluequareEmailBBCPopUp.jsx
@@ -20,6 +20,7 @@ import { faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 import { boxStyle, boxStyleDark } from 'styles';
 
 const BluequareEmailAssignmentPopUp = React.memo(props => {
+  const darkMode = useSelector(state => state.theme.darkMode);
   const dispatch = useDispatch();
   const [searchWord, setSearchWord] = useState('');
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -67,9 +68,9 @@ const BluequareEmailAssignmentPopUp = React.memo(props => {
   },[])
 
   return (
-    <Modal isOpen={props.isOpen} toggle={closePopup} size='lg'>
-      <ModalHeader toggle={closePopup}>Set blue square email recipients</ModalHeader>
-      <ModalBody>
+    <Modal isOpen={props.isOpen} toggle={closePopup} size='lg' className={darkMode ? 'dark-mode text-light' : ''}>
+      <ModalHeader toggle={closePopup} className={darkMode ? 'bg-space-cadet' : ''}>Set blue square email recipients</ModalHeader>
+      <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
         <Container>
         <InputGroup>
           <Input
@@ -112,7 +113,7 @@ const BluequareEmailAssignmentPopUp = React.memo(props => {
           </Dropdown>
         )}
         
-        <table className="table table-bordered table-responsive-lg mt-3">
+        <table className={`table table-bordered table-responsive-lg mt-3 ${darkMode ? 'text-light' : ''}`}>
           <thead>
             <tr>
               <th>Status</th>
@@ -153,11 +154,11 @@ const BluequareEmailAssignmentPopUp = React.memo(props => {
         </table>
         </Container>
       </ModalBody>
-      <ModalFooter>
+      <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
         <Button
           color="secondary"
           onClick={closePopup}
-          style={props.darkMode ? boxStyleDark : boxStyle}
+          style={darkMode ? boxStyleDark : boxStyle}
         >
           Close
         </Button>


### PR DESCRIPTION
# Description
This PR adds a new feature that makes the `send emails` page editor toggle with dark mode.
Also added dark mode on two new modals on the user profile.

## Related PRS (if any):
This frontend PR is related to the dev backend.

## Main changes explained:
- Added dark mode to  `send emails` page editor
- Added dark mode to `Blue Square Emails BCCs` (User Profile)
- Added dark mode to Blue Square table's `EditableInfoModal` (User Profile)

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ Other Links -> Send Emails
6. verify that editor is toggling themes along with dark mode
7. verify that `Blue Square Emails BCCs` (User Profile) toggles to dark mode
8. verify that the Blue Square table's `EditableInfoModal` (User Profile) toggles to dark mode

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/5762c99d-bcda-4a36-ab6a-e2b3fa6bb7b8

