### PR TITLE
Vishavdeep hotfix timelog page UI issues for 375px and up

### DIFF
--- a/src/components/Timelog/Timelog.css
+++ b/src/components/Timelog/Timelog.css
@@ -102,7 +102,7 @@
 
 @media screen and (max-width: 1100px) and (min-width: 800px) {
   .timelogPageContainer{
-    padding: 0 8%;
+    padding: 0 9%;
     margin-left: 15px;
   }
 }

--- a/src/components/Timelog/Timelog.css
+++ b/src/components/Timelog/Timelog.css
@@ -102,14 +102,14 @@
 
 @media screen and (max-width: 1100px) and (min-width: 800px) {
   .timelogPageContainer{
-    padding: 0 7%;
+    padding: 0 8%;
     margin-left: 15px;
   }
 }
 
 @media screen and (max-width: 800px) {
   .timelogPageContainer{
-    padding:0 9%;
+    padding:0 8%;
     margin-left: 15px; 
   }
 }

--- a/src/components/Timelog/Timelog.css
+++ b/src/components/Timelog/Timelog.css
@@ -109,10 +109,9 @@
 
 @media screen and (max-width: 800px) {
   .timelogPageContainer{
-    padding:0 10%;
+    padding:0 9%;
     margin-left: 15px; 
   }
-
 }
 
 @media screen and (max-width: 575px) and (min-width: 399px) {

--- a/src/components/Timelog/Timelog.css
+++ b/src/components/Timelog/Timelog.css
@@ -109,9 +109,10 @@
 
 @media screen and (max-width: 800px) {
   .timelogPageContainer{
-    padding: 0;
-    margin-left: 15px;
+    padding:0 10%;
+    margin-left: 15px; 
   }
+
 }
 
 @media screen and (max-width: 575px) and (min-width: 399px) {
@@ -131,7 +132,6 @@
     padding-right: 0px !important;
   } */
 }
-
 
 #projectSelected {
   max-width: 100%;
@@ -188,11 +188,7 @@
 .custom-text-alignment {
   text-align: center;
 }
-@media (max-width:377px){
-  .timelogPageContainer .col-md-12{
-    padding: 0 4px;
-  }
-}
+
 
 .tasks-and-timelog-header-row{
   display: grid;


### PR DESCRIPTION
# Description
![Screenshot 2024-07-22 181121](https://github.com/user-attachments/assets/41e3bc29-fbff-4428-aa01-0a7c9b56fc24)



## Related PRS (if any):
This frontend PR2643 is related to the Development backend branch.

…

## Main changes explained:
- Adjusted the margin on both the left and right sides of the Timelog component to ensure a consistent appearance across 
  screen sizes from 375px to 1144px.
- Implemented media queries for different screen sizes to ensure the Timelog component displays correctly on various 
-  devices.
- Removed the fixed right-side padding which was not required, to streamline the layout.

## How to test:
1. check into current branch
2. do `npm install` and `npm start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Timelog 
6. verify function on different screen sizes from 320px 
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

## Video Before changes : - 
 
![Screenshot 2024-09-04 172937](https://github.com/user-attachments/assets/98512ec1-4990-4639-a125-7a936ab5a562)
No margin both side


https://github.com/user-attachments/assets/23c2cf18-4f0a-4af3-bf0a-b86e85cb9507





## video after changes 



https://github.com/user-attachments/assets/db83c094-3828-41f7-958e-1e9496f37b65



