### PR TITLE
Peterson implement add members button and modal to profile teams tab teams

### DIFF
--- a/src/components/Badge/__tests__/NewBadges.test.js
+++ b/src/components/Badge/__tests__/NewBadges.test.js
@@ -49,7 +49,7 @@ describe('NewBadges component', () => {
     expect(screen.queryByRole('BadgeImage')).toBeNull();
   });
 
-  it('renders new badges correctly', () => {
+  it.skip('renders new badges correctly', () => {
     render(
       <NewBadges
         badges={mockBadges}

--- a/src/components/Badge/__tests__/NewBadges.test.js
+++ b/src/components/Badge/__tests__/NewBadges.test.js
@@ -49,7 +49,7 @@ describe('NewBadges component', () => {
     expect(screen.queryByRole('BadgeImage')).toBeNull();
   });
 
-  it.skip('renders new badges correctly', () => {
+  it('renders new badges correctly', () => {
     render(
       <NewBadges
         badges={mockBadges}

--- a/src/components/Teams/MembersAutoComplete.jsx
+++ b/src/components/Teams/MembersAutoComplete.jsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
 import { Dropdown, Input } from 'reactstrap';
-import { searchWithAccent } from 'utils/search'
+import { searchWithAccent } from 'utils/search';
 export const MemberAutoComplete = props => {
   const [isOpen, toggle] = useState(false);
 
   const dropdownStyle = {
     marginTop: '0px',
     width: '100%',
-    maxHeight: '350px',  // Adjust this value as needed
-    overflowY: 'auto'
+    maxHeight: '350px', // Adjust this value as needed
+    overflowY: 'auto',
   };
+
+  const validation = props.userProfileData?.userProfiles || props.userProfileData;
 
   return (
     <Dropdown
@@ -23,7 +25,7 @@ export const MemberAutoComplete = props => {
         autoFocus
         type="text"
         value={props.searchText}
-        data-testid='input-search'
+        data-testid="input-search"
         onChange={e => {
           props.setSearchText(e.target.value);
           toggle(true);
@@ -69,86 +71,83 @@ export const MemberAutoComplete = props => {
       ) : (
         <>{console.log('Not rendering dropdown')}</>
       )} */}
-      {props.context == "WeeklySummary" ?
-
-<>
-  {props.searchText !== '' &&
-    props.summaries &&
-    props.summaries.length > 0 ? (
-    <div
-      tabIndex="-1"
-      role="menu"
-      aria-hidden="false"
-      className={`dropdown-menu${isOpen ? ' show' : ''}`}
-      style={{ marginTop: '0px', width: '100%' }}
-    >
-      {props.summaries
-        .filter(user => {
-          if (
-            (user.firstName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1 ||
-              user.lastName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1)
-          ) {
-            return user;
-          }
-        })
-        .slice(0, 10)
-        .map(item => (
-          <div key={item._id}
-            className="user-auto-cpmplete"
-            onClick={() => {
-              props.setSearchText(`${item.firstName} ${item.lastName}`);
-              toggle(false);
-              props.onAddUser(item);
-            }}
-          >
-            {`${item.firstName} ${item.lastName}`}
-          </div>
-        ))}
-    </div>
-    ) : (
-      <></>
-    )}
-  </> :
-  <>
-    {props.searchText !== '' &&
-      props.userProfileData &&
-      props.userProfileData.userProfiles.length > 0 ? (
-      <div
-        tabIndex="-1"
-        role="menu"
-        aria-hidden="false"
-        className={`dropdown-menu${isOpen ? ' show' : ''}`}
-        style={{ marginTop: '0px', width: '100%' }}
-      >
-        {props.userProfileData.userProfiles
-          .filter(user => {
-            if (
-              user.isActive &&
-              (user.firstName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1 ||
-                user.lastName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1)
-            ) {
-              return user;
-            }
-          })
-          .slice(0, 10)
-          .map(item => (
+      {props.context == 'WeeklySummary' ? (
+        <>
+          {props.searchText !== '' && props.summaries && props.summaries.length > 0 ? (
             <div
-              className="user-auto-cpmplete"
-              onClick={() => {
-                props.setSearchText(`${item.firstName} ${item.lastName}`);
-                toggle(false);
-                props.onAddUser(item);
-              }}
+              tabIndex="-1"
+              role="menu"
+              aria-hidden="false"
+              className={`dropdown-menu${isOpen ? ' show' : ''}`}
+              style={{ marginTop: '0px', width: '100%' }}
             >
-              {`${item.firstName} ${item.lastName}`}
-          </div>
-        ))}
-    </div>
-  ) : (
-    <></>
-  )}
-</>
-}
+              {props.summaries
+                .filter(user => {
+                  if (
+                    user.firstName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1 ||
+                    user.lastName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1
+                  ) {
+                    return user;
+                  }
+                })
+                .slice(0, 10)
+                .map(item => (
+                  <div
+                    key={item._id}
+                    className="user-auto-cpmplete"
+                    onClick={() => {
+                      props.setSearchText(`${item.firstName} ${item.lastName}`);
+                      toggle(false);
+                      props.onAddUser(item);
+                    }}
+                  >
+                    {`${item.firstName} ${item.lastName}`}
+                  </div>
+                ))}
+            </div>
+          ) : (
+            <></>
+          )}
+        </>
+      ) : (
+        <>
+          {props.searchText !== '' && props.userProfileData && validation.length > 0 ? (
+            <div
+              tabIndex="-1"
+              role="menu"
+              aria-hidden="false"
+              className={`dropdown-menu${isOpen ? ' show' : ''}`}
+              style={{ marginTop: '0px', width: '100%' }}
+            >
+              {validation
+                .filter(user => {
+                  if (
+                    user.isActive &&
+                    (user.firstName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1 ||
+                      user.lastName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1)
+                  ) {
+                    return user;
+                  }
+                })
+                .slice(0, 10)
+                .map(item => (
+                  <div
+                    className="user-auto-cpmplete"
+                    onClick={() => {
+                      props.setSearchText(`${item.firstName} ${item.lastName}`);
+                      toggle(false);
+                      props.onAddUser(item);
+                    }}
+                  >
+                    {`${item.firstName} ${item.lastName}`}
+                  </div>
+                ))}
+            </div>
+          ) : (
+            <></>
+          )}
+        </>
+      )}
     </Dropdown>
   );
 };

--- a/src/components/Teams/MembersAutoComplete.jsx
+++ b/src/components/Teams/MembersAutoComplete.jsx
@@ -13,6 +13,13 @@ export const MemberAutoComplete = props => {
 
   const validation = props.userProfileData?.userProfiles || props.userProfileData;
 
+  const filterInputAutoComplete = result => {
+    return result
+      .toLowerCase()
+      .trim()
+      .replace(/\s+/g, '');
+  };
+
   return (
     <Dropdown
       isOpen={isOpen}
@@ -121,10 +128,11 @@ export const MemberAutoComplete = props => {
             >
               {validation
                 .filter(user => {
+                  const fullName = user.firstName + user.lastName;
                   if (
                     user.isActive &&
-                    (user.firstName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1 ||
-                      user.lastName.toLowerCase().indexOf(props.searchText.toLowerCase()) > -1)
+                    // prettier-ignore
+                    filterInputAutoComplete(fullName).indexOf(filterInputAutoComplete(props.searchText)) > -1
                   ) {
                     return user;
                   }

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Container, Alert } from 'reactstrap';
 import hasPermission from 'utils/permissions';
 import { boxStyle, boxStyleDark } from 'styles';
-import '../Header/DarkMode.css'
+import '../Header/DarkMode.css';
 import moment from 'moment';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSort, faSortUp, faSortDown } from '@fortawesome/free-solid-svg-icons';
@@ -22,19 +22,21 @@ export const TeamMembersPopup = React.memo(props => {
   const [memberList, setMemberList] = useState([]);
   const [sortOrder, setSortOrder] = useState(0);
   const [deletedPopup, setDeletedPopup] = useState(false);
-    
+
   const closeDeletedPopup = () => {
     setDeletedPopup(!deletedPopup);
-  }
+  };
 
-  const handleDelete = (id) => {
-    props.onDeleteClick(`${id}`)
+  const handleDelete = id => {
+    props.onDeleteClick(`${id}`);
     setDeletedPopup(true);
-  }
+  };
 
   const [infoModal, setInfoModal] = useState(false);
 
   const canAssignTeamToUsers = props.hasPermission('assignTeamToUsers');
+
+  const validation = props.members.teamMembers || props.members;
 
   const closePopup = () => {
     setMemberList([]);
@@ -43,7 +45,7 @@ export const TeamMembersPopup = React.memo(props => {
   };
   const onAddUser = () => {
     if (selectedUser) {
-      const isDuplicate = props.members.teamMembers.some(x => x._id === selectedUser._id);
+      const isDuplicate = validation.some(x => x._id === selectedUser._id);
       if (!isDuplicate) {
         props.onAddUser(selectedUser);
         setSearchText('');
@@ -95,7 +97,7 @@ export const TeamMembersPopup = React.memo(props => {
 
     if (sort === 0) {
       const groupByPermissionList =
-        props.members?.teamMembers?.reduce((pre, cur) => {
+        validation.reduce((pre, cur) => {
           const { role } = cur;
           pre[role] ? pre[role].push(cur) : (pre[role] = [cur]);
           return pre;
@@ -106,7 +108,7 @@ export const TeamMembersPopup = React.memo(props => {
         .map(list => list.toSorted(sortByAlpha))
         .flat();
     } else {
-      const sortByDateList = props.members.teamMembers.toSorted((a, b) => {
+      const sortByDateList = validation.toSorted((a, b) => {
         return moment(a.addDateTime).diff(moment(b.addDateTime)) * -sort;
       });
 
@@ -155,13 +157,13 @@ export const TeamMembersPopup = React.memo(props => {
       });
     }
     return memberVisibility;
-  }
+  };
 
   useEffect(() => {
     sortList(sortOrder);
     const newMemberVisibility = getMemberVisibility();
     setMemberVisibility(newMemberVisibility);
-  }, [props.members.teamMembers, sortOrder, props.teamData]);
+  }, [validation, sortOrder, props.teamData]);
 
   useEffect(() => {
     setIsValidUser(true);
@@ -181,19 +183,32 @@ export const TeamMembersPopup = React.memo(props => {
     <Container fluid>
       <InfoModal isOpen={infoModal} toggle={toggleInfoModal} />
 
-      <Modal isOpen={props.open} toggle={closePopup} autoFocus={false} size="lg" className={darkMode ? 'dark-mode text-light' : ''}>
-        <ModalHeader className={darkMode ? 'bg-space-cadet' : ''} toggle={closePopup}>{`Members of ${props.selectedTeamName}`}</ModalHeader>
+      <Modal
+        isOpen={props.open}
+        toggle={closePopup}
+        autoFocus={false}
+        size="lg"
+        className={darkMode ? 'dark-mode text-light' : ''}
+      >
+        <ModalHeader
+          className={darkMode ? 'bg-space-cadet' : ''}
+          toggle={closePopup}
+        >{`Members of ${props.selectedTeamName}`}</ModalHeader>
         <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''} style={{ textAlign: 'center' }}>
           {canAssignTeamToUsers && (
             <div className="input-group-prepend" style={{ marginBottom: '10px' }}>
               <MembersAutoComplete
                 userProfileData={props.usersdata}
-                existingMembers={props.members.teamMembers}
+                existingMembers={validation}
                 onAddUser={selectUser}
                 searchText={searchText}
                 setSearchText={setSearchText}
               />
-              <Button color="primary" onClick={onAddUser} style={darkMode ? boxStyleDark : boxStyle}>
+              <Button
+                color="primary"
+                onClick={onAddUser}
+                style={darkMode ? boxStyleDark : boxStyle}
+              >
                 Add
               </Button>
             </div>
@@ -207,7 +222,11 @@ export const TeamMembersPopup = React.memo(props => {
             <></>
           )}
 
-          <table className={`table table-bordered table-responsive-sm ${darkMode ? 'dark-mode text-light' : ''}`}>
+          <table
+            className={`table table-bordered table-responsive-sm ${
+              darkMode ? 'dark-mode text-light' : ''
+            }`}
+          >
             <thead>
               <tr className={darkMode ? 'bg-space-cadet' : ''}>
                 <th>Active</th>
@@ -232,9 +251,13 @@ export const TeamMembersPopup = React.memo(props => {
               </tr>
             </thead>
             <tbody>
-              {props.members.teamMembers.length > 0 && props.members.fetching === false && props.members.fetched && 
+              {((Array.isArray(props.members.teamMembers) &&
+                props.members.teamMembers.length > 0) ||
+                (typeof props.members.fetching === 'boolean' &&
+                  !props.members.fetching &&
+                  props.members.teamMembers) ||
+                (Array.isArray(props.members) && props.members.length > 0)) &&
                 memberList.toSorted().map((user, index) => {
-
                   return (
                     <tr key={`${props.selectedTeamName}-${user.id}-${index}`}>
                       <td>
@@ -288,10 +311,23 @@ export const TeamMembersPopup = React.memo(props => {
           </Button>
         </ModalFooter>
       </Modal>
-      <Modal isOpen={deletedPopup} toggle={closeDeletedPopup} className={darkMode ? 'dark-mode text-light' : ''}>
-        <ModalHeader toggle={closeDeletedPopup} className={`${darkMode ? 'bg-space-cadet' : ''} text-danger font-weight-bold`}>Member Deleted!</ModalHeader>
+      <Modal
+        isOpen={deletedPopup}
+        toggle={closeDeletedPopup}
+        className={darkMode ? 'dark-mode text-light' : ''}
+      >
+        <ModalHeader
+          toggle={closeDeletedPopup}
+          className={`${darkMode ? 'bg-space-cadet' : ''} text-danger font-weight-bold`}
+        >
+          Member Deleted!
+        </ModalHeader>
         <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
-          <p>Team member successfully deleted! Ryunosuke Satoro famously said, “Individually we are one drop, together we are an ocean.” Through the action you just took, this ocean is now one drop smaller.</p>
+          <p>
+            Team member successfully deleted! Ryunosuke Satoro famously said, “Individually we are
+            one drop, together we are an ocean.” Through the action you just took, this ocean is now
+            one drop smaller.
+          </p>
         </ModalBody>
       </Modal>
     </Container>

--- a/src/components/UserProfile/TeamsAndProjects/TeamMember.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamMember.jsx
@@ -1,8 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
 import TeamMembersPopup from './../../Teams/TeamMembersPopup.jsx';
-import DeleteTeamPopup from './../../Teams/DeleteTeamPopup';
-
 import {
   deleteTeamMember,
   addTeamMember,
@@ -29,7 +26,6 @@ export const TeamMember = props => {
         ? setMembers(prev => [...prev, newUser])
         : id &&
           setMembers(prev => {
-            newUser && prev.push(newUser);
             const index = prev.findIndex(item => item._id === id);
             if (index !== -1) {
               const updatedMembers = [...prev];

--- a/src/components/UserProfile/TeamsAndProjects/TeamMember.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamMember.jsx
@@ -18,22 +18,25 @@ export const TeamMember = props => {
 
   const allTeams = useSelector(state => state.allTeamsData?.allTeams || []);
 
+  const teamData = allTeams.filter(item => item._id === myTeamId);
+
   const [members, setMembers] = useState([]);
 
   const updateMyTeamMember = (id, newUser) => {
     setTimeout(() => {
-      newUser
-        ? setMembers(prev => [...prev, newUser])
-        : id &&
-          setMembers(prev => {
-            const index = prev.findIndex(item => item._id === id);
-            if (index !== -1) {
-              const updatedMembers = [...prev];
-              updatedMembers.splice(index, 1);
-              return updatedMembers;
-            }
-            return prev;
-          });
+      setMembers(prev => {
+        if (newUser) {
+          return [...prev, newUser];
+        } else if (id) {
+          const index = prev.findIndex(item => item._id === id);
+          if (index !== -1) {
+            const updatedMembers = [...prev];
+            updatedMembers.splice(index, 1);
+            return updatedMembers;
+          }
+        }
+        return prev;
+      });
     }, 5000);
   };
 
@@ -44,6 +47,10 @@ export const TeamMember = props => {
     addTeamMember(myTeamId, user._id, user.firstName, user.lastName, user.role, Date.now());
     updateMyTeamMember(null, user);
   };
+
+  const updateTeamMemberVisibility = (userId, visibility) =>
+    updateTeamMemeberVisibility(myTeamId, userId, visibility);
+
   // prettier-ignore
   useEffect(() => {myTeamId && TeamMembers();}, [myTeamId]);
 
@@ -66,8 +73,8 @@ export const TeamMember = props => {
           onDeleteClick={deleteMyTeamMember}
           usersdata={allUserProfiles}
           onAddUser={addMyTeamMember}
-          teamData={allTeams}
-          onUpdateTeamMemberVisibility={updateTeamMemeberVisibility}
+          teamData={teamData}
+          onUpdateTeamMemberVisibility={updateTeamMemberVisibility}
           selectedTeamName={teamName}
         />
       )}
@@ -77,12 +84,6 @@ export const TeamMember = props => {
 
 const mapStateToProps = state => ({ state });
 export default connect(mapStateToProps, {
-  //! getAllUserProfile,
-  // ! getAllUserTeams,
-  // ! postNewTeam,
-  // !deleteTeam,
-  //! updateTeam,
-  // ! getTeamMembers,
   deleteTeamMember,
   addTeamMember,
   updateTeamMemeberVisibility,

--- a/src/components/UserProfile/TeamsAndProjects/TeamMember.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamMember.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
+import TeamMembersPopup from './../../Teams/TeamMembersPopup.jsx';
+import DeleteTeamPopup from './../../Teams/DeleteTeamPopup';
+
+import {
+  deleteTeamMember,
+  addTeamMember,
+  updateTeamMemeberVisibility,
+} from '../../../actions/allTeamsAction.js';
+import { useSelector, connect } from 'react-redux';
+import axios from 'axios';
+import { ENDPOINTS } from '../../../utils/URL.js';
+
+export const TeamMember = props => {
+  const { isOpenModalTeamMember, setIsOpenModalTeamMember, teamName, myTeamId } = props;
+
+  const toggle = () => setIsOpenModalTeamMember(!isOpenModalTeamMember);
+
+  //const allUserProfiles = useSelector(state => state.allUserProfiles.userProfiles);
+
+  //const allTeams = useSelector(state => state.allTeamsData.allTeams);
+
+  const [members, setMembers] = useState([]);
+
+  const updateMyTeamMember = (id, newUser) => {
+    setTimeout(() => {
+      newUser
+        ? setMembers(prev => [...prev, newUser])
+        : id &&
+          setMembers(prev => {
+            newUser && prev.push(newUser);
+            const index = prev.findIndex(item => item._id === id);
+            if (index !== -1) {
+              const updatedMembers = [...prev];
+              updatedMembers.splice(index, 1);
+              return updatedMembers;
+            }
+            return prev;
+          });
+    }, 5000);
+  };
+
+  // prettier-ignore
+  const deleteMyTeamMember = id => {deleteTeamMember(myTeamId, id); updateMyTeamMember(id)};
+
+  const addMyTeamMember = user => {
+    addTeamMember(myTeamId, user._id, user.firstName, user.lastName, user.role, Date.now());
+    updateMyTeamMember(null, user);
+  };
+  // prettier-ignore
+  useEffect(() => {myTeamId && TeamMembers();}, [myTeamId]);
+
+  const TeamMembers = async () => {
+    const url = ENDPOINTS.TEAM_USERS(myTeamId);
+    try {
+      const response = await axios.get(url);
+      setMembers(response.data);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  return (
+    <>
+      {isOpenModalTeamMember && (
+        <TeamMembersPopup
+          open={isOpenModalTeamMember}
+          onClose={toggle}
+          members={members}
+          onDeleteClick={deleteMyTeamMember}
+          usersdata={allUserProfiles || []}
+          onAddUser={addMyTeamMember}
+          teamData={allTeams || []}
+          onUpdateTeamMemberVisibility={updateTeamMemeberVisibility}
+          selectedTeamName={teamName}
+        />
+      )}
+    </>
+  );
+};
+
+const mapStateToProps = state => ({ state });
+export default connect(mapStateToProps, {
+  //! getAllUserProfile,
+  // ! getAllUserTeams,
+  // ! postNewTeam,
+  // !deleteTeam,
+  //! updateTeam,
+  // ! getTeamMembers,
+  deleteTeamMember,
+  addTeamMember,
+  updateTeamMemeberVisibility,
+})(TeamMember);

--- a/src/components/UserProfile/TeamsAndProjects/TeamMember.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamMember.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import TeamMembersPopup from './../../Teams/TeamMembersPopup.jsx';
 import {
   deleteTeamMember,
@@ -6,76 +6,46 @@ import {
   updateTeamMemeberVisibility,
 } from '../../../actions/allTeamsAction.js';
 import { useSelector, connect } from 'react-redux';
-import axios from 'axios';
-import { ENDPOINTS } from '../../../utils/URL.js';
 
 export const TeamMember = props => {
-  const { isOpenModalTeamMember, setIsOpenModalTeamMember, teamName, myTeamId } = props;
+  const { isOpenModalTeamMember, setIsOpenModalTeamMember, members, fetchTeamSelected } = props;
 
   const toggle = () => setIsOpenModalTeamMember(!isOpenModalTeamMember);
 
   const allUserProfiles = useSelector(state => state.allUserProfiles?.userProfiles || []);
 
-  const allTeams = useSelector(state => state.allTeamsData?.allTeams || []);
-
-  const teamData = allTeams.filter(item => item._id === myTeamId);
-
-  const [members, setMembers] = useState([]);
-
-  const updateMyTeamMember = (id, newUser) => {
+  const updateMyTeamMember = () => {
     setTimeout(() => {
-      setMembers(prev => {
-        if (newUser) {
-          return [...prev, newUser];
-        } else if (id) {
-          const index = prev.findIndex(item => item._id === id);
-          if (index !== -1) {
-            const updatedMembers = [...prev];
-            updatedMembers.splice(index, 1);
-            return updatedMembers;
-          }
-        }
-        return prev;
-      });
-    }, 5000);
+      fetchTeamSelected(members.myTeamId, members.myTeamName, true);
+    }, 3000);
   };
 
   // prettier-ignore
-  const deleteMyTeamMember = id => {deleteTeamMember(myTeamId, id); updateMyTeamMember(id)};
+  const deleteMyTeamMember = id => {deleteTeamMember(members.myTeamId, id); updateMyTeamMember()};
 
   const addMyTeamMember = user => {
-    addTeamMember(myTeamId, user._id, user.firstName, user.lastName, user.role, Date.now());
-    updateMyTeamMember(null, user);
+    addTeamMember(members.myTeamId, user._id, user.firstName, user.lastName, user.role, Date.now());
+    updateMyTeamMember();
   };
 
-  const updateTeamMemberVisibility = (userId, visibility) =>
-    updateTeamMemeberVisibility(myTeamId, userId, visibility);
-
-  // prettier-ignore
-  useEffect(() => {myTeamId && TeamMembers();}, [myTeamId]);
-
-  const TeamMembers = async () => {
-    const url = ENDPOINTS.TEAM_USERS(myTeamId);
-    try {
-      const response = await axios.get(url);
-      setMembers(response.data);
-    } catch (error) {
-      console.log(error);
-    }
+  const updateTeamMemberVisibility = (userId, visibility) => {
+    updateTeamMemeberVisibility(members.myTeamId, userId, visibility);
+    updateMyTeamMember();
   };
+
   return (
     <>
       {isOpenModalTeamMember && (
         <TeamMembersPopup
           open={isOpenModalTeamMember}
           onClose={toggle}
-          members={members}
+          members={members.members}
           onDeleteClick={deleteMyTeamMember}
           usersdata={allUserProfiles}
           onAddUser={addMyTeamMember}
-          teamData={teamData}
+          teamData={members.TeamData}
           onUpdateTeamMemberVisibility={updateTeamMemberVisibility}
-          selectedTeamName={teamName}
+          selectedTeamName={members.myTeamName}
         />
       )}
     </>

--- a/src/components/UserProfile/TeamsAndProjects/TeamMember.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamMember.jsx
@@ -17,9 +17,9 @@ export const TeamMember = props => {
 
   const toggle = () => setIsOpenModalTeamMember(!isOpenModalTeamMember);
 
-  //const allUserProfiles = useSelector(state => state.allUserProfiles.userProfiles);
+  const allUserProfiles = useSelector(state => state.allUserProfiles?.userProfiles || []);
 
-  //const allTeams = useSelector(state => state.allTeamsData.allTeams);
+  const allTeams = useSelector(state => state.allTeamsData?.allTeams || []);
 
   const [members, setMembers] = useState([]);
 
@@ -68,9 +68,9 @@ export const TeamMember = props => {
           onClose={toggle}
           members={members}
           onDeleteClick={deleteMyTeamMember}
-          usersdata={allUserProfiles || []}
+          usersdata={allUserProfiles}
           onAddUser={addMyTeamMember}
-          teamData={allTeams || []}
+          teamData={allTeams}
           onUpdateTeamMemberVisibility={updateTeamMemeberVisibility}
           selectedTeamName={teamName}
         />

--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
@@ -212,7 +212,7 @@ const UserTeamsTable = props => {
                     {canAssignTeamToUsers ? (
                       <>
                         <th className={darkMode ? 'bg-space-cadet' : ''} style={{ width: '100px' }}>
-                          '
+                          Team Name
                         </th>
 
                         <th className={darkMode ? 'bg-space-cadet' : ''}>Members</th>
@@ -232,9 +232,10 @@ const UserTeamsTable = props => {
                       <td>{`${team.teamName}`}</td>
                       {props.edit && props.role && (
                         <>
-                          <td>
+                          <td style={{ textAlign: 'center', width: '10%' }}>
                             <button
                               style={darkMode ? {} : boxStyle}
+                              disabled={!canAssignTeamToUsers}
                               type="button"
                               className="btn btn-outline-info"
                               data-testid="members-btn"
@@ -276,6 +277,9 @@ const UserTeamsTable = props => {
           <TeamMember
             isOpenModalTeamMember={isOpenModalTeamMember}
             setIsOpenModalTeamMember={setIsOpenModalTeamMember}
+            myTeams={props.userTeamsById}
+            teamName={myTeamName}
+            myTeamId={myTeamId}
           />
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             {props.canEditVisibility && (
@@ -394,6 +398,7 @@ const UserTeamsTable = props => {
                           <td>
                             <button
                               style={darkMode ? {} : boxStyle}
+                              disabled={!canAssignTeamToUsers}
                               type="button"
                               className="btn btn-outline-info"
                               data-testid="members-btn"

--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
@@ -9,6 +9,9 @@ import { connect } from 'react-redux';
 import { AutoCompleteTeamCode } from './AutoCompleteTeamCode';
 import './../../Teams/Team.css';
 import { TeamMember } from './TeamMember';
+import axios from 'axios';
+import { ENDPOINTS } from '../../../utils/URL.js';
+import { toast } from 'react-toastify';
 
 const UserTeamsTable = props => {
   const { darkMode } = props;
@@ -30,8 +33,13 @@ const UserTeamsTable = props => {
   );
 
   const [isOpenModalTeamMember, setIsOpenModalTeamMember] = useState(false);
-  const [myTeamName, setMyTeamName] = useState('');
-  const [myTeamId, setMyTeamId] = useState();
+
+  const [members, setMembers] = useState({
+    members: [],
+    TeamData: [],
+    myTeamId: null,
+    myTeamName: '',
+  });
 
   const refDropdown = useRef();
 
@@ -87,6 +95,29 @@ const UserTeamsTable = props => {
 
   const toggleTeamCodeExplainTooltip = () => setTeamCodeExplainTooltip(!teamCodeExplainTooltip);
 
+  const fetchTeamSelected = async (teamId, teamName, isUpdate) => {
+    const urlTeamData = ENDPOINTS.TEAM_BY_ID(teamId);
+    const urlTeamMembers = ENDPOINTS.TEAM_USERS(teamId);
+    try {
+      const TeamDataMember = await axios.get(urlTeamMembers);
+      const TeamData = await axios.get(urlTeamData);
+
+      const array = [];
+      array.push(TeamData.data);
+
+      setMembers({
+        members: TeamDataMember.data,
+        TeamData: array,
+        myTeamId: teamId,
+        myTeamName: teamName,
+      });
+
+      isUpdate ? toast.info('Team updated successfully') : setIsOpenModalTeamMember(true);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   return (
     <div>
       {innerWidth >= 1025 ? (
@@ -94,9 +125,8 @@ const UserTeamsTable = props => {
           <TeamMember
             isOpenModalTeamMember={isOpenModalTeamMember}
             setIsOpenModalTeamMember={setIsOpenModalTeamMember}
-            myTeams={props.userTeamsById}
-            teamName={myTeamName}
-            myTeamId={myTeamId}
+            members={members}
+            fetchTeamSelected={fetchTeamSelected}
           />
           <div className="container" style={{ paddingLeft: '4px', paddingRight: '4px' }}>
             {props.canEditVisibility && (
@@ -239,11 +269,7 @@ const UserTeamsTable = props => {
                               type="button"
                               className="btn btn-outline-info"
                               data-testid="members-btn"
-                              onClick={() => {
-                                setMyTeamName(team.teamName);
-                                setIsOpenModalTeamMember(true);
-                                setMyTeamId(team._id);
-                              }}
+                              onClick={() => fetchTeamSelected(team._id, team.teamName)}
                             >
                               <i className="fa fa-users" aria-hidden="true" />
                             </button>
@@ -277,9 +303,8 @@ const UserTeamsTable = props => {
           <TeamMember
             isOpenModalTeamMember={isOpenModalTeamMember}
             setIsOpenModalTeamMember={setIsOpenModalTeamMember}
-            myTeams={props.userTeamsById}
-            teamName={myTeamName}
-            myTeamId={myTeamId}
+            members={members}
+            fetchTeamSelected={fetchTeamSelected}
           />
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             {props.canEditVisibility && (
@@ -402,7 +427,7 @@ const UserTeamsTable = props => {
                               type="button"
                               className="btn btn-outline-info"
                               data-testid="members-btn"
-                              onClick={() => setIsOpenModalTeamMember(true)}
+                              onClick={() => fetchTeamSelected(team._id, team.teamName)}
                             >
                               <i className="fa fa-users" aria-hidden="true" />
                             </button>

--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
@@ -7,13 +7,15 @@ import styles from './UserTeamsTable.css';
 import { boxStyle, boxStyleDark } from 'styles';
 import { connect } from 'react-redux';
 import { AutoCompleteTeamCode } from './AutoCompleteTeamCode';
+import './../../Teams/Team.css';
+import { TeamMember } from './TeamMember';
 
 const UserTeamsTable = props => {
   const { darkMode } = props;
 
   const [tooltipOpen, setTooltip] = useState(false);
 
-  const [ teamCodeExplainTooltip, setTeamCodeExplainTooltip ] = useState(false);
+  const [teamCodeExplainTooltip, setTeamCodeExplainTooltip] = useState(false);
 
   const [showDropdown, setShowDropdown] = useState(false);
 
@@ -26,6 +28,10 @@ const UserTeamsTable = props => {
   const [teamCode, setTeamCode] = useState(
     props.userProfile ? props.userProfile.teamCode : props.teamCode,
   );
+
+  const [isOpenModalTeamMember, setIsOpenModalTeamMember] = useState(false);
+  const [myTeamName, setMyTeamName] = useState('');
+  const [myTeamId, setMyTeamId] = useState();
 
   const refDropdown = useRef();
 
@@ -79,13 +85,19 @@ const UserTeamsTable = props => {
     setInnerWidth(window.innerWidth);
   }, [window.innerWidth]);
 
-
   const toggleTeamCodeExplainTooltip = () => setTeamCodeExplainTooltip(!teamCodeExplainTooltip);
 
   return (
     <div>
       {innerWidth >= 1025 ? (
         <div className={`${darkMode ? 'bg-yinmn-blue' : ''}`}>
+          <TeamMember
+            isOpenModalTeamMember={isOpenModalTeamMember}
+            setIsOpenModalTeamMember={setIsOpenModalTeamMember}
+            myTeams={props.userTeamsById}
+            teamName={myTeamName}
+            myTeamId={myTeamId}
+          />
           <div className="container" style={{ paddingLeft: '4px', paddingRight: '4px' }}>
             {props.canEditVisibility && (
               <div className="row ml-1">
@@ -138,15 +150,15 @@ const UserTeamsTable = props => {
                     </>
                   ) : (
                     <>
-                        <Button
-                          id='teamCodeAssign'
-                          className="btn-addteam"
-                          color="primary"
-                          onClick={() => {
-                            props.onButtonClick();
-                          }}
-                          style={darkMode ? {} : boxStyle}
-                        >
+                      <Button
+                        id="teamCodeAssign"
+                        className="btn-addteam"
+                        color="primary"
+                        onClick={() => {
+                          props.onButtonClick();
+                        }}
+                        style={darkMode ? {} : boxStyle}
+                      >
                         Assign Team
                       </Button>
                       <Tooltip
@@ -155,7 +167,8 @@ const UserTeamsTable = props => {
                         target="teamCodeAssign"
                         toggle={toggleTeamCodeExplainTooltip}
                       >
-                      This team code should only used by admin/owner, and has nothing to do with the team data model.
+                        This team code should only used by admin/owner, and has nothing to do with
+                        the team data model.
                       </Tooltip>
                     </>
                   )}
@@ -179,13 +192,10 @@ const UserTeamsTable = props => {
                     />
                   </>
                 ) : (
-                  <div id="teamCodeAssignText"
-                    style={{ fontSize: '12px', textAlign: 'center' }}
-                  >
+                  <div id="teamCodeAssignText" style={{ fontSize: '12px', textAlign: 'center' }}>
                     {teamCode == '' ? 'No assigned team code' : teamCode}
                   </div>
-                  )}
-                 
+                )}
               </Col>
             </div>
           </div>
@@ -200,9 +210,13 @@ const UserTeamsTable = props => {
                       #
                     </th>
                     {canAssignTeamToUsers ? (
-                      <th className={darkMode ? 'bg-space-cadet' : ''} style={{ width: '100px' }}>
-                        Team Name
-                      </th>
+                      <>
+                        <th className={darkMode ? 'bg-space-cadet' : ''} style={{ width: '100px' }}>
+                          '
+                        </th>
+
+                        <th className={darkMode ? 'bg-space-cadet' : ''}>Members</th>
+                      </>
                     ) : null}
                     {props.userTeamsById.length > 0 ? (
                       <th className={darkMode ? 'bg-space-cadet' : ''}></th>
@@ -217,18 +231,36 @@ const UserTeamsTable = props => {
                       <td style={{ textAlign: 'center', width: '10%' }}>{index + 1}</td>
                       <td>{`${team.teamName}`}</td>
                       {props.edit && props.role && (
-                        <td style={{ textAlign: 'center', width: '20%' }}>
-                          <Button
-                            disabled={!canAssignTeamToUsers}
-                            color="danger"
-                            onClick={e => {
-                              props.onDeleteClick(team._id);
-                            }}
-                            style={darkMode ? boxStyleDark : boxStyle}
-                          >
-                            Delete
-                          </Button>
-                        </td>
+                        <>
+                          <td>
+                            <button
+                              style={darkMode ? {} : boxStyle}
+                              type="button"
+                              className="btn btn-outline-info"
+                              data-testid="members-btn"
+                              onClick={() => {
+                                setMyTeamName(team.teamName);
+                                setIsOpenModalTeamMember(true);
+                                setMyTeamId(team._id);
+                              }}
+                            >
+                              <i className="fa fa-users" aria-hidden="true" />
+                            </button>
+                          </td>
+
+                          <td style={{ textAlign: 'center', width: '20%' }}>
+                            <Button
+                              disabled={!canAssignTeamToUsers}
+                              color="danger"
+                              onClick={e => {
+                                props.onDeleteClick(team._id);
+                              }}
+                              style={darkMode ? boxStyleDark : boxStyle}
+                            >
+                              Delete
+                            </Button>
+                          </td>
+                        </>
                       )}
                     </tr>
                   ))
@@ -241,6 +273,10 @@ const UserTeamsTable = props => {
         </div>
       ) : (
         <div className={`teamtable-container tablet  ${darkMode ? 'bg-yinmn-blue' : ''}`}>
+          <TeamMember
+            isOpenModalTeamMember={isOpenModalTeamMember}
+            setIsOpenModalTeamMember={setIsOpenModalTeamMember}
+          />
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             {props.canEditVisibility && (
               <>
@@ -337,9 +373,12 @@ const UserTeamsTable = props => {
                     <th className={darkMode ? 'bg-space-cadet' : ''}>#</th>
                     <th className={darkMode ? 'bg-space-cadet' : ''}>Team Name</th>
                     {canAssignTeamToUsers ? (
-                      <th style={{ flex: 2 }} className={darkMode ? 'bg-space-cadet' : ''}>
-                        {}
-                      </th>
+                      <>
+                        <th className={darkMode ? 'bg-space-cadet' : ''}>Members</th>
+                        <th style={{ flex: 2 }} className={darkMode ? 'bg-space-cadet' : ''}>
+                          {}
+                        </th>
+                      </>
                     ) : null}
                   </tr>
                 )}
@@ -351,25 +390,39 @@ const UserTeamsTable = props => {
                       <td>{index + 1}</td>
                       <td>{`${team.teamName}`}</td>
                       {props.edit && props.role && (
-                        <td>
-                          <div
-                            style={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'center',
-                            }}
-                          >
-                            <Button
-                              disabled={!canAssignTeamToUsers}
-                              color="danger"
-                              onClick={e => {
-                                props.onDeleteClick(team._id);
+                        <>
+                          <td>
+                            <button
+                              style={darkMode ? {} : boxStyle}
+                              type="button"
+                              className="btn btn-outline-info"
+                              data-testid="members-btn"
+                              onClick={() => setIsOpenModalTeamMember(true)}
+                            >
+                              <i className="fa fa-users" aria-hidden="true" />
+                            </button>
+                          </td>
+
+                          <td>
+                            <div
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
                               }}
                             >
-                              Delete
-                            </Button>
-                          </div>
-                        </td>
+                              <Button
+                                disabled={!canAssignTeamToUsers}
+                                color="danger"
+                                onClick={e => {
+                                  props.onDeleteClick(team._id);
+                                }}
+                              >
+                                Delete
+                              </Button>
+                            </div>
+                          </td>
+                        </>
                       )}
                     </tr>
                   ))
@@ -383,6 +436,6 @@ const UserTeamsTable = props => {
       )}
     </div>
   );
-  };
-  
+};
+
 export default connect(null, { hasPermission })(UserTeamsTable);


### PR DESCRIPTION
# Description
This pull request has been opened to implement the 'Add Members' button and modal, specifically in the 'Teams' table within the 'Profile' section and 'Teams' tab.

## Related PRS (if any):
None
…

## Main changes explained:
Four components (MembersAutoComplete.jsx, TeamMembersPopup.jsx,  TeamMember.jsx and UserTeamsTable.jsx) have been modified to implement the 'Add Members' button and modal.

## How to test:
1. check into current branch
2. do npm install, git pull and ... to run this PR locally
3. Clear site data/cache
4. Log in as an administrator or owner.
5. go to view profile→ Teams tab
6. After clicking on the button in the members column of the teams table, a modal will open. Test if it is possible to add or remove users.

## Screenshots or videos of changes:
![Peterson_implement_Add_Members_button_and_modal_to_Profile_Teams_tab_teams](https://github.com/user-attachments/assets/77e68dff-07fa-4d18-840a-1d7f4a3f674a)

## Note:
None
