### PR TITLE
Ishan- hotfix for teams table and badge redirection issues

### DIFF
--- a/src/components/Reports/TeamTable.css
+++ b/src/components/Reports/TeamTable.css
@@ -13,3 +13,9 @@
 .block {
   width: 120px;
 }
+
+.team-code-form-field {
+  width: fit-content;
+  min-width: 8em;
+  max-width: 13em;
+}

--- a/src/components/Reports/TeamTable.jsx
+++ b/src/components/Reports/TeamTable.jsx
@@ -39,6 +39,7 @@ function TeamTable({ allTeams, auth, hasPermission, darkMode }) {
   
     return (
       <>
+        <div className='team-code-form-field'>
         {canEditTeamCode ?
           <div style={{paddingRight: "5px"}}>
             <FormGroup>
@@ -61,6 +62,7 @@ function TeamTable({ allTeams, auth, hasPermission, darkMode }) {
         : 
           `${teamCode == ''? "No assigned code!": teamCode}`
         }
+        </div>
       </>
     )
   };

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -205,7 +205,7 @@ const Timelog = props => {
     };
 
   useEffect(() => {
-    const tab = location.hash ? tabMapping[location.hash] : defaultTab();
+    const tab = tabMapping[location.hash];
     if (tab !== undefined) {
       changeTab(tab);
     }
@@ -324,6 +324,12 @@ const Timelog = props => {
     if (tab === 6) {
       props.resetBadgeCount(displayUserId);
     }
+
+    // Clear the hash to trigger the useEffect on hash change
+    if (location.hash) {
+      window.location.hash='';
+    }
+
     setTimeLogState({
       ...timeLogState,
       activeTab: tab,


### PR DESCRIPTION
# Description
This PR is a hotfix for issues found in 2 previous PRs.
**Issue 1:**
- The team code field in the teams table on the reports page was getting cut off for mobile dimensions.

![Screenshot 2024-08-22 at 6 52 45 PM](https://github.com/user-attachments/assets/6f7e4471-2dbd-4df4-85c3-145252cfac8e)
![Screenshot 2024-08-22 at 6 52 59 PM](https://github.com/user-attachments/assets/77fd1ad9-eab1-4a1a-ab52-94f68a488abb)
Loom Link for Teams Table Issue: https://www.loom.com/share/e6dd4bc836a84e0dace3edece47bd194 

**Issue 2:**
- The redirection on clicking the badges and tasks icon form the summary bar in dashboard was working intermittently.

![Screenshot 2024-08-22 at 6 52 05 PM](https://github.com/user-attachments/assets/77bb3d9b-f23b-4bd7-8fd0-0ba7bbe0ff5d)
![Screenshot 2024-08-22 at 6 52 20 PM](https://github.com/user-attachments/assets/fc825d88-cc33-4556-94f1-47b84ff3e062)
Loom Link for Badges Redirection: https://www.loom.com/share/152e9d62f04f4e87b161d94aa58f4051?sid=3d9a3d4e-d2f6-44f0-8bd8-848a7ec98392 



## Related PRS (if any):

To test this PR you need to checkout the development backend branch.

## Main changes explained:
- Fixed redirection for badges and tasks icons in Timelog.jsx
- Added css class in TeamTable so that teamCode field has minimum width


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user

 **Issue #1**
5. go to dashboard→ Reports→ Teams→…
6. verify for mobile dimensions the teamCode field is not cut off and has enough width.

**Issue #2**
7. go to dashboard→ badges & tasks icon in the summary bar.
8. verify that clicking these icons redirects you to the correct tabs. Verify that changing between tabs and clicking the icons again works correctly
9. verify this new feature works in dark mode

## Screenshots or videos of changes:
**Before:** 

https://github.com/user-attachments/assets/870416a4-15bf-42bf-ab42-55313df8a49e



**After:**

https://github.com/user-attachments/assets/afac7061-5e7a-44c7-ba32-75ccfbe9b83f


## Note:
Include the information the reviewers need to know.
