### PR TITLE
Nahiyan_Added Dark Mode on Time Off Modal

### DIFF
--- a/src/components/Dashboard/TimeOffRequestDetailModal.jsx
+++ b/src/components/Dashboard/TimeOffRequestDetailModal.jsx
@@ -5,6 +5,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { hideTimeOffRequestModal } from '../../actions/timeOffRequestAction';
 
 const TimeOffRequestDetailModal = () => {
+  const darkMode = useSelector(state => state.theme.darkMode);
   const { isOpen, data } = useSelector(state => state.timeOffRequests.timeOffModal);
   const dispatch = useDispatch();
   const detailModalClose = () => {
@@ -28,9 +29,16 @@ const TimeOffRequestDetailModal = () => {
 
   return (
     <div>
-      <Modal isOpen={isOpen} toggle={() => detailModalClose()} returnFocusAfterClose={true}>
-        <ModalHeader toggle={() => detailModalClose()}>Time Off Details</ModalHeader>
-        <ModalBody className="time-off-detail-modal">
+      <Modal
+        isOpen={isOpen}
+        toggle={() => detailModalClose()}
+        returnFocusAfterClose={true}
+        className={darkMode ? 'dark-mode text-light' : ''}
+      >
+        <ModalHeader toggle={() => detailModalClose()} className={darkMode ? 'bg-space-cadet' : ''}>
+          Time Off Details
+        </ModalHeader>
+        <ModalBody className={`${darkMode ? 'bg-yinmn-blue' : ''}`}>
           {data?.leaderboard ? (
             <>
               <Container>
@@ -39,7 +47,7 @@ const TimeOffRequestDetailModal = () => {
                 </Row>
               </Container>
               {data.requests?.map(req => (
-                <Container className='time-off-detail-modal-card-container' key={req._id}>
+                <Container className="time-off-detail-modal-card-container" key={req._id}>
                   <Row className="pl-2">
                     <Col className="mb-2 font-italic">
                       {getWeekIntervals(req)[0].map((week, index) => (

--- a/src/components/TeamMemberTasks/ReviewButton.jsx
+++ b/src/components/TeamMemberTasks/ReviewButton.jsx
@@ -106,17 +106,17 @@ const ReviewButton = ({
             </DropdownToggle>
             <DropdownMenu className={darkMode ? 'bg-space-cadet' : ''}>
             {task.relatedWorkLinks && task.relatedWorkLinks.map((link, index) => (
-              <DropdownItem key={index} href={link} target="_blank" className={darkMode ? 'text-light' : ''}>
+              <DropdownItem key={index} href={link} target="_blank" className={darkMode ? 'text-light dark-mode-btn' : ''}>
                 View Link
               </DropdownItem>
             ))}
-            <DropdownItem onClick={() => { setSelectedAction('Complete and Remove'); toggleVerify(); }} className={darkMode ? 'text-light' : ''}>
+            <DropdownItem onClick={() => { setSelectedAction('Complete and Remove'); toggleVerify(); }} className={darkMode ? 'text-light dark-mode-btn' : ''}>
               <FontAwesomeIcon
                 className="team-member-tasks-done"
                 icon={faCheck}
               /> as complete and remove task
             </DropdownItem>
-            <DropdownItem onClick={() => { setSelectedAction('More Work Needed'); toggleVerify()}} className={darkMode ? 'text-light' : ''}>
+            <DropdownItem onClick={() => { setSelectedAction('More Work Needed'); toggleVerify()}} className={darkMode ? 'text-light dark-mode-btn' : ''}>
               More work needed, reset this button
             </DropdownItem>
             </DropdownMenu>

--- a/src/components/TeamMemberTasks/ReviewButton.jsx
+++ b/src/components/TeamMemberTasks/ReviewButton.jsx
@@ -104,19 +104,19 @@ const ReviewButton = ({
             <DropdownToggle className="btn--dark-sea-green reviewBtn" caret style={darkMode ? boxStyleDark : boxStyle}>
               Ready for Review
             </DropdownToggle>
-            <DropdownMenu>
+            <DropdownMenu className={darkMode ? 'bg-space-cadet' : ''}>
             {task.relatedWorkLinks && task.relatedWorkLinks.map((link, index) => (
-              <DropdownItem key={index} href={link} target="_blank">
+              <DropdownItem key={index} href={link} target="_blank" className={darkMode ? 'text-light' : ''}>
                 View Link
               </DropdownItem>
             ))}
-            <DropdownItem onClick={() => { setSelectedAction('Complete and Remove'); toggleVerify(); }}>
+            <DropdownItem onClick={() => { setSelectedAction('Complete and Remove'); toggleVerify(); }} className={darkMode ? 'text-light' : ''}>
               <FontAwesomeIcon
                 className="team-member-tasks-done"
                 icon={faCheck}
               /> as complete and remove task
             </DropdownItem>
-            <DropdownItem onClick={() => { setSelectedAction('More Work Needed'); toggleVerify()}}>
+            <DropdownItem onClick={() => { setSelectedAction('More Work Needed'); toggleVerify()}} className={darkMode ? 'text-light' : ''}>
               More work needed, reset this button
             </DropdownItem>
             </DropdownMenu>

--- a/src/components/TeamMemberTasks/reviewButton.css
+++ b/src/components/TeamMemberTasks/reviewButton.css
@@ -5,6 +5,10 @@
   overflow: hidden; /* Hide any overflowing content */
 }
 
+.dark-mode-btn:hover{
+  background-color: #2f4157 !important;
+}
+
 
 @media screen and (max-width: 1307px) and (min-width: 1152px) {
   .reviewBtn {


### PR DESCRIPTION
# Description
Added dark mode on Time off modal and Ready for Review dropdown

## Related PRS (if any):
This frontend PR is related to the dev backend

## Main changes explained:
- Added dark mode to Time Off Modal
- Added dark mode to Ready for Review dropdown

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ Tasks and Timelogs → Tasks
6. verify that when clicking "Ready for Review", the dropdown background is in dark mode
7. verify that when you click on details after finding a user who has taken time off, the modal is in mode.
8. You can find these options if you scroll on the tasks section on a owner account

## Screenshots or videos of changes:
![Screenshot 2024-08-16 193032](https://github.com/user-attachments/assets/830c79a3-72af-42cb-bd18-6720e5fb0ade)
![Screenshot 2024-08-16 193033](https://github.com/user-attachments/assets/5547c559-5c89-4bd4-a0ab-67f2114e9401)

