### PR TITLE
Ishan - Fix green dot and timelog icon on profile page

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -593,23 +593,6 @@ const Timelog = props => {
                               }}
                             />
                           </span>
-
-                          <span className="mr-2" style={{ padding: '1px' }}>
-                            <ActiveCell
-                              isActive={displayUserProfile.isActive}
-                              user={displayUserProfile}
-                              onClick={() => {
-                                props.updateUserProfile({
-                                  ...displayUserProfile,
-                                  isActive: !displayUserProfile.isActive,
-                                  endDate:
-                                    !displayUserProfile.isActive === false
-                                      ? moment(new Date()).format('YYYY-MM-DD')
-                                      : undefined,
-                                });
-                              }}
-                            />
-                          </span>
                           <ProfileNavDot userId={displayUserId} style={{ marginLeft: '2px', padding: '1px' }} />
                         </div>
                       </CardTitle>

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -629,12 +629,11 @@ function UserProfile(props) {
     });
   };
 
-  const setActiveInactive = async(isActive) => {
-    setActiveInactivePopupOpen(false);
+  const setActiveInactive = (isActive) => {
     let endDate;
 
     if (!isActive) {
-      endDate = await dispatch(getTimeEndDateEntriesByPeriod(userProfile._id, userProfile.createdDate, userProfile.toDate));
+      endDate = dispatch(getTimeEndDateEntriesByPeriod(userProfile._id, userProfile.createdDate, userProfile.toDate));
       if (endDate == "N/A"){
         endDate = userProfile.createdDate
       }
@@ -646,12 +645,13 @@ function UserProfile(props) {
     };
 
     try{
-      await updateUserStatus(newUserProfile, isActive? UserStatus.Active : UserStatus.InActive, undefined);
+      props.updateUserStatus(newUserProfile, isActive? UserStatus.Active : UserStatus.InActive, undefined);
       setUserProfile(newUserProfile);
       setOriginalUserProfile(newUserProfile);
     } catch (error) {
       console.error("Failed to update user status:", error);
     }
+    setActiveInactivePopupOpen(false);
   };
 
   const activeInactivePopupClose = () => {
@@ -939,7 +939,6 @@ function UserProfile(props) {
                         e.preventDefault();
                         props.history.push(`/timelog/${targetUserId}`);
                       }
-                      setActiveInactivePopupOpen(true);
                     }}
                   />
                 </span>
@@ -1786,4 +1785,4 @@ function UserProfile(props) {
   );
 }
 
-export default connect(null, { hasPermission })(UserProfile);
+export default connect(null, { hasPermission, updateUserStatus })(UserProfile);


### PR DESCRIPTION
# Description
<img width="614" alt="Screenshot 2024-08-27 at 3 40 52 PM" src="https://github.com/user-attachments/assets/5e1303c4-574d-44a5-8a1b-698caa811466">


## Related PRS (if any):
To test this PR you need to checkout the development backend branch. 
…

## Main changes explained:
- Removed duplicate green dot code in Timelog.jsx
- Fixed Prop management in UserProfile.jsx
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ User Profile Page
6. Click on the green dot next to the Username. It should toggle the active inactive status of the user and it should persist on reload.
7. Next click on the timelog icon next to the Username with Cmd Key on Mac and Ctrl on Windows. This should open up the timelog page in a new tab and no popup should open before the new tab opens.
8. In the timelog Component there should now only be 1 green dot to show active/inactive instead of the 2 that were there earlier.
8. Verify this new feature works in dark mode.

## Screenshots or videos of changes:
Before:
1. 2 green dots instead of 1
2. opening Timelog from userProfile in new tab opens unnecessary popup
3. Making active/inactive from userprofile page does not persist after reload.

https://github.com/user-attachments/assets/ca2269cd-ca98-4d3d-b14c-87057968f467



After:
1. 1 green dot now instead of two
2. no unnecessary popup on opening timelog in new tab from userProfile Page
3. Making active/inactive from userprofile page now persists after reload.

https://github.com/user-attachments/assets/751bf5cf-7c3b-4908-bd19-f214bd17c80a


