### PR TITLE
Deepthi fix adjust spacing between label and input field

### DIFF
--- a/src/components/Announcements/Announcements.css
+++ b/src/components/Announcements/Announcements.css
@@ -8,13 +8,18 @@ h3 {
 
 label {
   display: block;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
   font-weight: bold;
   color: #333;
 }
 
+.emails p {
+  margin-bottom: 3px;  /* Reduce margin between the text and input field */
+}
+
 .input-text-for-announcement,
 textarea {
+  margin-top: 3px;  /* Equal spacing above both input fields */
   width: 100%;
   padding: 10px;
   border: 1px solid #ccc;
@@ -28,7 +33,7 @@ button.send-button {
   border-radius: 4px;
   padding: 10px 20px;
   cursor: pointer;
-  margin-top: 20px;
+  margin-top: 10px;
 }
 
 button.send-button:hover {
@@ -66,6 +71,7 @@ button.send-button:hover {
   width: 300px;
   /* Set a fixed width for the email inputs container */
 }
+
 
 .emails h3 {
   margin-top: 0;

--- a/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
@@ -76,19 +76,29 @@ function AssignSetUpModal({ isOpen, setIsOpen, title, userProfile, setUserProfil
           {googleDoc.length !== 0 ? '' : <p className="text-danger">{warning.googleDoc}</p>}
 
           <h6>Team Code: {title?.teamCode}</h6>
-          <h6>Project Assignment: {title?.projectAssigned?.projectName}</h6>
-          <h6>Media Folder: {title?.mediaFolder}</h6>
+          <h6>Project Assignment: {title?.projectAssigned?.projectName}</h6> 
+          <h6> {/* Media Folder adjusted */}
+            <span style={{ whiteSpace: 'nowrap'}}>Media Folder: </span>
+            <span style={{ 
+              whiteSpace: 'normal',
+              wordBreak: 'break-all', 
+              overflowWrap: 'anywhere',
+              display: 'inline'
+            }}>
+              {title?.mediaFolder}
+            </span>
+          </h6>
           {title?.teamAssiged?.teamName ? <h6>Team Assignment: {title?.teamAssiged?.teamName}</h6> : '' }
-          <div className="container ml-1">
+          <div className="container ml-1 d-flex align-items-center"> {/* Checkbox alignment fixed */}
             <Input
               type="checkbox"
               required
               id="agreement"
               value="true"
               onClick={() => checkboxOnClick()}
-              style={{ paddingLeft: '10px' }} //padding added
+              style={{ marginRight: '8px', marginTop: '2px' }} 
             />
-            <Label for="agreement" className={fontColor}>
+            <Label for="agreement" className={`${fontColor} mb-0`} style={{ marginLeft: '2px' }}>
               Volunteer Agreement Confirmed
             </Label>
           </div>

--- a/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
@@ -86,6 +86,7 @@ function AssignSetUpModal({ isOpen, setIsOpen, title, userProfile, setUserProfil
               id="agreement"
               value="true"
               onClick={() => checkboxOnClick()}
+              style={{ paddingLeft: '10px' }} //padding added
             />
             <Label for="agreement" className={fontColor}>
               Volunteer Agreement Confirmed


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/ab408bb7-fa2b-40be-bd93-06152dbdc1e5)
…

## Main changes explained:
- Reduced the margin-bottom of labels (label element) to 5px to ensure tighter spacing between the label and its respective input field.
- Adjusted the spacing for paragraph elements within the form (.emails p) by setting margin-bottom to 3px to bring text descriptions closer to the input fields below.
- Set a margin-top of 3px for input fields and textareas (.input-text-for-announcement, textarea) to ensure uniform and minimal spacing across all input components.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other links→ Send email …
6. verify that the label and it's respective input field spacing has been adjusted for consistency, ensuring proper alignment.

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/da699255-c804-4cd1-bdca-f8903c624a80)

