### PR TITLE
Deepthi Fix SEND EMAILS PAGE UI issues for 375px and up

### DIFF
--- a/src/components/Announcements/Announcements.css
+++ b/src/components/Announcements/Announcements.css
@@ -16,9 +16,10 @@ label {
 .input-text-for-announcement,
 textarea {
   width: 100%;
-  padding: 10px;
+  padding: 12px; /* Increased padding */
   border: 1px solid #ccc;
   border-radius: 4px;
+  box-sizing: border-box; /* Ensures padding is included in width */
 }
 
 button.send-button {
@@ -26,9 +27,10 @@ button.send-button {
   color: white;
   border: none;
   border-radius: 4px;
-  padding: 10px 20px;
+  padding: 12px 24px; /* Increased padding */
   cursor: pointer;
   margin-top: 20px;
+  box-sizing: border-box; /* Ensures padding is included in width */
 }
 
 button.send-button:hover {
@@ -44,6 +46,7 @@ button.send-button:hover {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  box-sizing: border-box; /* Ensures padding is included in width */
 }
 
 .editor {
@@ -60,10 +63,11 @@ button.send-button:hover {
 
 .emails {
   margin-top: 65px;
-  padding: 20px;
+  padding: 24px; /* Increased padding */
   border: solid 1px #cacaca;
   border-radius: 20px;
   width: 300px;
+  box-sizing: border-box; /* Ensures padding is included in width */
   /* Set a fixed width for the email inputs container */
 }
 
@@ -105,6 +109,7 @@ button.send-button:hover {
       display: flex;
       flex-direction: column;
       padding: 20px;
+      box-sizing: border-box; /* Ensures padding is included in width */
   }
   .editor {
       width: 100%;
@@ -114,14 +119,19 @@ button.send-button:hover {
   .emails {
       width: 100%;
       margin-top: 20px;
-      padding: 20px 0;
+      padding: 20px 12px; /* Adjust padding for smaller screens */
+      box-sizing: border-box; /* Ensures padding is included in width */
   }
   .send-button {
       width: 100%;
       margin-bottom: 10px;
+      padding: 12px; /* Ensures padding is consistent */
+      box-sizing: border-box; /* Ensures padding is included in width */
   }
   .input-text-for-announcement,
   textarea {
       width: 100%;
+      padding: 12px; /* Ensures padding is consistent */
+      box-sizing: border-box; /* Ensures padding is included in width */
   }
 }

--- a/src/components/Announcements/Announcements.css
+++ b/src/components/Announcements/Announcements.css
@@ -99,3 +99,29 @@ button.send-button:hover {
     /* Reduce margin top on smaller screens */
   }
 }
+/* Responsive design: Adjust the layout for smaller screens */
+@media (max-width: 800px) {
+  .email-update-container {
+      display: flex;
+      flex-direction: column;
+      padding: 20px;
+  }
+  .editor {
+      width: 100%;
+      margin-right: 0;
+      margin-bottom: 20px;
+  }
+  .emails {
+      width: 100%;
+      margin-top: 20px;
+      padding: 20px 0;
+  }
+  .send-button {
+      width: 100%;
+      margin-bottom: 10px;
+  }
+  .input-text-for-announcement,
+  textarea {
+      width: 100%;
+  }
+}


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/83337914/d0863232-a9cd-4e43-9b49-d0a29ea29831)
…

## Main changes explained:
Updated Announcements.css: Added media queries to adjust the layout for various screen widths, ensuring that elements stack vertically around 800px and below.
Modified index.jsx: Adjusted component structure and styles to work with the new responsive design changes.
Verified the design: Ensured the layout works as expected at multiple breakpoints including 800px, 600px, 480px, and 375px.
…

## How to test:
1. check into current branch: git checkout deepthikannan-fix-email-ui
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other links→ Send email …
6. Verify the functionality of the SEND EMAILS page:
Ensure the editor and form elements stack vertically around 800px and below.
Test the page at various screen widths around 800px to ensure responsiveness.

## Screenshots or videos of changes:
![localhost_3000_announcements (4)](https://github.com/user-attachments/assets/2a82c154-c9a8-4e97-92da-dbbd72552088)


