### PR TITLE
Pranay badge assignment tab should be disabled unless user has access to badge assignment

### DIFF
--- a/bashrc.sh
+++ b/bashrc.sh
@@ -1,0 +1,2 @@
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm

--- a/bashrc.sh
+++ b/bashrc.sh
@@ -1,2 +1,0 @@
-export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm

--- a/src/components/Badge/BadgeManagement.jsx
+++ b/src/components/Badge/BadgeManagement.jsx
@@ -10,8 +10,9 @@ import { fetchAllBadges } from '../../actions/badgeManagement';
 
 function BadgeManagement(props) {
   const { darkMode } = props;
+  const badgeAssignmentPermissions = checkIfBadgeAssignmentIsAllowed(props.permissions, props.role);
 
-  const [activeTab, setActiveTab] = useState('1');
+  const [activeTab, setActiveTab] = useState(badgeAssignmentPermissions?'1':'2');
 
   const toggle = tab => {
     if (activeTab !== tab) setActiveTab(tab);
@@ -21,6 +22,8 @@ function BadgeManagement(props) {
   useEffect(() => {
     props.fetchAllBadges();
   }, []);
+
+
 
   return (
     <div
@@ -48,10 +51,11 @@ function BadgeManagement(props) {
               darkMode && activeTab !== '1' ? 'bg-light' : ''
             }`}
             onClick={() => {
-              toggle('1');
+              if(badgeAssignmentPermissions){toggle('1');}
+              
             }}
             style={
-              darkMode ? { ...boxStyleDark, cursor: 'pointer' } : { ...boxStyle, cursor: 'pointer' }
+              darkMode ? { ...boxStyleDark, cursor: badgeAssignmentPermissions?'pointer': 'no-drop' } : { ...boxStyle, cursor: badgeAssignmentPermissions?'pointer': 'no-drop' }
             }
           >
             Badge Assignment
@@ -75,7 +79,9 @@ function BadgeManagement(props) {
       </Nav>
       <TabContent activeTab={activeTab}>
         <TabPane tabId="1">
-          <AssignBadge allBadgeData={props.allBadgeData} />
+          <AssignBadge
+            allBadgeData={props.allBadgeData}
+          />
         </TabPane>
         <TabPane tabId="2" className="h-100">
           <BadgeDevelopment allBadgeData={props.allBadgeData} darkMode={darkMode} />
@@ -89,10 +95,16 @@ const mapStateToProps = state => ({
   allBadgeData: state.badge.allBadgeData,
   role: state.userProfile.role,
   darkMode: state.theme.darkMode,
+  permissions: state.userProfile.permissions,
 });
 
 const mapDispatchToProps = dispatch => ({
   fetchAllBadges: () => dispatch(fetchAllBadges()),
 });
+
+function checkIfBadgeAssignmentIsAllowed(permissions, role) {
+  if (role === 'Administrator' || role === 'Owner') return true;
+  return permissions?.frontPermissions.includes('assignBadges');
+}
 
 export default connect(mapStateToProps, mapDispatchToProps)(BadgeManagement);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b8d5837e-3667-4053-bed3-d5bef6cad4fc)

Related PRS
This frontend PR is related to the Development backend PR.
…

 Main changes:
Created a Function to Check is the user Has a Badge Assignment Permission 
If Yes Badge Assignment Tab is Enabled Else Disabled
…

Steps To Test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in as Volunteer User with No badge Assignment Permission, but has access to badge management page via other permissions.
5. Try to open the badge assignment Tab it should be disabled
6. Now login with Admin Role and Assign Permission to One of the Volunteer, Then Login Back with Volunteer Account this time it should be Enabled.

Screenshots or videos of changes:
Please Check The Video Of Change
https://www.loom.com/share/e4ec218053ce469b89433854872750f1?sid=aa77e788-2788-418a-b37a-e2292fb32bd8

