### PR TITLE
Yili fix active status issue on team management page

### DIFF
--- a/src/components/Teams/TeamStatusPopup.jsx
+++ b/src/components/Teams/TeamStatusPopup.jsx
@@ -14,7 +14,7 @@ export const TeamStatusPopup = React.memo(props => {
     <Modal isOpen={props.open} toggle={closePopup} className={darkMode ? 'dark-mode text-light' : ''}>
       <ModalHeader toggle={closePopup} className={darkMode ? 'bg-space-cadet' : ''}>Status Popup</ModalHeader>
       <ModalBody style={{ textAlign: 'center' }} className={darkMode ? 'bg-yinmn-blue' : ''}>
-        <span>{`Are you sure you want to change the status of this team ${props.selectedTeamName}`}</span>
+        <span>{`Are you sure you want to change the status of this team ${props.selectedTeamName} to ${props.selectedStatus ? 'inactive' : 'active'}?`}</span>
         <br />
       </ModalBody>
       <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -154,9 +154,7 @@ class Teams extends React.PureComponent {
        */
       return teamSearchData
         .sort((a, b) => {
-          if (a.modifiedDatetime > b.modifiedDatetime) return -1;
-          if (a.modifiedDatetime < b.modifiedDatetime) return 1;
-          return 0;
+          return a.modifiedDatetime === b.modifiedDatetime ? 0 : b.modifiedDatetime - a.modifiedDatetime;
         })
         .map((team, index) => (
           <Team
@@ -289,10 +287,10 @@ class Teams extends React.PureComponent {
   /**
    * call back to show delete team popup
    */
-  onDeleteTeamPopupShow = (deletedname, teamId, status, teamCode) => {
+  onDeleteTeamPopupShow = (deletedName, teamId, status, teamCode) => {
     this.setState({
       deleteTeamPopupOpen: true,
-      selectedTeam: deletedname,
+      selectedTeam: deletedName,
       selectedTeamId: teamId,
       isActive: status,
       selectedTeamCode: teamCode,
@@ -430,10 +428,12 @@ class Teams extends React.PureComponent {
   onConfirmClick = async (teamName, teamId, isActive, teamCode) => {
     const updateTeamResponse = await this.props.updateTeam(teamName, teamId, isActive, teamCode);
     if (updateTeamResponse.status === 200) {
-      toast.success('Status Updated Successfully');
+      toast.success(`Status Updated to ${isActive ? 'active' : 'inactive'} Successfully`);
     } else {
       toast.error(updateTeamResponse);
     }
+    this.props.getAllUserTeams();
+    this.props.getAllUserProfile();
     this.setState({
       teamStatusPopupOpen: false,
       deleteTeamPopupOpen: false,

--- a/src/components/Teams/__tests__/TeamStatusPopup.test.js
+++ b/src/components/Teams/__tests__/TeamStatusPopup.test.js
@@ -20,7 +20,7 @@ describe('TeamStatusPopup', () => {
     expect(getByText('Status Popup')).toBeInTheDocument();
 
     expect(
-      getByText('Are you sure you want to change the status of this team Team 1'),
+      getByText('Are you sure you want to change the status of this team Team 1 to inactive?'),
     ).toBeInTheDocument();
 
     expect(getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
@@ -62,7 +62,7 @@ describe('TeamStatusPopup', () => {
     );
 
     expect(
-      getByText('Are you sure you want to change the status of this team Team 2'),
+      getByText('Are you sure you want to change the status of this team Team 2 to active?'),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Description
<img width="744" alt="image" src="https://github.com/user-attachments/assets/d7425320-8a62-4c43-8a6d-884341a921f3">

## Related PRS (if any):
For backend use development branch

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ Other Links→ Teams
6. Click the `active` indicator of any team
7. Click `confirm` to change the active status
8. Verify that the indicator color changes immediately to reflect the new status (green for active and grey for inactive)
9. Verify that the page will not be stuck and no page refresh is needed to see the updated indicator status

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/3c62df8b-7629-414c-8bd2-3be82b1e7994


