### PR TITLE
Jiayu Sort projects by most recent edited inventories and members

### DIFF
--- a/src/components/Projects/ProjectTableHeader/ProjectTableHeader.jsx
+++ b/src/components/Projects/ProjectTableHeader/ProjectTableHeader.jsx
@@ -13,7 +13,7 @@ import hasPermission from 'utils/permissions';
 import { connect } from 'react-redux';
 import EditableInfoModal from 'components/UserProfile/EditableModal/EditableInfoModal';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowUp, faArrowDown, faSortDown} from '@fortawesome/free-solid-svg-icons';
+import { faSort, faArrowUp, faArrowDown, faSortDown} from '@fortawesome/free-solid-svg-icons';
 import { Dropdown,DropdownButton, Divider } from 'react-bootstrap';
 
 // import DropdownButton from 'react-bootstrap/DropdownButton';
@@ -76,7 +76,10 @@ const ProjectTableHeader = props => {
         <span className='d-flex justify-content-between'>
           {MEMBERS}
           <Button size='sm' className='ml-2' id='SortingByRecentEditedMembers' onClick={props.handleSort}>
-            <FontAwesomeIcon icon={faSortDown} pointerEvents="none"/>
+          <FontAwesomeIcon 
+            icon={props.sorted === 'SortingByRecentEditedMembers' ? faSort : faSortDown} 
+            pointerEvents="none"
+          />
           </Button>
         </span>
       </th>

--- a/src/components/Projects/ProjectTableHeader/ProjectTableHeader.jsx
+++ b/src/components/Projects/ProjectTableHeader/ProjectTableHeader.jsx
@@ -67,10 +67,10 @@ const ProjectTableHeader = props => {
       <th scope="col" id="projects__inv">
         <span className='d-flex justify-content-between'>
           {INVENTORY}
-          <Button size='sm' className='ml-2' id='SortingByRecentEditedInventory' onClick={props.handleSort}>
+          {/* <Button size='sm' className='ml-2' id='SortingByRecentEditedInventory' onClick={props.handleSort}>
             <FontAwesomeIcon icon={faSortDown} pointerEvents="none"/>
-          </Button>
-        </span>
+          </Button>*/}
+        </span> 
       </th>
       <th scope="col" id="projects__members">
         <span className='d-flex justify-content-between'>

--- a/src/components/Projects/ProjectTableHeader/ProjectTableHeader.jsx
+++ b/src/components/Projects/ProjectTableHeader/ProjectTableHeader.jsx
@@ -13,7 +13,7 @@ import hasPermission from 'utils/permissions';
 import { connect } from 'react-redux';
 import EditableInfoModal from 'components/UserProfile/EditableModal/EditableInfoModal';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowUp, faArrowDown} from '@fortawesome/free-solid-svg-icons';
+import { faArrowUp, faArrowDown, faSortDown} from '@fortawesome/free-solid-svg-icons';
 import { Dropdown,DropdownButton, Divider } from 'react-bootstrap';
 
 // import DropdownButton from 'react-bootstrap/DropdownButton';
@@ -65,10 +65,20 @@ const ProjectTableHeader = props => {
        </span> 
       </th>
       <th scope="col" id="projects__inv">
-        {INVENTORY}
+        <span className='d-flex justify-content-between'>
+          {INVENTORY}
+          <Button size='sm' className='ml-2' id='SortingByRecentEditedInventory' onClick={props.handleSort}>
+            <FontAwesomeIcon icon={faSortDown} pointerEvents="none"/>
+          </Button>
+        </span>
       </th>
       <th scope="col" id="projects__members">
-        {MEMBERS}
+        <span className='d-flex justify-content-between'>
+          {MEMBERS}
+          <Button size='sm' className='ml-2' id='SortingByRecentEditedMembers' onClick={props.handleSort}>
+            <FontAwesomeIcon icon={faSortDown} pointerEvents="none"/>
+          </Button>
+        </span>
       </th>
       <th scope="col" id="projects__wbs">
         <div className="d-flex align-items-center">

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -94,7 +94,8 @@ const Projects = function(props) {
   }
 
   const handleSort = (e) => {
-    setSortedByName(e.target.id);
+    const clickedId = e.target.id;
+    setSortedByName(prevState => prevState === clickedId ? "" : clickedId);
   }
 
   const onUpdateProject = async (updatedProject) => {
@@ -139,8 +140,7 @@ const Projects = function(props) {
         // FIXME: 
         return a.modifiedDatetime < b.modifiedDatetime ? 1 : -1;
       } else if (sortedByName === "SortingByRecentEditedMembers") {
-        // FIXME: 
-        return a.modifiedDatetime < b.modifiedDatetime ? 1 : -1;
+        return a.membersModifiedDatetime < b.membersModifiedDatetime ? 1 : -1;
       } else {
         return 0;
       }

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -135,6 +135,12 @@ const Projects = function(props) {
         return a.projectName[0].toLowerCase() < b.projectName[0].toLowerCase() ? -1 : 1;
       } else if (sortedByName === "Descending") {
         return a.projectName[0].toLowerCase() < b.projectName[0].toLowerCase() ? 1 : -1;
+      } else if (sortedByName === "SortingByRecentEditedInventory") {
+        // FIXME: 
+        return a.modifiedDatetime < b.modifiedDatetime ? 1 : -1;
+      } else if (sortedByName === "SortingByRecentEditedMembers") {
+        // FIXME: 
+        return a.modifiedDatetime < b.modifiedDatetime ? 1 : -1;
       } else {
         return 0;
       }

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -136,9 +136,6 @@ const Projects = function(props) {
         return a.projectName[0].toLowerCase() < b.projectName[0].toLowerCase() ? -1 : 1;
       } else if (sortedByName === "Descending") {
         return a.projectName[0].toLowerCase() < b.projectName[0].toLowerCase() ? 1 : -1;
-      } else if (sortedByName === "SortingByRecentEditedInventory") {
-        // FIXME: 
-        return a.modifiedDatetime < b.modifiedDatetime ? 1 : -1;
       } else if (sortedByName === "SortingByRecentEditedMembers") {
         return a.membersModifiedDatetime < b.membersModifiedDatetime ? 1 : -1;
       } else {


### PR DESCRIPTION
# Description
<img width="677" alt="image" src="https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/58479595/407f127d-08e3-492d-8690-970d8c02707a">

This is only for sorting the members since inventory is not in use.

## Related PRS (if any):
To test this PR you need to checkout [backend PR1025](https://github.com/OneCommunityGlobal/HGNRest/pull/1025).

## Main changes explained:
- Update `ProjectTableHeader.jsx` to include sorting button
- Update `Projects.jsx` to include correct comparison logic for sorting

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner/admin user
5. go to dashboard→ Other Links -> Projects
6. select a project except the first one and add a member
7. go back to projects page and click on the sort button next to the members header
8. verify that the project you've added the member to is now the first project
9. click again the button to reset the sorting
10. add a member to another project and verify that it goes to the top after sorting
11. go to the project you added the member first, click into the user profile of the member and in their projects tab remove the member from the project. 
12. go back to projects page and click the sort button.
13. verify that this project goes to the top again.
14. **You can also follow the video bellow for testing steps.**

## Screenshots or videos of changes:
https://www.loom.com/share/f90a2754cee444f8ae711a0a0f09c749?sid=3a343985-0bc6-480a-9942-b18bda25ec1e

## Note:
Include the information the reviewers need to know.
