### PR TITLE
Jiadong - Replace Badges Section on Dashboard 

### DIFF
--- a/src/actions/badgeManagement.js
+++ b/src/actions/badgeManagement.js
@@ -10,6 +10,8 @@ import {
   GET_MESSAGE,
   CLOSE_ALERT,
   GET_USER_ID,
+  GET_BADGE_COUNT,
+  RESET_BADGE_COUNT,
 } from '../constants/badge';
 import { ENDPOINTS } from '../utils/URL';
 import moment from 'moment';
@@ -31,6 +33,37 @@ export const fetchAllBadges = () => {
       return err.response.status;
     }
   };
+};
+
+const getBadgeCountSuccess = badgeCount => ({
+  type: GET_BADGE_COUNT,
+  payload: badgeCount,
+});
+
+export const getBadgeCount = userId => {
+  return async dispatch => {
+    try {
+      const response = await axios.get(ENDPOINTS.BADGE_COUNT(userId));
+      dispatch(getBadgeCountSuccess(response.data.count));
+    } catch (err) {
+      return err.response.status;
+    }
+  };
+};
+
+export const resetBadgeCount = userId => async dispatch => {
+  try {
+    const updatedBadgeCountResponse = await axios.put(ENDPOINTS.BADGE_COUNT_RESET(userId));
+    const updatedBadgeCount = updatedBadgeCountResponse.data.count;
+    if (updatedBadgeCountResponse.status === 201) {
+      dispatch({
+        type: RESET_BADGE_COUNT,
+        payload: updatedBadgeCount,
+      });
+    }
+  } catch (error) {
+    console.error("Failed to reset badge count", error);
+  }
 };
 
 export const closeAlert = () => {
@@ -239,7 +272,7 @@ export const returnUpdatedBadgesCollection = (badgeCollection, selectedBadgesId)
 
       newBadgeCollection.forEach(badgeObj => {
         if (badgeId === badgeObj.badge) {
-          if (!included) { 
+          if (!included) {
             // Only update the first instance
             // Increment count only for the first instance found
             badgeObj.count = badgeObj.count ? badgeObj.count + 1 : 1;

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -121,13 +121,6 @@ export function Dashboard(props) {
               isNotAllowedToEdit={isNotAllowedToEdit}
             />
           </div>
-          <div className="my-5">
-            <Badge
-              userId={displayUserId}
-              role={authUser.role}
-              isNotAllowedToEdit={isNotAllowedToEdit}
-            />
-          </div>
         </Col>
       </Row>
       <TimeOffRequestDetailModal isNotAllowedToEdit={isNotAllowedToEdit} />

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -533,32 +533,33 @@ const Timelog = props => {
                   <Row style={{ minWidth: "100%" }} className='px-0 mx-0'>
                     <Col style={{ minWidth: "100%" }} className='px-0 mx-0'>
                       <CardTitle tag="h4">
-                      <div className="d-flex align-items-center">
-                        <span className="taskboard-header-title mb-1 mr-2">Tasks and Timelogs</span>
-                        <EditableInfoModal
-                          areaName="TasksAndTimelogInfoPoint"
-                          areaTitle="Tasks and Timelogs"
-                          fontSize={24}
-                          isPermissionPage={true}
-                          role={authUser.role} // Pass the 'role' prop to EditableInfoModal
-                          darkMode={darkMode}
-                        />
-                      
-                        <span className="mr-2" style={{padding: '1px'}}>
-                          <ActiveCell
-                            isActive={displayUserProfile.isActive}
-                            user={displayUserProfile}
-                            onClick={() => {
-                              props.updateUserProfile({
-                                ...displayUserProfile,
-                                isActive: !displayUserProfile.isActive,
-                                endDate:
-                                  !displayUserProfile.isActive === false
-                                    ? moment(new Date()).format('YYYY-MM-DD')
-                                    : undefined,
-                              });
-                            }}
+                        <div className="d-flex align-items-center">
+                          <span className="taskboard-header-title mb-1 mr-2">Tasks and Timelogs</span>
+                          <EditableInfoModal
+                            areaName="TasksAndTimelogInfoPoint"
+                            areaTitle="Tasks and Timelogs"
+                            fontSize={24}
+                            isPermissionPage={true}
+                            role={authUser.role} // Pass the 'role' prop to EditableInfoModal
+                            darkMode={darkMode}
                           />
+
+                          <span className="mr-2" style={{ padding: '1px' }}>
+                            <ActiveCell
+                              isActive={displayUserProfile.isActive}
+                              user={displayUserProfile}
+                              onClick={() => {
+                                props.updateUserProfile({
+                                  ...displayUserProfile,
+                                  isActive: !displayUserProfile.isActive,
+                                  endDate:
+                                    !displayUserProfile.isActive === false
+                                      ? moment(new Date()).format('YYYY-MM-DD')
+                                      : undefined,
+                                });
+                              }}
+                            />
+                          </span>
 
                           <span className="mr-2" style={{ padding: '1px' }}>
                             <ActiveCell

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -36,6 +36,7 @@ import { getTimeEntriesForWeek, getTimeEntriesForPeriod } from '../../actions/ti
 import { getUserProfile, updateUserProfile, getUserTasks } from '../../actions/userProfile';
 import { getUserProjects } from '../../actions/userProjects';
 import { getAllRoles } from '../../actions/role';
+import { getBadgeCount, resetBadgeCount } from '../../actions/badgeManagement';
 import TimeEntryForm from './TimeEntryForm';
 import TimeEntry from './TimeEntry';
 import EffortBar from './EffortBar';
@@ -54,6 +55,7 @@ import {
   PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE,
 } from 'utils/constants';
 import PropTypes from 'prop-types';
+import Badge from '../Badge';
 
 const doesUserHaveTaskWithWBS = (tasks = [], userId) => {
   if (!Array.isArray(tasks)) return false;
@@ -91,7 +93,7 @@ const endOfWeek = offset => {
 const Timelog = props => {
   const darkMode = useSelector(state => state.theme.darkMode)
   const location = useLocation();
- 
+
   // Main Function component
   const canPutUserProfileImportantInfo = props.hasPermission('putUserProfileImportantInfo');
 
@@ -117,6 +119,7 @@ const Timelog = props => {
     information: '',
     currentWeekEffort: 0,
     isTimeEntriesLoading: true,
+    badgeCount: 0,
   };
 
   const intangibletimeEntryFormData = {
@@ -139,27 +142,27 @@ const Timelog = props => {
 
   const checkSessionStorage = () => JSON.parse(sessionStorage.getItem('viewingUser')) ?? false;
   const [viewingUser, setViewingUser] = useState(checkSessionStorage());
-  const getUserId =()=>{
+  const getUserId = () => {
     try {
-         if(viewingUser){
-            return viewingUser.userId;
-         }
-         else if(userId!=null){
-            return userId;
-         }
-         return authUser.userid;
+      if (viewingUser) {
+        return viewingUser.userId;
+      }
+      else if (userId != null) {
+        return userId;
+      }
+      return authUser.userid;
     } catch (error) {
-       return null;
+      return null;
     }
-}
+  }
 
   const [displayUserId, setDisplayUserId] = useState(
-     getUserId()
+    getUserId()
   );
   const isAuthUser = authUser.userid === displayUserId;
   const fullName = `${displayUserProfile.firstName} ${displayUserProfile.lastName}`;
 
-  
+
   const defaultTab = () => {
     //change default to time log tab(1) in the following cases:
     const role = authUser.role;
@@ -212,7 +215,7 @@ const Timelog = props => {
        * changed, it will trigger a rerender of TimeEntry, then userProject and userTasks wouldn't
        * be for the same display user. But here loadAsyncData will make sure TimeLog will rerender only
        * when all states in store are updated to the same display user.
-       *  */ 
+       *  */
       <TimeEntry
         from='WeeklyTab'
         data={entry}
@@ -294,6 +297,9 @@ const Timelog = props => {
   };
 
   const changeTab = tab => {
+    if (tab === 6) {
+      props.resetBadgeCount(displayUserId);
+    }
     setTimeLogState({
       ...timeLogState,
       activeTab: tab,
@@ -316,7 +322,7 @@ const Timelog = props => {
   };
 
   const renderViewingTimeEntriesFrom = () => {
-    if (timeLogState.activeTab === 0 || timeLogState.activeTab === 5) {
+    if (timeLogState.activeTab === 0 || timeLogState.activeTab === 5 || timeLogState.activeTab === 6) {
       return <></>;
     } else if (timeLogState.activeTab === 4) {
       return (
@@ -361,29 +367,29 @@ const Timelog = props => {
     disPlayUserTasks.forEach(task => {
       const { projectId, wbsId, _id: taskId, wbsName, projectName } = task;
       if (!projectsObject[projectId]) {
-        projectsObject[projectId] = { 
-          projectName, 
+        projectsObject[projectId] = {
+          projectName,
           WBSObject: {
-            [wbsId]: { 
-              wbsName, 
+            [wbsId]: {
+              wbsName,
               taskObject: {
                 [taskId]: task
-              } 
+              }
             }
           }
-        } 
+        }
       } else if (!projectsObject[projectId].WBSObject[wbsId]) {
         projectsObject[projectId].WBSObject[wbsId] = {
-          wbsName, 
+          wbsName,
           taskObject: {
             [taskId]: task
-          } 
+          }
         }
       } else {
         projectsObject[projectId].WBSObject[wbsId].taskObject[taskId] = task;
       }
     });
-    
+
     for (const [projectId, project] of Object.entries(projectsObject)) {
       const { projectName, WBSObject } = project;
       options.push(
@@ -395,14 +401,14 @@ const Timelog = props => {
         const { wbsName, taskObject } = WBS;
         options.push(
           <option value={wbsId} key={`TimeLog_${wbsId}`} disabled className={`${darkMode ? "text-white-50" : ''} responsive-font-size`}>
-              {`\u2003WBS: ${wbsName}`}
+            {`\u2003WBS: ${wbsName}`}
           </option>
         )
         for (const [taskId, task] of Object.entries(taskObject)) {
           const { taskName } = task;
           options.push(
             <option className='responsive-font-size' value={taskId} key={`TimeLog_${taskId}`} >
-                {`\u2003\u2003 ↳ ${taskName}`}
+              {`\u2003\u2003 ↳ ${taskName}`}
             </option>
           )
         }
@@ -423,10 +429,10 @@ const Timelog = props => {
     setShouldFetchData(true);
   }, []);
 
-  const handleStorageEvent = () =>{
+  const handleStorageEvent = () => {
     const sessionStorageData = checkSessionStorage();
     setViewingUser(sessionStorageData || false);
-    if(sessionStorageData && sessionStorageData.userId!=authUser.userId) {
+    if (sessionStorageData && sessionStorageData.userId != authUser.userId) {
       setDisplayUserId(sessionStorageData.userId);
     }
   }
@@ -439,12 +445,17 @@ const Timelog = props => {
       setUserProfileId(urlId);
     }
   }, [urlId]);
-  
+
   useEffect(() => {
     if (userprofileId) {
       setDisplayUserId(userprofileId);
     }
   }, [userprofileId]);
+
+  useEffect(() => {
+    props.getBadgeCount(displayUserId);
+  }, [displayUserId, props]);
+
 
   useEffect(() => {
     changeTab(initialTab);
@@ -458,25 +469,25 @@ const Timelog = props => {
   }, [timeLogState.isTimeEntriesLoading, timeEntries, displayUserId]);
 
   useEffect(() => {
-      loadAsyncData(displayUserId);
+    loadAsyncData(displayUserId);
   }, [displayUserId]);
 
   useEffect(() => {
     // Filter the time entries
     updateTimeEntryItems();
   }, [timeLogState.projectsSelected]);
-  
+
   useEffect(() => {
     // Listens to sessionStorage changes, when setting viewingUser in leaderboard, an event is dispatched called storage. This listener will catch it and update the state.
     window.addEventListener('storage', handleStorageEvent);
     return () => {
       window.removeEventListener('storage', handleStorageEvent);
     };
-  },[]);
+  }, []);
 
   return (
-    <div className={`container-timelog-wrapper ${darkMode ? 'bg-oxford-blue' : ''}`} 
-         style={darkMode ? (!props.isDashboard ? {padding: "0 15px 300px 15px"} : {}) : {}}>
+    <div className={`container-timelog-wrapper ${darkMode ? 'bg-oxford-blue' : ''}`}
+      style={darkMode ? (!props.isDashboard ? { padding: "0 15px 300px 15px" } : {}) : {}}>
       {!props.isDashboard ? (
         <Container fluid>
           <SummaryBar
@@ -488,10 +499,10 @@ const Timelog = props => {
           <br />
         </Container>
       ) : (
-        <Container style={{textAlign: 'right', minWidth: '100%'}}>
+        <Container style={{ textAlign: 'right', minWidth: '100%' }}>
           {
-            props.isDashboard ? 
-              <></> : 
+            props.isDashboard ?
+              <></> :
               <EditableInfoModal
                 areaName="DashboardTimelog"
                 areaTitle="Timelog"
@@ -499,7 +510,7 @@ const Timelog = props => {
                 isPermissionPage={true}
                 role={authUser.role}
                 darkMode={darkMode}
-              /> 
+              />
           }
         </Container>
       )}
@@ -511,45 +522,45 @@ const Timelog = props => {
           {timeLogState.summary ? (
             <div className="my-2">
               <div id="weeklySum">
-                <WeeklySummary displayUserId={displayUserId} setPopup={toggleSummary} darkMode={darkMode}/>
+                <WeeklySummary displayUserId={displayUserId} setPopup={toggleSummary} darkMode={darkMode} />
               </div>
             </div>
           ) : null}
-          <Row style={{minWidth: "100%"}}>
+          <Row style={{ minWidth: "100%" }}>
             <Col md={12} className='px-0 mx-0'>
               <Card className={darkMode ? 'border-0' : ''}>
                 <CardHeader className={darkMode ? 'card-header-shadow-dark bg-space-cadet text-light' : 'card-header-shadow'}>
-                  <Row style={{minWidth: "100%"}} className='px-0 mx-0'>
-                    <Col style={{minWidth: "100%"}} className='px-0 mx-0'>
+                  <Row style={{ minWidth: "100%" }} className='px-0 mx-0'>
+                    <Col style={{ minWidth: "100%" }} className='px-0 mx-0'>
                       <CardTitle tag="h4">
-                      <div className="d-flex align-items-center">
-                        <span className="mb-1 mr-2">Tasks and Timelogs</span>
-                        <EditableInfoModal
-                          areaName="TasksAndTimelogInfoPoint"
-                          areaTitle="Tasks and Timelogs"
-                          fontSize={24}
-                          isPermissionPage={true}
-                          role={authUser.role} // Pass the 'role' prop to EditableInfoModal
-                          darkMode={darkMode}
-                        />
-                      
-                        <span className="mr-2" style={{padding: '1px'}}>
-                          <ActiveCell
-                            isActive={displayUserProfile.isActive}
-                            user={displayUserProfile}
-                            onClick={() => {
-                              props.updateUserProfile({
-                                ...displayUserProfile,
-                                isActive: !displayUserProfile.isActive,
-                                endDate:
-                                  !displayUserProfile.isActive === false
-                                    ? moment(new Date()).format('YYYY-MM-DD')
-                                    : undefined,
-                              });
-                            }}
+                        <div className="d-flex align-items-center">
+                          <span className="mb-1 mr-2">Tasks and Timelogs</span>
+                          <EditableInfoModal
+                            areaName="TasksAndTimelogInfoPoint"
+                            areaTitle="Tasks and Timelogs"
+                            fontSize={24}
+                            isPermissionPage={true}
+                            role={authUser.role} // Pass the 'role' prop to EditableInfoModal
+                            darkMode={darkMode}
                           />
-                        </span>
-                        <ProfileNavDot userId={displayUserId} style={{marginLeft: '2px', padding: '1px'}} />
+
+                          <span className="mr-2" style={{ padding: '1px' }}>
+                            <ActiveCell
+                              isActive={displayUserProfile.isActive}
+                              user={displayUserProfile}
+                              onClick={() => {
+                                props.updateUserProfile({
+                                  ...displayUserProfile,
+                                  isActive: !displayUserProfile.isActive,
+                                  endDate:
+                                    !displayUserProfile.isActive === false
+                                      ? moment(new Date()).format('YYYY-MM-DD')
+                                      : undefined,
+                                });
+                              }}
+                            />
+                          </span>
+                          <ProfileNavDot userId={displayUserId} style={{ marginLeft: '2px', padding: '1px' }} />
                         </div>
                       </CardTitle>
                       <CardSubtitle tag="h6" className={`${darkMode ? "text-azure" : "text-muted"} responsive-font-size`}>
@@ -725,6 +736,18 @@ const Timelog = props => {
                         Weekly Summaries
                       </NavLink>
                     </NavItem>
+                    <NavItem>
+                      <NavLink
+                        className={classnames({ active: timeLogState.activeTab === 6 })}
+                        onClick={() => {
+                          changeTab(6);
+                        }}
+                        href="#"
+                        to="#"
+                      >
+                        Badges<span className="badge badge-pill badge-danger ml-2">{props.badgeCount}</span>
+                      </NavLink>
+                    </NavItem>
                   </Nav>
 
                   <TabContent activeTab={timeLogState.activeTab} className={darkMode ? "bg-space-cadet" : ""}>
@@ -767,7 +790,7 @@ const Timelog = props => {
                         </Button>
                       </Form>
                     )}
-                    {timeLogState.activeTab === 0 || timeLogState.activeTab === 5 ? (
+                    {timeLogState.activeTab === 0 || timeLogState.activeTab === 5 || timeLogState.activeTab === 6 ? (
                       <></>
                     ) : (
                       <Form className="mb-2 responsive-font-size">
@@ -799,7 +822,7 @@ const Timelog = props => {
                       </Form>
                     )}
 
-                    {timeLogState.activeTab === 0 || timeLogState.activeTab === 5 ? (
+                    {timeLogState.activeTab === 0 || timeLogState.activeTab === 5 || timeLogState.activeTab === 6 ? (
                       <></>
                     ) : (
                       <EffortBar
@@ -809,7 +832,7 @@ const Timelog = props => {
                       />
                     )}
                     <TabPane tabId={0}>
-                      <TeamMemberTasks/>
+                      <TeamMemberTasks />
                     </TabPane>
                     <TabPane tabId={1}>{currentWeekEntries}</TabPane>
                     <TabPane tabId={2}>{lastWeekEntries}</TabPane>
@@ -817,6 +840,9 @@ const Timelog = props => {
                     <TabPane tabId={4}>{periodEntries}</TabPane>
                     <TabPane tabId={5}>
                       <WeeklySummaries userProfile={displayUserProfile} />
+                    </TabPane>
+                    <TabPane tabId={6}>
+                      <Badge userId={displayUserId} role={authUser.role} />
                     </TabPane>
                   </TabContent>
                 </CardBody>
@@ -844,6 +870,7 @@ const mapStateToProps = state => ({
   displayUserProjects: state.userProjects.projects,
   disPlayUserTasks: state.userTask,
   roles: state.role.roles,
+  badgeCount: state.badge.badgeCount,
 });
 
 
@@ -856,4 +883,6 @@ export default connect(mapStateToProps, {
   updateUserProfile,
   getAllRoles,
   hasPermission,
+  getBadgeCount,
+  resetBadgeCount,
 })(Timelog);

--- a/src/constants/badge.js
+++ b/src/constants/badge.js
@@ -8,4 +8,6 @@ export const GET_LAST_NAME = 'GET_LAST_NAME';
 export const GET_USER_ID = 'GET_USER_ID';
 export const GET_MESSAGE = 'GET_MESSAGE';
 export const CLOSE_ALERT = 'CLOSE_ALERT';
+export const GET_BADGE_COUNT = 'GET_BADGE_COUNT';
+export const RESET_BADGE_COUNT = 'BADGE_COUNT_RESET';
 export const WEEK_DIFF = 7 * 24 * 60 * 60 * 1000;

--- a/src/reducers/badgeReducer.js
+++ b/src/reducers/badgeReducer.js
@@ -9,6 +9,8 @@ import {
   GET_USER_ID,
   GET_MESSAGE,
   CLOSE_ALERT,
+  GET_BADGE_COUNT,
+  RESET_BADGE_COUNT
 } from '../constants/badge';
 
 const badgeInitial = {
@@ -20,6 +22,7 @@ const badgeInitial = {
   message: '',
   color: null,
   alertVisible: false,
+  badgeCount: 0,
 };
 
 export const badgeReducer = (state = badgeInitial, action) => {
@@ -34,6 +37,17 @@ export const badgeReducer = (state = badgeInitial, action) => {
       const toRemove = state.selectedBadges;
       toRemove.splice(toRemove.indexOf(action.badgeId), 1);
       return { ...state, selectedBadges: toRemove };
+    case GET_BADGE_COUNT:
+      return {
+        ...state,
+        badgeCount: action.payload,
+        error: null,
+      };
+    case RESET_BADGE_COUNT:
+      return {
+        ...state,
+        badgeCount: action.payload,
+      };
     case CLEAR_NAME_AND_SELECTED:
       return { ...state, selectedBadges: [], firstName: '', lastName: '', userId: '' };
     case CLEAR_SELECTED:

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -25,7 +25,8 @@ export const ENDPOINTS = {
   USER_PROJECTS: userId => `${APIEndpoint}/projects/user/${userId}`,
   PROJECT: `${APIEndpoint}/project/`,
   PROJECT_BY_ID: projectId => `${APIEndpoint}/project/${projectId}`,
-
+  BADGE_COUNT: userId => `${APIEndpoint}/badge/badgecount/${userId}`,
+  BADGE_COUNT_RESET: userId => `${APIEndpoint}/badge/badgecount/reset/${userId}`,
   PROJECT_MEMBER: projectId => `${APIEndpoint}/project/${projectId}/users`,
   UPDATE_PASSWORD: userId => `${APIEndpoint}/userprofile/${userId}/updatePassword`,
   FORCE_PASSWORD: `${APIEndpoint}/forcepassword`,
@@ -64,7 +65,7 @@ export const ENDPOINTS = {
   SAVE_SUMMARY_RECEPIENTS: (userid) => `${APIEndpoint}/reports/recepients/${userid}`,
   GET_SUMMARY_RECEPIENTS: () => `${APIEndpoint}/reports/getrecepients`,
   AUTHORIZE_WEEKLY_SUMMARY_REPORTS: () => `${APIEndpoint}/userProfile/authorizeUser/weeeklySummaries`,
-  TOTAL_ORG_SUMMARY: (startDate,endDate) => `${APIEndpoint}/reports/volunteerstats?startDate=${startDate}&endDate=${endDate}`,
+  TOTAL_ORG_SUMMARY: (startDate, endDate) => `${APIEndpoint}/reports/volunteerstats?startDate=${startDate}&endDate=${endDate}`,
 
   POPUP_EDITORS: `${APIEndpoint}/popupeditors/`,
   POPUP_EDITOR_BY_ID: id => `${APIEndpoint}/popupeditor/${id}`,
@@ -170,7 +171,7 @@ export const ENDPOINTS = {
 
   GET_ALL_FOLLOWUPS: () => `${APIEndpoint}/followup`,
 
-  SET_USER_FOLLOWUP: (userId,taskId) => `${APIEndpoint}/followup/${userId}/${taskId}`,
+  SET_USER_FOLLOWUP: (userId, taskId) => `${APIEndpoint}/followup/${userId}/${taskId}`,
   GET_PROJECT_BY_PERSON: (searchName) => `${APIEndpoint}/userProfile/projects/${searchName}`,
 
   // bm dashboard endpoints
@@ -186,7 +187,7 @@ export const ENDPOINTS = {
   BM_REUSABLES: `${APIEndpoint}/bm/reusables`,
   BM_PURCHASE_REUSABLES: `${APIEndpoint}/bm/reusables/purchase`,
   BM_EQUIPMENTS: `${APIEndpoint}/bm/equipments`,
-  BM_EQUIPMENT_TYPES : `${APIEndpoint}/bm/invtypes/equipments`,
+  BM_EQUIPMENT_TYPES: `${APIEndpoint}/bm/invtypes/equipments`,
   BM_EQUIPMENT_PURCHASE: `${APIEndpoint}/bm/equipment/purchase`,
   BM_PROJECTS: `${APIEndpoint}/bm/projects`,
   BM_PROJECT_BY_ID: projectId => `${APIEndpoint}/project/${projectId}`,
@@ -215,8 +216,8 @@ export const ENDPOINTS = {
   ADD_TIME_OFF_REQUEST: () => `${APIEndpoint}/setTimeOffRequest`,
   UPDATE_TIME_OFF_REQUEST: id => `${APIEndpoint}/updateTimeOffRequest/${id}`,
   DELETE_TIME_OFF_REQUEST: id => `${APIEndpoint}/deleteTimeOffRequest/${id}`,
-  BLUE_SQUARE_EMAIL_BCC : () => `${APIEndpoint}/AssignBlueSquareEmail`,
-  DELETE_BLUE_SQUARE_EMAIL_BCC : id => `${APIEndpoint}/AssignBlueSquareEmail/${id}`,
+  BLUE_SQUARE_EMAIL_BCC: () => `${APIEndpoint}/AssignBlueSquareEmail`,
+  DELETE_BLUE_SQUARE_EMAIL_BCC: id => `${APIEndpoint}/AssignBlueSquareEmail/${id}`,
 };
 
 export const ApiEndpoint = APIEndpoint;


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/65985986/300cfd3d-41ba-4a0a-80f7-dd6ce75d5670)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/65985986/cd0822c0-3b69-4227-a64a-ff1f1e1e8acf)

## Related PRS (if any):
This frontend PR is related to the #https://github.com/OneCommunityGlobal/HGNRest/pull/1053
…

## Main changes explained:
replace badge section on the dash board to Timlog component
add number indicator
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
4. log as admin user
5. go to dashboard -> Other Links -> Badge Management -> assign a new badge to another user.
6. log out
7. Log in as the user who was recently assigned the badge.
8. Check the number indicator on the dashboard.
9. Click on the "Badge" tab to view the assigned badge.
10. Check if the number indicator reset to 0.

## Screenshots or videos of changes:


https://github.com/user-attachments/assets/476243f0-9309-4d25-8df2-4062e0e72453

