### PR TITLE
Hoang hotfix cannot access /timelog page

### DIFF
--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -382,7 +382,7 @@ const SummaryBar = props => {
       loadUserProfile();
       getUserTasks();
     } else {
-      setUserProfile(userProfile);
+      setUserProfile(authUser);
       setTasks(displayUserTask.length);
     }
   }, [displayUserId]);
@@ -423,7 +423,8 @@ const SummaryBar = props => {
                 </font>
                 <CardTitle className={`align-middle ${darkMode ? 'text-light' : 'text-dark'}`} tag="h3">
                   <div className='font-weight-bold'>
-                    {userProfile?.firstName ||displayUserProfile.firstName + ' '}
+                    {userProfile?.firstName || displayUserProfile.firstName}
+                    {' '} 
                     {userProfile?.lastName || displayUserProfile.lastName}
                   </div>
                 </CardTitle>

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -104,15 +104,6 @@ const Timelog = props => {
     disPlayUserTasks,
   } = props;
 
-  function displayUserIdRoute() {
-    const path =  location.pathname
-    const id = path.split('/').pop()
-    if(id.includes("dashboard")||id.includes("users")){
-      return authUser?.userid
-    }
-    return id;
-   }
-   displayUserIdRoute();
   const initialState = {
     timeEntryFormModal: false,
     summary: false,
@@ -145,7 +136,7 @@ const Timelog = props => {
   const checkSessionStorage = () => JSON.parse(sessionStorage.getItem('viewingUser')) ?? false;
   const [viewingUser, setViewingUser] = useState(checkSessionStorage());
   const [displayUserId, setDisplayUserId] = useState(
-    viewingUser ? viewingUser.userId :  displayUserIdRoute() || userId 
+    viewingUser ? viewingUser.userId : userId 
   );
   
   const isAuthUser = authUser.userid === displayUserId;
@@ -417,7 +408,13 @@ const Timelog = props => {
   const handleStorageEvent = () =>{
     const sessionStorageData = checkSessionStorage();
     setViewingUser(sessionStorageData || false);
-    setDisplayUserId(sessionStorageData ? sessionStorageData.userId : authUser.userid);
+    setDisplayUserId(
+      !isAuthUser 
+        ? userId 
+        : sessionStorageData
+          ? sessionStorageData.userId 
+          : authUser.userid
+    );
   }
 
   /*---------------- useEffects -------------- */
@@ -437,13 +434,16 @@ const Timelog = props => {
   }, [displayUserId]);
 
   useEffect(() => {
+    setDisplayUserId(userId);
+  }, [userId]);
+
+  useEffect(() => {
     // Filter the time entries
     updateTimeEntryItems();
   }, [timeLogState.projectsSelected]);
   
   useEffect(() => {
-
-    setDisplayUserId( viewingUser ? viewingUser.userId : displayUserIdRoute()||userId);
+    setDisplayUserId( viewingUser ? viewingUser.userId : userId);
     // Listens to sessionStorage changes, when setting viewingUser in leaderboard, an event is dispatched called storage. This listener will catch it and update the state.
     window.addEventListener('storage', handleStorageEvent);
     return () => {


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/58d12d15-9082-4393-b749-e8e654b09a14)

## Related PRS (if any):
None.
…

## Main changes explained:
- Remove displayUserIdRoute() function
- Update displayUserId on userId param change
- Update display first and last name on SummaryBar
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run dev` to run this PR locally
3. Verify `/timelog` page works correctly
4. Verify that opening multiple other timelog pages at the same time displays their timelogs correctly (related to https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2307).
5. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/698b485f-12ad-4fbc-90a1-e6bb4b68a449



## Note:
None.
