### PR TITLE
Ishan -> Reports Page on Mobile dimensions can’t scroll horizontally for results

### DIFF
--- a/src/components/Reports/PeopleTable.js
+++ b/src/components/Reports/PeopleTable.js
@@ -44,10 +44,10 @@ function PeopleTable({ userProfiles, darkMode }) {
               )}
             </div>
           </td>
-          <td className={`hide-mobile-start-end ${darkMode ? 'text-light' : ''}`} style={{ width: '110px' }}>
+          <td className={`${darkMode ? 'text-light' : ''}`} style={{ width: '110px' }}>
             {moment(person.startDate).format('MM-DD-YY')}
           </td>
-          <td className={`hide-mobile-start-end ${darkMode ? 'text-light' : ''}`} style={{ width: '110px' }}>
+          <td className={`${darkMode ? 'text-light' : ''}`} style={{ width: '110px' }}>
           {person.endDate ? moment(person.endDate).format('MM-DD-YY') : 'N/A'}
           </td>
         </tr>
@@ -55,7 +55,8 @@ function PeopleTable({ userProfiles, darkMode }) {
   }
 
   return (
-    <table className={`table ${darkMode ? 'bg-yinmn-blue' : 'table-bordered'}`} style={darkMode ? boxStyleDark : boxStyle}>
+    <div className="custom-scrollbar">
+      <table className={`table ${darkMode ? 'bg-yinmn-blue' : 'table-bordered'}`} style={darkMode ? boxStyleDark : boxStyle}>
       <thead>
         <tr className={darkMode ? 'bg-space-cadet text-light' : ''}>
           <th scope="col" id="projects__order">
@@ -65,16 +66,17 @@ function PeopleTable({ userProfiles, darkMode }) {
           <th scope="col" id="projects__active">
             Active
           </th>
-          <th className="hide-mobile-start-end" scope="col">
+          <th scope="col">
             Start Date
           </th>
-          <th className="hide-mobile-start-end" scope="col">
+          <th scope="col">
             End Date
           </th>
         </tr>
       </thead>
       <tbody className={darkMode ? 'dark-mode' : ''}>{PeopleList}</tbody>
     </table>
+    </div>
   );
 }
 export default PeopleTable;

--- a/src/components/Reports/reports.css
+++ b/src/components/Reports/reports.css
@@ -2,7 +2,8 @@
   box-shadow: 2px 2px 4px 1px rgba(78, 32, 125, 0.2);
 }
 @media screen and (max-width: 1100px) {
-  .hide-mobile-start-end {
-    display: none;
+  .custom-scrollbar {
+    overflow-y: scroll;
+    display: relative;
   }
 }


### PR DESCRIPTION
# Description
<img width="559" alt="Screenshot 2024-08-09 at 8 32 18 PM" src="https://github.com/user-attachments/assets/50631a85-82f3-4052-8117-32642bcfde1a">


## Related PRS (if any):
To test this PR you need to checkout the development branch of backend
…

## Main changes explained:
- Added new css class for table scrolling in reports.css
- Applied css to table in PeopleTable.js

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ People→…
6. verify for mobile dimensions the People table is able to scroll horizontally
7. Also verify this for the Teams and the Projects Table
8. verify this new feature works in dark mode

## Screenshots or videos of changes:
Before Changes: 
<img width="568" alt="Screenshot 2024-08-09 at 8 35 47 PM" src="https://github.com/user-attachments/assets/58c58ec8-5922-42b9-851d-f9a41154bec4">

After Changes:

https://github.com/user-attachments/assets/7a568c3e-b286-42fb-a18e-dcedaa9f377a




