### PR TITLE
Ambika fix Badge Development > Edit and Delete buttons must be disabled/enabled based on permissions

### DIFF
--- a/src/components/Badge/BadgeDevelopmentTable.jsx
+++ b/src/components/Badge/BadgeDevelopmentTable.jsx
@@ -19,6 +19,7 @@ import BadgeTableHeader from './BadgeTableHeader';
 import BadgeTableFilter from './BadgeTableFilter';
 import EditBadgePopup from './EditBadgePopup';
 import DeleteBadgePopup from './DeleteBadgePopup';
+import hasPermission from '../../utils/permissions';
 import './Badge.css';
 
 function BadgeDevelopmentTable(props) {
@@ -34,6 +35,9 @@ function BadgeDevelopmentTable(props) {
 
   const [editBadgeValues, setEditBadgeValues] = useState('');
   const [editPopup, setEditPopup] = useState(false);
+
+  const canDeleteBadges = props.hasPermission('deleteBadges');
+  const canUpdateBadges = props.hasPermission('updateBadges');
 
   const detailsText = badegValue => {
     let returnText = '';
@@ -235,6 +239,7 @@ function BadgeDevelopmentTable(props) {
                   <Button
                     outline
                     color="info"
+                    disabled = {!canUpdateBadges}
                     onClick={() => onEditButtonClick(value)}
                     style={darkMode ? {} : boxStyle}
                   >
@@ -245,6 +250,7 @@ function BadgeDevelopmentTable(props) {
                   <Button
                     outline
                     color="danger"
+                    disabled = {!canDeleteBadges}
                     onClick={() => onDeleteButtonClick(value._id, value.badgeName)}
                     style={darkMode ? {} : boxStyle}
                   >
@@ -298,6 +304,7 @@ const mapDispatchToProps = dispatch => ({
   deleteBadge: badgeId => dispatch(deleteBadge(badgeId)),
   updateBadge: (badgeId, badgeData) => dispatch(updateBadge(badgeId, badgeData)),
   closeAlert: () => dispatch(closeAlert()),
+  hasPermission: permission => dispatch(hasPermission(permission)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(BadgeDevelopmentTable);

--- a/src/components/Badge/__tests__/BadgeDevelopmentTable.test.js
+++ b/src/components/Badge/__tests__/BadgeDevelopmentTable.test.js
@@ -7,6 +7,7 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { shallow } from 'enzyme';
 import { themeMock } from '__tests__/mockStates';
+import { updateBadge } from 'actions/badgeManagement';
 
 const mockStore = configureStore([thunk]);
 
@@ -50,7 +51,7 @@ const mockData = {
   color: null,
   message: '',
 };
-
+ 
 const renderComponent = mockProps => {
   const store = mockStore({
     badge: {
@@ -61,6 +62,26 @@ const renderComponent = mockProps => {
     },
     allProjects: {
       projects: [],
+    },
+    auth: {
+      isAuthenticated: true,
+      user: {
+        userid: '123',
+        role: 'Owner',
+        firstName: 'John',
+        profilePic: '/path/to/image.jpg',
+        permissions: {
+          frontPermissions: ['updateBadges', 'deleteBadges'],
+          backPermissions: [],
+        },
+      },
+    },
+    userProfile: {
+      email: 'test@example.com',
+    },
+    taskEditSuggestionCount: 0,
+    role: {
+      roles: ['Owner'],
     },
     theme: themeMock,
   });

--- a/src/components/Badge/__tests__/BadgeDevelopmentTable.test.js
+++ b/src/components/Badge/__tests__/BadgeDevelopmentTable.test.js
@@ -7,7 +7,6 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { shallow } from 'enzyme';
 import { themeMock } from '__tests__/mockStates';
-import { updateBadge } from 'actions/badgeManagement';
 
 const mockStore = configureStore([thunk]);
 
@@ -51,7 +50,7 @@ const mockData = {
   color: null,
   message: '',
 };
- 
+
 const renderComponent = mockProps => {
   const store = mockStore({
     badge: {


### PR DESCRIPTION
# Description
Edit and Delete buttons must be enabled/disabled based on user permissions in badge management
![image](https://github.com/user-attachments/assets/fa7ca053-e3fc-445d-922b-e55db74b4944)

Fixes # (bug list priority high)

## Related PRS (if any):
To test this frontend PR you need to checkout the development branch of backend PR.

## Main changes explained:
- import for the hasPermission function from '../../utils/permissions'
- Two new constants, canDeleteBadges and canUpdateBadges. These constants are set using the props.hasPermission function to check whether the user has permissions to delete badges ('deleteBadges') and update badges ('updateBadges'), respectively.
- The logic for enabling or disabling buttons has been modified
  - the edit button is now disabled if the user lacks the canUpdateBadges permission.
  - the delete button is disabled if the user lacks the canDeleteBadges permission.
- the hasPermission utility is dispatched with the user's permissions.
- Updated mockdata in test class src/components/Badge/__tests__/BadgeDevelopmentTable.test.js for above permissions

## How to test:
1. check into current branch, `git checkout ambika-fix-disable-badges-button-based-on-permissions`
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. To test this bug you will use two roles, owner and volunteer
5. You can create a new volunteer role if needed
6. Log in as an owner user (a user who has access to the permission management menu).
7. Navigate to Dashboard → Other Links → Permission Management.
8. Click on Manage User Permissions button
9. Search for your user with a volunteer role, grant only the "Edit Badge" permission.
10. Log in as the volunteer user you just modified.
11. Go to Dashboard → Other Links → Badge Management.
12. Navigate to the Badge Development button and observe the behavior of the Edit and Delete buttons.
13. Verify that the Edit button is enabled and the Delete button is disabled because edit permission was given only
14. Repeat the above steps, this time granting "Delete Badge" permission and removing "Edit Badge" permission for the volunteer user.
15. Log out as a volunteer user if already logged in
16. Log in again as a volunteer user
17. Verify that the Edit and Delete buttons in the Badge Development table accurately reflect the permissions granted to the user roles.
27. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

### Refer to this video for step-by-step testing instructions
https://www.loom.com/share/0c0b541ee8bf4b15a804690652e2bdb0

## Note:
Permission changes will take effect after the user logs out and logs back in.
