### PR TITLE
Export Featured Badges button disable

### DIFF
--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -484,6 +484,7 @@ function BadgeReport(props) {
           Export All Badges to PDF
         </Button>
         <Button
+          disabled={numFeatured === 0}
           className="btn--dark-sea-green float-right"
           style={darkMode ? { ...boxStyleDark, margin: 5 } : { ...boxStyle, margin: 5 }}
           onClick={pdfFeaturedDocGenerator}
@@ -684,6 +685,7 @@ function BadgeReport(props) {
             <span>Export All Badges to PDF</span>
           </Button>
           <Button
+            disabled={numFeatured === 0}
             className="btn--dark-sea-green float-right"
             style={{ margin: 5 }}
             onClick={pdfFeaturedDocGenerator}


### PR DESCRIPTION
# Description
<img width="737" alt="Screenshot 2024-08-14 at 6 04 58 AM" src="https://github.com/user-attachments/assets/affd635e-18e2-4ade-8036-85a7f7761b47">

## Related PRS (if any):
N/A

## Main changes explained:
- Added the disable property in the 'Button' tag

## How to test:
1. Check into current branch
2. Do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as any user
5. Go to View Profile → Select Featured
6. Verify that if none of the badges are featured, the 'Export Selected/Featured Badges to PDF' button is disabled.

## Screenshots or videos of changes:
<img width="799" alt="Screenshot 2024-08-14 at 6 09 02 AM" src="https://github.com/user-attachments/assets/7a47ab58-ed37-434f-b775-5439c0bf2094">
