### PR TITLE
Peter - Hotfix (timelog): blank page due to bad request

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -105,11 +105,11 @@ const Timelog = props => {
   } = props;
 
   function displayUserIdRoute() {
+    if (authUser?.userid) {
+      return authUser?.userid;
+    }
     const path =  location.pathname
     const id = path.split('/').pop()
-    if(id.includes("dashboard")||id.includes("users")){
-      return authUser?.userid
-    }
     return id;
    }
    displayUserIdRoute();
@@ -147,7 +147,6 @@ const Timelog = props => {
   const [displayUserId, setDisplayUserId] = useState(
     viewingUser ? viewingUser.userId :  displayUserIdRoute() || userId 
   );
-  
   const isAuthUser = authUser.userid === displayUserId;
   const fullName = `${displayUserProfile.firstName} ${displayUserProfile.lastName}`;
 


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/9b5c6917-98a3-466e-bc3c-31124a187681)

This is a temp fix. A further analysis of the issue is required.

## Related PRS (if any):


## Main changes explained:

- Update displayUserIdRoute() in `timelog.jsx` to get the user's ID from Redux as the preferred method. Otherwise, get it from url path.

<img width="552" alt="image" src="https://github.com/user-attachments/assets/1857b880-e908-406e-93c5-f37445ee4e76">



## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to timelog page

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
