### PR TITLE
Hoang prevent overriding task edit suggestion's approval/rejection

### DIFF
--- a/src/actions/task.js
+++ b/src/actions/task.js
@@ -17,6 +17,7 @@ import { createTaskEditSuggestionHTTP } from 'components/TaskEditSuggestions/ser
 import * as types from '../constants/task';
 import { ENDPOINTS } from '../utils/URL';
 import { createOrUpdateTaskNotificationHTTP } from './taskNotification';
+import { fetchTaskEditSuggestions } from 'components/TaskEditSuggestions/thunks';
 
 const selectFetchTeamMembersTaskData = state => state.auth.user.userid;
 const selectUserId = state => state.auth.user.userid;
@@ -143,7 +144,9 @@ export const updateTask = (taskId, updatedTask, hasPermission, prevTask) => asyn
       const userIds = updatedTask.resources.map(resource => resource.userID);
       await createOrUpdateTaskNotificationHTTP(taskId, oldTask, userIds);   
     } else {
-      await createTaskEditSuggestionHTTP(taskId, selectUserId(state), oldTask, updatedTask);
+      await createTaskEditSuggestionHTTP(taskId, selectUserId(state), oldTask, updatedTask).then(() => {
+        dispatch(fetchTaskEditSuggestions())   
+      });
     }
   } catch (error) {
     // dispatch(fetchTeamMembersTaskError());

--- a/src/components/TaskEditSuggestions/Components/TaskEditSuggestionsModal.jsx
+++ b/src/components/TaskEditSuggestions/Components/TaskEditSuggestionsModal.jsx
@@ -10,11 +10,14 @@ import {
 } from 'components/TeamMemberTasks/components/TaskDifferenceModal';
 import DiffedText from 'components/TeamMemberTasks/components/DiffedText';
 import { useDispatch } from 'react-redux';
-import { rejectTaskEditSuggestion } from '../thunks';
 import { updateTask } from 'actions/task';
 import hasPermission from 'utils/permissions';
 import { useSelector, useStore } from 'react-redux';
 import { useState } from 'react';
+import { toast } from 'react-toastify';
+import { rejectTaskEditSuggestionHTTP } from '../service';
+import { rejectTaskEditSuggestionSuccess } from '../actions';
+import { fetchTaskEditSuggestions } from '../thunks';
 
 export const TaskEditSuggestionsModal = ({
   isTaskEditSuggestionModalOpen,
@@ -25,16 +28,33 @@ export const TaskEditSuggestionsModal = ({
 
   const { getState } = useStore();
 
-  const approveTask = () => {
-    // console.log('mainproblem', taskEditSuggestion);
-    updateTask(
-      taskEditSuggestion.taskId,
-      taskEditSuggestion.newTask,
-      dispatch(hasPermission('updateTask')),
-    )(dispatch, getState);
-    dispatch(rejectTaskEditSuggestion(taskEditSuggestion._id));
+  const approveTask = async () => {
+    try {
+      await rejectTaskEditSuggestionHTTP(taskEditSuggestion._id).then(() => {
+        updateTask(
+          taskEditSuggestion.taskId,
+          taskEditSuggestion.newTask,
+          dispatch(hasPermission('updateTask')),
+        )(dispatch, getState);
+      });
+      dispatch(rejectTaskEditSuggestionSuccess(taskEditSuggestion._id));
+    } catch (e) {
+      dispatch(fetchTaskEditSuggestions()); 
+      toast.error('The suggestion might have already been resolved. Reloading the suggestion list...');
+    }
     handleToggleTaskEditSuggestionModal();
   };
+  
+  const rejectTask = async () => {
+    try {
+      await rejectTaskEditSuggestionHTTP(taskEditSuggestion._id);
+      dispatch(rejectTaskEditSuggestionSuccess(taskEditSuggestion._id));
+    } catch (e) {
+      dispatch(fetchTaskEditSuggestions());
+      toast.error('The suggestion might have already been resolved. Reloading the suggestion list...');
+    }
+    handleToggleTaskEditSuggestionModal();
+  }
 
   return (
     <Modal
@@ -234,10 +254,7 @@ export const TaskEditSuggestionsModal = ({
             <Button
               color="danger"
               style={{ marginLeft: 'auto' }}
-              onClick={() => {
-                dispatch(rejectTaskEditSuggestion(taskEditSuggestion._id));
-                handleToggleTaskEditSuggestionModal();
-              }}
+              onClick={rejectTask}
             >
               Reject
             </Button>

--- a/src/components/TaskEditSuggestions/TaskEditSuggestions.css
+++ b/src/components/TaskEditSuggestions/TaskEditSuggestions.css
@@ -1,0 +1,6 @@
+.task-edit-suggestions-title {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: 1rem;
+  padding-top: 1rem;
+}

--- a/src/components/TaskEditSuggestions/TaskEditSuggestions.jsx
+++ b/src/components/TaskEditSuggestions/TaskEditSuggestions.jsx
@@ -1,11 +1,14 @@
+import "./TaskEditSuggestions.css"
 import Loading from 'components/common/Loading';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector, connect } from 'react-redux';
 import { Container, Table } from 'reactstrap';
+import { FaUndoAlt } from 'react-icons/fa';
 import { TaskEditSuggestionRow } from './Components/TaskEditSuggestionRow';
 import { TaskEditSuggestionsModal } from './Components/TaskEditSuggestionsModal';
 import { getTaskEditSuggestionsData } from './selectors';
 import { toggleDateSuggestedSortDirection, toggleUserSortDirection } from './actions';
+import { fetchTaskEditSuggestions } from './thunks';
 
 export const TaskEditSuggestions = () => {
   const [isTaskEditSuggestionModalOpen, setIsTaskEditSuggestionModalOpen] = useState(false);
@@ -19,7 +22,6 @@ export const TaskEditSuggestions = () => {
     userRole,
     darkMode
   } = useSelector(getTaskEditSuggestionsData);
-  
 
   const dispatch = useDispatch();
 
@@ -27,6 +29,10 @@ export const TaskEditSuggestions = () => {
     setCurrentTaskEditSuggestion(currentTaskEditSuggestion);
     setIsTaskEditSuggestionModalOpen(!isTaskEditSuggestionModalOpen);
   };
+
+  const handleLoadTaskEditSuggestions = () => {
+    dispatch(fetchTaskEditSuggestions());
+  }
 
   const SortArrow = ({ sortDirection }) => {
     if (sortDirection === 'asc') {
@@ -38,10 +44,19 @@ export const TaskEditSuggestions = () => {
     }
   };
 
+  useEffect(() => {
+    handleLoadTaskEditSuggestions();
+  }, [])
+
   return (
     <div className={darkMode ? 'bg-oxford-blue text-light' : ''} style={{minHeight: "100%"}}>
       <Container>
-        <h1 className="pt-3">Task Edit Suggestions</h1>
+        <div className='task-edit-suggestions-title'>
+          <h1>Task Edit Suggestions</h1>
+          <button type='button' title='Refresh' onClick={handleLoadTaskEditSuggestions}>
+            <FaUndoAlt size={20} className={darkMode ? 'text-light' : ''}/>
+          </button>
+        </div>
         {/* {isUserPermitted ? <h1>Task Edit Suggestions</h1> : <h1>{userRole} is not permitted to view this</h1>} */}
         {isLoading && <Loading />}
         {!isLoading && taskEditSuggestions && (

--- a/src/components/TaskEditSuggestions/__tests__/service.test.js
+++ b/src/components/TaskEditSuggestions/__tests__/service.test.js
@@ -38,7 +38,12 @@ describe('HTTP Service Functions',()=>{
 
   it('should reject task edit suggestion', async () => {
     const taskEditSuggestionId = '1234';
-    const result = await rejectTaskEditSuggestionHTTP(taskEditSuggestionId);
+    let result;
+
+    try {
+      result = await rejectTaskEditSuggestionHTTP(taskEditSuggestionId);
+    } catch (_e) {};
+
     expect(result).toBeUndefined();
   });
 
@@ -84,11 +89,14 @@ describe('HTTP other Service Functions', () => {
 
   it('should reject task edit suggestion', async () => {
     const taskEditSuggestionId = '1234';
-    mock.onDelete(ENDPOINTS.REJECT_TASK_EDIT_SUGGESTION('1234')).reply(200, { status: 'deleted' });
+    mock.onDelete(ENDPOINTS.REJECT_TASK_EDIT_SUGGESTION('1234')).reply(400);
     let result;
     
-    result = await rejectTaskEditSuggestionHTTP(taskEditSuggestionId);
-    expect(result).toEqual({ status: 'deleted' });
+    try {
+      result = await rejectTaskEditSuggestionHTTP(taskEditSuggestionId)
+    } catch (_e) {};
+
+    expect(result).toBeUndefined();
    
   });
 

--- a/src/components/TaskEditSuggestions/service.js
+++ b/src/components/TaskEditSuggestions/service.js
@@ -28,6 +28,7 @@ export const rejectTaskEditSuggestionHTTP = async taskEditSuggestionId => {
     return response.data;
   } catch (error) {
     console.log(`reject task edit suggestion http error ${  error}`);
+    throw error;
   }
 };
 

--- a/src/components/TaskEditSuggestions/thunks.js
+++ b/src/components/TaskEditSuggestions/thunks.js
@@ -3,12 +3,10 @@ import {
   fetchTaskEditSuggestionsBegin,
   fetchTaskEditSuggestionsError,
   fetchTaskEditSuggestionsSuccess,
-  rejectTaskEditSuggestionSuccess,
   fetchTaskEditSuggestionCountSuccess,
 } from './actions';
 import {
   getTaskEditSuggestionsHTTP,
-  rejectTaskEditSuggestionHTTP,
   getTaskEditSuggestionCountHTTP,
 } from './service';
 
@@ -23,15 +21,6 @@ export const fetchTaskEditSuggestions = () => async (dispatch, getState) => {
     dispatch(fetchTaskEditSuggestionsSuccess(response));
   } catch (error) {
     dispatch(fetchTaskEditSuggestionsError());
-  }
-};
-
-export const rejectTaskEditSuggestion = taskEditSuggestionId => async (dispatch, getState) => {
-  try {
-    await rejectTaskEditSuggestionHTTP(taskEditSuggestionId);
-    dispatch(rejectTaskEditSuggestionSuccess(taskEditSuggestionId));
-  } catch (error) {
-    console.log(`reject task edit suggestion thunk error\n${  error}`);
   }
 };
 


### PR DESCRIPTION
# Description
<img width="706" alt="Screenshot 2024-07-03 at 11 49 21 AM" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/f30bb9c7-bc60-4bf4-8c82-dd51af9a7b1a">

Issue videos: 
- https://drive.google.com/file/d/10EGb6LMg6LxpAYdRhUZoHlaZgMe1xHFE/view
- https://drive.google.com/file/d/1WyJIv5byGLI0UcwV01nnxkF4Tpz525bY/view
- https://drive.google.com/file/d/1atldiRx1NMd2dkuzjo-agL9sm_N_cerg/view *(have to reload to get the suggestions data)*.

## Related PRS (if any):
This frontend PR is related to the https://github.com/OneCommunityGlobal/HGNRest/pull/1018 backend PR.


## Main changes explained:
- Added fetching suggestion list when navigating to `/taskeditsuggestions`.
- The person who suggests a change has their number of suggestions updated immediately on their header.
- Added a toast when an approval/rejection can't be made, and automatically refetch suggestion list.
- Added a reload button to manually refetch suggestion list.


## How to test:
1. Check into current branch
2. Run `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. Open two browsers, log in as Admin and Owner. ***Both of these roles have the permission to interact with the task suggestion list, so they can be used interchangeably to create/approve/reject a suggestion***.
5. Verify that:
  - 5.1. The person who suggests a change *(on the left)* has their number of suggestions updated immediately on their header. The other person *(on the right)* when navigating to `/taskeditsuggestions` *(by clicking on the red circle on the header)* have their suggestion list updated automatically.

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/4d3da2b2-4245-4c10-b81c-761e916f0bc4

  - 5.2. An error toast appears when an approval/rejection can't be made, and the suggestion list is automatically refreshed.

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/adecb46e-fd7b-425f-acd3-2abb519b80e6

  - 5.3. The refresh button works.

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/35129229/500f575e-9fd7-4f2d-b4f5-b623b3492786

6. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
See above.

## Note:
None.
