### PR TITLE
Howie accurate end date

### DIFF
--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -71,6 +71,8 @@ export const getTimeEntriesForPeriod = (userId, fromDate, toDate) => {
   };
 };
 
+export const getTimeEndDateEntriesByPeriod = (userId, fromDate, toDate) => { //Find last week of work in date
+  toDate = moment(toDate)
     .endOf('day')
     .format('YYYY-MM-DD');
   const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate,toDate);

--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -95,11 +95,8 @@ export const getTimeEndDateEntriesByPeriod = (userId, fromDate, toDate) => { //F
       if(!lastEntry){
         return "N/A";
       }
-      const dayOfWeek = moment(lastEntry.dateOfWork).day();
-      const daysUntilSat = dayOfWeek <= 6 ? 6 - dayOfWeek : 6 + (7 - dayOfWeek);
-      const lastSat = moment(lastEntry.dateOfWork).add(daysUntilSat, 'days');
-      const formattedLastSatday = moment.utc(lastSat).format('YYYY-MM-DD');
-      return formattedLastSatday;
+      const formattedLastEntryDate = moment(lastEntry.dateOfWork).format('YYYY-MM-DD');
+      return formattedLastEntryDate;
     } catch (error) {
       console.error("Error fetching time entries:", error);
       if (error.response && error.response.status === 401) {

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -607,7 +607,9 @@ function UserProfile(props) {
 
     if (!isActive) {
       endDate = await dispatch(getTimeEndDateEntriesByPeriod(userProfile._id, userProfile.createdDate, userProfile.toDate));
-      console.log("Enddate: " + endDate);
+      if (endDate == "N/A"){
+        endDate = userProfile.createdDate
+      }
     }
     const newUserProfile = {
       ...userProfile,

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -64,6 +64,7 @@ import {
   DEV_ADMIN_ACCOUNT_CUSTOM_WARNING_MESSAGE_DEV_ENV_ONLY,
   PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE,
 } from 'utils/constants';
+import { getTimeEndDateEntriesByPeriod } from '../../actions/timeEntries.js';
 
 function UserProfile(props) {
   const darkMode = useSelector(state => state.theme.darkMode);
@@ -600,16 +601,27 @@ function UserProfile(props) {
     });
   };
 
-  const setActiveInactive = isActive => {
+  const setActiveInactive = async(isActive) => {
     setActiveInactivePopupOpen(false);
+    let endDate;
+
+    if (!isActive) {
+      endDate = await dispatch(getTimeEndDateEntriesByPeriod(userProfile._id, userProfile.createdDate, userProfile.toDate));
+      console.log("Enddate: " + endDate);
+    }
     const newUserProfile = {
       ...userProfile,
-      isActive: !userProfile.isActive,
-      endDate: userProfile.isActive ? moment(new Date()).format('YYYY-MM-DD') : undefined,
+      isActive: isActive,
+      endDate: endDate || undefined,
     };
-    updateUserStatus(newUserProfile, isActive ? UserStatus.Active : UserStatus.InActive, undefined);
-    setUserProfile(newUserProfile);
-    setOriginalUserProfile(newUserProfile);
+
+    try{
+      await updateUserStatus(newUserProfile, isActive? UserStatus.Active : UserStatus.InActive, undefined);
+      setUserProfile(newUserProfile);
+      setOriginalUserProfile(newUserProfile);
+    } catch (error) {
+      console.error("Failed to update user status:", error);
+    }
   };
 
   const activeInactivePopupClose = () => {


### PR DESCRIPTION
# Description
If a person stops working without notice, or is activated and deactivated at some point in the future, their end date is the day I deactivate them. This is not accurate. A person’s end date should be the last week they contributed hours. 
Making a person inactive should have the software check for the last week they contributed hours and set the last day of that week as their end date. 
This should be reflected in these 3 areas:
Profile Page
Reports → Reports → People → Their report page
Other Links → User Management page

## Main changes explained:
- Updated timeEntries.js to add getTimeEndDateEntriesByPeriod to return day with time entries based on date range
- Updated userManagement.js so when a user is set to inactive, calls getTimeEndDateEntriesByPeriod to find last week worked and set End Date as the last day they worked. If no work history is found, sets the user's End Date to the date their account was created.
- Updated UserProfile.jsx so that when a user is toggled inactive from their profile, getTimeEndDateEntriesByPeriod is also called to set the End Date as the last day they worked. If no work history is found, sets the user's End Date to the date their account was created.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Other Links→ User Management Page
6. verify that when a user WITH work history is set to inactive, their end date is set to the last week they worked, not current date
7. verify that when a user WITHOUT work history is set to inactive, their end date is set to the date their account was created
8. verify that when a user is set to inactive from their user profile as well (http://localhost:3000/userprofile/{userid}) 
![image](https://github.com/user-attachments/assets/1e3e5e47-440d-4579-b7a7-bb9f89061e9a)
That the end date reflected is also the same as expected above
9. Make sure the end dates reflected are all the same in Reports, User Management, and the User Profile -> Volunteering Times tab

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/3ba9acdc-81e3-4ae6-abaf-4d8a8787b56e

https://github.com/user-attachments/assets/f769883e-9141-4eaa-9fa7-c8483ff0ce73



## Note:
If you don't have accounts with/without work history
Howie Volunteer has work history the week of July 27th
Howie test has NO work history

Feel free to try out with these accounts

There is a inaccuracy bug with start dates sometimes between Reports and User Managment that has been noted but not a bug with this PR

I have had some issues with this version of Development where the User Profile doesn't always save when made inactive, this is NOT from this PR. 
