### PR TITLE
Ishan - Fix Badges Icon Redirection Behaviour

### DIFF
--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -353,6 +353,15 @@ const SummaryBar = props => {
     setShowSuggestionModal(prev => !prev);
   };
 
+  const onTaskClick = () => {
+    window.location.hash = '#tasks';
+  };
+
+  const onBadgeClick = () => {
+    window.location.hash = '#badgesearned';
+  };
+
+
   const getWeeklySummary = user => {
     const latestSummary = user?.weeklySummaries?.[0];
     return latestSummary && new Date() < new Date(latestSummary.dueDate)
@@ -541,38 +550,24 @@ const SummaryBar = props => {
           <div className={"d-flex justify-content-around no-gutters"}>
             &nbsp;&nbsp;
             <div className="image_frame">
+              <div className="redBackgroup">
+                <span>{tasks}</span>
+              </div>
               {isAuthUser || canEditData() ? (
-                <Link to={`/dashboard#tasks`}>
-                  <img className="sum_img" src={task_icon} alt=""></img>
-                  <div className="redBackgroup">
-                    <span>{tasks}</span>
-                  </div>
-                </Link>
+                <img className="sum_img" src={task_icon} alt="" onClick={onTaskClick}></img>
               ) : (
-                <div>
-                  <img className="sum_img" src={task_icon} alt=""></img>
-                  <div className="redBackgroup">
-                    <span>{tasks}</span>
-                  </div>
-                </div>
+                <img className="sum_img" src={task_icon} alt=""></img>
               )}
             </div>
             &nbsp;&nbsp;
             <div className="image_frame">
+              <div className="redBackgroup">
+                <span>{badges}</span>
+              </div>
               {isAuthUser || canEditData() ? (
-                <Link to={`/dashboard#badges`}>
-                    <img className="sum_img" src={badges_icon} alt=""/>
-                    <div className="redBackgroup">
-                      <span>{badges}</span>
-                    </div>
-                </Link>
-              ) : (
-                <div>
-                    <img className="sum_img" src={badges_icon} alt="" />
-                    <div className="redBackgroup">
-                      <span>{badges}</span>
-                    </div>
-                </div>
+                <img className="sum_img" src={badges_icon} alt="" onClick={onBadgeClick}/>
+                ) : (
+                <img className="sum_img" src={badges_icon} alt="" />
               )}
             </div>
             &nbsp;&nbsp;

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -353,14 +353,6 @@ const SummaryBar = props => {
     setShowSuggestionModal(prev => !prev);
   };
 
-  const onTaskClick = () => {
-    window.location.hash = '#tasks';
-  };
-
-  const onBadgeClick = () => {
-    window.location.hash = '#badgesearned';
-  };
-
   const getWeeklySummary = user => {
     const latestSummary = user?.weeklySummaries?.[0];
     return latestSummary && new Date() < new Date(latestSummary.dueDate)
@@ -549,25 +541,39 @@ const SummaryBar = props => {
           <div className={"d-flex justify-content-around no-gutters"}>
             &nbsp;&nbsp;
             <div className="image_frame">
-              <div className="redBackgroup">
-                <span>{tasks}</span>
-              </div>
               {isAuthUser || canEditData() ? (
-                <img className="sum_img" src={task_icon} alt="" onClick={onTaskClick}></img>
+                <Link to={`/dashboard#tasks`}>
+                  <img className="sum_img" src={task_icon} alt=""></img>
+                  <div className="redBackgroup">
+                    <span>{tasks}</span>
+                  </div>
+                </Link>
               ) : (
-                <img className="sum_img" src={task_icon} alt=""></img>
+                <div>
+                  <img className="sum_img" src={task_icon} alt=""></img>
+                  <div className="redBackgroup">
+                    <span>{tasks}</span>
+                  </div>
+                </div>
               )}
             </div>
             &nbsp;&nbsp;
             <div className="image_frame">
               {isAuthUser || canEditData() ? (
-                <img className="sum_img" src={badges_icon} alt="" onClick={onBadgeClick} />
+                <Link to={`/dashboard#badges`}>
+                    <img className="sum_img" src={badges_icon} alt=""/>
+                    <div className="redBackgroup">
+                      <span>{badges}</span>
+                    </div>
+                </Link>
               ) : (
-                <img className="sum_img" src={badges_icon} alt="" />
+                <div>
+                    <img className="sum_img" src={badges_icon} alt="" />
+                    <div className="redBackgroup">
+                      <span>{badges}</span>
+                    </div>
+                </div>
               )}
-              <div className="redBackgroup">
-                <span>{badges}</span>
-              </div>
             </div>
             &nbsp;&nbsp;
             <div className="image_frame">

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -184,8 +184,32 @@ const Timelog = props => {
     if (!props.isDashboard) {
       tab = 1;
     }
+
+    if (location.hash) {
+      const redirectToTab = tabMapping[location.hash];
+      if (redirectToTab !== undefined) {
+        tab = redirectToTab;
+      }
+    }
     return tab;
   };
+
+    const tabMapping = {
+      '#tasks': 0,
+      '#currentWeek': 1,
+      '#lastWeek': 2,
+      '#beforeLastWeek': 3,
+      '#dateRange': 4,
+      '#weeklySummaries': 5,
+      '#badges': 6,
+    };
+
+  useEffect(() => {
+    const tab = location.hash ? tabMapping[location.hash] : defaultTab();
+    if (tab !== undefined) {
+      changeTab(tab);
+    }
+  }, [location.hash]);  // This effect will run whenever the hash changes
 
   /*---------------- methods -------------- */
   const updateTimeEntryItems = () => {

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -201,7 +201,7 @@ const Timelog = props => {
       '#beforeLastWeek': 3,
       '#dateRange': 4,
       '#weeklySummaries': 5,
-      '#badges': 6,
+      '#badgesearned': 6,
     };
 
   useEffect(() => {


### PR DESCRIPTION
# Description
<img width="584" alt="BugDescription" src="https://github.com/user-attachments/assets/6cccb624-9be7-4a83-a2d9-a12f2dfe4b81">

## Related PRS (if any):
To test this PR you need to checkout the development branch backend.

## Main changes explained:
- Updated code in Timelog.jsx to show the correct tab depending on the hash in the url

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Badges icon in summary bar 
6. Verify that clicking on it redirects you to the badges tab
7. Do the same from the summary bar in the Timelog page
8. Verify steps 5,6,7 for the tasks icon too.

## Screenshots or videos of changes:
Before: 

https://github.com/user-attachments/assets/8ef9050c-c1a0-4cad-8213-2e2d78c773cd


After:

https://github.com/user-attachments/assets/caa93ad2-a940-4323-b8f3-c2da7c9713da



## Note:
You should now be able to redirect to the badges & tasks tabs in the Timelog from both the Dashboard and the Timelog pages

