### PR TITLE
Huijie - fix ability to edit start and end date

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -66,6 +66,9 @@ import {
   PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE,
 } from 'utils/constants';
 import { getTimeEndDateEntriesByPeriod } from '../../actions/timeEntries.js';
+import { formatDateYYYYMMDD } from 'utils/formatDate.js';
+
+const CREATED_DATE_CRITERIA = '2022-01-01';
 
 function UserProfile(props) {
   const darkMode = useSelector(state => state.theme.darkMode);
@@ -345,13 +348,19 @@ function UserProfile(props) {
         ...newUserProfile,
         jobTitle: newUserProfile.jobTitle[0],
         phoneNumber: newUserProfile.phoneNumber[0],
-        startDate: newUserProfile?.startDate.split('T')[0],
+        // startDate: newUserProfile?.startDate.split('T')[0],
+        startDate: newUserProfile?.startDate ? formatDateYYYYMMDD(newUserProfile?.startDate) : "",
+        createdDate: formatDateYYYYMMDD(newUserProfile?.createdDate),
+        ...(newUserProfile?.endDate && newUserProfile.endDate !== "" && { endDate: formatDateYYYYMMDD(newUserProfile.endDate) })
       });
       setOriginalUserProfile({
         ...newUserProfile,
         jobTitle: newUserProfile.jobTitle[0],
         phoneNumber: newUserProfile.phoneNumber[0],
-        startDate: newUserProfile?.startDate.split('T')[0],
+        // startDate: newUserProfile?.startDate.split('T')[0],
+        startDate: newUserProfile?.startDate ? formatDateYYYYMMDD(newUserProfile?.startDate) : "",
+        createdDate: formatDateYYYYMMDD(newUserProfile?.createdDate),
+        ...(newUserProfile?.endDate && newUserProfile.endDate !== "" && { endDate: formatDateYYYYMMDD(newUserProfile.endDate) })
       });
       setUserStartDate(newUserProfile?.startDate.split('T')[0]);
       checkIsProjectsEqual();
