### PR TITLE
Peizhou_Fix the To Date to be Earlier than From Date Issue

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -311,8 +311,13 @@ const Timelog = props => {
   };
 
   const handleSearch = e => {
-    e.preventDefault();
-    props.getTimeEntriesForPeriod(displayUserId, timeLogState.fromDate, timeLogState.toDate);
+    //check if the toDate is before the fromDate
+    if (moment(timeLogState.fromDate).isAfter(moment(timeLogState.toDate))) {
+      alert('Invalid Date Range: the From Date must be before the To Date');
+    }else{
+      e.preventDefault();
+      props.getTimeEntriesForPeriod(displayUserId, timeLogState.fromDate, timeLogState.toDate);
+    }
   };
 
   const calculateTotalTime = (data, isTangible) => {


### PR DESCRIPTION
# Description
![Capture2](https://github.com/user-attachments/assets/5be9d75a-3845-4f5e-a0ed-c3b452a9abd2)

## Related PRS (if any):
This frontend PR is not related to any backend PR, please just check in to the development branch.

## Main changes explained:
- Fix the issue that on the Dashboard, under Tasks and Timelogs, in Search by Date Range, the To date can be earlier than the From date

## How to test:
1. check into the current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in
5. on the Dashboard, under Tasks and Timelogs, in Search by Date Range, check if the To date can be earlier than the From date. An alert will be displayed if so.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/8b5d9c82-6b91-4431-9e4f-2d3770fdb28d

![3](https://github.com/user-attachments/assets/ee1867a7-9832-415f-9bdd-2ed72b3929d3)



## Note:
The issue of the system default alert not being beautiful enough will be handled in a separate PR. This PR focuses on functionality.
