### PR TITLE
Nathan add '(Self and Others)' to permission names

### DIFF
--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -318,12 +318,12 @@ export const permissionLabels = [
             description: 'Category for all permissions related to editing timelogs',
             subperms: [
               {
-                label: 'Edit Timelog Time',
+                label: 'Edit Timelog Time (Self and Others)',
                 key: 'editTimeEntryTime',
                 description: 'Gives the user permission to edit the time of any time log entry.',
               },
               {
-                label: 'Edit Timelog Description',
+                label: 'Edit Timelog Description (Self and Others)',
                 key: 'editTimeEntryDescription',
                 description:
                   'Gives the user permission to edit the description of any time log entry.',
@@ -335,7 +335,7 @@ export const permissionLabels = [
                   'Gives the user permission to toggle the tangible check when editing a time entry of another user.',
               },
               {
-                label: 'Change Time Entry Date',
+                label: 'Change Time Entry Date (Self and Others)',
                 key: 'editTimeEntryDate',
                 description:
                   'Gives the user permission to edit the date when adding an intangible time entry.',


### PR DESCRIPTION
# Description
Adds '(Self and Others)' to relevant time entry edit permission names

## Main changes explained:
- Add '(Self and Others)' to relevant time entry edit permission names


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Other Links→ Permissions Management→ any role or manage individual permissions
6. check permission names
