### PR TITLE
Chetan - fixed the ux issue with the summary bar

### DIFF
--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -29,7 +29,7 @@ export function Dashboard(props) {
   const isNotAllowedToEdit = cantUpdateDevAdminDetails(viewingUser?.email, authUser.email);
   const darkMode = useSelector(state => state.theme.darkMode);
 
-  const toggle = () => {
+  const toggle = (forceOpen = null) => {
     if (isNotAllowedToEdit) {
       const warningMessage =
         viewingUser?.email === DEV_ADMIN_ACCOUNT_EMAIL_DEV_ENV_ONLY
@@ -38,7 +38,10 @@ export function Dashboard(props) {
       alert(warningMessage);
       return;
     }
-    setPopup(!popup);
+  
+    const shouldOpen = forceOpen !== null ? forceOpen : !popup;
+    setPopup(shouldOpen);
+  
     setTimeout(() => {
       const elem = document.getElementById('weeklySum');
       if (elem) {
@@ -46,6 +49,7 @@ export function Dashboard(props) {
       }
     }, 150);
   };
+  
 
   const handleStorageEvent = () => {
     const sessionStorageData = checkSessionStorage();

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -262,7 +262,7 @@ const Timelog = props => {
 
   const showSummary = isAuthUser => {
     if (isAuthUser) {
-      setTimeLogState({ ...timeLogState, summary: !timeLogState.summary });
+      setTimeLogState({ ...timeLogState, summary: true });
       setTimeout(() => {
         const elem = document.getElementById('weeklySum');
         if (elem) {


### PR DESCRIPTION
# Description
Fixed the pop up issue of the summary buttons on the summary bar
![image](https://github.com/user-attachments/assets/21b0cfa2-7f36-4208-9727-528bd26f0b4d)

## Related PRS (if any):
This frontend PR is related to the development backend PR.

## Main changes explained:
- Updated the toggle functionality in dashboard.jsx and timelog.jsx

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner/admin user
5. go to dashboard→ On the summary bar find the summary/You still need to complete the weekly summary. Click here to submit it. tab (Follow the video attached)
6. verify that even after clicking the tab multiple times the popup shouldn't get closed.
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
After the changes:

https://github.com/user-attachments/assets/b3f93663-11e0-4b44-9c55-1f68010d431e

Before:

https://github.com/user-attachments/assets/77db6b61-2c37-4b37-a601-385197889519


## Note:
Include the information the reviewers need to know.
