### PR TITLE
XiaoW_Hotfix of timer won't max out 5 hour limit

### DIFF
--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -152,7 +152,7 @@ export default function Timer({ darkMode }) {
       return (
         remainingDuration.asMinutes() + addition > 0 &&
         goalDuration.asMinutes() + addition >= MIN_MINS &&
-        goalDuration.asHours() + addition / 60 <= MAX_HOURS
+        goalDuration.asHours() < MAX_HOURS
       );
     },
     [remaining],
@@ -168,15 +168,18 @@ export default function Timer({ darkMode }) {
 
   const handleAddButton = useCallback(
     duration => {
+      if (goal >= MAX_HOURS * 3600000) {
+        toast.error(`Goal time cannot be set over ${MAX_HOURS} hours!`);
+        return;
+      }
       const goalAfterAdditionAsHours = moment
         .duration(goal)
         .add(duration, 'minutes')
         .asHours();
       if (goalAfterAdditionAsHours > MAX_HOURS) {
-        toast.error(`Goal time cannot be set over ${MAX_HOURS} hours!`);
-      } else {
-        sendAddGoal(moment.duration(duration, 'minutes').asMilliseconds());
+        toast.info(`Goal time cannot be set over ${MAX_HOURS} hours, Goal time is set to 5 hours`);
       }
+      sendAddGoal(moment.duration(duration, 'minutes').asMilliseconds());
     },
     [remaining],
   );


### PR DESCRIPTION
# Description
Previously if timer goal is within 15 mins range to 5 hour limit, add more time button won't work. This PR address this issue by allowing user to max out to 5 hour limit even when their goal is within 15 min to 5 hour.

## Related PRS (if any):
This frontend PR is related to the #[1030](https://github.com/OneCommunityGlobal/HGNRest/pull/1030#issue-2409730842) backend PR.
