### PR TITLE
Fixed alignment issue with time off icons

### DIFF
--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -117,6 +117,9 @@
 }
 
 .circle-border {
+  vertical-align: middle;
+  align-items: center;
+  justify-content: center;
   border-radius: 6px;
   width: 42px;
   height: 42px;
@@ -194,6 +197,7 @@
   color: white;
   box-shadow: 2px 2px 4px 1px lightgray;
   box-sizing: border-box;
+  vertical-align: middle;
 }
 
 .show-time-off-btn-selected {


### PR DESCRIPTION
# Description
A. Fixes # (PRIORITY LOW) Jae: Fix alignment of the scheduled time off icon (WIP Pavan)

## Related PRS (if any):
This frontend PR is not related to the any backend PR.
…

## Main changes explained:
Added alignment attributes to style.css file in order to remove any further alignment issues with time off icons
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ look for timeoff icons
6. verify function “A” (feel free to include screenshot here)
7. verify this new feature works in [dark mode]

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/f4ca85a0-5d2b-4ead-86ce-561c760fc06c

<img width="374" alt="Screenshot 2024-08-03 at 7 35 40 PM" src="https://github.com/user-attachments/assets/bfb45ad0-27b5-408c-a6ee-000efa7081d8">
![Screenshot 2024-08-03 at 8 09 45 PM](https://github.com/user-attachments/assets/7f19d7b9-0dc4-4d41-9164-20d5c37311f2)
![Screenshot 2024-08-03 at 8 09 54 PM](https://github.com/user-attachments/assets/afcd7c2b-b86e-4c3b-97ac-9f0e6f8b56ba)
<img width="746" alt="Screenshot 2024-08-03 at 8 10 05 PM" src="https://github.com/user-attachments/assets/5af820c8-b5b5-4c02-984e-4086f992add8">

