### PR TITLE
Diya Fix to reports page UI

### DIFF
--- a/src/components/Reports/TotalReport/TotalReport.css
+++ b/src/components/Reports/TotalReport/TotalReport.css
@@ -5,6 +5,7 @@
     background-color:#f1ebf7;
     border-radius: 16px;
     padding: 20px 40px;
+    margin-bottom: 30px;
 }
 
 .total-title{


### PR DESCRIPTION
# Description
<img width="763" alt="Screenshot 2024-07-24 at 6 12 18 AM" src="https://github.com/user-attachments/assets/4e4be1f4-7e30-4d04-a04e-7ec1db3945e1">

## Related PRS (if any):
To test this frontend PR, you need to check in to the development branch at the backend

## Main changes explained:
Added a bottom margin to the purple box in the screenshot above.

## How to test:
1. Check into current branch
2. Do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Login as admin user
5. Go to Reports → Show total reports → Click on 'Show Details'
6. Verify the gap between the purple box and the details table.

## Screenshots or videos of changes:
<img width="635" alt="Screenshot 2024-07-24 at 6 16 40 AM" src="https://github.com/user-attachments/assets/4c98a0de-8969-48d0-992a-bab71b4a7e6f">
