### PR TITLE
Shengwei hotfix (TimeEnty): Jae's account info deletion

### DIFF
--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -71,9 +71,10 @@ const TimeEntry = (props) => {
     ) && !cantEditJaeRelatedRecord;
 
   //permission to Delete time entry from other user's Dashboard
-  const canDelete = (dispatch(hasPermission('deleteTimeEntryOthers')) && !cantEditJaeRelatedRecord) ||
-    //permission to delete any time entry on their own time logs tab
-    dispatch(hasPermission('deleteTimeEntry')) ||
+  const canDelete = ((dispatch(hasPermission('deleteTimeEntryOthers')) ||
+    //permission to delete any time entry on their own time logs tab.
+    // Must consider the case of the target record being Jae related 
+    dispatch(hasPermission('deleteTimeEntry')))  && !cantEditJaeRelatedRecord ) ||
     //default permission: delete own sameday tangible entry
     isAuthUserAndSameDayEntry;
   


### PR DESCRIPTION


# Description
* One line changer for permission control
Fixes # [PR 2314](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2314)


## Related PRS (if any):
 [PR 2314](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2314)

## Main changes explained:


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ TimeLog → server_ip/timelog/jae_account_user_id
6. verify delete button is hidden

## Screenshots or videos of changes:
> **Before**

<img width="787" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69882989/5eeb4787-0b1a-4805-ba51-86253013a664">

> **After fix**

<img width="724" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/69882989/c2fb6bfc-9c2b-4a5d-a8a8-de2c0f0e9d03">


## Note:
Include the information the reviewers need to know.
