### PR TITLE
Ambika - do not allow picture additions in timelog and summaries

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -31,12 +31,17 @@ import hasPermission from 'utils/permissions';
 import { boxStyle, boxStyleDark } from 'styles';
 import '../../Header/DarkMode.css'
 
+//Images are not allowed in timelog
+const disable_image_upload_handler = (blobInfo, progress) =>
+  new Promise((resolve, reject) => {
+    return reject({ message: 'Pictures are not allowed here!', remove: true });
+  });
+
 const TINY_MCE_INIT_OPTIONS = {
   license_key: 'gpl',
   menubar: false,
   placeholder: 'Description (10-word minimum) and reference link',
-  plugins:
-    'advlist autolink autoresize lists link charmap table paste help wordcount',
+  plugins: 'advlist autolink autoresize lists link charmap table paste help wordcount',
   toolbar:
     'bold italic underline link removeformat | bullist numlist outdent indent |\
                     styleselect fontsizeselect | table| strikethrough forecolor backcolor |\
@@ -46,6 +51,7 @@ const TINY_MCE_INIT_OPTIONS = {
   max_height: 300,
   autoresize_bottom_margin: 1,
   content_style: 'body { cursor: text !important; }',
+  images_upload_handler: disable_image_upload_handler
 };
 
 /**

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -31,10 +31,11 @@ import hasPermission from 'utils/permissions';
 import { boxStyle, boxStyleDark } from 'styles';
 import '../../Header/DarkMode.css'
 
-//Images are not allowed in timelog
-const disable_image_upload_handler = (blobInfo, progress) =>
-  new Promise((resolve, reject) => {
-    return reject({ message: 'Pictures are not allowed here!', remove: true });
+// Images are not allowed in timelog
+const customImageUploadHandler = () =>
+  new Promise((_, reject) => {
+    // eslint-disable-next-line prefer-promise-reject-errors
+    reject({ message: 'Pictures are not allowed here!', remove: true });
   });
 
 const TINY_MCE_INIT_OPTIONS = {
@@ -51,7 +52,7 @@ const TINY_MCE_INIT_OPTIONS = {
   max_height: 300,
   autoresize_bottom_margin: 1,
   content_style: 'body { cursor: text !important; }',
-  images_upload_handler: disable_image_upload_handler
+  images_upload_handler: customImageUploadHandler,
 };
 
 /**

--- a/src/components/Timelog/WeeklySummaries.jsx
+++ b/src/components/Timelog/WeeklySummaries.jsx
@@ -102,6 +102,13 @@ const WeeklySummaries = ({ userProfile }) => {
 
   };
 
+  // Images are not allowed while editing weekly summaries
+  const customImageUploadHandler = () =>
+    new Promise((_, reject) => {
+      // eslint-disable-next-line prefer-promise-reject-errors
+      reject({ message: 'Pictures are not allowed here!', remove: true });
+    });
+
   const TINY_MCE_INIT_OPTIONS = {
     license_key: 'gpl',
     menubar: false,
@@ -112,6 +119,7 @@ const WeeklySummaries = ({ userProfile }) => {
     min_height: 180,
     max_height: 500,
     autoresize_bottom_margin: 1,
+    images_upload_handler: customImageUploadHandler,
   }; 
 
   const renderSummary = (title, summary, index) => {

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -53,10 +53,11 @@ import {
 import CurrentPromptModal from './CurrentPromptModal';
 // import WriteItForMeModal from './WriteForMeModal';
 
-//Images are not allowed in weekly summary
-const disable_image_upload_handler = (blobInfo, progress) =>
-  new Promise((resolve, reject) => {
-    return reject({ message: 'Pictures are not allowed here!', remove: true });
+// Images are not allowed in weekly summary
+const customImageUploadHandler = () =>
+  new Promise((_, reject) => {
+    // eslint-disable-next-line prefer-promise-reject-errors
+    reject({ message: 'Pictures are not allowed here!', remove: true });
   });
 
 const TINY_MCE_INIT_OPTIONS = {
@@ -71,7 +72,7 @@ const TINY_MCE_INIT_OPTIONS = {
   max_height: 500,
   autoresize_bottom_margin: 1,
   content_style: 'body { font-size: 14px; }',
-  images_upload_handler: disable_image_upload_handler,
+  images_upload_handler: customImageUploadHandler,
 };
 
 // Need this export here in order for automated testing to work.

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -53,6 +53,12 @@ import {
 import CurrentPromptModal from './CurrentPromptModal';
 // import WriteItForMeModal from './WriteForMeModal';
 
+//Images are not allowed in weekly summary
+const disable_image_upload_handler = (blobInfo, progress) =>
+  new Promise((resolve, reject) => {
+    return reject({ message: 'Pictures are not allowed here!', remove: true });
+  });
+
 const TINY_MCE_INIT_OPTIONS = {
   license_key: 'gpl',
   menubar: false,
@@ -65,6 +71,7 @@ const TINY_MCE_INIT_OPTIONS = {
   max_height: 500,
   autoresize_bottom_margin: 1,
   content_style: 'body { font-size: 14px; }',
+  images_upload_handler: disable_image_upload_handler,
 };
 
 // Need this export here in order for automated testing to work.


### PR DESCRIPTION
# Description
The purpose is to prevent users from uploading images in timelog and summaries.
![image](https://github.com/user-attachments/assets/fcdc1f88-eb91-4511-8aa9-db993a06413c)

## Related PRS (if any):
To test this frontend PR you need to checkout the development branch of backend.

## Main changes explained:
- Updated the TINY_MCE_INIT_OPTIONS object related to editor
- the `images_upload_handler` is set to use the new `customImageUploadHandler` function
  - `customImageUploadHandler` handler rejects image uploads with a message "Pictures are not allowed here!" and sets `remove: true`

## How to test:
1. check into current branch `git checkout ambika_impl_pictures_not_allow_timelog_summaries`
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin/owner/volunteer user
5. go to dashboard
6. verify that user should not be able to upload images in timelog and summaries in all scenarios/cases
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
**Video**
https://www.loom.com/share/724bed3818d94c9fb2a674fa822727eb?t=113&sid=33f2a904-c145-457e-8479-1e41d9566475

## Note:
You can experiment with adding images using various methods, such as copy-pasting or drag-and-dropping. Additionally, there are several scenarios to consider where you might need to add or edit timelogs and summaries.

### Case 1: Add tangible/Intangible from dashboard 
file: HighestGoodNetworkApp/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx

- Add Tangible timelog by starting the clock
    - Click "Stop" on the dashboard to log tangible time
    - Add notes in "Add Tangible Time Entry" modal and attempt to add images
    -  Add Tangible timelog by starting the clock and complete 15 mins and wait for clock to ring
    - Click the "Log time" button
    - Add notes in "Add Tangible Time Entry" modal and attempt to add images
- Add Intangible Time Log
  - Click the "Add Intangible Time Log" button on the dashboard
  - Add notes in "Add Intangible Time Entry" modal and attempt to add images
- Edit Time Logs
  - Click on current week timelog tab on dashboard
  - Edit the tangible or intangible time log from the dashboard’s current week timelog tab, last week tab and week before last tab
  - Edit notes in "Add Tangible/Intangible Time Entry" modal and attempt to add images


### Case 2: Add Weekly Summary from dashboard
file: HighestGoodNetworkApp/src/components/WeeklySummary/WeeklySummary.jsx

- Add weekly summary for current week, last week, week before last, three week ago on dashboard
  - Click on the summary icon or text on the dashboard to add a new summary.
  - Add notes under "Enter your weekly summary below. (required)" and attempt to add images

### Case 3: Edit the weekly summaries on dashboard
file: HighestGoodNetworkApp/src/components/Timelog/WeeklySummaries.jsx

- Edit Weekly Summaries
  - Move to Weekly summaries tab
  - Edit the added weekly summary for the current week, last week's summary, and the week before last’s summary and attempt to add images