### PR TITLE
Peizhou_Improve the Red/Grreen dot on LeaderBoard

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -465,7 +465,7 @@ function LeaderBoard({
                       showStar(item.tangibletime, item.weeklycommittedHours) ? (
                         <i
                           className="fa fa-star"
-                          title={`Weekly Committed: ${item.weeklycommittedHours} hours`}
+                          title={`Weekly Committed: ${item.weeklycommittedHours} hours\nClick to view their Dashboard`}
                           style={{
                             color: assignStarDotColors(
                               item.tangibletime,
@@ -479,7 +479,7 @@ function LeaderBoard({
                         />
                       ) : (
                         <div
-                          title={`Weekly Committed: ${item.weeklycommittedHours} hours`}
+                          title={`Weekly Committed: ${item.weeklycommittedHours} hours\nClick to view their Dashboard`}
                           style={{
                             backgroundColor:
                               item.tangibletime >= item.weeklycommittedHours ? '#32CD32' : 'red',


### PR DESCRIPTION
# Description
![C1](https://github.com/user-attachments/assets/c3592c08-5a04-4d29-ad47-7a4fe50c029a)
![C2](https://github.com/user-attachments/assets/47846362-2a2f-41bd-bef0-94e7f7e1e6a1)


## Related PRS (if any):
This frontend PR is not related to any backend PR, please just check in to the development branch.

## Main changes explained:
- Improve the red/grreen dot on LeaderBoard

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ LeaderBoard
6. move the mouse over a red/green dot, and see if the text is improved like this: 
"Weekly Committed: 10 hours
Click to view their Dashboard"

## Screenshots or videos of changes:
![4](https://github.com/user-attachments/assets/9b4775b6-4ef5-4e7f-b254-52df4ce88176)

