### PR TITLE
ambika hotfix user profile wild search space problem

### DIFF
--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -568,7 +568,7 @@ class UserManagement extends React.PureComponent {
    */
   onWildCardSearch = searchText => {
     this.setState({
-      wildCardSearchText: searchText.trim(),
+      wildCardSearchText: searchText,
       selectedPage: 1,
     });
   };

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -8,6 +8,9 @@ export const searchWithAccent = (input, searchText) => {
   // check if searchText has accent
   if(!searchText) return true;
   if(!input) return false;
+  
+  searchText = searchText.trim();
+  
   const searchNormalized = normalizeString(searchText);
   const hasAccents = searchNormalized !== searchText.toLowerCase();
 


### PR DESCRIPTION
# Description
Cannot add space after a word in search of user in user management

## Related PRS (if any):
This frontend PR is related to the development branch of backend.

## Main changes explained:
- #2344 PR implemented trim() function on search text which was causing the problem
- Removed the trim() function on search text
- Added trim() function before filtering the results

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ other links -> User management
6. verify that in wild search, a space is allowed between the words and results are appearing correctly
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)