### PR TITLE
ambika volunteer should not be able to complete reviews for their own tasks

### DIFF
--- a/src/components/TeamMemberTasks/ReviewButton.jsx
+++ b/src/components/TeamMemberTasks/ReviewButton.jsx
@@ -24,10 +24,16 @@ const ReviewButton = ({
   const [link, setLink] = useState("");
   const [verifyModal, setVerifyModal] = useState(false);
   const [selectedAction, setSelectedAction] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const toggleModal = () => {
     setModal(!modal);
   };
+
+  const modalCancelButtonHandler = () => {
+    toggleModal();
+    setIsSubmitting(false);
+  }
 
   const toggleVerify = () => {
     setVerifyModal(!verifyModal);
@@ -77,16 +83,18 @@ const ReviewButton = ({
         setLink("");
       } else {
         alert('Invalid URL. Please enter a valid URL of at least 20 characters');
+        setIsSubmitting(false);
         return;
       }
     }
     updateTask(task._id, updatedTask);
     setModal(false);
+    setIsSubmitting(true);
   };
 
   const buttonFormat = () => {
     if (user.personId === myUserId && reviewStatus === "Unsubmitted") {
-      return <Button className='reviewBtn' color='primary' onClick={toggleModal} style={darkMode ? boxStyleDark : boxStyle}>
+      return <Button className='reviewBtn' color='primary' onClick={toggleModal} style={darkMode ? boxStyleDark : boxStyle} disabled = { isSubmitting }>
         Submit for Review
       </Button>;
      } else if (reviewStatus === "Submitted")  {
@@ -211,7 +219,7 @@ const ReviewButton = ({
               : `Complete`}
           </Button>
           <Button
-            onClick={toggleModal}
+            onClick={modalCancelButtonHandler}
             style={darkMode ? boxStyleDark : boxStyle}
           >
             Cancel


### PR DESCRIPTION
# Description
Volunteer role should not be allowed to complete the review of their own task
Fixes # (bug)
![image](https://github.com/user-attachments/assets/7492e5a5-d3c6-4e5c-a6b8-e5103a108b08)

## Related PRS (if any):
To test this frontend PR you need to checkout the development branch of backend repository.
…

## Main changes explained:
- Introduced a new state variable `isSubmitting` and its setter to manage the submit state.
- Created a `modalCancelButtonHandler` function to reset the submit state and toggle the modal.
- Updated the `updReviewStat` function : After updating the task and closing the modal, the `setIsSubmitting(true)` function is called, setting `isSubmitting` to true.
- Modified the button “Submit for review” rendering logic to disable the button when `isSubmitting` is true.
- Changed the cancel button’s onClick event to use the new `modalCancelButtonHandler` function.

## How to test:
1. check into current branch, `git checkout ambika-fix-volunteer-cannot-complete-own-review`
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. There are two different roles involved in testing this PR: owner and volunteer.
5. Open an incognito tab and log in as an admin/owner user.
6. Open another tab and log in as a volunteer user (create a new volunteer user if needed).
7. As an owner, go to Dashboard -> Other Links -> Projects.
8. Choose any project and click on the WBS button.
9. Create a new WBS with a new name and click on plus button, now click on the newly created WBS name link.
10. Click on "Add Task," add a new task, provide a task name, and in the resource field, type the name of the user with a volunteer role and assign the task to this user and submit. 
11. Now, as the volunteer user in the other tab, verify that the task is visible under the Task tab in the dashboard.
12. Click on the "Submit for Review" button.
13. Verify that the volunteer cannot click on the same button again if submission is successful
14. Verify that the "Submit for Review" button is disabled in case of a successful link submission.
15. Verify that the "Submit for Review" button remains accessible if an invalid link is provided or if the cancel button or close button is clicked during the submission.
16. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
**Before changes:**
After the second click, observe that the volunteer can change the review status and complete their own review by clicking on the "Complete" button. Notice that this modal is asking for a complete review which should not be allowed.
Notice that the button changes after completion and the task disappears from the volunteer dashboard now.

https://www.loom.com/share/a118314ca1484728b7869d17e76a5747?sid=85765788-0e55-47be-952d-509f0f5d2455 

**After changes**
https://www.loom.com/share/7766428647a24750bf896cfd9adab4bd?sid=b3877400-e7a1-48d6-ad47-549683940ca3

## Note:
- The system should not allow users with a volunteer role to complete their own task reviews.
- The "Submit for Review" button should not open the modal for completing the review if a volunteer clicks on submit for review
- Users should not be able to accidentally complete a review for their own task by clicking the button multiple times.
- The task should remain visible and accessible after a volunteer submits their work, without allowing them to complete their own review.
