### PR TITLE
ambika fix tasks contributed section of people reports page

### DIFF
--- a/src/components/Reports/PeopleTableDetails.css
+++ b/src/components/Reports/PeopleTableDetails.css
@@ -13,7 +13,7 @@
 
 .people-table-row {
   display: grid;
-  grid-template-columns: 300px repeat(auto-fit, minmax(50px, 1fr));
+  grid-template-columns: 200px repeat(auto-fit, minmax(50px, 1fr));
   /* display: flex; */
   justify-content: space-between;
   align-items: center;
@@ -117,7 +117,7 @@
 }
 
 /* Large screens (less than 1020px) */
-@media only screen and (max-width: 1020px) {
+@media only screen and (max-width: 1024px) {
 
   /* CSS rules for large screens */
   .people-table {

--- a/src/components/Reports/PeopleTableDetails.css
+++ b/src/components/Reports/PeopleTableDetails.css
@@ -37,7 +37,6 @@
 .people-table-row-dark:hover {
   background-color: #1C2541;
   color:black;
-
 }
 
 .people-table-body-row:hover {

--- a/src/components/Reports/PeopleTableDetails.css
+++ b/src/components/Reports/PeopleTableDetails.css
@@ -36,6 +36,8 @@
 
 .people-table-row-dark:hover {
   background-color: #1C2541;
+  color:black;
+
 }
 
 .people-table-body-row:hover {

--- a/src/components/Reports/PeopleTableDetails.jsx
+++ b/src/components/Reports/PeopleTableDetails.jsx
@@ -293,7 +293,7 @@ function PeopleTableDetails(props) {
 
   const renderFilteredTask = value => (
     <div>
-      <div key={value._id} className="people-table-row people-table-body-row">
+      <div key={value._id} className={`people-table-row people-table-body-row ${darkMode ? 'people-table-row-dark' : ''}`}>
         <div>{value.taskName}</div>
         <div>{value.priority}</div>
         <div>{value.status}</div>

--- a/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
+++ b/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
@@ -28,13 +28,12 @@
   margin-bottom: 24px;
 }
 
-@media (max-width: 1250px) {
+@media (max-width: 1300px) {
   .report-page-wrapper {
     display: flex;
     flex-direction: column;
     padding: 40px;
     align-items: center;
-    /* max-width: 100vw; */
   }
 }
 

--- a/src/components/UserManagement/TextSuggestion.jsx
+++ b/src/components/UserManagement/TextSuggestion.jsx
@@ -28,9 +28,9 @@ class TextSuggestion extends React.Component {
 
         />
         <datalist id={this.props.list} >
-          {options.map((item) => {
+          {options.map((item, index) => {
             return (
-              <option value={item}>
+              <option value={item} key={index}>
               </option>
             )
           })}


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/084de909-8b72-44fc-9b6a-271d07d02141)

Here’s [a video about all this](https://www.loom.com/share/981c7dde2feb4219883e83b6b6d3bc9e)
* Overlapping of the column names in the header of the "Tasks contributed" table.
* Overlapping columns "Priority" with "Status".

Fixes # (bug list priority high)

## Related PRS (if any):
- Continued after PR #2005
- To test this frontend PR you need to checkout the development branch of backend PR.

## Main changes explained:
- Updated css in file src/components/Reports/PeopleTableDetails.css and src/components/Reports/sharedComponents/ReportPage/ReportPage.css
- Updated src/components/UserManagement/TextSuggestion.jsx for console error for missing key prop

## How to test:
1. check into current branch `git checkout ambika-fix-tasks-contributed-people-reports`
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports -> Reports ->People Choose people
6. Verify that in task contributed section, table columns should not be overlapping on each other in different viewport sizes 
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
**Before implementation**
![image](https://github.com/user-attachments/assets/0f5c2c22-4ffb-4a9f-bc7a-9af5cd5a9ccf)
![image](https://github.com/user-attachments/assets/2e8b122c-3175-4452-9dd1-ba683c2e2649)

**After implementation**
![image](https://github.com/user-attachments/assets/4476dead-3aee-4e3d-97ca-18d541a0ad0b)

## Note:

