### PR TITLE
Shengwei - Fix Team Name Validation in the QSC Modal

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
@@ -25,7 +25,7 @@ function AddNewTitleModal({ isOpen, setIsOpen, refreshModalTitles, teamsData, pr
     mediaFolder: '',
     teamCode: '',
     projectAssigned: '',
-    // teamAssiged: {},
+    teamAssiged: {},
   });
 
   let existTeamCodes = new Set();
@@ -149,8 +149,8 @@ function AddNewTitleModal({ isOpen, setIsOpen, refreshModalTitles, teamsData, pr
   }
 
   const onTeamNameValidation = (teamName) => {
-    if (teamName !== '') {
-      // debugger;
+    debugger;
+    if (teamName && teamName !== '') {
       if (!existTeamName.has(teamName.teamName)) {
         setWarningMessage({ title: "Error", content: "Team Name Not Exists" });
         setShowMessage(true);

--- a/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
@@ -149,7 +149,6 @@ function AddNewTitleModal({ isOpen, setIsOpen, refreshModalTitles, teamsData, pr
   }
 
   const onTeamNameValidation = (teamName) => {
-    debugger;
     if (teamName && teamName !== '') {
       if (!existTeamName.has(teamName.teamName)) {
         setWarningMessage({ title: "Error", content: "Team Name Not Exists" });

--- a/src/components/UserProfile/QuickSetupModal/AssignTeamCodeField.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AssignTeamCodeField.jsx
@@ -48,7 +48,7 @@ const AssignTeamCodeField = React.memo(props => {
             .map(item => (
               <div
                 className="project-auto-complete"
-                key={item._id}
+                key={item}
                 onClick={() => {
                   onInputChange(item);
                   toggle(false);

--- a/src/components/UserProfile/QuickSetupModal/AssignTeamField.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AssignTeamField.jsx
@@ -4,11 +4,6 @@ import { Dropdown, Input } from 'reactstrap';
 const AssignTeamField = React.memo(props => {
   const [isOpen, toggle] = React.useState(false);
 
-//   React.useEffect(() => {
-//     if (!props.selectedTeam) props.setSearchText('');
-//     else props.setSearchText(props.selectedTeam.teamName);
-//   }, [props.selectedTeam, props.setSearchText]);
-
   React.useEffect(() => {
     if (props.selectedTeam && props.selectedTeam.teamName !== props.searchText) {
       props.onSelectTeam(undefined);
@@ -19,11 +14,6 @@ const AssignTeamField = React.memo(props => {
       props.cleanTeamAssigned();
     }
   }, [props.searchText]);
-
-  const sTeam = props.teamsData.allTeams.find(team => team.teamName === '2021 Test new');
-  if (sTeam) {
-    console.log('sTeam', sTeam);
-  }
   
   return (
     <Dropdown


### PR DESCRIPTION
# Description
- Error displayed upon submission when the optional field team name is empty.
- Frontend "unique key required for child component" issue in the QSC form for team code.

## Related PRS (if any):

## Main changes explained:
- Update file AddNewTitleModal to include new validation logic.
- Update file AssignTeamCodeField to assign new unique key value for child components.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to view user profile
6. verify button “Add a New Title” work
7. verify that you're able to create a title.
![image](https://github.com/user-attachments/assets/0081670d-bf6c-466a-b644-a3bb2cd2d1ff)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/2c2d20d3-68a2-4339-b01b-00512567db71


## Note:
Include the information the reviewers need to know.