@@ -810,6 +819,17 @@ function UserProfile(props) {
   const handleEndDate = async endDate => {
     setUserEndDate(endDate);
   };
+
+  const startDateValidation = (createdDate, startDate) => {
+    // console.log("userProfile:createdDate, startDate", createdDate, startDate === '' ? "EMPTY" : startDate);
+    return startDate === '' ? false : (createdDate < CREATED_DATE_CRITERIA || createdDate <= startDate);
+  };
+  
+  const endDateValidation = (startDate, endDate) => {
+    console.log("userProfile:startDate, endDate", startDate === '' ? "EMPTY" : startDate, endDate === '' ? "EMPTY" : endDate );
+    return endDate ? (startDate <= endDate) : true;
+  }
+
   return (
     <div className={darkMode ? 'bg-oxford-blue' : ''} style={{ minHeight: '100%' }}>
       <ActiveInactiveConfirmationPopup
@@ -1278,6 +1298,7 @@ function UserProfile(props) {
               {canEdit && activeTab && (
                 <>
                   <SaveButton
+                    index={1}
                     className="mr-1 btn-bottom"
                     handleSubmit={async () => await handleSubmit()}
                     disabled={
@@ -1285,7 +1306,9 @@ function UserProfile(props) {
                       !formValid.lastName ||
                       !formValid.email ||
                       !codeValid ||
-                      (userStartDate > userEndDate && userEndDate !== '') ||
+                      // (userStartDate > userEndDate && userEndDate !== '') ||
+                      !startDateValidation(userProfile.createdDate, userProfile.startDate) ||
+                      !endDateValidation(userProfile.startDate, userProfile.endDate) ||
                       (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual) ||
                       isTeamSaved
                     }
@@ -1409,6 +1432,7 @@ function UserProfile(props) {
                       {canEdit && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
+                            index={2}
                             className="mr-1 btn-bottom"
                             handleSubmit={async () => await handleSubmit()}
                             disabled={
@@ -1484,6 +1508,7 @@ function UserProfile(props) {
                       {canEdit && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
+                            index={3}
                             className="mr-1 btn-bottom"
                             handleSubmit={async () => await handleSubmit()}
                             disabled={
@@ -1491,6 +1516,7 @@ function UserProfile(props) {
                               !formValid.lastName ||
                               !formValid.email ||
                               !codeValid ||
+                              !startDateValidation(userProfile.createdDate, userProfile.startDate) ||
                               (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
                             }
                             userProfile={userProfile}
@@ -1580,6 +1606,7 @@ function UserProfile(props) {
                       {canEdit && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
+                            index={4}
                             className="mr-1 btn-bottom"
                             handleSubmit={async () => await handleSubmit()}
                             disabled={
@@ -1663,6 +1690,7 @@ function UserProfile(props) {
                       {canEdit && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
+                            index={5}
                             className="mr-1 btn-bottom"
                             handleSubmit={async () => await handleSubmit()}
                             disabled={
@@ -1733,6 +1761,7 @@ function UserProfile(props) {
                       {canEdit && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
+                            index={6}
                             className="mr-1 btn-bottom"
                             handleSubmit={async () => await handleSubmit()}
                             disabled={

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -66,9 +66,7 @@ import {
   PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE,
 } from 'utils/constants';
 import { getTimeEndDateEntriesByPeriod } from '../../actions/timeEntries.js';
-import { formatDateYYYYMMDD } from 'utils/formatDate.js';
-
-const CREATED_DATE_CRITERIA = '2022-01-01';
+import { formatDateYYYYMMDD, CREATED_DATE_CRITERIA } from 'utils/formatDate.js';
 
 function UserProfile(props) {
   const darkMode = useSelector(state => state.theme.darkMode);
@@ -826,9 +824,12 @@ function UserProfile(props) {
   };
   
   const endDateValidation = (startDate, endDate) => {
-    console.log("userProfile:startDate, endDate", startDate === '' ? "EMPTY" : startDate, endDate === '' ? "EMPTY" : endDate );
+    // console.log("userProfile:startDate, endDate", startDate === '' ? "EMPTY" : startDate, endDate === '' ? "EMPTY" : endDate );
     return endDate ? (startDate <= endDate) : true;
   }
+
+  const isStartDateValid = startDateValidation(userProfile.createdDate, userProfile.startDate);
+  const isEndDateValid = endDateValidation(userProfile.startDate, userProfile.endDate);
 
   return (
     <div className={darkMode ? 'bg-oxford-blue' : ''} style={{ minHeight: '100%' }}>
@@ -1298,7 +1299,6 @@ function UserProfile(props) {
               {canEdit && activeTab && (
                 <>
                   <SaveButton
-                    index={1}
                     className="mr-1 btn-bottom"
                     handleSubmit={async () => await handleSubmit()}
                     disabled={
@@ -1306,10 +1306,8 @@ function UserProfile(props) {
                       !formValid.lastName ||
                       !formValid.email ||
                       !codeValid ||
-                      // (userStartDate > userEndDate && userEndDate !== '') ||
-                      !startDateValidation(userProfile.createdDate, userProfile.startDate) ||
-                      !endDateValidation(userProfile.startDate, userProfile.endDate) ||
                       (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual) ||
+                      !(isStartDateValid && isEndDateValid) ||
                       isTeamSaved
                     }
                     userProfile={userProfile}
@@ -1432,7 +1430,6 @@ function UserProfile(props) {
                       {canEdit && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
-                            index={2}
                             className="mr-1 btn-bottom"
                             handleSubmit={async () => await handleSubmit()}
                             disabled={
@@ -1508,7 +1505,6 @@ function UserProfile(props) {
                       {canEdit && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
-                            index={3}
                             className="mr-1 btn-bottom"
                             handleSubmit={async () => await handleSubmit()}
                             disabled={
@@ -1516,8 +1512,8 @@ function UserProfile(props) {
                               !formValid.lastName ||
                               !formValid.email ||
                               !codeValid ||
-                              !startDateValidation(userProfile.createdDate, userProfile.startDate) ||
-                              (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual)
+                              (isProfileEqual && isTasksEqual && isTeamsEqual && isProjectsEqual) ||
+                              !(isStartDateValid && isEndDateValid)
                             }
                             userProfile={userProfile}
                             setSaved={() => setSaved(true)}
@@ -1606,7 +1602,6 @@ function UserProfile(props) {
                       {canEdit && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
-                            index={4}
                             className="mr-1 btn-bottom"
                             handleSubmit={async () => await handleSubmit()}
                             disabled={
@@ -1690,7 +1685,6 @@ function UserProfile(props) {
                       {canEdit && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
-                            index={5}
                             className="mr-1 btn-bottom"
                             handleSubmit={async () => await handleSubmit()}
                             disabled={
@@ -1761,7 +1755,6 @@ function UserProfile(props) {
                       {canEdit && (activeTab == '1' || canPutUserProfile) && (
                         <>
                           <SaveButton
-                            index={6}
                             className="mr-1 btn-bottom"
                             handleSubmit={async () => await handleSubmit()}
                             disabled={

--- a/src/components/UserProfile/UserProfileEdit/SaveButton.jsx
+++ b/src/components/UserProfile/UserProfileEdit/SaveButton.jsx
@@ -31,7 +31,7 @@ const stillSavingMessage = 'Saving, will take just a second...';
  * @returns
  */
 const SaveButton = props => {
-  const { handleSubmit, disabled, userProfile, setSaved, darkMode, index } = props;
+  const { handleSubmit, disabled, userProfile, setSaved, darkMode } = props;
   const [modal, setModal] = useState(false);
   const [randomMessage, setRandomMessage] = useState(getRandomMessage());
   const [isLoading,setIsLoading] = useState(false);
@@ -107,7 +107,7 @@ const SaveButton = props => {
         className='mr-1'
         style={darkMode ? boxStyleDark : boxStyle}
       >
-        Save Changes {index}
+        Save Changes
       </Button>
     </React.Fragment>
   );

--- a/src/components/UserProfile/UserProfileEdit/SaveButton.jsx
+++ b/src/components/UserProfile/UserProfileEdit/SaveButton.jsx
@@ -31,7 +31,7 @@ const stillSavingMessage = 'Saving, will take just a second...';
  * @returns
  */
 const SaveButton = props => {
-  const { handleSubmit, disabled, userProfile, setSaved, darkMode } = props;
+  const { handleSubmit, disabled, userProfile, setSaved, darkMode, index } = props;
   const [modal, setModal] = useState(false);
   const [randomMessage, setRandomMessage] = useState(getRandomMessage());
   const [isLoading,setIsLoading] = useState(false);
@@ -107,7 +107,7 @@ const SaveButton = props => {
         className='mr-1'
         style={darkMode ? boxStyleDark : boxStyle}
       >
-        Save Changes
+        Save Changes {index}
       </Button>
     </React.Fragment>
   );

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -35,14 +35,14 @@ const StartDate = props => {
       id="startDate"
       className={startEndDateValidation(props) ? 'border-error-validation' : null}
       value={props.userProfile.startDate}
-      min={formatDateYYYYMMDD(props.userProfile.createdDate)}
+      min={props.userProfile.createdDate}
       onChange={e => {
         props.setUserProfile({ ...props.userProfile, startDate: e.target.value });
         props.onStartDateComponent(e.target.value);
       }}
       placeholder="Start Date"
       invalid={!props.canEdit}
-      max={props.userProfile.endDate ? formatDateYYYYMMDD(props.userProfile.endDate) : ''}
+      max={props.userProfile.endDate ? formatDateYYYYMMDD(props.userProfile.endDate) : '9999-12-31'}
     />
   );
 };
@@ -67,7 +67,7 @@ const EndDate = props => {
       name="EndDate"
       id="endDate"
       value={
-        props.userProfile.endDate ? props.userProfile.endDate.toLocaleString().split('T')[0] : ''
+        props.userProfile.endDate ? props.userProfile.endDate : ''
       }
       onChange={e => {
         props.setUserProfile({ ...props.userProfile, endDate: e.target.value });
@@ -77,9 +77,10 @@ const EndDate = props => {
       invalid={!props.canEdit}
       min={
         props.userProfile.startDate
-          ? formatDateYYYYMMDD(props.userProfile.startDate)
+          ? props.userProfile.startDate
           : ''
       }
+      max={'9999-12-31'}
     />
   );
 };
@@ -250,10 +251,9 @@ const ViewTab = props => {
   const [historyModal, setHistoryModal] = useState(false);
 
   const handleStartDates = async startDate => {
-
-    if(!userProfile.isFirstTimelog) {
-      alert('This user has already logged time in the system. Are you sure you want to change the start date?');
-    }
+    // if(!userProfile.isFirstTimelog) {
+    //   alert('This user has already logged time in the system. Are you sure you want to change the start date?');
+    // }
     props.onStartDate(startDate);
   };
 

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Row, Label, Input, Col, Button, FormGroup } from 'reactstrap';
+import { Row, Label, Input, Col, Button, FormGroup, FormFeedback } from 'reactstrap';
 import moment from 'moment-timezone';
 import { capitalize } from 'lodash';
 import { ENDPOINTS } from 'utils/URL';
@@ -7,7 +7,7 @@ import axios from 'axios';
 import HistoryModal from './HistoryModal';
 import './timeTab.css';
 import { boxStyle, boxStyleDark } from 'styles';
-import { formatDate, formatDateYYYYMMDD, formatDateMMDDYYYY  } from 'utils/formatDate';
+import { formatDate, formatDateYYYYMMDD, formatDateMMDDYYYY, CREATED_DATE_CRITERIA  } from 'utils/formatDate';
 
 
 const MINIMUM_WEEK_HOURS = 0;
@@ -21,34 +21,38 @@ const startEndDateValidation = props => {
 
 
 const StartDate = props => {
-  const {darkMode} = props;
+  const {darkMode, startDateAlert} = props;
 
   if (!props.canEdit) {
     return <p className={darkMode ? 'text-azure' : ''}>{formatDateYYYYMMDD(props.userProfile.startDate)}</p>;
   }
   
-  
   return (
-    <Input
-      type="date"
-      name="StartDate"
-      id="startDate"
-      className={startEndDateValidation(props) ? 'border-error-validation' : null}
-      value={props.userProfile.startDate}
-      min={props.userProfile.createdDate}
-      onChange={e => {
-        props.setUserProfile({ ...props.userProfile, startDate: e.target.value });
-        props.onStartDateComponent(e.target.value);
-      }}
-      placeholder="Start Date"
-      invalid={!props.canEdit}
-      max={props.userProfile.endDate ? formatDateYYYYMMDD(props.userProfile.endDate) : '9999-12-31'}
-    />
+    <FormGroup>
+      <Input
+        type="date"
+        name="StartDate"
+        id="startDate"
+        className={startEndDateValidation(props) ? 'border-error-validation' : null}
+        value={props.userProfile.startDate}
+        min={props.userProfile.createdDate < CREATED_DATE_CRITERIA ? '' : props.userProfile.createdDate}
+        onChange={e => {
+          props.setUserProfile({ ...props.userProfile, startDate: e.target.value });
+          props.onStartDateComponent(e.target.value);
+        }}
+        placeholder="Start Date"
+        invalid={!props.canEdit}
+        max={props.userProfile.endDate ? formatDateYYYYMMDD(props.userProfile.endDate) : '9999-12-31'}
+      />
+      {startDateAlert && (
+        <FormFeedback style={{ display: 'block' }}>{startDateAlert}</FormFeedback>
+      )}
+    </FormGroup>
   );
 };
 
 const EndDate = props => {
-  const {darkMode} = props;
+  const {darkMode, endDateAlert} = props;
 
   if (!props.canEdit) {
     return (
@@ -61,27 +65,32 @@ const EndDate = props => {
   }
 
   return (
-    <Input
-      className={startEndDateValidation(props) ? 'border-error-validation' : null}
-      type="date"
-      name="EndDate"
-      id="endDate"
-      value={
-        props.userProfile.endDate ? props.userProfile.endDate : ''
-      }
-      onChange={e => {
-        props.setUserProfile({ ...props.userProfile, endDate: e.target.value });
-        props.onEndDateComponent(e.target.value);
-      }}
-      placeholder="End Date"
-      invalid={!props.canEdit}
-      min={
-        props.userProfile.startDate
-          ? props.userProfile.startDate
-          : ''
-      }
-      max={'9999-12-31'}
-    />
+    <FormGroup>
+      <Input
+        className={startEndDateValidation(props) ? 'border-error-validation' : null}
+        type="date"
+        name="EndDate"
+        id="endDate"
+        value={
+          props.userProfile.endDate ? props.userProfile.endDate : ''
+        }
+        onChange={e => {
+          props.setUserProfile({ ...props.userProfile, endDate: e.target.value });
+          props.onEndDateComponent(e.target.value);
+        }}
+        placeholder="End Date"
+        invalid={!props.canEdit}
+        min={
+          props.userProfile.startDate
+            ? props.userProfile.startDate
+            : ''
+        }
+        max={'9999-12-31'}
+      />
+      {endDateAlert && (
+        <FormFeedback style={{ display: 'block' }}>{endDateAlert}</FormFeedback>
+      )}
+    </FormGroup>
   );
 };
 
@@ -249,6 +258,8 @@ const ViewTab = props => {
   const [totalTangibleHours, setTotalTangibleHours] = useState(0);
   const { hoursByCategory, totalIntangibleHrs } = userProfile;
   const [historyModal, setHistoryModal] = useState(false);
+  const [startDateAlert, setStartDateAlert] = useState('');
+  const [endDateAlert, setEndDateAlert] = useState('');
 
   const handleStartDates = async startDate => {
     // if(!userProfile.isFirstTimelog) {
@@ -344,6 +355,24 @@ const ViewTab = props => {
     });
   };
 
+  useEffect(() => {
+    if (userProfile.startDate === ''){
+      setStartDateAlert("Invalid date");
+    } else if (userProfile.createdDate >= CREATED_DATE_CRITERIA && userProfile.startDate < userProfile.createdDate){
+      setStartDateAlert("The start date is before the account created date");
+    } else{
+      setStartDateAlert('')
+    }
+  }, [userProfile.startDate, userProfile.createdDate]);
+
+  useEffect(() => {
+    if (userProfile.endDate !== '' && userProfile.endDate < userProfile.startDate){
+      setEndDateAlert("The end date is before the start date");
+    } else {
+      setEndDateAlert('');
+    }
+  }, [userProfile.startDate, userProfile.endDate]);
+
   return (
     <div data-testid="volunteering-time-tab">
       <Row className="volunteering-time-row">
@@ -366,6 +395,7 @@ const ViewTab = props => {
             canEdit={canEdit}
             onStartDateComponent={handleStartDates}
             darkMode={darkMode}
+            startDateAlert={startDateAlert}
           />
         </Col>
       </Row>
@@ -382,6 +412,7 @@ const ViewTab = props => {
             canEdit={canEdit}
             onEndDateComponent={handleEndDates}
             darkMode={darkMode}
+            endDateAlert={endDateAlert}
           />
         </Col>
       </Row>

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -45,3 +45,4 @@ const DAY_OF_WEEK = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Fr
  */
 export const getDayOfWeekStringFromUTC = (utcTs) => moment(utcTs).tz('America/Los_Angeles').day();
 
+export const CREATED_DATE_CRITERIA = '2022-01-01';


### PR DESCRIPTION
# Description
![task description](https://github.com/user-attachments/assets/f691254b-0923-4fa3-aaac-842e201eac2f)
Video Link:
https://www.loom.com/share/331a47ec61094572ad7a8665c76059a3?sid=8b7adba3-784f-478f-b977-c6aa3741e24c

## Related PRS (if any):
This frontend PR is related to the #1092 backend PR (https://github.com/OneCommunityGlobal/HGNRest/pull/1092). 

## Main changes explained:
1. Remove the error message that prevents users from editing the start and end dates.
2. If the account created date is before 2022-01-01, then the start date could be set to a date before the account created date. Otherwise, it can only be set to a date on or after the created date. When the start date doesn't meet the requirement, a form validation message will be displayed and the save button will be disabled.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. clear site data/cache
4. log as an owner or admin user
5. either change the user's own dates, or change another user's dates
To change dates for themselves: go to dashboard → View Profile → Volunteering Time
To change another user's dates: go to Other Link → User Management
<img width="300" alt="1" src="https://github.com/user-attachments/assets/fed4094d-8c5f-406e-a2fe-6c4765641887">
<img width="400" alt="2" src="https://github.com/user-attachments/assets/9fe00dc0-519e-4453-8211-d95e14976bca">

6. Make sure the account whose date will be modified have a jobTitle! If the account has the jobTitle, you can find it in the userProfile page right under the user's name. One way to add the jobTitle for the user is to directly edit it in the database. If the jobTitle field is empty, there will be a mongoose validation error when saving the updated dates.
<img width="800" alt="1" src="https://github.com/user-attachments/assets/fe4335de-f3fc-4e48-a12c-6c79e1f3a0e8">
<img width="700" alt="1" src="https://github.com/user-attachments/assets/cdd3b7cb-6626-44fc-a92c-9a9391e42d83">

7. verify that (1) when the account created date is before 2022-01-01, an admin/owner can modify the user's start date to a date before the created date. (2) when the account created date is after 2022-01-01, the admin/owner can only modify the user's start date to a date after the created date.

## Screenshots or videos of changes:
The userprofile page will act as follows:
1. For accounts with created date before 2022
https://www.dropbox.com/scl/fi/o3e7h22x95oeq14wkobmz/created-date-before.mov?rlkey=krhv8mvpctmcbskgrwe5p5k9f&st=4ops17c2&dl=0
2. For accounts with created date after 2022
https://www.dropbox.com/scl/fi/ujtinm19d3dt9tybxuam2/created-date-after.mov?rlkey=lchwsvxn3aszvg795lik9lbd7&st=8k1y71gh&dl=0

Thank you!