### PR TITLE
jatin fix the the urls inside team-weekly-summaries tab.

### DIFF
--- a/src/components/UserProfile/TeamWeeklySummaries/TeamWeeklySummaries.css
+++ b/src/components/UserProfile/TeamWeeklySummaries/TeamWeeklySummaries.css
@@ -41,4 +41,5 @@
 .team-week-summary-text {
   max-width: 100%;
   margin-right: 20px;
+  word-wrap: break-word;
 }


### PR DESCRIPTION
# Description
<img width="762" alt="Screenshot 2024-08-13 at 5 52 34 PM" src="https://github.com/user-attachments/assets/eae8bcf9-4217-4111-853c-6928e3cb1fc0">

## Files Changed
`components/UserProfile/TeamWeeklySummaries/TeamWeeklySummaries.css`

## Related PRS (if any):
This frontend PR is related to the dev branch of backend.

## Main changes explained:
- Added word wrap property to teamweeklysummaries.css

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user.
5.  Edit your weekly summary and add a very long url to the summary at the end and save it.
6. Go to Profile -> Show team weekly summaries -> Select the user you changed the summary for.
7. Check is the URL is not coming out of the container and the text is being wrapped.

## Screenshots or videos of changes:
![Screenshot 2024-08-23 at 3 37 03 PM (2)](https://github.com/user-attachments/assets/cf632003-d56c-4e5a-8959-85b2354b2878)

