### PR TITLE
Delete Time Entry permissions

### DIFF
--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -298,6 +298,17 @@ export const permissionLabels = [
           'Gives the user permission to toggle the Tangible check when editing their own time entry.',
       },
       {
+        label:'Timelog Management (Own)',
+        description: 'Category for all permissions related to timelog management',
+        subperms: [
+          {
+            label: 'Delete Time Entry (Own)',
+            key: 'deleteTimeEntryOwn',
+            description: 'Gives the user permission to Delete time entry from others users "Dashboard" -> "Leaderboard" -> "Dot By the side of user\'s name" -> "Current Time Log" -> "Trash button on bottom right"',
+          }
+        ]
+      },
+      {
         label: 'Timelog Management (Others)',
         description: 'Category for all permissions related to timelog management',
         subperms: [
@@ -309,7 +320,7 @@ export const permissionLabels = [
           },
           {
             label: 'Delete Time Entry (Others)',
-            key: 'deleteTimeEntry',
+            key: 'deleteTimeEntryOthers',
             description:
               'Gives the user permission to Delete time entry from others users "Dashboard" -> "Leaderboard" -> "Dot By the side of user\'s name" -> "Current Time Log" -> "Trash button on bottom right"',
           },

--- a/src/components/Timelog/DeleteModal.jsx
+++ b/src/components/Timelog/DeleteModal.jsx
@@ -6,7 +6,7 @@ import { faTrashAlt } from '@fortawesome/free-regular-svg-icons';
 import { deleteTimeEntry } from '../../actions/timeEntries';
 import {toast} from 'react-toastify';
 
-const DeleteModal = ({ timeEntry }) => {
+const DeleteModal = ({ timeEntry, projectCategory, taskClassification,userProfile }) => {
   const [isOpen, setOpen] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
   const dispatch = useDispatch();

--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -75,13 +75,15 @@ const TimeEntry = (props) => {
       dispatch(hasPermission('editTimeEntryToggleTangible'))
     ) && !cantEditJaeRelatedRecord;
 
-  //permission to Delete time entry from other user's Dashboard
-  const canDelete = ((dispatch(hasPermission('deleteTimeEntryOthers')) ||
-    //permission to delete any time entry on their own time logs tab.
-    // Must consider the case of the target record being Jae related 
-    dispatch(hasPermission('deleteTimeEntry')))  && !cantEditJaeRelatedRecord ) ||
-    //default permission: delete own sameday tangible entry
-    isAuthUserAndSameDayEntry;
+  //permission to Delete any time entry from other user's Dashboard
+  const canDeleteOther = (dispatch(hasPermission('deleteTimeEntryOthers')));
+
+  //permission to delete any time entry on their own time logs tab
+  const canDeleteOwn=(dispatch(hasPermission('deleteTimeEntryOwn')));
+
+  // condition for allowing delete in delete model
+  //default permission: delete own sameday tangible entry = isAuthUserAndSameDayEntry
+  const canDelete = canDeleteOther || canDeleteOwn;
   
   const toggleTangibility = async () => {
     setIsProcessing(true);


### PR DESCRIPTION
# Description

This is a continuation of [PR#2087](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2087).

<img width="610" alt="Screenshot 2024-08-09 at 3 32 09 PM" src="https://github.com/user-attachments/assets/517fbcdf-3745-4dc0-ba21-8333cf5519b1">

## Related PRS (if any):
This frontend PR is related to the dev backend PR.
…

## Main changes explained:
- Added a delete own entry section in Permissions Management.
- Changed conditional logic to enable delete functionality.
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links → Permission Management → Manage User Permissions → Choose a USER without Delete Time Entry (Own or Others) permission under Timelog Management -> click on Add -> Scroll down then submit
6. verify that the user who was given the permission is now able to see delete button in any of time entry log on dashboard and able delete it.

## Screenshots or videos of changes:


https://github.com/user-attachments/assets/8ed2b9d3-89b0-4b98-968f-e024ea91ee45


## Note:
Include the information the reviewers need to know.
