### PR TITLE
Nathan Hotfix add conditions to see edit time entry icon

### DIFF
--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -52,6 +52,11 @@ const TimeEntry = (props) => {
   const [filteredColor,setFilteredColor] = useState(hrsFilterBtnColorMap[7]);
   const dispatch = useDispatch();
 
+  const hasATimeEntryEditPermission = props.hasPermission('editTimeEntryTime') ||
+    props.hasPermission('editTimeEntryDescription') ||
+    props.hasPermission('editTimeEntryDate');
+
+
   const cantEditJaeRelatedRecord = cantUpdateDevAdminDetails(timeEntryUserProfile?.email ? timeEntryUserProfile.email : '', authUser.email);
 
   const toggle = () => setTimeEntryFormModal(modal => !modal);
@@ -183,14 +188,13 @@ const TimeEntry = (props) => {
             <div className="text-muted">Notes:</div>
             {ReactHtmlParser(notes)}
             <div className="buttons">
-              {((true || isAuthUserAndSameDayEntry )&& !cantEditJaeRelatedRecord) 
-                && from === 'WeeklyTab' 
+              {((hasATimeEntryEditPermission || isAuthUserAndSameDayEntry )&& !cantEditJaeRelatedRecord) 
                 && (
                   <button className="mr-3 text-primary">
                     <FontAwesomeIcon icon={faEdit} size="lg" onClick={toggle} />
                   </button>
                 )}
-              {canDelete && from === 'WeeklyTab' && (
+              {canDelete && (
                 <button className='text-primary'>
                   <DeleteModal timeEntry={data} />
                 </button>
@@ -216,4 +220,8 @@ const mapStateToProps = (state) => ({
   authUser: state.auth.user,
 })
 
-export default connect(mapStateToProps, null)(TimeEntry);
+const mapDispatchToProps = dispatch => ({
+  hasPermission: permission => dispatch(hasPermission(permission)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(TimeEntry);


### PR DESCRIPTION
# Description
Requires a user to have a time entry edit permission or to be the user who created it on the same day in order to see the edit icon for a time entry.