### PR TITLE
Gowtham - hotfix for timelog userid in multiple components

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -53,6 +53,7 @@ import {
   DEV_ADMIN_ACCOUNT_CUSTOM_WARNING_MESSAGE_DEV_ENV_ONLY,
   PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE,
 } from 'utils/constants';
+import PropTypes from 'prop-types';
 
 const doesUserHaveTaskWithWBS = (tasks = [], userId) => {
   if (!Array.isArray(tasks)) return false;
@@ -102,17 +103,9 @@ const Timelog = props => {
     roles,
     displayUserProjects,
     disPlayUserTasks,
+    userId
   } = props;
 
-  function displayUserIdRoute() {
-    const path =  location.pathname
-    const id = path.split('/').pop()
-    if(id.includes("dashboard")||id.includes("users")){
-      return authUser?.userid
-    }
-    return id;
-   }
-   displayUserIdRoute();
   const initialState = {
     timeEntryFormModal: false,
     summary: false,
@@ -140,17 +133,31 @@ const Timelog = props => {
   const [summaryBarData, setSummaryBarData] = useState(null);
   const [timeLogState, setTimeLogState] = useState(initialState);
   const isNotAllowedToEdit = cantUpdateDevAdminDetails(displayUserProfile.email, authUser.email);
-  const { userId = authUser.userid } = useParams();
+  const { userprofileId = authUser.userid } = useParams();
 
   const checkSessionStorage = () => JSON.parse(sessionStorage.getItem('viewingUser')) ?? false;
   const [viewingUser, setViewingUser] = useState(checkSessionStorage());
+  const getUserId =()=>{
+    try {
+         if(viewingUser){
+            return viewingUser.userId;
+         }
+         else if(userId!=null){
+            return userId;
+         }
+         return authUser.userid;
+    } catch (error) {
+       return null;
+    }
+}
+
   const [displayUserId, setDisplayUserId] = useState(
-    viewingUser ? viewingUser.userId :  displayUserIdRoute() || userId 
+     getUserId()
   );
-  
   const isAuthUser = authUser.userid === displayUserId;
   const fullName = `${displayUserProfile.firstName} ${displayUserProfile.lastName}`;
 
+  
   const defaultTab = () => {
     //change default to time log tab(1) in the following cases:
     const role = authUser.role;
@@ -443,7 +450,7 @@ const Timelog = props => {
   
   useEffect(() => {
 
-    setDisplayUserId( viewingUser ? viewingUser.userId : displayUserIdRoute()||userId);
+    setDisplayUserId( getUserId());
     // Listens to sessionStorage changes, when setting viewingUser in leaderboard, an event is dispatched called storage. This listener will catch it and update the state.
     window.addEventListener('storage', handleStorageEvent);
     return () => {
@@ -802,6 +809,14 @@ const Timelog = props => {
       )}
     </div>
   );
+};
+
+Timelog.prototype = {
+  userId: PropTypes.string,
+};
+
+Timelog.defaultProps = {
+  userId: null,
 };
 
 const mapStateToProps = state => ({

--- a/src/routes.js
+++ b/src/routes.js
@@ -107,8 +107,11 @@ export default (
         <ProtectedRoute path="/dashboard" exact component={Dashboard} />
         <ProtectedRoute path="/dashboard/:userId" exact component={Dashboard} />
         <ProtectedRoute path="/project/members/:projectId" fallback component={Members} />
-        <ProtectedRoute path="/timelog/" exact component={Timelog} />
-        <ProtectedRoute path="/timelog/:userId" exact component={Timelog} />
+        <ProtectedRoute path="/timelog/" exact render={() => <Timelog userId={null} />} />
+        <ProtectedRoute path="/timelog/:userId" exact render ={(props) => {
+           const {userId} = props.match.params;
+            return <Timelog userId ={userId}/>
+        }} />
         <ProtectedRoute path="/peoplereport/:userId" component={PeopleReport} fallback />
         <ProtectedRoute path="/projectreport/:projectId" component={ProjectReport} fallback />
         <ProtectedRoute path="/teamreport/:teamId" component={TeamReport} fallback />


### PR DESCRIPTION
# Description
![image (2)](https://github.com/user-attachments/assets/262a7c34-467d-4da6-9425-1f519353bc90)
Hotfix for this issue

## Related PRS (if any):
Please use Dev backend to test this PR.

## Main changes explained:
- Updated the props for timelog 
- Updated the way userprofileid based on props / authuserid
…

## How to Test This PR
1. Check into the Current Branch
2. Install Dependencies Run npm install to install the necessary dependencies.
3. Run the Application Locally Follow the usual steps to start the application locally.
4. Clear the site data and cache in your browser to ensure no old data interferes with the test.
5. Log in to the application as an admin, owner, or any user role.
6. Verify API Calls for Timelog - Open the console in your browser's developer tools and check that the API calls related to timelog are functioning correctly.
7. Test Timelog Page Navigate to /timelog and verify that the timelog is working properly. Ensure that the console shows the expected API calls for /timelog.
8. Navigate to Another User's Timelog From the dashboard, click on the progress bar of another user (preferably in another tab) and confirm that the correct user's time and name are displayed.

