### PR TITLE
Nahiyan_Dark mode on single task page

### DIFF
--- a/src/components/Projects/WBS/SingleTask/SingleTask.js
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.js
@@ -11,7 +11,7 @@ import { Link, useHistory } from 'react-router-dom';
 import { ENDPOINTS } from 'utils/URL';
 import { getUserProfile } from 'actions/userProfile';
 import hasPermission from 'utils/permissions';
-import { boxStyle } from 'styles';
+import { boxStyle, boxStyleDark } from 'styles';
 import EditTaskModal from '../WBSDetail/EditTask/EditTaskModal';
 import ModalDelete from '../../../common/Modal';
 import { deleteTask } from '../../../../actions/task';
@@ -32,6 +32,7 @@ const TINY_MCE_INIT_OPTIONS =
 };
   
 function SingleTask(props) {
+  const darkMode = useSelector(state => state.theme.darkMode);
   const {taskId} = props.match.params;
   const { user } = props.auth;
   const [task, setTask] = useState({});
@@ -68,17 +69,18 @@ function SingleTask(props) {
 
   return (
     <>
+    <div className={`${darkMode ? 'bg-oxford-blue' : 'bg-white'} h-100`}>
       <ReactTooltip />
       <div className="container-single-task">
         {canPostProject && (
           <nav aria-label="breadcrumb">
-            <ol className="breadcrumb">
+            <ol className={`breadcrumb mx-2 ${darkMode ? 'bg-space-cadet text-light' : ''}`} style={darkMode ? boxStyleDark : boxStyle}>
               <NavItem tag={Link} to={`/wbs/samefoldertasks/${taskId}`}>
-                <Button type="button" className="btn btn-secondary" style={boxStyle}>
+                <Button type="button" className="btn btn-secondary" style={darkMode ? boxStyleDark : boxStyle}>
                   <i className="fa fa-chevron-circle-left" aria-hidden="true" />
                 </Button>
               </NavItem>
-              <div id="single_task_name">
+              <div id="single_task_name" className='ml-2'>
                 See tasks in the same folder as &quot;
                 {task.taskName}
                 &quot;
@@ -87,8 +89,8 @@ function SingleTask(props) {
           </nav>
         )}
 
-        <table className="table table-bordered tasks-table">
-          <thead>
+        <table className={`table table-bordered tasks-table ${darkMode ? 'dark-mode text-light' : ''}`}>
+          <thead className={darkMode ? 'bg-space-cadet' : ''}>
             <tr>
               <th scope="col" data-tip="Action" colSpan="1">
                 Action
@@ -144,7 +146,7 @@ function SingleTask(props) {
               </th>
             </tr>
           </thead>
-          <tbody>
+          <tbody className={darkMode ? 'bg-yinmn-blue' : ''}>
             <tr>
               <th scope="row">
                 <EditTaskModal
@@ -166,9 +168,9 @@ function SingleTask(props) {
                       <Button
                         type="button"
                         size="sm"
-                        className="btn btn-danger"
+                        className="btn btn-danger mt-1"
                         onClick={() => showUpDeleteModal()}
-                        style={boxStyle}
+                        style={darkMode ? boxStyleDark : boxStyle}
                       >
                         Delete
                         {' '}
@@ -182,6 +184,7 @@ function SingleTask(props) {
                           props.popupEditor.currPopup.popupContent || 'DELETE THIS TASK ?'
                         }
                         modalTitle={Message.CONFIRM_DELETION}
+                        darkMode={darkMode}
                       />
                     </>
                   )}
@@ -248,7 +251,7 @@ function SingleTask(props) {
       </div>
 
       <Modal isOpen={modal} toggle={toggleModel}>
-        <ModalBody>
+        <ModalBody className={darkMode ? 'bg-yinmn-blue text-light' : ''}>
           <h6>WHY THIS TASK IS IMPORTANT:</h6>
           <Editor
             tinymceScriptSrc="/tinymce/tinymce.min.js"
@@ -277,6 +280,7 @@ function SingleTask(props) {
           />
         </ModalBody>
       </Modal>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
# Description
Created dark mode for single task page.

## Related PRS (if any):
This frontend PR is related to the dev backend.

## Main changes explained:
- Added dark mode on page and all modals.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ Go to the timelog section -> Select a task from any user
6. verify that dark mode works on the page and all the modals.
7. NOTE: The hover effect on the modal will be fixed with another PR. 

## Screenshots or videos of changes:
![Screenshot 2024-07-06 170409](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/71025942/21c311e0-eba7-4544-8f82-08a0dae4083a)
