### PR TITLE
Nahiyan_Fix Total Org Summary Label

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -337,7 +337,7 @@ export function Header(props) {
                         </DropdownItem>
                       )}
                       {canGetWeeklyVolunteerSummary && (
-                        <DropdownItem tag={Link} to="/totalorgsummary">
+                        <DropdownItem tag={Link} to="/totalorgsummary" className={fontColor}>
                           {TOTAL_ORG_SUMMARY}
                         </DropdownItem>
                       )}


### PR DESCRIPTION
# Description
Fixed the Total Org Summary Label in dark mode

## Related PRS (if any):
This frontend PR is related to the dev backend.

## Main changes explained:
- Fixed the Total Org Summary Label in dark mode

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ click on reports -> hover over total org summary
6. Verify that this works fine in dark and light mode

## Screenshots or videos of changes:
![Screenshot 2024-08-10 145843](https://github.com/user-attachments/assets/b7c41ae8-0f7a-4298-882a-816635527218)
