### PR TITLE
Ishan fix profile page formatting

### DIFF
--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.css
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.css
@@ -6,6 +6,10 @@
   max-width: 350px; 
 }
 
+.label-with-icon {
+  display: inline-block;
+}
+
 @media (max-width: 1024px) {
   .basic-info-tab-desktop {
     display: none;

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -677,7 +677,7 @@ const BasicInformationTab = props => {
             <Label className={darkMode ? 'text-light' : ''}>Status</Label>
           </Col>
           <Col>
-            <Label className={darkMode ? 'text-light' : ''}>
+            <Label className={darkMode ? 'text-light label-with-icon' : 'label-with-icon'}>
               {userProfile.isActive
                 ? 'Active'
                 : userProfile.reactivationDate

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -365,7 +365,7 @@ const BasicInformationTab = props => {
   const nameComponent = (
     <>
       <Col>
-        <Label className={darkMode ? 'text-light' : ''}>Name</Label>
+        <Label className={darkMode ? 'text-light label-with-icon' : 'label-with-icon'}>Name</Label>
         <i
           data-toggle="tooltip"
           data-placement="right"
@@ -394,7 +394,7 @@ const BasicInformationTab = props => {
   const titleComponent = (
     <>
       <Col>
-        <Label className={darkMode ? 'text-light' : ''}>Title</Label>
+        <Label className={darkMode ? 'text-light label-with-icon' : 'label-with-icon'}>Title</Label>
         <i
           data-toggle="tooltip"
           data-placement="right"
@@ -422,7 +422,7 @@ const BasicInformationTab = props => {
   const emailComponent = (
     <>
       <Col>
-        <Label className={darkMode ? 'text-light' : ''}>Email</Label>
+        <Label className={darkMode ? 'text-light label-with-icon' : ' label-with-icon'}>Email</Label>
         <i
           data-toggle="tooltip"
           data-placement="right"
@@ -451,7 +451,7 @@ const BasicInformationTab = props => {
   const phoneComponent = (
     <>
       <Col>
-        <Label className={darkMode ? 'text-light' : ''}>Phone</Label>
+        <Label className={darkMode ? 'text-light label-with-icon' : 'label-with-icon'}>Phone</Label>
         <i
           data-toggle="tooltip"
           data-placement="right"


### PR DESCRIPTION
# Description
![Screenshot 2024-08-22 at 6 45 30 PM](https://github.com/user-attachments/assets/ae3f80ce-8ccc-4171-b41a-458ad3b8259a)


## Related PRS (if any):

To test this PR you need to checkout the development backend branch.

## Main changes explained:
- added css class to keep labels inline with icons in BasicInformationTab.css
- applied css class to labels in BasicInformationTab.jsx

…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ View Profile→ Basic Information→…
6. Verify the 4 info icons next to Name, Title, Email and Phone are in the same line as the labels.
7. Verify the Pause button is now in the same line as the Active label.
8. Verify these new features work in dark mode.

## Screenshots or videos of changes:
Before:

https://github.com/user-attachments/assets/9652873d-4bab-45cb-b533-bd35cffd8d74

After:

https://github.com/user-attachments/assets/5ff7d734-9a72-482b-b23e-cef6050f181e


