### PR TITLE
 fix: route /totalorgsummary in Header.jsx

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -334,6 +334,11 @@ export function Header(props) {
                           {WEEKLY_SUMMARIES_REPORT}
                         </DropdownItem>
                       )}
+                      {canGetWeeklyVolunteerSummary && (
+                        <DropdownItem tag={Link} to="/totalorgsummary">
+                          {TOTAL_ORG_SUMMARY}
+                        </DropdownItem>
+                      )}
                       <DropdownItem tag={Link} to="/teamlocations" className={fontColor}>
                         {TEAM_LOCATIONS}
                       </DropdownItem>


### PR DESCRIPTION
# Description
'totalorgsummary' option did not  apper in report menu

   

## Main changes explained:

' <DropdownItem tag={Link} to="/totalorgsummary"> '  was added again  in Header.jsx
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to /totalorgsummary in report menu
6. verify option 'totalorgsummary' appers
7. check /totalorgsummary

## Screenshots or videos of changes:

![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/55204862/e53f158c-6d2a-4212-803e-50adbb480838)

