### PR TITLE
Diya Updated disabled property on checkbox

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -609,7 +609,7 @@ const TimeEntryForm = props => {
                   name="isTangible"
                   checked={formValues.isTangible}
                   onChange={handleInputChange}
-                  disabled={!canEditTimeEntryToggleTangible || from !== 'Timer'}
+                  disabled={!canEditTimeEntryToggleTangible}
                 />
                 Tangible&nbsp;
                 <i


### PR DESCRIPTION
# Description
When an owner or any user logs their time, they should be allowed to make it tangible in the modal itself (only if they have the toggle tangible time permission) instead of registering it as an intangible entry and then clicking on the checkbox to make it tangible.

## Related PRS (if any):
None.
To test this frontend PR you need to check in to the development branch

## Main changes explained:
Changed the condition of having the checkbox disabled.

## How to test:
1. Check into current branch
2. Do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Login as admin user
5. Go to Permissions Management → Owner. Make sure the Toggle Tangible Time (self) permission is provided.
6. Head back to the Dashboard and add intangible time. In the modal, the checkbox on the left of Tangible must be enabled.
7. Try providing this permission to other roles and test or revoking the permission for the owner and ensure that the checkbox is disabled.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/d4fe46d6-f6a7-4a4d-885c-9dc1cd10ee4c


