### PR TITLE
Peterson_fixed_the_create_team_bug_on_the_profile_page_and_Teams_tab

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/AddTeamPopup.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/AddTeamPopup.jsx
@@ -90,14 +90,13 @@ const AddTeamPopup = React.memo(props => {
       clearTimeout(timeout);
       if (response.status === 200) {
         setDuplicateTeam(false);
-
+        !isNotDisplayAlert && setIsNotDisplayAlert(true);
         // Get updated teams list and select the new team
         await dispatch(getAllUserTeams());
         toast.success('Team created successfully');
         const newTeam = response.data; // Assuming response contains the new team data
-        onSelectTeam(newTeam);
-        setSearchText(newTeam.teamName); // Update search text to reflect new team name
         setIsLoading(false);
+        onAssignTeam(newTeam);
       } else {
         setIsLoading(false);
         const messageToastError =
@@ -150,7 +149,23 @@ const AddTeamPopup = React.memo(props => {
           </Button>
         </div>
         {!isNotDisplayAlert && (
-          <Alert color="danger">Oops, this team does not exist! Create it if you want it.</Alert>
+          <>
+            <Alert color="danger">Oops, this team does not exist! Create it if you want it.</Alert>
+            <div
+              style={{
+                marginBottom: '10px',
+                display: 'flex',
+                flexDirection: 'row',
+                gap: '10px',
+                justifyContent: 'center',
+              }}
+            >
+              {/* prettier-ignore  */}
+              <Button color="info" onClick={onCreateTeam}><b>Create Team</b></Button>
+              {/* prettier-ignore  */}
+              <Button color="danger" onClick={() => setIsNotDisplayAlert(true)}><b>Cancel team creation </b></Button>
+            </div>
+          </>
         )}
 
         {!isValidTeam && !searchText && (


### PR DESCRIPTION
# Description
This pull request has been opened to fix the bugs with the create team feature on the profile page and Teams tab.

## Related PRS (if any):
None.

## Main changes explained:
The component AddTeamPopup has been modified to fix the bugs.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an administrator or owner.
5. Go to view profile→ Teams tab
6. Your user should be added to a team after it has been created.
7. After clicking the confirm button with a team that doesn't exist, two buttons should be displayed: one to create a team and the other to cancel the create team mode.

## Screenshots or videos of changes:
![Peterson_fixed_the_create_team_bug_on_the_profile_page_and_Teams_tab](https://github.com/user-attachments/assets/27d55161-4cc3-42ea-9bca-845bc99fa89a)

## Note:
None.