### PR TITLE
Imran_Fix_Rehireable_status 

### DIFF
--- a/src/actions/userManagement.js
+++ b/src/actions/userManagement.js
@@ -60,15 +60,15 @@ export const updateUserStatus = (user, status, reactivationDate) => {
  * @param{boolean} isRehireable - the new rehireable status
  */
 export const updateRehireableStatus = (user, isRehireable) => {
-  const userProfile = { ...user };
-  userProfile.isRehireable = isRehireable
-  const requestData = { isRehireable };
-  
-  const updateProfilePromise = axios.patch(ENDPOINTS.UPDATE_REHIREABLE_STATUS(user._id), requestData)
   return async dispatch => {
-    updateProfilePromise.then(res => {
+    const userProfile = { ...user, isRehireable };
+    const requestData = { isRehireable };
+    try {
+      await axios.patch(ENDPOINTS.UPDATE_REHIREABLE_STATUS(user._id), requestData);
       dispatch(userProfileUpdateAction(userProfile));
-    });
+    } catch (err) {
+      throw err;
+    }
   };
 };
 

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -608,16 +608,21 @@ function UserProfile(props) {
     setShowConfirmDialog(true);
   };
 
-  const handleConfirmChange = () => {
+  const handleConfirmChange = async () => {
     setShowConfirmDialog(false);
     const updatedUserProfile = {
       ...userProfile,
       isRehireable: pendingRehireableStatus,
     };
-    updateRehireableStatus(updatedUserProfile, pendingRehireableStatus);
-    setIsRehireable(pendingRehireableStatus);
-    setUserProfile(updatedUserProfile);
-    setOriginalUserProfile(updatedUserProfile);
+    try{
+      await dispatch(updateRehireableStatus(updatedUserProfile, pendingRehireableStatus));
+      setIsRehireable(pendingRehireableStatus);
+      setUserProfile(updatedUserProfile);
+      setOriginalUserProfile(updatedUserProfile);
+    }catch(error){
+      toast.error('Unable change rehireable status');
+
+    }
   };
 
   const handleCancelChange = () => {


### PR DESCRIPTION
# Description
 Fix Rehireable status is updated in the frontend regardless of the response status 
![Screenshot (492)](https://github.com/user-attachments/assets/3963d48c-f869-43a8-8f07-b1e469176c4d)


## Related PRS (if any):
This frontend PR is related to the backend PR [#PR1046](https://github.com/OneCommunityGlobal/HGNRest/pull/1046).

## Main changes explained:
- Updated updateRehireableStatus function in actions/userManagement.js
- Update userProfile.js to display error if backend doesn't return 200 status when updating rehireable status

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user/ user with Change Rehireable Status permission
5. go to dashboard→ User Management → search for the protected accounts
'[jae@onecommunityglobal.org](mailto:jae@onecommunityglobal.org), '[one.community@me.com](mailto:one.community@me.com)', '[jsabol@me.com](mailto:jsabol@me.com)', '[devadmin@hgn.net](mailto:devadmin@hgn.net)' , and access their profile.
6. verify you can't update the Rehireable status of any of the protected accounts.
7. You could also add your email to the list of protected emails in the backend via editing the src\utilities\constants.js

## Screenshots or videos of changes:
![Screenshot (493)](https://github.com/user-attachments/assets/9f35cce8-4409-4eb0-9bf3-82a2a35648dc)


## Note:
Include the information the reviewers need to know.
