### PR TITLE
Rama fixed text color darkmode

### DIFF
--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -515,7 +515,7 @@ function BadgeReport(props) {
       </div>
       <div className="tablet">
         <div style={{ overflow: 'auto', height: '68vh' }}>
-          <Table>
+          <Table className={darkMode ? 'text-light' : ''}>
             <thead style={{ zIndex: '10' }}>
               <tr style={{ zIndex: '10' }}>
                 <th style={{ width: '93px' }}>Badge</th>


### PR DESCRIPTION
# Description
Fixed  Mobile View/Downsized view for Featured badges in does not update text color when in Dark Mode and stays as black text instead of changing to white 

![image](https://github.com/user-attachments/assets/4dda303e-7592-451e-96bd-2e250bcd8046)



## Related PRS (if any):
This frontend PR is related to the dev backend.

## Main changes explained:
- Made changes in BadgeReport.jsx 

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner/admin user
5. go to dashboard→ Viewprofile→ In feature badges->click on assign badges -> add at least one badge
-> After Select Featured -> Then Inspect the page below 1025px -> Check if the text changes to a White color. 
6. verify this in dark mode
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/8a55b4b7-6a39-49ac-9f88-fe57f90d0fde


## Note:
Make sure you are verifying in the dark mode. 
