### PR TITLE
Aaryaneil - Added test cases for ProfileNavDot.

### DIFF
--- a/src/components/UserManagement/__tests__/ProfileNavDot.test.jsx
+++ b/src/components/UserManagement/__tests__/ProfileNavDot.test.jsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+import { ProfileNavDot } from '../ProfileNavDot';
+
+describe('ProfileNavDot Component Tests', () => {
+  test('renders ProfileNavDot without errors', () => {
+    render(<ProfileNavDot userId="123" />);
+  });
+
+  test('navigates to user profile on click', () => {
+    const history = createMemoryHistory();
+    const userId = '123';
+
+    const { getByTitle } = render(
+      <Router history={history}>
+        <ProfileNavDot userId={userId} />
+      </Router>
+    );
+
+    fireEvent.click(getByTitle("Click here to go to the user's profile."));
+    expect(history.location.pathname).toBe(`/userprofile/${userId}`);
+  });
+
+  test('opens user profile in a new tab when Command/Control key is pressed', () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    const history = createMemoryHistory();
+    const userId = '123';
+
+    const { getByTitle } = render(
+      <Router history={history}>
+        <ProfileNavDot userId={userId} />
+      </Router>
+    );
+
+    fireEvent.click(getByTitle("Click here to go to the user's profile."), { metaKey: true });
+    expect(openSpy).toHaveBeenCalledWith(`/userprofile/${userId}`, '_blank', 'noopener,noreferrer');
+
+    openSpy.mockRestore();
+  });
+
+  test('renders with correct title attribute', () => {
+    const userId = '123';
+
+    const { getByTitle } = render(<ProfileNavDot userId={userId} />);
+    expect(getByTitle("Click here to go to the user's profile.")).toBeInTheDocument();
+  });
+
+  test('renders the correct icon', () => {
+    const userId = '123';
+    const { container } = render(<ProfileNavDot userId={userId} />);
+    
+    const icon = container.querySelector('i.fa-user');
+    expect(icon).toBeInTheDocument();
+  });
+  test('clicking on non-interactive parts does not trigger navigation', () => {
+    const history = createMemoryHistory();
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+    const { container } = render(
+      <Router history={history}>
+        <ProfileNavDot userId="123" />
+      </Router>
+    );
+
+    // Simulate clicking outside the interactive part
+    fireEvent.click(container);
+    
+    // Should not have navigated
+    expect(history.location.pathname).toBe('/');
+    // Should not have opened a new tab
+    expect(openSpy).not.toHaveBeenCalled();
+
+    openSpy.mockRestore();
+  });
+
+  test('handles left and right mouse button clicks', () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    const history = createMemoryHistory();
+    const userId = '123';
+
+    const { getByTitle } = render(
+      <Router history={history}>
+        <ProfileNavDot userId={userId} />
+      </Router>
+    );
+
+    // Left mouse click (button: 0)
+    fireEvent.click(getByTitle("Click here to go to the user's profile."), { button: 0 });
+    expect(history.location.pathname).toBe(`/userprofile/${userId}`);
+
+    // Right mouse click (button: 2)
+    fireEvent.click(getByTitle("Click here to go to the user's profile."), { button: 2 });
+    // Check if right-click was correctly handled if applicable
+    // This may depend on additional logic if you handle right-clicks differently
+
+    openSpy.mockRestore();
+  });
+
+  test('does not navigate or open tab if userId is undefined', () => {
+    const history = createMemoryHistory();
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+  
+    const { getByTitle } = render(
+      <Router history={history}>
+        <ProfileNavDot />
+      </Router>
+    );
+  
+    fireEvent.click(getByTitle("Click here to go to the user's profile."));
+    
+    // Expect navigation to `/userprofile/undefined`
+    expect(history.location.pathname).toBe('/userprofile/undefined');
+    // Should not open a new tab since ctrlKey/metaKey weren't pressed
+    expect(openSpy).not.toHaveBeenCalled();
+  
+    openSpy.mockRestore();
+  });
+
+  test('does not navigate or open a new tab if userId is an empty string', () => {
+    const history = createMemoryHistory();
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+  
+    const { getByTitle } = render(
+      <Router history={history}>
+        <ProfileNavDot userId="" />
+      </Router>
+    );
+  
+    fireEvent.click(getByTitle("Click here to go to the user's profile."));
+    
+    // Expect navigation to `/userprofile/`
+    expect(history.location.pathname).toBe('/userprofile/');
+    // Should not open a new tab since ctrlKey/metaKey weren't pressed
+    expect(openSpy).not.toHaveBeenCalled();
+  
+    openSpy.mockRestore();
+  });
+  
+});
+


### PR DESCRIPTION
# Description
Unit test for `src/components/UserManagement/ProfileNavDot.jsx`


## Related PRS (if any):
Updated PR from #1680

## Main changes explained:
Added test cases for the following:

- Renders ProfileNavDot without errors
- Navigates to user profile on click
- Opens user profile in a new tab when Command/Control key is pressed
- Renders with correct title attribute
- Renders the correct icon
- Clicking on non-interactive parts does not trigger navigation
- Handles left and right mouse button clicks
- Does not navigate or open tab if userId is undefined
- Does not navigate or open a new tab if userId is an empty string

## How to test:
1. check into current branch
2. do `npm install` and `npm test ProfileNavDot.test.jsx`

## Screenshots or videos of changes:
<img width="830" alt="Screenshot 2024-08-24 at 7 59 34 PM" src="https://github.com/user-attachments/assets/749f408a-fa59-4383-9e3b-388f9951c6d1">

