### PR TITLE
Jay unit test for InfoModal component

### DIFF
--- a/src/components/BMDashboard/Equipment/List/EquipmentsTable.jsx
+++ b/src/components/BMDashboard/Equipment/List/EquipmentsTable.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Table, Button } from 'reactstrap';

--- a/src/components/PermissionsManagement/PermissionChangeLogTable.jsx
+++ b/src/components/PermissionsManagement/PermissionChangeLogTable.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import { useState } from 'react';
 import './PermissionChangeLogTable.css';
 import { FiChevronLeft, FiChevronRight, FiChevronDown, FiChevronUp } from 'react-icons/fi';

--- a/src/components/Teams/__tests__/InfoModal.test.js
+++ b/src/components/Teams/__tests__/InfoModal.test.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import configureStore from 'redux-mock-store';
 import { themeMock } from '__tests__/mockStates';
@@ -15,27 +15,40 @@ describe('InfoModal', () => {
   });
 
   let renderInfoModal = props => {
-    render(
+    const { rerender } = render(
       <Provider store={store}>
         <InfoModal {...props} />
       </Provider>,
     );
-  };
 
-  describe('Renders correctly with text', () => {
+    return rerender;
+  };
+  const headerText = 'Restrict the team member visiblity';
+
+  describe('Renders correctly with text and toggle button', () => {
     it('InfoModal renders with expected text', () => {
       renderInfoModal(props);
-
-      const headerText = 'Restrict the team member visiblity';
       expect(screen.getByText(headerText));
+    });
+
+    it('Clicking  `Ok` button closes InfoModal so it is not present', () => {
+      const rerender = renderInfoModal(props);
+      const okButton = screen.getByText('Ok');
+      fireEvent.click(okButton);
+      rerender();
+      expect(screen.queryByText(headerText)).not.toBeInTheDocument();
     });
 
     beforeEach(() => {
       let isOpen = true;
 
+      const toggle = () => {
+        isOpen = !isOpen;
+      };
+
       props = {
         isOpen,
-        toggle: () => (isOpen = !isOpen),
+        toggle,
       };
     });
   });

--- a/src/components/Teams/__tests__/InfoModal.test.js
+++ b/src/components/Teams/__tests__/InfoModal.test.js
@@ -1,0 +1,42 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import configureStore from 'redux-mock-store';
+import { themeMock } from '__tests__/mockStates';
+import { Provider } from 'react-redux';
+import InfoModal from '../InfoModal';
+
+const mockStore = configureStore();
+
+describe('InfoModal', () => {
+  let props;
+
+  const store = mockStore({
+    theme: themeMock,
+  });
+
+  let renderInfoModal = props => {
+    render(
+      <Provider store={store}>
+        <InfoModal {...props} />
+      </Provider>,
+    );
+  };
+
+  describe('Renders correctly with text', () => {
+    it('InfoModal renders with expected text', () => {
+      renderInfoModal(props);
+
+      const headerText = 'Restrict the team member visiblity';
+      expect(screen.getByText(headerText));
+    });
+
+    beforeEach(() => {
+      let isOpen = true;
+
+      props = {
+        isOpen,
+        toggle: () => (isOpen = !isOpen),
+      };
+    });
+  });
+});


### PR DESCRIPTION
# Description
Implements unit test for the `src/components/Teams/InfoModal.jsx`

## Related PRS (if any):
This is not related to any backend PR

## Main changes explained:
- Create file `src/components/Teams/__tests__/InfoModal.test.js` which implements the following unit tests:
  - Tests that the InfoModal component renders with the correct text
  - Tests that the InfoModal component is not in the document after toggling it closed

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. run `npm test -- src/components/Teams/__tests__/InfoModal.test.js` and verify that it achieves complete code coverage

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/8c00fbbd-2fc5-403c-8d40-334e374a834e)
