### PR TITLE
Peizhou_fix the assigning blue square with future date issue

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -496,11 +496,18 @@ function UserProfile(props) {
    */
   const modifyBlueSquares = (id, dateStamp, summary, operation) => {
     if (operation === 'add') {
-      /* peizhou: check that the date of the blue square is not future */
-      if (moment(dateStamp).isAfter(moment().format('YYYY-MM-DD'))) {
-        console.log('WARNING: Future Blue Square');
-        alert('WARNING: Cannot Assign Blue Square with a Future Date');
-      } else {
+      /* peizhou: check that the date of the blue square is not future or empty. */
+      if (moment(dateStamp).isAfter(moment().format('YYYY-MM-DD')) || dateStamp === '') {
+        if (moment(dateStamp).isAfter(moment().format('YYYY-MM-DD'))) {
+          console.log('WARNING: Future Blue Square');
+          alert('WARNING: Cannot Assign Blue Square with a Future Date');
+        }
+        if (dateStamp === '') {
+          console.log('WARNING: Empty Date');
+          alert('WARNING: Cannot Assign Blue Square with an Empty Date');
+        }
+      } 
+      else {
         const newBlueSquare = {
           date: dateStamp,
           description: summary,

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -496,23 +496,29 @@ function UserProfile(props) {
    */
   const modifyBlueSquares = (id, dateStamp, summary, operation) => {
     if (operation === 'add') {
-      const newBlueSquare = {
-        date: dateStamp,
-        description: summary,
-        createdDate: moment
-          .tz('America/Los_Angeles')
-          .toISOString()
-          .split('T')[0],
-      };
-      setOriginalUserProfile({
-        ...originalUserProfile,
-        infringements: userProfile.infringements?.concat(newBlueSquare),
-      });
-      setUserProfile({
-        ...userProfile,
-        infringements: userProfile.infringements?.concat(newBlueSquare),
-      });
-      setModalTitle('Blue Square');
+      /* peizhou: check that the date of the blue square is not future */
+      if (moment(dateStamp).isAfter(moment().format('YYYY-MM-DD'))) {
+        console.log('WARNING: Future Blue Square');
+        alert('WARNING: Cannot Assign Blue Square with a Future Date');
+      } else {
+        const newBlueSquare = {
+          date: dateStamp,
+          description: summary,
+          createdDate: moment
+            .tz('America/Los_Angeles')
+            .toISOString()
+            .split('T')[0],
+        };
+        setOriginalUserProfile({
+          ...originalUserProfile,
+          infringements: userProfile.infringements?.concat(newBlueSquare),
+        });
+        setUserProfile({
+          ...userProfile,
+          infringements: userProfile.infringements?.concat(newBlueSquare),
+        });
+        setModalTitle('Blue Square');
+      }
     } else if (operation === 'update') {
       const currentBlueSquares = [...userProfile?.infringements] || [];
       if (dateStamp != null && currentBlueSquares.length !== 0) {


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/597d1761-27bb-43fc-86cd-5f1caea69103)

## Related PRS (if any):
This frontend PR is not related to any backend PR, please just check in to the development branch.

## Main changes explained:
- Fix the issue of being able to assign the blue square with a future date.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to a user's profile, assign a blue square with a future date
6. an alert message should occur, saying "WARNING: Cannot Assign Blue Square with a Future Date", and the blue square should not be added

## Screenshots or videos of changes:
![1](https://github.com/user-attachments/assets/d5905d9a-3c5a-4834-b2a6-4b0452080226)

https://github.com/user-attachments/assets/2fe7302b-714a-494e-a099-4d9e49572a09



