### PR TITLE
Shiwani UserProfileModal unit test

### DIFF
--- a/src/components/UserProfile/UserProfileModal/__tests__/USerProfileModal.test.js
+++ b/src/components/UserProfile/UserProfileModal/__tests__/USerProfileModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import UserProfileModal from '..';
 import { Provider } from 'react-redux';
@@ -149,7 +149,7 @@ describe('UserProfileModal component', () => {
     expect(screen.queryByText('Admin Links:')).not.toBeInTheDocument()
 
   })
-  it('check type addBlueSquare',()=>{
+  it('check if add blue square works as expected when type is set to addBlueSquare',()=>{
     
     renderComponent(store,'addBlueSquare',true)
 
@@ -168,7 +168,7 @@ describe('UserProfileModal component', () => {
     expect(modifyBlueSquares).toHaveBeenCalled()
 
   })
-  it('check type modBlueSquare',()=>{
+  it('check if modify blue square works a s expected when type is set to modBlueSquare',()=>{
     renderComponent(store,'modBlueSquare',true)
     const summaryElement=document.body.querySelector('[id="summary"]')
     fireEvent.change(summaryElement,{target:{value:"This is a second test blue square summary"}})
@@ -185,13 +185,43 @@ describe('UserProfileModal component', () => {
     
   })
 
-  it('check type viewBlueSquare',()=>{
+  it('check if view blue square works as expected whe type is set to viewBlueSquare',()=>{
     renderComponent(store,'viewBlueSquare',true)
     expect(screen.getByText(`Date:${userProfile.infringements[0].date}`)).toBeInTheDocument()
     expect(screen.getByText(`Created Date:${userProfile.infringements[0].createdDate}`)).toBeInTheDocument()
     expect(screen.getByText('Summary')).toBeInTheDocument()
     expect(screen.getByText(`${userProfile.infringements[0].description}`)).toBeInTheDocument()
-
   })
-  
+  it("check if close button gets displayed when type is set to save",()=>{
+    renderComponent(store,'save',true)
+    const closeButton=screen.getByText('Close')
+    fireEvent.click(closeButton)
+
+    expect(screen.getByText('modal message')).toBeInTheDocument()
+    expect(closeModal).toHaveBeenCalled();
+  })
+  it("check if cancel button gets displayed when type is not set to save",()=>{
+    renderComponent(store,"image",true)
+    const cancelButton=screen.getByText('Cancel')
+    fireEvent.click(cancelButton)
+
+    expect(screen.getByText('modal message')).toBeInTheDocument()
+    expect(closeModal).toHaveBeenCalled()
+  })
+  it("check if add blue square do not get displayed type is not set to addBlueSquare",()=>{
+    renderComponent(store,"image",true)
+    expect(document.body.querySelector("[id='addBlueSquare']")).not.toBeInTheDocument()
+  })
+  it("check if modify blue square do not get displayed type is not set to modBlueSquare",()=>{
+    renderComponent(store,"image",true)
+    expect(screen.queryByText('Update')).not.toBeInTheDocument()
+  })
+  it("check if view blue square do not get displayed type is not set to viewBlueSquare",()=>{
+    renderComponent(store,"image",true)
+    expect(screen.queryByText(`Date:${userProfile.infringements[0].date}`)).not.toBeInTheDocument()
+    expect(screen.queryByText(`Created Date:${userProfile.infringements[0].createdDate}`)).not.toBeInTheDocument()
+    expect(screen.queryByText('Summary')).not.toBeInTheDocument()
+    expect(screen.queryByText(`${userProfile.infringements[0].description}`)).not.toBeInTheDocument()
+  })
+
 });

--- a/src/components/UserProfile/UserProfileModal/__tests__/USerProfileModal.test.js
+++ b/src/components/UserProfile/UserProfileModal/__tests__/USerProfileModal.test.js
@@ -1,9 +1,178 @@
 import React from 'react';
-import { screen, render, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { authMock, userProfileMock, timeEntryMock, userProjectMock } from '../../../../__tests__/mockStates';
-import { renderWithProvider, renderWithRouterMatch } from '../../../../__tests__/utils';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import UserProfileModal from '..';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import { rolesMock } from '__tests__/mockStates';
 
-describe('UserProfileModal', () => {
-  it('should do nothing', () => {});
+const match = {params:{teamId:"team123"}}
+
+const mockStore = configureStore([thunk]);
+
+const auth={user: {
+  permissions: {
+    frontPermissions: [],
+    backPermissions: [],
+  },
+  role: 'Manager',
+  userid:'user123'
+}}
+
+const theme={darkMode:false}
+
+const userProfile={
+  infringements:[]
+}
+
+let store;
+
+beforeEach(() => {
+  store = mockStore({
+    auth: auth,
+    userProfile:userProfile,
+    theme:theme,
+    role: rolesMock
+  })
+});
+
+jest.mock('axios');
+const modifyBlueSquares=jest.fn()
+const closeModal=jest.fn()
+const updateLink=jest.fn()
+
+
+describe('UserProfileModal component', () => {
+  it('renders without crashing', () => {
+    render(<Provider store={store}><UserProfileModal isOpen={true}
+      closeModal={closeModal}
+      updateLink={updateLink}
+      modifyBlueSquares={modifyBlueSquares}
+      modalTitle={"modal title"}
+      modalMessage={"modal message"}
+      type={'viewBlueSquare'}
+      userProfile={userProfile}
+      id={"user123"}
+      /></Provider>)
+  });
+  it('check if modal is open when isOpen is set to true',()=>{
+    render(<Provider store={store}><UserProfileModal isOpen={true}
+      closeModal={closeModal}
+      updateLink={updateLink}
+      modifyBlueSquares={modifyBlueSquares}
+      modalTitle={"modal title"}
+      modalMessage={"modal message"}
+      type={'viewBlueSquare'}
+      userProfile={userProfile}
+      id={"user123"}
+      /></Provider>)
+    
+    expect(screen.getByRole('document')).toBeInTheDocument()
+  })
+  it('check if modal is closed when isOpen is set to false',()=>{
+    render(<Provider store={store}><UserProfileModal isOpen={false}
+      closeModal={closeModal}
+      updateLink={updateLink}
+      modifyBlueSquares={modifyBlueSquares}
+      modalTitle={"modal title"}
+      modalMessage={"modal message"}
+      type={'viewBlueSquare'}
+      userProfile={userProfile}
+      id={"user123"}
+      /></Provider>)
+    
+    expect(screen.queryByRole('document')).not.toBeInTheDocument()
+  })
+  it('check modal title displays as expected',()=>{
+    render(<Provider store={store}><UserProfileModal isOpen={true}
+      closeModal={closeModal}
+      updateLink={updateLink}
+      modifyBlueSquares={modifyBlueSquares}
+      modalTitle={"modal title"}
+      modalMessage={"modal message"}
+      type={'viewBlueSquare'}
+      userProfile={userProfile}
+      id={"user123"}
+      /></Provider>)
+    
+    expect(screen.getByText('modal title')).toBeInTheDocument()
+  })
+  it('check if Cancel button works as expected when the type is not save',()=>{
+    render(<Provider store={store}><UserProfileModal isOpen={true}
+      closeModal={closeModal}
+      updateLink={updateLink}
+      modifyBlueSquares={modifyBlueSquares}
+      modalTitle={"modal title"}
+      modalMessage={"modal message"}
+      type={'viewBlueSquare'}
+      userProfile={userProfile}
+      id={"user123"}
+      /></Provider>)
+    
+    const cancelButton=screen.getByText('Cancel')
+    fireEvent.click(cancelButton)
+    expect(closeModal).toHaveBeenCalled()
+  })
+  it('check if Close button works as expected when the type is save',()=>{
+    render(<Provider store={store}><UserProfileModal isOpen={true}
+      closeModal={closeModal}
+      updateLink={updateLink}
+      modifyBlueSquares={modifyBlueSquares}
+      modalTitle={"modal title"}
+      modalMessage={"modal message"}
+      type={'save'}
+      userProfile={userProfile}
+      id={"user123"}
+      /></Provider>)
+    
+    const closeButton=screen.getByText('Close')
+    fireEvent.click(closeButton)
+    expect(closeModal).toHaveBeenCalled()
+  })
+  it('check if modal message gets displayed as expected when the type is save',()=>{
+    render(<Provider store={store}><UserProfileModal isOpen={true}
+      closeModal={closeModal}
+      updateLink={updateLink}
+      modifyBlueSquares={modifyBlueSquares}
+      modalTitle={"modal title"}
+      modalMessage={"modal message"}
+      type={'save'}
+      userProfile={userProfile}
+      id={"user123"}
+      /></Provider>)
+    expect(screen.getByText('modal message')).toBeInTheDocument()
+  })
+  it('check if Resize button works as expected when type is image',()=>{
+    render(<Provider store={store}><UserProfileModal isOpen={true}
+      closeModal={closeModal}
+      updateLink={updateLink}
+      modifyBlueSquares={modifyBlueSquares}
+      modalTitle={"modal title"}
+      modalMessage={"modal message"}
+      type={'image'}
+      userProfile={userProfile}
+      id={"user123"}
+      /></Provider>)
+
+      const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+      const resizeButton=screen.getByText('Resize')
+      fireEvent.click(resizeButton)
+      expect(windowOpenSpy).toHaveBeenCalledWith('https://picresize.com/');
+      windowOpenSpy.mockRestore();
+  })
+  it('check if Resize button does not get displayed when type is not image',()=>{
+    render(<Provider store={store}><UserProfileModal isOpen={true}
+      closeModal={closeModal}
+      updateLink={updateLink}
+      modifyBlueSquares={modifyBlueSquares}
+      modalTitle={"modal title"}
+      modalMessage={"modal message"}
+      type={'save'}
+      userProfile={userProfile}
+      id={"user123"}
+      /></Provider>)
+      expect(screen.queryByText('Resize')).not.toBeInTheDocument()
+  })
+
 });

--- a/src/components/UserProfile/UserProfileModal/__tests__/USerProfileModal.test.js
+++ b/src/components/UserProfile/UserProfileModal/__tests__/USerProfileModal.test.js
@@ -7,8 +7,6 @@ import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { rolesMock } from '__tests__/mockStates';
 
-const match = {params:{teamId:"team123"}}
-
 const mockStore = configureStore([thunk]);
 
 const auth={user: {
@@ -23,7 +21,9 @@ const auth={user: {
 const theme={darkMode:false}
 
 const userProfile={
-  infringements:[]
+  infringements:[{_id:"user123", date:'2024-04-04T12:00:00.000+00:00',createdDate:'2024-04-04T12:00:00.000+00:00',description:"This is a test blue square"}],
+  personalLinks:[],
+  adminLinks:[]
 }
 
 let store;
@@ -33,7 +33,7 @@ beforeEach(() => {
     auth: auth,
     userProfile:userProfile,
     theme:theme,
-    role: rolesMock
+    role: {roles: rolesMock.role.roles}
   })
 });
 
@@ -42,137 +42,156 @@ const modifyBlueSquares=jest.fn()
 const closeModal=jest.fn()
 const updateLink=jest.fn()
 
+const renderComponent = (testStore,type,isOpen) =>{
+  return render(<Provider store={testStore}><UserProfileModal 
+    isOpen={isOpen}
+    closeModal={closeModal}
+    updateLink={updateLink}
+    modifyBlueSquares={modifyBlueSquares}
+    modalTitle={"modal title"}
+    modalMessage={"modal message"}
+    type={type}
+    userProfile={userProfile}
+    id={"user123"}
+    /></Provider>)
+}
+
 
 describe('UserProfileModal component', () => {
   it('renders without crashing', () => {
-    render(<Provider store={store}><UserProfileModal isOpen={true}
-      closeModal={closeModal}
-      updateLink={updateLink}
-      modifyBlueSquares={modifyBlueSquares}
-      modalTitle={"modal title"}
-      modalMessage={"modal message"}
-      type={'viewBlueSquare'}
-      userProfile={userProfile}
-      id={"user123"}
-      /></Provider>)
+    renderComponent(store,'viewBlueSquare',true)
   });
   it('check if modal is open when isOpen is set to true',()=>{
-    render(<Provider store={store}><UserProfileModal isOpen={true}
-      closeModal={closeModal}
-      updateLink={updateLink}
-      modifyBlueSquares={modifyBlueSquares}
-      modalTitle={"modal title"}
-      modalMessage={"modal message"}
-      type={'viewBlueSquare'}
-      userProfile={userProfile}
-      id={"user123"}
-      /></Provider>)
-    
+    renderComponent(store,'viewBlueSquare',true)
     expect(screen.getByRole('document')).toBeInTheDocument()
   })
   it('check if modal is closed when isOpen is set to false',()=>{
-    render(<Provider store={store}><UserProfileModal isOpen={false}
-      closeModal={closeModal}
-      updateLink={updateLink}
-      modifyBlueSquares={modifyBlueSquares}
-      modalTitle={"modal title"}
-      modalMessage={"modal message"}
-      type={'viewBlueSquare'}
-      userProfile={userProfile}
-      id={"user123"}
-      /></Provider>)
-    
+    renderComponent(store,'viewBlueSquare',false)
     expect(screen.queryByRole('document')).not.toBeInTheDocument()
   })
   it('check modal title displays as expected',()=>{
-    render(<Provider store={store}><UserProfileModal isOpen={true}
-      closeModal={closeModal}
-      updateLink={updateLink}
-      modifyBlueSquares={modifyBlueSquares}
-      modalTitle={"modal title"}
-      modalMessage={"modal message"}
-      type={'viewBlueSquare'}
-      userProfile={userProfile}
-      id={"user123"}
-      /></Provider>)
-    
+    renderComponent(store,'viewBlueSquare',true)
     expect(screen.getByText('modal title')).toBeInTheDocument()
   })
   it('check if Cancel button works as expected when the type is not save',()=>{
-    render(<Provider store={store}><UserProfileModal isOpen={true}
-      closeModal={closeModal}
-      updateLink={updateLink}
-      modifyBlueSquares={modifyBlueSquares}
-      modalTitle={"modal title"}
-      modalMessage={"modal message"}
-      type={'viewBlueSquare'}
-      userProfile={userProfile}
-      id={"user123"}
-      /></Provider>)
-    
+    renderComponent(store,'viewBlueSquare',true)
     const cancelButton=screen.getByText('Cancel')
     fireEvent.click(cancelButton)
     expect(closeModal).toHaveBeenCalled()
   })
   it('check if Close button works as expected when the type is save',()=>{
-    render(<Provider store={store}><UserProfileModal isOpen={true}
-      closeModal={closeModal}
-      updateLink={updateLink}
-      modifyBlueSquares={modifyBlueSquares}
-      modalTitle={"modal title"}
-      modalMessage={"modal message"}
-      type={'save'}
-      userProfile={userProfile}
-      id={"user123"}
-      /></Provider>)
-    
+    renderComponent(store,'save',true)
     const closeButton=screen.getByText('Close')
     fireEvent.click(closeButton)
     expect(closeModal).toHaveBeenCalled()
   })
   it('check if modal message gets displayed as expected when the type is save',()=>{
-    render(<Provider store={store}><UserProfileModal isOpen={true}
-      closeModal={closeModal}
-      updateLink={updateLink}
-      modifyBlueSquares={modifyBlueSquares}
-      modalTitle={"modal title"}
-      modalMessage={"modal message"}
-      type={'save'}
-      userProfile={userProfile}
-      id={"user123"}
-      /></Provider>)
+    renderComponent(store,'save',true)
     expect(screen.getByText('modal message')).toBeInTheDocument()
   })
   it('check if Resize button works as expected when type is image',()=>{
-    render(<Provider store={store}><UserProfileModal isOpen={true}
-      closeModal={closeModal}
-      updateLink={updateLink}
-      modifyBlueSquares={modifyBlueSquares}
-      modalTitle={"modal title"}
-      modalMessage={"modal message"}
-      type={'image'}
-      userProfile={userProfile}
-      id={"user123"}
-      /></Provider>)
-
-      const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
-      const resizeButton=screen.getByText('Resize')
-      fireEvent.click(resizeButton)
-      expect(windowOpenSpy).toHaveBeenCalledWith('https://picresize.com/');
-      windowOpenSpy.mockRestore();
+    renderComponent(store,'image',true)
+    const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    const resizeButton=screen.getByText('Resize')
+    fireEvent.click(resizeButton)
+    expect(windowOpenSpy).toHaveBeenCalledWith('https://picresize.com/');
+    windowOpenSpy.mockRestore();
   })
   it('check if Resize button does not get displayed when type is not image',()=>{
-    render(<Provider store={store}><UserProfileModal isOpen={true}
-      closeModal={closeModal}
-      updateLink={updateLink}
-      modifyBlueSquares={modifyBlueSquares}
-      modalTitle={"modal title"}
-      modalMessage={"modal message"}
-      type={'save'}
-      userProfile={userProfile}
-      id={"user123"}
-      /></Provider>)
-      expect(screen.queryByText('Resize')).not.toBeInTheDocument()
+    renderComponent(store,'save',true)
+    expect(screen.queryByText('Resize')).not.toBeInTheDocument()
+  })
+  it('check type updateLink when putUserProfile permission is present',async ()=>{
+
+    const testAuth={user: {
+      permissions: {
+        frontPermissions: ['putUserProfile'],
+        backPermissions: [],
+      },
+      role: 'Manager',
+      userid:'user123'
+    }}
+
+    const testStore=mockStore({
+      auth: testAuth,
+      userProfile:userProfile,
+      theme:theme,
+      role: {roles: rolesMock.role.roles}
+    })
+
+    renderComponent(testStore,'updateLink',true)
+    
+    expect(screen.getByText('Admin Links:')).toBeInTheDocument()
+    expect(screen.getAllByText('Name')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('Link URL')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('+ ADD LINK:')[0]).toBeInTheDocument()
+
+    const linkName=document.body.querySelector('[id="linkName"]')
+    
+
+    fireEvent.change(linkName,{target:{value:"link 1"}})
+    expect(linkName.value).toBe("link 1")
+
+    const linkURL=document.body.querySelector('[id="linkURL"')
+    fireEvent.change(linkURL,{target:{value:"http://link1.com"}})
+    expect(linkURL.value).toBe("http://link1.com")
+
+    const updateButton=screen.getByText("Update")
+    fireEvent.click(updateButton)
+    expect(updateLink).toHaveBeenCalled()
+
+    expect(screen.getByText("Personal Links:")).toBeInTheDocument()
+    
+
+  })
+  it('check type updateLink when putUserProfile permission is not present',()=>{
+    renderComponent(store,'addBlueSquare',true)
+    expect(screen.queryByText('Admin Links:')).not.toBeInTheDocument()
+
+  })
+  it('check type addBlueSquare',()=>{
+    
+    renderComponent(store,'addBlueSquare',true)
+
+    const dateElement=document.body.querySelector('[id="date"]')
+    fireEvent.change(dateElement,{target:{value:"2024-03-15"}})
+
+    expect(screen.getByText("Date")).toBeInTheDocument()
+    expect(screen.getByText("Summary")).toBeInTheDocument()
+
+    const summaryElement=document.body.querySelector('[id="summary"]')
+    fireEvent.change(summaryElement,{target:{value:"This is a test summary"}})
+    expect(summaryElement.value).toBe("This is a test summary")
+
+    const addBlueSquareButton=screen.getByText('Submit')
+    fireEvent.click(addBlueSquareButton)
+    expect(modifyBlueSquares).toHaveBeenCalled()
+
+  })
+  it('check type modBlueSquare',()=>{
+    renderComponent(store,'modBlueSquare',true)
+    const summaryElement=document.body.querySelector('[id="summary"]')
+    fireEvent.change(summaryElement,{target:{value:"This is a second test blue square summary"}})
+    expect(summaryElement.value).toBe("This is a second test blue square summary")
+
+    const updateButton=screen.getByText('Update')
+    fireEvent.click(updateButton)
+    expect(screen.getByText('This is a second test blue square summary')).toBeInTheDocument()
+    expect(modifyBlueSquares).toHaveBeenCalled()
+
+    const cancelButton=screen.getByText('Cancel')
+    fireEvent.click(cancelButton)
+    expect(modifyBlueSquares).toHaveBeenCalled()
+    
   })
 
+  it('check type viewBlueSquare',()=>{
+    renderComponent(store,'viewBlueSquare',true)
+    expect(screen.getByText(`Date:${userProfile.infringements[0].date}`)).toBeInTheDocument()
+    expect(screen.getByText(`Created Date:${userProfile.infringements[0].createdDate}`)).toBeInTheDocument()
+    expect(screen.getByText('Summary')).toBeInTheDocument()
+    expect(screen.getByText(`${userProfile.infringements[0].description}`)).toBeInTheDocument()
+
+  })
+  
 });


### PR DESCRIPTION
# Description
Unit test for `src/components/UserProfile/UserProfileModal/UserProfileModal.jsx`

## Main changes explained:
- Added 19 test cases: renders without crashing, check if modal is open when isOpen is set to true, check if modal is closed when isOpen is set to false, check modal title displays as expected, check if Cancel button works as expected when the type is not save, check if Close button works as expected when the type is save, check if modal message gets displayed as expected when the type is save, check if Resize button works as expected when type is image, check if Resize button does not get displayed when type is not image, check type updateLink when putUserProfile permission is present, check type updateLink when putUserProfile permission is not present, check if add blue square works as expected when type is set to addBlueSquare, check if modify blue square works a s expected when type is set to modBlueSquare, check if view blue square works as expected when type is set to viewBlueSquare, check if close button gets displayed when type is set to save, check if cancel button gets displayed when type is not set to save, check if add blue square do not get displayed type is not set to addBlueSquare, check if modify blue square do not get displayed type is not set to modBlueSquare, check if view blue square do not get displayed type is not set to viewBlueSquare 


## How to test:
1. check into current branch
2. do `npm test src/components/UserProfile/UserProfileModal/__tests__/USerProfileModal.test.js` 
3. check if all the test cases passes without any errors or warnings

## Screenshots or videos of changes:
<img width="1129" alt="Screenshot 2024-07-14 at 2 11 34 AM" src="https://github.com/user-attachments/assets/919b8d20-3cd6-4fc3-9dca-a933303ab258">


## Note:
- There are a couple of console.log statements which was already added in the component before testing.
