### PR TITLE
Jay Increased margins for volunteer time tab

### DIFF
--- a/src/components/UserProfile/VolunteeringTimeTab/timeTab.css
+++ b/src/components/UserProfile/VolunteeringTimeTab/timeTab.css
@@ -1,5 +1,6 @@
 .volunteering-time-row {
   align-items: center;
+  margin-top: 8px;
 }
 
 .volunteering-time-row .col-md-6 > p {


### PR DESCRIPTION
# Description
Fixes margins for volunteer time cells
![image](https://github.com/user-attachments/assets/eb88720a-cf98-4c4d-88ea-de5fe5f5ef34)


## Related PRS (if any):
This is not related to a backend PR

## Main changes explained:
- Update `components/UserProfile/VolunteeringTimeTab/timeTab.css` to have a margin for volunteer rows

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ View Profile→ Volunteering Time
6. Verify margins are updated

## Screenshots or videos of changes:
![updated margins](https://github.com/user-attachments/assets/72235a7e-ecb9-4f56-860a-b27730e303be)
