### PR TITLE
Lin pagination UI members table fix

### DIFF
--- a/src/components/common/Paging/Paging.css
+++ b/src/components/common/Paging/Paging.css
@@ -12,6 +12,13 @@
   margin: auto;
 }
 
+@media (max-width: 1353px) {
+  .pagination-buttons-wrapper {
+    bottom: -65px;
+    padding-bottom: 5px;
+  }
+}
+
 .pagination-buttons {
   display: flex;
   align-items: baseline;

--- a/src/components/common/Paging/Paging.jsx
+++ b/src/components/common/Paging/Paging.jsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import './Paging.css';
 
 // eslint-disable-next-line react/function-component-definition
-const Paging = ({ maxElemPerPage = 6, totalElementsCount, children, darkMode }) => {
+const Paging = ({ maxElemPerPage = 5, totalElementsCount, children, darkMode }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
   const pageIndexButton = darkMode ? 'page-index-button-dark' : 'page-index-button';
@@ -31,7 +31,7 @@ const Paging = ({ maxElemPerPage = 6, totalElementsCount, children, darkMode }) 
   const renderPageIndexes = () => {
     const indexesButtons = [];
 
-    if (pagesCount <= 6) {
+    if (pagesCount <= 5) {
       for (let i = 1; i <= pagesCount; i += 1) {
         indexesButtons.push(renderPageNumberButton(i));
       }


### PR DESCRIPTION
# Description
<img width="796" alt="Screenshot 2024-07-20 at 11 39 33 PM" src="https://github.com/user-attachments/assets/fb249b82-b45b-4e34-b8b5-1451348df41b">


## Related PRS (if any):
This frontend PR is related to the #2201 frontend PR.
…

## Main changes explained:
1. Fixed UI for handling overlap of pagination and table values
2. Fixed CSS styling for smaller width screen
…

## How to test:
1. check into current branch
2. do npm install and npm run start:local to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. Go to Reports -> Projects -> Any project with 7 or more members
6. Make Screen Smaller
7. Check that pagination doesn't overlaps with table values on different screen size
...

## Screenshots or videos of changes:
Before
<img width="1438" alt="Screenshot 2024-07-20 at 11 46 44 PM" src="https://github.com/user-attachments/assets/c2427d4f-48e0-48d3-9476-190872359211">

After
<img width="1440" alt="Screenshot 2024-07-20 at 11 35 39 PM" src="https://github.com/user-attachments/assets/37ed138b-7378-41d6-b171-b95fa88798a9">

## Note:
