### PR TITLE
Peterson_fix_bug_team_code_does_not_accept_codes_with_seven_characters

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
@@ -28,7 +28,7 @@ const UserTeamsTable = props => {
   const refDropdown = useRef();
 
   const canAssignTeamToUsers = props.hasPermission('assignTeamToUsers');
-  const fullCodeRegex = /^([a-zA-Z]-[a-zA-Z]{3}|[a-zA-Z]{5})$/;
+  const fullCodeRegex = /^.{5,7}$/;
   const toggleTooltip = () => setTooltip(!tooltipOpen);
 
   const handleCodeChange = (e, autoComplete) => {


### PR DESCRIPTION
# Description
This pull request has been opened to fix the bug where the team code input does not accept codes with seven characters.

## Related PRS (if any):
None.

## Main changes explained:
The component UserTeamsTable has been modified to fix the bug.


## How to test:
1. Check into current branch
2. Do npm install and ... to run this PR locally
3. Run npm run build in the backend terminal.
4. Clear site data/cache
5. Log in as an administrator or owner.
6. Go View Profile →  Teams.
7. Write a seven-character code in the team code input, and the 'Save Changes' button should be enabled.

## Screenshots or videos of changes:
![Peterson_fix_bug_team_code_does_not_accept_codes_with_seven_characters](https://github.com/user-attachments/assets/a3e2eecb-0999-4ad7-b777-92847c24098f)

## Note:
None