### PR TITLE
Nahiyan_Added dark mode to Total Org Summary Page

### DIFF
--- a/src/components/TotalOrgSummary/AccordianWrapper/AccordianWrapper.css
+++ b/src/components/TotalOrgSummary/AccordianWrapper/AccordianWrapper.css
@@ -23,7 +23,6 @@
   display: block;
   font-weight: 600;
   text-decoration: none;
-  color: black;
   padding-left: 2%;
   font-size: 30px;
 }
@@ -58,5 +57,4 @@
   padding: 5px;
   font-size: 12px;
   background-color: #cbb700;
-  color: black;
 }

--- a/src/components/TotalOrgSummary/AccordianWrapper/AccordianWrapper.jsx
+++ b/src/components/TotalOrgSummary/AccordianWrapper/AccordianWrapper.jsx
@@ -1,6 +1,17 @@
 import Collapsible from 'react-collapsible';
 import './AccordianWrapper.css';
+import { useSelector } from 'react-redux';
 
 export default function AccordianWrapper({ children, title }) {
-  return <Collapsible trigger={title}>{children}</Collapsible>;
+  const darkMode = useSelector(state => state.theme.darkMode);
+
+  return (
+    <Collapsible
+      className={darkMode ? 'bg-space-cadet text-light' : ''}
+      openedClassName={darkMode ? 'bg-space-cadet text-light' : ''}
+      trigger={title}
+    >
+      {children}
+    </Collapsible>
+  );
 }

--- a/src/components/TotalOrgSummary/VolunteerHoursDistribution/VolunteerHoursDistribution.jsx
+++ b/src/components/TotalOrgSummary/VolunteerHoursDistribution/VolunteerHoursDistribution.jsx
@@ -1,7 +1,11 @@
+import { useSelector } from 'react-redux';
+
 export default function VolunteerHoursDistribution() {
+  const darkMode = useSelector(state => state.theme.darkMode);
+
   return (
     <div>
-      <h3 style={{ color: 'black' }}>Volunteer Hours Distribution</h3>
+      <h3 style={{ color: darkMode ? 'white' : 'black' }}>Volunteer Hours Distribution</h3>
     </div>
   );
 }


### PR DESCRIPTION
# Description
Added dark mode to Total Org Summary Page

## Related PRS (if any):
This frontend PR is related to the dev backend

## Main changes explained:
- Added dark mode to Total Org Summary Page

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ reports -> Total Org Summary
6. verify that this page is working properly both in dark and light mode

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/7bd8f709-bf8d-477d-98fe-6a04f3bcfb23


