### PR TITLE
Diya Teams Page Load - Hotfix

### DIFF
--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -449,6 +449,11 @@ class Teams extends React.PureComponent {
 
   sortTeams = () => {
     const { teams, sortTeamNameState, sortTeamActiveState } = this.state;
+    
+    if (!Array.isArray(teams)) {
+    console.error("Teams is not an array:", teams);
+    return;
+  }
     const sortedTeams = [...teams].sort((a, b) => {
       const dateA = new Date(a.props.team.modifiedDatetime);
       const dateB = new Date(b.props.team.modifiedDatetime);


### PR DESCRIPTION
# Description
Teams page is not loading

## Related PRS (if any):
No related PRs, check in to the current branch and dev branch in the backend to test this.

## Main changes explained:
Added a check in sortTeams function to check whether the teams object is an array or not.

## How to test:
1. Check into current branch
2. Do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Login as admin user
5. Go to Other Links > Teams

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/f1c5ee56-1a39-4197-b080-76f1259a491b

