### PR TITLE
Vijay Anand fix for unusual timelog active or inactive popup when cmd/ctrl + timelog icon is clicked

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -23,6 +23,7 @@ import classnames from 'classnames';
 import moment from 'moment';
 import Alert from 'reactstrap/lib/Alert';
 import axios from 'axios';
+import { boxStyle, boxStyleDark } from 'styles';
 import hasPermission, {
   cantDeactivateOwner,
   cantUpdateDevAdminDetails,
@@ -48,7 +49,6 @@ import { updateUserStatus, updateRehireableStatus } from '../../actions/userMana
 import { UserStatus } from '../../utils/enums';
 import BlueSquareLayout from './BlueSquareLayout';
 import TeamWeeklySummaries from './TeamWeeklySummaries/TeamWeeklySummaries';
-import { boxStyle, boxStyleDark } from 'styles';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { convertDateFormatToMMMDDYY, formatDateLocal } from 'utils/formatDate';
 import EditableInfoModal from './EditableModal/EditableInfoModal';
@@ -794,9 +794,15 @@ function UserProfile(props) {
       )}
       <TabToolTips />
       <BasicToolTips />
-      <Container 
+      <Container
         className={`py-5 ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}
-        style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flexDirection: 'column'}}>
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          flexDirection: 'column',
+        }}
+      >
         <Row>
           <Col md="4" id="profileContainer">
             <div className="profile-img">
@@ -805,7 +811,7 @@ function UserProfile(props) {
                 alt="Profile Picture"
                 roundedCircle
                 className="profilePicture bg-white"
-                //this line below should fix the image formatting issue
+                // this line below should fix the image formatting issue
                 style={profilePic ? {} : { width: '240px', height: '240px' }}
               />
               {canEdit ? (
@@ -863,7 +869,7 @@ function UserProfile(props) {
                   areaName="UserProfileInfoModal"
                   areaTitle="User Profile"
                   fontSize={24}
-                  isPermissionPage={true}
+                  isPermissionPage
                   role={requestorRole} // Pass the 'role' prop to EditableInfoModal
                   darkMode={darkMode}
                 />
@@ -875,7 +881,7 @@ function UserProfile(props) {
                   canChange={canChangeUserStatus}
                   onClick={() => {
                     if (cantDeactivateOwner(userProfile, requestorRole)) {
-                      //Owner user cannot be deactivated by another user that is not an Owner.
+                      // Owner user cannot be deactivated by another user that is not an Owner.
                       alert('You are not authorized to deactivate an owner.');
                       return;
                     }
@@ -897,8 +903,8 @@ function UserProfile(props) {
                       } else {
                         e.preventDefault();
                         props.history.push(`/timelog/${targetUserId}`);
+                        setActiveInactivePopupOpen(true);
                       }
-                      setActiveInactivePopupOpen(true);
                     }}
                   />
                 </span>
@@ -946,9 +952,15 @@ function UserProfile(props) {
             <h6 className={darkMode ? 'text-light' : 'text-azure'}>{jobTitle}</h6>
             <p className={`proile-rating ${darkMode ? 'text-light' : ''}`}>
               {/* use converted date without tz otherwise the record's will updated with timezoned ts for start date.  */}
-              From : <span className={darkMode ? 'text-light' : ''}>{formatDateLocal(userProfile.startDate)}</span>
+              From :{' '}
+              <span className={darkMode ? 'text-light' : ''}>
+                {formatDateLocal(userProfile.startDate)}
+              </span>
               {'   '}
-              To: <span className={darkMode ? 'text-light' : ''}>{userProfile.endDate ? formatDateLocal(userProfile.endDate) : 'N/A'}</span>
+              To:{' '}
+              <span className={darkMode ? 'text-light' : ''}>
+                {userProfile.endDate ? formatDateLocal(userProfile.endDate) : 'N/A'}
+              </span>
             </p>
             {showSelect && summaries === undefined ? <div>Loading</div> : <div />}
             {showSelect && summaries !== undefined ? (
@@ -972,7 +984,7 @@ function UserProfile(props) {
               summarySelected.map((data, i) => {
                 return (
                   <TeamWeeklySummaries
-                    key={data['_id']}
+                    key={data._id}
                     i={i}
                     name={summaryName}
                     data={data}
@@ -1119,20 +1131,18 @@ function UserProfile(props) {
                 />
               </TabPane>
               <TabPane tabId="2">
-                {
-                  <VolunteeringTimeTab
-                    userProfile={userProfile}
-                    setUserProfile={setUserProfile}
-                    isUserSelf={isUserSelf}
-                    role={requestorRole}
-                    onEndDate={handleEndDate}
-                    loadUserProfile={loadUserProfile}
-                    canEdit={canEditUserProfile}
-                    canUpdateSummaryRequirements={canUpdateSummaryRequirements}
-                    onStartDate={handleStartDate}
-                    darkMode={darkMode}
-                  />
-                }
+                <VolunteeringTimeTab
+                  userProfile={userProfile}
+                  setUserProfile={setUserProfile}
+                  isUserSelf={isUserSelf}
+                  role={requestorRole}
+                  onEndDate={handleEndDate}
+                  loadUserProfile={loadUserProfile}
+                  canEdit={canEditUserProfile}
+                  canUpdateSummaryRequirements={canUpdateSummaryRequirements}
+                  onStartDate={handleStartDate}
+                  darkMode={darkMode}
+                />
               </TabPane>
               <TabPane tabId="3">
                 <TeamsTab
@@ -1402,7 +1412,7 @@ function UserProfile(props) {
                         <i
                           className={`fa fa-refresh ${darkMode ? 'text-light' : ''}`}
                           aria-hidden="true"
-                        ></i>
+                        />
                       </Button>
                     </div>
                   </Row>
@@ -1477,7 +1487,7 @@ function UserProfile(props) {
                         <i
                           className={`fa fa-refresh ${darkMode ? 'text-light' : ''}`}
                           aria-hidden="true"
-                        ></i>
+                        />
                       </Button>
                     </div>
                   </Row>
@@ -1573,7 +1583,7 @@ function UserProfile(props) {
                         <i
                           className={`fa fa-refresh ${darkMode ? 'text-light' : ''}`}
                           aria-hidden="true"
-                        ></i>
+                        />
                       </Button>
                     </div>
                   </Row>
@@ -1656,7 +1666,7 @@ function UserProfile(props) {
                         <i
                           className={`fa fa-refresh ${darkMode ? 'text-light' : ''}`}
                           aria-hidden="true"
-                        ></i>
+                        />
                       </Button>
                     </div>
                   </Row>
@@ -1683,7 +1693,7 @@ function UserProfile(props) {
                     userProfile={userProfile}
                     setUserProfile={setUserProfile}
                     darkMode={darkMode}
-                    tabletView={true}
+                    tabletView
                   />
                 </ModalBody>
                 <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
@@ -1726,7 +1736,7 @@ function UserProfile(props) {
                         <i
                           className={`fa fa-refresh ${darkMode ? 'text-light' : ''}`}
                           aria-hidden="true"
-                        ></i>
+                        />
                       </Button>
                     </div>
                   </Row>
@@ -1736,7 +1746,7 @@ function UserProfile(props) {
           </Col>
         </Row>
         <Row>
-          <Col md="4"></Col>
+          <Col md="4" />
           {/* <Col md="8" className="desktop-panel">
           </Col> */}
         </Row>


### PR DESCRIPTION
# Description
![Screenshot 2024-07-29 at 1 08 59 PM](https://github.com/user-attachments/assets/9caed0f8-3fc6-4adf-ae07-4636a525f8de)


## Related PRS (if any):
To test this frontend PR you need to checkout the development branch for the backend .
…

## Main changes explained:
- This fix, separates the logic for handling the metaKey/ctrlKey click and the regular click, and ensures setActiveInactivePopupOpen(true) is not called when the metaKey or ctrlKey is pressed.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ click on User Profile name→ View Profile
6. verify if the "change user status modal" doesn't pops-up and timelog page open as a new tab when Cmd/Ctrl + Timelog icon is clicked.

## Screenshots or videos of changes:
**Before Fix**:
[Before Fix Video](https://www.loom.com/share/c526e97dfaa1423fb6826b70d45ba328?sid=1d832dab-5ef5-4975-b5d6-bd393f4a3dcf)

**After Fix**:

[After Fix Video](https://www.loom.com/share/9bce4dfe58844c828d1e5b90569d1119?sid=e72c7c64-d593-4516-9ab4-ba686e1ff3ec)

