### PR TITLE
Howie update dark mode text for /totalorgsummary

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -340,7 +340,7 @@ export function Header(props) {
                         </DropdownItem>
                       )}
                       {canGetWeeklyVolunteerSummary && (
-                        <DropdownItem tag={Link} to="/totalorgsummary">
+                        <DropdownItem tag={Link} to="/totalorgsummary" className={fontColor}>
                           {TOTAL_ORG_SUMMARY}
                         </DropdownItem>
                       )}


### PR DESCRIPTION
# Description
total org summary in Reports drop down menu did not change text color upon swapping to dark mode

## Related PRS (if any):
N/A

## Main changes explained:
Updated DropdownItem "/totalorgsummary" to update with dark mode

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports
6. Total Org Summary is in the correct text color in both light and dark mode and all links work

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/48d1ad87-fa46-447c-9961-b399d6135c1b)

Old:
![image](https://github.com/user-attachments/assets/ae17fe02-ae0e-4d89-a67d-96144342f748)

## Note:
Include the information the reviewers need to know.
