### PR TITLE
Diya Export All Badges to PDF Fix

### DIFF
--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -54,8 +54,14 @@ function BadgeReport(props) {
     const ctx = canvas.getContext('2d');
     const baseImage = new Image();
     baseImage.crossOrigin = 'anonymous';
+
+    // Fallback image URL or blank image data URL
+    const fallbackImage =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wcAAwAB/4H6YwAAAABJRU5ErkJggg=='; // 1x1 transparent PNG
+
     baseImage.src = url.replace('dropbox.com', 'dl.dropboxusercontent.com');
     baseImage.src = baseImage.src.replace('www.dropbox.com', 'dl.dropboxusercontent.com');
+
     baseImage.onload = function handleImageLoad() {
       canvas.width = baseImage.width;
       canvas.height = baseImage.height;
@@ -66,37 +72,50 @@ function BadgeReport(props) {
 
       canvas.remove();
     };
+
+    baseImage.onerror = function handleImageError() {
+      // Use fallback image on error
+      canvas.width = 1;
+      canvas.height = 1;
+      ctx.fillStyle = 'white';
+      ctx.fillRect(0, 0, 1, 1);
+      const uri = canvas.toDataURL('image/png');
+      callback(uri);
+
+      canvas.remove();
+    };
   }
 
   const FormatReportForPdf = (badges, callback) => {
     const bgReport = [];
     bgReport[0] = `<h3>Badge Report (Page 1 of ${Math.ceil(badges.length / 4)})</h3>
-    <div style="margin-bottom: 20px; color: orange;"><h4>For ${props.firstName} ${
+  <div style="margin-bottom: 20px; color: orange;"><h4>For ${props.firstName} ${
       props.lastName
     }</h4></div>
-    <div style="color:#DEE2E6; margin:10px 0px 20px 0px; text-align:center;">_______________________________________________________________________________________________</div>`;
+  <div style="color:#DEE2E6; margin:10px 0px 20px 0px; text-align:center;">_______________________________________________________________________________________________</div>`;
+
     for (let i = 0; i < badges.length; i += 1) {
       imageToUri(badges[i].badge.imageUrl, function(uri) {
         bgReport[i + 1] = `
-        <table>
-          <thead>
-            <tr>
-              <th>Badge Image</th>
-              <th>Badge Name, Count Awarded & Badge Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td style="width:160px">
-                <div><img height="150" width="150" src=${uri}/></div>
-              </td>
-              <td style="width:500px">
-                <div><b>Name:</b> <span class="name">${badges[i].badge.badgeName}</span></div>
-                <div><b>Count:</b> ${badges[i].count}</div>
-                <div><b>Description:</b> ${badges[i].badge.description}</div>
-              </td>
-            </tr>
-          </tbody>
+      <table>
+        <thead>
+          <tr>
+            <th>Badge Image</th>
+            <th>Badge Name, Count Awarded & Badge Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style="width:160px">
+              <div><img height="150" width="150" src=${uri}/></div>
+            </td>
+            <td style="width:500px">
+              <div><b>Name:</b> <span class="name">${badges[i].badge.badgeName}</span></div>
+              <div><b>Count:</b> ${badges[i].count}</div>
+              <div><b>Description:</b> ${badges[i].badge.description}</div>
+            </td>
+          </tr>
+        </tbody>
       </table>
       ${
         (i + 1) % 4 === 0 && i + 1 !== badges.length


### PR DESCRIPTION
# Description
Export All Badges to PDF exports only old assigned badges and not any newly created and assigned badge.
User Profile > Select Featured > Export All Badges to PDF does not work as expected.


## Related PRS (if any):
N/A

## Main changes explained:
Added a fallback image if the image of the badge cannot load which fails the conversion of that badge to be added to the PDF

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to view profile → select featured → export all badges to PDF
6. verify that all badges get added to the PDF
7. create new badges, assign them to a user and verify if required.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/100e25b4-f91e-43e3-9d84-7dc57649c1de
