### PR TITLE
Youyou_timelogs_show_icons_with_long_text_inputs

### DIFF
--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -185,20 +185,23 @@ const TimeEntry = (props) => {
             </div>
           </Col>
           <Col md={5} className="pl-2 pr-0">
-            <div className="text-muted">Notes:</div>
-            {ReactHtmlParser(notes)}
-            <div className="buttons">
-              {((hasATimeEntryEditPermission || isAuthUserAndSameDayEntry )&& !cantEditJaeRelatedRecord) 
-                && (
+            <div className="time-entry-container">
+              <div className="notes-section">
+                <div className="text-muted">Notes:</div>
+                {ReactHtmlParser(notes)}
+              </div>
+              <div className="buttons">
+                {((hasATimeEntryEditPermission || isAuthUserAndSameDayEntry) && !cantEditJaeRelatedRecord) && (
                   <button className="mr-3 text-primary">
                     <FontAwesomeIcon icon={faEdit} size="lg" onClick={toggle} />
                   </button>
                 )}
-              {canDelete && (
-                <button className='text-primary'>
-                  <DeleteModal timeEntry={data} />
-                </button>
-              )}
+                {canDelete && (
+                  <button className='text-primary'>
+                    <DeleteModal timeEntry={data} />
+                  </button>
+                )}
+              </div>
             </div>
           </Col>
         </Row>

--- a/src/components/Timelog/Timelog.css
+++ b/src/components/Timelog/Timelog.css
@@ -20,6 +20,23 @@
   margin-bottom:1px;
 }
 
+.time-entry-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.notes-section {
+  flex: 1;
+  margin-bottom: 13px; 
+  overflow-wrap: break-word; 
+}
+
+.buttons {
+  display: flex;
+  justify-content: flex-start;
+  gap: 10px; 
+}
+
 .buttons {
   right: 0;
   bottom: 0;


### PR DESCRIPTION
# Description
<img width="761" alt="Screenshot 2024-08-03 at 7 49 48 PM" src="https://github.com/user-attachments/assets/33e544a3-f4e9-43ae-9620-5bfbfb1d41bf">


## Related PRS (if any):
This frontend PR is related to the development backend branch

## Main changes explained:
- Edited TimeEntry.jsx to include a wrapper container for the description text section
- Edited Timelog.css to include more margin space for the icons on the page

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as any user who has access to Timelog page
5. go to dashboard→ Timelog 
6. Add Intangible or Tangible Time Entry. For the Notes section, enter a super long text to test. Submit the time entry.
7. Resize the browser to force the Notes section to resize. Check if the icons are too close to the text above it.

## Screenshots or videos of changes:
**Before:**
<img width="500" alt="PR - before change" src="https://github.com/user-attachments/assets/3d084e18-3878-466f-9d00-077614f342b0">


**After:**
https://github.com/user-attachments/assets/840ec290-fe6f-492a-bc69-ea0ef301d7bf


## Note:
N/A
