### PR TITLE
Aaryaneil - Added tests cases for PeopleTasksPieChart.

### DIFF
--- a/src/components/Reports/PeopleReport/components/PeopleTasksPieChart.test.jsx
+++ b/src/components/Reports/PeopleReport/components/PeopleTasksPieChart.test.jsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useSelector } from 'react-redux';
+import { PeopleTasksPieChart } from './PeopleTasksPieChart';
+
+// Mock useSelector
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+describe('PeopleTasksPieChart', () => {
+  beforeEach(() => {
+    useSelector.mockClear();
+  });
+
+  const defaultSelectorData = {
+    tasksWithLoggedHoursById: { task1: 10, task2: 20 },
+    showTasksPieChart: true,
+    showProjectsPieChart: false,
+    tasksLegend: {
+      task1: ['Task 1', '10 hours'],
+      task2: ['Task 2', '20 hours'],
+    },
+    projectsWithLoggedHoursById: {},
+    projectsWithLoggedHoursLegend: {},
+    displayedTasksWithLoggedHoursById: { task1: 10, task2: 20 },
+    displayedTasksLegend: {
+      task1: ['Task 1', '10 hours'],
+      task2: ['Task 2', '20 hours'],
+    },
+    showViewAllTasksButton: true,
+  };
+
+  it('renders PieChart for tasks when showTasksPieChart is true', () => {
+    useSelector.mockReturnValue(defaultSelectorData);
+
+    render(<PeopleTasksPieChart darkMode={false} />);
+    
+    expect(screen.getByText(/Tasks With Completed Hours/i)).toBeInTheDocument();
+  });
+
+  it('renders without crashing when showTasksPieChart and showProjectsPieChart are false', () => {
+    useSelector.mockReturnValue({
+      ...defaultSelectorData,
+      showTasksPieChart: false,
+      showProjectsPieChart: false,
+    });
+
+    const { container } = render(<PeopleTasksPieChart darkMode={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders PieChart for projects when showProjectsPieChart is true', () => {
+    useSelector.mockReturnValue({
+      ...defaultSelectorData,
+      showProjectsPieChart: true,
+    });
+
+    render(<PeopleTasksPieChart darkMode={false} />);
+    
+    expect(screen.getByText('Projects With Completed Hours')).toBeInTheDocument();
+  });
+
+  it('renders in dark mode when darkMode prop is true', () => {
+    useSelector.mockReturnValue(defaultSelectorData);
+
+    const { container } = render(<PeopleTasksPieChart darkMode={true} />);
+    expect(container.firstChild).toHaveClass('text-light');
+  });
+
+  it('toggles "View all" button correctly', () => {
+    useSelector.mockReturnValue(defaultSelectorData);
+
+    render(<PeopleTasksPieChart darkMode={false} />);
+    
+    const viewAllButton = screen.getByText('View all');
+    expect(viewAllButton).toBeInTheDocument();
+    
+    fireEvent.click(viewAllButton);
+    
+    expect(screen.getByText('Collapse')).toBeInTheDocument();
+  });
+
+  it('does not show "View all" button when showViewAllTasksButton is false', () => {
+    useSelector.mockReturnValue({
+      ...defaultSelectorData,
+      showViewAllTasksButton: false,
+    });
+
+    render(<PeopleTasksPieChart darkMode={false} />);
+    
+    expect(screen.queryByText('View all')).not.toBeInTheDocument();
+  });
+
+  it('displays total hours as 0.00 when there is no task data', () => {
+    useSelector.mockReturnValue({
+      ...defaultSelectorData,
+      tasksWithLoggedHoursById: {},
+      displayedTasksWithLoggedHoursById: {},
+    });
+
+    render(<PeopleTasksPieChart darkMode={false} />);
+    
+    expect(screen.getByText('Total Hours : 0.00')).toBeInTheDocument();
+  });
+
+  it('displays correct legend information for tasks', () => {
+    useSelector.mockReturnValue(defaultSelectorData);
+
+    render(<PeopleTasksPieChart darkMode={false} />);
+    
+    expect(screen.getByText('Task 1')).toBeInTheDocument();
+    expect(screen.getByText('10 hours')).toBeInTheDocument();
+    expect(screen.getByText('Task 2')).toBeInTheDocument();
+    expect(screen.getByText('20 hours')).toBeInTheDocument();
+  });
+
+  it('renders PieChart for tasks and projects based on their respective flags', () => {
+    useSelector.mockReturnValue({
+      ...defaultSelectorData,
+      showTasksPieChart: true,
+      showProjectsPieChart: true,
+    });
+
+    render(<PeopleTasksPieChart darkMode={false} />);
+    
+    expect(screen.getByText(/Tasks With Completed Hours/i)).toBeInTheDocument();
+    expect(screen.getByText('Projects With Completed Hours')).toBeInTheDocument();
+  });
+
+});


### PR DESCRIPTION
# Description
Unit test for `src/components/Reports/PeopleReport/components/PeopleTasksPieChart.jsx`



## Main changes explained:

Added test cases for the following:
- Renders PieChart for tasks when `showTasksPieChart` is true
- Renders without crashing when `showTasksPieChart` and `showProjectsPieChart` are false
- Renders PieChart for projects when `showProjectsPieChart` is true
- Renders in dark mode when `darkMode` prop is true
- Toggles "View all" button correctly
- Does not show "View all" button when `showViewAllTasksButton` is false
- Displays total hours as 0.00 when there is no task data
- Displays correct legend information for tasks
- Renders PieChart for tasks and projects based on their respective flags

## How to test:
1. check into current branch
2. do `npm install` and `npm test PeopleTasksPieChart.test.jsx`

## Screenshots or videos of changes:
<img width="857" alt="Screenshot 2024-08-24 at 2 13 02 PM" src="https://github.com/user-attachments/assets/3f40b3ed-ab0e-4518-b91b-ccba672f0757">

