### PR TITLE
Howie Add Dropdowns for Owner Perms Table and removing bloat

### DIFF
--- a/src/components/PermissionsManagement/PermissionChangeLogTable.jsx
+++ b/src/components/PermissionsManagement/PermissionChangeLogTable.jsx
@@ -65,6 +65,24 @@ function PermissionChangeLogTable({ changeLogs, darkMode }) {
     }));
   };
 
+  const renderPermissions = (permissions, rowId) => {
+    // Filter out empty or falsy values before joining the permissions
+    const filteredPermissions = permissions.filter(permission => permission);
+
+    return (
+      <div className="permissions-cell">
+        {expandedRows[rowId]
+          ? filteredPermissions.join(', ') // Show all filtered permissions if expanded
+          : filteredPermissions.slice(0, 5).join(', ') +
+            (filteredPermissions.length > 5 ? ', ...' : '')}
+        {filteredPermissions.length > 5 && (
+          <button className="toggle-button" onClick={() => toggleExpandRow(rowId)} type="button">
+            {expandedRows[rowId] ? <FiChevronUp /> : <FiChevronDown />}
+          </button>
+        )}
+      </div>
+    );
+  };
   return (
     <>
       <div className="table-responsive">
@@ -97,27 +115,13 @@ function PermissionChangeLogTable({ changeLogs, darkMode }) {
                   {log.roleName}
                 </td>
                 <td className={`permission-change-log-table--cell permissions ${bgYinmnBlue}`}>
-                  <div className="permissions-cell">
-                    {expandedRows[log._id]
-                      ? log.permissions.join(', ')
-                      : log.permissions.slice(0, 5).join(', ') +
-                        (log.permissions.length > 5 ? ', ...' : '')}
-                    {log.permissions.length > 5 && (
-                      <button
-                        className="toggle-button"
-                        onClick={() => toggleExpandRow(log._id)}
-                        type="button"
-                      >
-                        {expandedRows[log._id] ? <FiChevronUp /> : <FiChevronDown />}
-                      </button>
-                    )}
-                  </div>
+                  {renderPermissions(log.permissions, log._id)}
                 </td>
                 <td className={`permission-change-log-table--cell ${bgYinmnBlue}`}>
-                  {log.permissionsAdded.join(', ')}
+                  {renderPermissions(log.permissionsAdded, `${log._id}_added`)}
                 </td>
                 <td className={`permission-change-log-table--cell ${bgYinmnBlue}`}>
-                  {log.permissionsRemoved.join(', ')}
+                  {renderPermissions(log.permissionsRemoved, `${log._id}_removed`)}
                 </td>
                 <td className={`permission-change-log-table--cell ${bgYinmnBlue}`}>
                   {log.requestorRole}

--- a/src/components/PermissionsManagement/PermissionChangeLogTable.jsx
+++ b/src/components/PermissionsManagement/PermissionChangeLogTable.jsx
@@ -117,10 +117,10 @@ function PermissionChangeLogTable({ changeLogs, darkMode }) {
                 <td className={`permission-change-log-table--cell permissions ${bgYinmnBlue}`}>
                   {renderPermissions(log.permissions, log._id)}
                 </td>
-                <td className={`permission-change-log-table--cell ${bgYinmnBlue}`}>
+                <td className={`permission-change-log-table--cell permissions ${bgYinmnBlue}`}>
                   {renderPermissions(log.permissionsAdded, `${log._id}_added`)}
                 </td>
-                <td className={`permission-change-log-table--cell ${bgYinmnBlue}`}>
+                <td className={`permission-change-log-table--cell permissions ${bgYinmnBlue}`}>
                   {renderPermissions(log.permissionsRemoved, `${log._id}_removed`)}
                 </td>
                 <td className={`permission-change-log-table--cell ${bgYinmnBlue}`}>


### PR DESCRIPTION
Howie Add Dropdowns for Owner Perms Table and removing bloat

# Description
Need expand/collapse arrow in Permissions Added and Permissions Removed columns
Need to figure out why what’s seen below is showing up in the Main
[VIDEO](https://www.loom.com/share/1688cb3f99514fe8bb80f9a8124bc1b1?sid=a06d80a9-05dd-4ba3-ad46-091e38e0df44)
![image](https://github.com/user-attachments/assets/e800ddbd-002f-4138-88c5-a1e1434dd48b)

## Main changes explained:
Added drop-down menu functionality already in Permissions column to Permission Added/Removed columns as well
Added front end filter to skip and not add any Permissions added that are empty to the table to remove the bloat mentioned

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as **OWNER** user
5. go to dashboard→ Other Links→ Permissions Managment→ 
6. verify function Dropdown menu button on all 3 permissions columns (![image](https://github.com/user-attachments/assets/47ee5722-3084-484a-9c6c-0a0e2797e6f6))
7. There are no empty columns with commas 
![image](https://github.com/user-attachments/assets/dce9d898-6fed-4a5d-b18b-4e281ee25f99)
8. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/8ba9a76e-1a61-40b4-b33b-190f33df00a2


## Note:
## WHEN TESTING ON ROLES MAKE SURE YOU DO NOT PERMANTLY CHANGE PERMISSIONS FOR ANY ACTIVE/IMPORTANT ROLES STICK WITH TEST ROLES, MAKE A NEW ROLE TO TEST OR MAKE SURE YOU CHANGE THINGS BACK
