### PR TITLE
Peizhou_fix the duplicate display issue

### DIFF
--- a/src/components/Reports/TeamReport/__tests__/TeamReport.test.js
+++ b/src/components/Reports/TeamReport/__tests__/TeamReport.test.js
@@ -94,10 +94,10 @@ describe("Team Report component",()=>{
       data: [],
     });
     render(<Provider store={store}><TeamReport match={match}/></Provider>)
-    /*await waitFor(()=>{
+    await waitFor(()=>{
       expect(screen.getByText('Apr-04-18')).toBeInTheDocument()
       expect(screen.getByText('Created Date')).toBeInTheDocument()
-    })*/
+    })
     
   })
   it('check if team ID header and its value is getting displayed when the team is present',async ()=>{

--- a/src/components/Reports/TeamReport/__tests__/TeamReport.test.js
+++ b/src/components/Reports/TeamReport/__tests__/TeamReport.test.js
@@ -94,10 +94,10 @@ describe("Team Report component",()=>{
       data: [],
     });
     render(<Provider store={store}><TeamReport match={match}/></Provider>)
-    await waitFor(()=>{
+    /*await waitFor(()=>{
       expect(screen.getByText('Apr-04-18')).toBeInTheDocument()
       expect(screen.getByText('Created Date')).toBeInTheDocument()
-    })
+    })*/
     
   })
   it('check if team ID header and its value is getting displayed when the team is present',async ()=>{

--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
@@ -183,39 +183,6 @@ const UserTeamsTable = props => {
                   </tr>
                 )}
               </thead>
-              <tbody className={darkMode ? 'text-light' : ''}>
-                {props.userTeamsById.length > 0 ? (
-                  props.userTeamsById.map((team, index) => (
-                    <tr key={index} className="tr">
-                      <td>{index + 1}</td>
-                      <td>{`${team.teamName}`}</td>
-                      {props.edit && props.role && (
-                        <td>
-                          <div
-                            style={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'center',
-                            }}
-                          >
-                            <Button
-                              disabled={!canAssignTeamToUsers}
-                              color="danger"
-                              onClick={e => {
-                                props.onDeleteClick(team._id);
-                              }}
-                            >
-                              Delete
-                            </Button>
-                          </div>
-                        </td>
-                      )}
-                    </tr>
-                  ))
-                ) : (
-                  <></>
-                )}
-              </tbody>
               <tbody>
                 {props.userTeamsById.length > 0 ? (
                   props.userTeamsById.map((team, index) => (


### PR DESCRIPTION
# Description
![82d23dfc4eedae6f4a6509af12b3a9f](https://github.com/user-attachments/assets/eb96a47b-3fa3-47ff-ad51-f96f4147ed75)

## Related PRS (if any):
This frontend PR is not related to any backend PR, please just check in to the development branch.

## Main changes explained:
- Fix the duplicate display issue of the teams under Teams, on the User Profile page.

## How to test:
1. check into the current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in as admin user
5. go to dashboard→ User Profile→ Teams
6. assign new teams to the user
7. verify the team entities under the Teams appear only once

## Screenshots or videos of changes:
![1](https://github.com/user-attachments/assets/98cfe05b-f8ba-4fab-b171-fc5a6e1daf35)
