### PR TITLE
Ivy-invalid password alert and errors to be displayed appropriately below the text input area.

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -31,7 +31,6 @@ export const loginUser = credentials => dispatch => {
         });
       }else if (err.response && err.response.status === 403){
         errors = {email: err.response.data.message};
-  
         dispatch({
           type: GET_ERRORS,
           payload: errors,

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -22,8 +22,16 @@ export const loginUser = credentials => dispatch => {
       }
     })
     .catch(err => {
-      if (err.response && err.response.status === 403) {
-        const errors = { email: err.response.data.message };
+      let errors;
+      if(err.response && err.response.status === 404){
+        errors = {password: err.response.data.message};
+        dispatch({
+          type: GET_ERRORS,
+          payload: errors,
+        });
+      }else if (err.response && err.response.status === 403){
+        errors = {email: err.response.data.message};
+  
         dispatch({
           type: GET_ERRORS,
           payload: errors,

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -47,10 +47,13 @@ export class Login extends Form {
   }
 
   doSubmit = async () => {
-    const email = this.state.data.email.replace(/[A-Z]/g, char => char.toLowerCase());
-    const { password } = this.state.data;
-    this.props.loginUser({ email, password });
-    this.setState({ errors: this.props.errors });
+    const { email, password } = this.state.data;
+    const formattedEmail = email.replace(/[A-Z]/g, char => char.toLowerCase());
+    await this.props.loginUser({ email:formattedEmail, password });
+    if(this.props.errors){
+      this.setState({ errors: this.props.errors });
+    }
+    
   };
 
   render() {

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -49,11 +49,10 @@ export class Login extends Form {
   doSubmit = async () => {
     const { email, password } = this.state.data;
     const formattedEmail = email.replace(/[A-Z]/g, char => char.toLowerCase());
-    await this.props.loginUser({ email:formattedEmail, password });
-    if(this.props.errors){
+    await this.props.loginUser({ email: formattedEmail, password });
+    if (this.props.errors) {
       this.setState({ errors: this.props.errors });
     }
-    
   };
 
   render() {

--- a/src/components/UpdatePassword/__tests__/UpdatePassword.test.js
+++ b/src/components/UpdatePassword/__tests__/UpdatePassword.test.js
@@ -106,7 +106,7 @@ describe('Update Password Page', () => {
       const newPassword = screen.getByLabelText(/new password:/i);
       await userEvent.type(newPassword, 'abc', { allAtOnce: false });
       userEvent.clear(newPassword);
-      expect(screen.getByText(errorMessages.curentpasswordEmpty)).toBeInTheDocument();
+      expect(screen.getByText(errorMessages.newpasswordEmpty)).toBeInTheDocument();
       expect(screen.getByRole('button')).toBeDisabled();
     });
 
@@ -170,13 +170,13 @@ describe('Update Password Page', () => {
     });
 
     it('should show error if old,new, and confirm passwords are same', async () => {
-      await userEvent.type(screen.getByLabelText(/current password:/i), 'ABCDabc123', {
+      await userEvent.type(screen.getByLabelText(/current password:/i), 'ABCDabc123!', {
         allAtOnce: false,
       });
-      await userEvent.type(screen.getByLabelText(/new password:/i), 'ABCDabc123', {
+      await userEvent.type(screen.getByLabelText(/new password:/i), 'ABCDabc123!', {
         allAtOnce: false,
       });
-      await userEvent.type(screen.getByLabelText(/confirm password:/i), 'ABCDabc123', {
+      await userEvent.type(screen.getByLabelText(/confirm password:/i), 'ABCDabc123!', {
         allAtOnce: false,
       });
       expect(screen.getByText(errorMessages.oldnewPasswordsSame)).toBeInTheDocument();

--- a/src/components/common/Form/Form.jsx
+++ b/src/components/common/Form/Form.jsx
@@ -286,11 +286,13 @@ class Form extends Component {
     this.handleState = (name, value) => {
       const { errors, data } = this.state;
       data[name] = value;
-      const errorMessage = this.validateProperty(name, value);
-      if (errorMessage) {
-        errors[name] = errorMessage;
-      } else {
-        delete errors[name];
+      for(const field in data){
+        const errorMessage = this.validateProperty(field, data[field]);
+        if (errorMessage) {
+          errors[field] = errorMessage;
+        } else {
+          delete errors[field];
+        }
       }
       this.setState({ data, errors });
     };

--- a/src/components/common/Form/Form.jsx
+++ b/src/components/common/Form/Form.jsx
@@ -307,9 +307,11 @@ class Form extends Component {
           obj[ref] = this.state.data[ref];
         });
       }
-      const { error } = Joi.validate(obj[name], schema[name]);
+      const objectSchema = Joi.object(schema);
+      const { error } = objectSchema.validate(obj, { abortEarly: false });
       if (!error) return null;
-      return error.details[0].message;
+      const fieldError = error.details.find(detail => detail.path[0] === name);
+      return fieldError ? fieldError.message : null;
     };
 
     this.validateForm = () => {

--- a/src/components/common/Form/Form.jsx
+++ b/src/components/common/Form/Form.jsx
@@ -307,7 +307,7 @@ class Form extends Component {
           obj[ref] = this.state.data[ref];
         });
       }
-      const { error } = Joi.validate(obj, schema);
+      const { error } = Joi.validate(obj[name], schema[name]);
       if (!error) return null;
       return error.details[0].message;
     };


### PR DESCRIPTION
# Description
<img width="701" alt="Screenshot 2024-08-09 at 2 59 52 PM" src="https://github.com/user-attachments/assets/c211fb21-db2a-4842-b36f-f8a7cc438364">
<img width="759" alt="Screenshot 2024-08-09 at 3 00 06 PM" src="https://github.com/user-attachments/assets/c28cbc7c-7e9f-4c57-be94-4c54f9709513">

## 
This frontend PR is related to the [#1077](https://github.com/OneCommunityGlobal/HGNRest/pull/1077) backend PR.

## Main changes explained:
- Delete file A for removing unused components …
- Update file B for including new pattern …
- Create file C for introducing new components …
…

## How to test:
1. check into current branch for frontend and backend
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ yourname → update password → enter the new password first, followed by the confirm and then type the current password, check the error displayed properly
https://github.com/user-attachments/assets/b88dde7f-967e-464a-a62b-7e0dcd95cd6f



6. go to login → update password → incorrect email format error
 <img width="1078" alt="Screenshot 2024-08-09 at 2 43 49 PM" src="https://github.com/user-attachments/assets/39d1a189-91d5-437e-a224-adb9814f5db6">
<img width="1039" alt="Screenshot 2024-08-09 at 2 43 56 PM" src="https://github.com/user-attachments/assets/8ea6f03c-75f2-49ab-bee1-60fe5883a4f4">

## Note:
Include the information the reviewers need to know.
