### PR TITLE
Vijay Anand assign badge popup ui fix

### DIFF
--- a/src/components/Badge/AssignBadgePopup.css
+++ b/src/components/Badge/AssignBadgePopup.css
@@ -1,0 +1,4 @@
+.max-h-300 {
+    max-height: 300px;
+  }
+  

--- a/src/components/Badge/AssignBadgePopup.jsx
+++ b/src/components/Badge/AssignBadgePopup.jsx
@@ -34,42 +34,50 @@ function AssignBadgePopup(props) {
           onSearch(e.target.value);
         }}
       />
-      <Table className={darkMode ? 'text-light' : ''}>
-        <thead>
-          <tr className={darkMode ? 'bg-space-cadet' : ''}>
-            <th>Badge</th>
-            <th>Name</th>
-            <th>
-              <i className="fa fa-info-circle" id="SelectInfo" />
-              <UncontrolledTooltip
-                placement="right"
-                target="SelectInfo"
-                style={{ backgroundColor: '#666', color: '#fff' }}
-              >
-                <p className="badge_info_icon_text">
-                  Hmmm, little blank boxes... what could they mean? Yep, you guessed it, check those
-                  boxes to select the badges you wish to assign a person. Click the
-                  &quot;Confirm&quot; button at the bottom when you&apos;ve selected all you wish to
-                  add.
-                </p>
-                <p className="badge_info_icon_text">
-                  Want to assign multiple of the same badge to a person? Repeat the process!!
-                </p>
-              </UncontrolledTooltip>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {filteredBadges.map((value, index) => (
-            <AssignTableRow
-              badge={value}
-              index={index}
-              key={index}
-              selectedBadges={props.selectedBadges}
-            />
-          ))}
-        </tbody>
-      </Table>
+      <div
+        style={{
+          maxHeight: '300px',
+          overflowY: 'auto',
+          marginBottom: '10px',
+        }}
+      >
+        <Table className={darkMode ? 'text-light' : ''}>
+          <thead>
+            <tr className={darkMode ? 'bg-space-cadet' : ''}>
+              <th>Badge</th>
+              <th>Name</th>
+              <th>
+                <i className="fa fa-info-circle" id="SelectInfo" />
+                <UncontrolledTooltip
+                  placement="right"
+                  target="SelectInfo"
+                  style={{ backgroundColor: '#666', color: '#fff' }}
+                >
+                  <p className="badge_info_icon_text">
+                    Hmmm, little blank boxes... what could they mean? Yep, you guessed it, check those
+                    boxes to select the badges you wish to assign a person. Click the
+                    &quot;Confirm&quot; button at the bottom when you&apos;ve selected all you wish to
+                    add.
+                  </p>
+                  <p className="badge_info_icon_text">
+                    Want to assign multiple of the same badge to a person? Repeat the process!!
+                  </p>
+                </UncontrolledTooltip>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredBadges.map((value, index) => (
+              <AssignTableRow
+                badge={value}
+                index={index}
+                key={index}
+                selectedBadges={props.selectedBadges}
+              />
+            ))}
+          </tbody>
+        </Table>
+      </div>
       <Button
         className="btn--dark-sea-green float-right"
         style={darkMode ? { ...boxStyleDark, margin: 5 } : { ...boxStyle, margin: 5 }}

--- a/src/components/Badge/AssignBadgePopup.jsx
+++ b/src/components/Badge/AssignBadgePopup.jsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Table, Button, UncontrolledTooltip } from 'reactstrap';
-import { boxStyle, boxStyleDark } from 'styles';
 import AssignTableRow from './AssignTableRow';
 import { useSelector } from 'react-redux';
+import './AssignBadgePopup.css';
 
 function AssignBadgePopup(props) {
   const darkMode = useSelector(state => state.theme.darkMode);
@@ -28,16 +28,16 @@ function AssignBadgePopup(props) {
     <div>
       <input
         type="text"
-        className="form-control assign_badge_search_box"
+        className="form-control assign_badge_search_box mb-3"
         placeholder="Search Badge Name"
         onChange={e => {
           onSearch(e.target.value);
         }}
       />
-      <div className="overflow-auto mb-2" style={{ maxHeight: '300px' }}>
-        <Table className={darkMode ? 'text-light' : ''}>
+      <div className={`overflow-auto mb-2 max-h-300 ${darkMode ? 'bg-dark text-light' : ''}`}>
+        <Table className={darkMode ? 'table-dark' : ''}>
           <thead>
-            <tr className={darkMode ? 'bg-space-cadet' : ''}>
+            <tr>
               <th>Badge</th>
               <th>Name</th>
               <th>
@@ -45,7 +45,7 @@ function AssignBadgePopup(props) {
                 <UncontrolledTooltip
                   placement="right"
                   target="SelectInfo"
-                  style={{ backgroundColor: '#666', color: '#fff' }}
+                  className="bg-secondary text-light"
                 >
                   <p className="badge_info_icon_text">
                     Hmmm, little blank boxes... what could they mean? Yep, you guessed it, check those
@@ -73,8 +73,7 @@ function AssignBadgePopup(props) {
         </Table>
       </div>
       <Button
-        className="btn--dark-sea-green float-right"
-        style={darkMode ? { ...boxStyleDark, margin: 5 } : { ...boxStyle, margin: 5 }}
+        className={`btn btn-success float-right ${darkMode ? 'bg-dark text-light' : 'bg-success text-white'}`}
         onClick={props.submit}
       >
         Confirm

--- a/src/components/Badge/AssignBadgePopup.jsx
+++ b/src/components/Badge/AssignBadgePopup.jsx
@@ -34,13 +34,7 @@ function AssignBadgePopup(props) {
           onSearch(e.target.value);
         }}
       />
-      <div
-        style={{
-          maxHeight: '300px',
-          overflowY: 'auto',
-          marginBottom: '10px',
-        }}
-      >
+      <div className="overflow-auto mb-2" style={{ maxHeight: '300px' }}>
         <Table className={darkMode ? 'text-light' : ''}>
           <thead>
             <tr className={darkMode ? 'bg-space-cadet' : ''}>


### PR DESCRIPTION
# Description

![Screenshot 2024-08-06 at 10 06 07 PM](https://github.com/user-attachments/assets/c8041ead-1e57-4def-90b0-97848df0857b)


## Related PRS (if any):
To test this frontend PR you need to checkout the development branch in the backend.

## Main changes explained:
- Added UI fix to display the badges with a scrollable list inside the popup instead of scrolling the entire page to click the confirm for better user experience.

## How to test:
1. check into the current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→Other Links→ Badge Management
6. Search and select a name from the search result and click on assign badge a popup with a list of badges.
7. verify if the popup has an internal scrollable list of badges and it fits the browser's viewport.
8. verify the responsiveness and also in dark mode.

## Screenshots or videos of changes:
**Before Change**
https://www.loom.com/share/7a04336ed0b747fb8808a24cc91af8e8?sid=e98f0534-8298-4b88-a52b-6df33ab1c834

**After Change**
https://www.loom.com/share/d12be2f3c90046c08f86b2026bd504c1?sid=7af373c4-7cc6-487d-9bd9-f4f4b1c3bf0d

## Note:
These changes are related only to the assign badge popup.
