### PR TITLE
Satya_Improve_modal_efficiency_for_adding_Teams

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/AddTeamPopup.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/AddTeamPopup.jsx
@@ -68,6 +68,7 @@ const AddTeamPopup = React.memo(props => {
       setSearchText('');
 
       selectedTeam && (onSelectTeam(undefined), onValidation(false));
+      closePopup() // automatically closes the popup after team assigned
     } else
       toast.error(
         'Your user has been found in this team. Please select another team to add your user.',

--- a/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
@@ -49,6 +49,7 @@ const TeamsTab = props => {
 
   const onAddTeamPopupClose = () => {
     setaddTeamPopupOpen(false);
+    if (isTeamSaved) isTeamSaved(true);
   };
   const onSelectDeleteTeam = teamId => {
     setRemovedTeams([...removedTeams, teamId]);


### PR DESCRIPTION
Description:

The bug fix addresses the issue of the "Save Changes" button remaining active after assigning a team, which is unnecessary. Additionally, the modal does not close automatically after a team is added. The modal should close after assigning a team, as multiple team assignments are rare.

Main changes explained:

Updated the 'TeamsTab.jsx' and 'AddTeamPopup.jsx' to automatically close the modal after adding a team and disabled the "Save Changes" button once a team is added.

How to test:

Check into the current branch.
Run npm install and npm start to run this PR locally.
Clear site data/cache.
Log in as an admin user.
Go to the Dashboard → Profile → Teams → Assign Team.
Verify that the modal closes after assigning a team and the "Save Changes" button is disabled.


https://github.com/user-attachments/assets/ed50bcd5-bbd5-4071-a1b2-9a5047abeb3b

