### PR TITLE
Nahiyan_Fixed Numbering Issue in Dark Mode

### DIFF
--- a/src/components/Projects/Project/Project.jsx
+++ b/src/components/Projects/Project/Project.jsx
@@ -66,7 +66,7 @@ const Project = props => {
     <tr className="projects__tr" id={'tr_' + props.projectId}>
 
       <th className="projects__order--input" scope="row">
-        <div>{index + 1}</div>
+        <div className={darkMode ? 'text-light' : ''}>{index + 1}</div>
       </th>
 
 

--- a/src/components/Projects/WBS/WBSItem/WBSItem.jsx
+++ b/src/components/Projects/WBS/WBSItem/WBSItem.jsx
@@ -4,7 +4,7 @@
  * Display member of the members list
  ********************************************************************************/
 import React, { useState } from 'react';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import ModalDelete from './../../../common/Modal';
 import { deleteWbs } from './../../../../actions/wbs';
 import { getPopupById } from './../../../../actions/popupEditorAction';
@@ -15,7 +15,7 @@ import { Link } from 'react-router-dom';
 
 
 const WBSItem = props => {
-  const { darkMode } = props;
+  const darkMode = useSelector(state => state.theme.darkMode)
   const [showModalDelete, setShowModalDelete] = useState(false);
 
   const canDeleteWBS = props.hasPermission('deleteWbs');

--- a/src/components/Projects/WBS/wbs.test.jsx
+++ b/src/components/Projects/WBS/wbs.test.jsx
@@ -5,6 +5,7 @@ import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import mockAdminState from '__tests__/mockAdminState';
 import WBSItem from './WBSItem';
+import { themeMock } from '__tests__/mockStates';
 
 
 const mockStore = configureStore([thunk]);
@@ -22,6 +23,7 @@ beforeEach(() => {
       },
     },
     role: mockAdminState.role,
+    theme: themeMock,
   });
 });
 


### PR DESCRIPTION
# Description
Fixed numbering issue in dark mode on the Projects page.

## Related PRS (if any):
This frontend PR is related to the dev backend.

## Main changes explained:
- Fixed numbering issue in dark mode on the projects page
- Fixed delete icon in projects wbs

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner
5. go to dashboard→ Projects
6. verify the number is working in dark mode
7. go to a project's wbs
8. verify that the delete icon is working properly in dark mode

## Screenshots or videos of changes:
![Screenshot 2024-08-17 124423](https://github.com/user-attachments/assets/92fdf671-d469-415e-9caf-e1d499c1ae23)
![Screenshot 2024-08-17 124449](https://github.com/user-attachments/assets/c6e24d00-e104-48d9-854c-7d98e49170ed)

