### PR TITLE
Select color multiselect in Weekly Summaries Report overlaps with toggle buttons

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.css
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.css
@@ -86,6 +86,10 @@
     padding: 5px 10px;
     margin-bottom: 0.25rem;
   }
+
+  .dropdown-container {
+    z-index: 2;
+  }
 }
 
 .weekly-summary-report-container {


### PR DESCRIPTION
# Description
The toggle buttons are visible over the search bar in the multi-select dropdown for selecting a color in the Weekly Summaries Report.

Fixes # (bug list priority low)
![image](https://github.com/user-attachments/assets/b9826493-2e35-4bbc-a8dc-6a73e4a273da)

## Related PRS (if any):
To test this frontend PR, you need to checkout the development branch of the backend.
…

## Main changes explained:
- Increased the z-index of the dropdown container to 2, ensuring that toggle buttons with a z-index of 1 are not visible when the multi-select dropdown is open.

## How to test:
1. check into current branch, `git checkout ambika_fix_select_color_dropdown_ui` and then, `git pull`
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to Reports→ Weekly Summaries Reports menu
6. Attempt to select a color from the dropdown "Select Color"
![image](https://github.com/user-attachments/assets/cc16a537-6740-4eeb-9db0-2eb3271263bb)
7. Verify that toggle buttons do not overlay the search bar in the multi-select dropdown.
8. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
**Before changes:**
![image](https://github.com/user-attachments/assets/47c2e7a2-5ba3-4420-81a6-f38f030d5c0c)

**After changes:**
![image](https://github.com/user-attachments/assets/927e1d65-42e3-4757-b1dc-240761de693e)

## Note:
This change applies only to the multi-select dropdown in the Weekly Summaries Report.
