### PR TITLE
Peizhou_Fix Add New Project Category & Ability to Change Category

### DIFF
--- a/src/components/Projects/Project/Project.jsx
+++ b/src/components/Projects/Project/Project.jsx
@@ -92,15 +92,13 @@ const Project = props => {
           <select
 
             data-testid="projects__category--input" //added for unit test
-            value={props.category}
+            value={category}
             onChange={e => {
-              setCategory(e.target.value);
+              onUpdateProjectCategory(e);
             }}
 
           >
-            <option default value="Unspecified">
-              Unspecified
-            </option>
+            <option value="Unspecified">Unspecified</option>
             <option value="Food">Food</option>
             <option value="Energy">Energy</option>
             <option value="Housing">Housing</option>

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -100,6 +100,8 @@ const Projects = function(props) {
 
   const onUpdateProject = async (updatedProject) => {
     await props.modifyProject(updatedProject);  
+    /* refresh the page after updating the project */
+    await props.fetchAllProjects();
   };
 
   const confirmArchive = async () => {


### PR DESCRIPTION
# Description
![Capture](https://github.com/user-attachments/assets/1725d15c-e489-4b78-9f30-f579eae5ff5c)

## Related PRS (if any):
This frontend PR is not related to any backend PR, please just check in to the development branch.

## Main changes explained:
- Fix the issue of the category becoming "Unspecified" when creating new projects.
- Fix the issue of not being able to change the category of existing projects.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Other Link→ Projects
6. create a project with a specified category, and the project will be shown with the specific category. It may take one minute or two.
7. change the category of an existing project, and check in the database. That project's category will be changed. You can also check by refreshing the page and find the project you just changed, see if its category changed.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/07b2d49f-cf65-47fb-804c-39af37d8e19c


