### PR TITLE
Logeshwari  - fix for team management page struck on team edit

### DIFF
--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -70,7 +70,7 @@ class Teams extends React.PureComponent {
       this.sortTeams();
     }
     if (
-      prevProps.state.allTeamsData.allTeams.length !== this.props.state.allTeamsData.allTeams.length
+      (prevProps.state.allTeamsData.allTeams && prevProps.state.allTeamsData.allTeams.length) !== (this.props.state.allTeamsData.allTeams && this.props.state.allTeamsData.allTeams.length)
     ) {
       // Teams length has changed, update or re-fetch them
       this.props.getAllUserTeams();
@@ -98,7 +98,7 @@ class Teams extends React.PureComponent {
   render() {
     const { allTeams, fetching } = this.props.state.allTeamsData;
     const { darkMode } = this.props.state.theme;
-    const numberOfTeams = allTeams.length;
+    const numberOfTeams = allTeams && allTeams.length;
     const numberOfActiveTeams = numberOfTeams ? allTeams.filter(team => team.isActive).length : 0;
 
     return (
@@ -388,16 +388,20 @@ class Teams extends React.PureComponent {
         this.state.isActive,
         this.state.selectedTeamCode,
       );
-      if (updateTeamResponse.status === 200) {
+      if (updateTeamResponse && updateTeamResponse.status === 200) {
         toast.success('Team updated successfully');
-      } else {
+      } else if(!updateTeamResponse) {
+        toast.error("You are not authorized to edit team code.");
+      }else{
         toast.error(updateTeamResponse);
       }
     } else {
       const postResponse = await this.props.postNewTeam(name, true);
-      if (postResponse.status === 200) {
+      if (postResponse.status && postResponse.status === 200) {
         toast.success('Team added successfully');
-      } else {
+      } else if(!postResponse) {
+        toast.error("You are not authorized to add team code.");
+      }else{
         toast.error(postResponse);
       }
     }


### PR DESCRIPTION
# Description
![Page struck Task](https://github.com/user-attachments/assets/2ba7dba8-e9e0-4e32-8036-62b123f6a145)

## Related PRS (if any):
This frontend PR is related to the backend [#PR1087](https://github.com/OneCommunityGlobal/HGNRest/pull/1087#issue-2492617032).

## Main changes explained:
- Handled the error for Unauthorized error message in the Team update API and edited Toaster message for user to display the message. 

## How to test:
1. check into current branch
2. do `npm install`, `npm run start:local` to run this PR locally
3. Clear site data/cache
4. Log as Any user.
5. Go to Other Links -> Teams.
6. Select the "Edit" option and edit the Name of the Team and click "Ok".
7. "Team Updated successfully" toaster message should be displayed.
8. Verify the team names can be edited and the page is not struck anytime during editing and saving.
 Note: If the user is not having permission to edit, then "You are not authorized to edit team code." will be displayed. 
 Go to "Other Links" -> "Permission Management" -> "Manage User Permission" to provide Team Edit Permission for specific user .

## Screenshots or videos of changes:

Before Changes:
https://github.com/user-attachments/assets/c82b9427-2570-45de-aa46-1f56633db845

After Changes:
https://github.com/user-attachments/assets/3df2eaa6-2dc8-43c7-8826-16f564d32782