### PR TITLE
min add manager icons to task tab

### DIFF
--- a/src/actions/allTeamsAction.js
+++ b/src/actions/allTeamsAction.js
@@ -150,7 +150,7 @@ export const postNewTeam = (name, status) => {
           return { status: 500, message: error.message };
         }
       });
-  }; 
+  };
 };
 
 
@@ -254,5 +254,21 @@ export const updateTeamMemeberVisibility = (teamId, userId, visibility) => {
           console.error('Error updating visibility:', error.message);
         }
       });
+  };
+};
+
+/**
+ * Get team members id based on teamId
+ */
+export const getTeamMembersId = (teamId) => {
+  const url = ENDPOINTS.TEAM_DATA(teamId);
+  return async (dispatch) => {
+    try {
+      const teamMembersResponse = await axios.get(url);
+      const memberIds = teamMembersResponse.data.members.map(member => member.userId);
+      return memberIds;
+    } catch (error) {
+      return error.response ? error.response.data.error : error.message;
+    }
   };
 };

--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -91,6 +91,28 @@ export const getProjectsByUsersName = searchName => {
   };
 };
 
+/**
+ * Retrieve only the role, firstName, lastName of a user
+ */
+export const getMinimalUserProfile = async (userId) => {
+  try {
+    const url = ENDPOINTS.USER_PROFILE(userId);
+    let loggedOut = false;
+    const response = await axios.get(url).catch(error => {
+      if (error.response && error.response.status === 401) {
+        loggedOut = true;
+      }
+    });
+    if (response && !loggedOut) {
+      const { role, firstName, lastName } = response.data;
+      return { role, firstName, lastName, _id: userId };
+    }
+  } catch (error) {
+    console.error('Error fetching role, firstName, lastName:', error);
+    return null;
+  }
+};
+
 export const getProjectsByPersonActionCreator = data => ({
   type: GET_PROJECT_BY_USER_NAME,
   payload: data


### PR DESCRIPTION
# Description
Added clickable Managers, Assistant Managers and Mentors Icons for every user which nevigates to user profile page on dashboard task tab

## Related PRS (if any):
This frontend PR is related to the development backend

## Main changes explained:
- Added clickable Managers, Assistant Managers and Mentors Icons for each user
- Added a scroll bar if there are many icons to show

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard
6. verify that you can see the icons
7. verify that the scroll bar works
8. verify that the icon takes you to the profile page
9. verify in dark mode

Screenshots or videos of changes:https://github.com/user-attachments/assets/cf00eed8-8f9f-4ec2-b1fd-d0c1a43f2cf4

