### PR TITLE
Diya Changes to display specific error

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -512,8 +512,7 @@ function UserProfile(props) {
       axios.put(url, updatedTask.updatedTask).catch(err => console.log(err));
     }
     try {
-      await props.updateUserProfile(userProfileRef.current);
-
+      const result = await props.updateUserProfile(userProfileRef.current);
       if (userProfile._id === props.auth.user.userid && props.auth.user.role !== userProfile.role) {
         await props.refreshToken(userProfile._id);
       }
@@ -521,9 +520,11 @@ function UserProfile(props) {
       await loadUserTasks();
       setSaved(false);
     } catch (err) {
-      console.log(err);
-      alert('An error occurred while attempting to save this profile.');
-      return err.message;
+      if (err.response && err.response.data && err.response.data.error) {
+        const errorMessage = err.response.data.error.join('\n');
+        alert(errorMessage);
+      }
+      return err;
     }
   };
 


### PR DESCRIPTION
# Description
Updating the Last Name on the User Profile to an initial throws a 400 error with a localhost webpage error saying "An error occurred while attempting to save this profile"

## Related PRS (if any):
This frontend PR is related to the backend PR [#1024](https://github.com/OneCommunityGlobal/HGNRest/pull/1024)

## Main changes explained:
- Displaying the error returned from backend

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. View Profile > Change the last name to an initial
6. Verify the localhost:3000 shows the error 'Path 'lastname' ('[_your entered initial_]') is shorter than the minimum allowed length (2).

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/54880903/1b4edeac-f9d4-4cf5-a17d-e7404f50988e

