### PR TITLE
Ambika fix add permissions checks to disable buttons in user management

### DIFF
--- a/src/components/UserManagement/ResetPasswordButton.jsx
+++ b/src/components/UserManagement/ResetPasswordButton.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ResetPasswordPopup from './ResetPasswordPopup';
 import { cantUpdateDevAdminDetails } from 'utils/permissions';
 import { resetPassword } from '../../services/userProfileService';
-import { Button } from 'reactstrap';
+import { Button, Tooltip } from 'reactstrap';
 import { toast } from 'react-toastify';
 import { boxStyle, boxStyleDark } from 'styles';
 
@@ -11,8 +11,15 @@ class ResetPasswordButton extends React.PureComponent {
     super(props);
     this.state = {
       resetPopupOpen: false,
+      resetPasswordTooltipOpen: false,
     };
   }
+
+  toggleResetPasswordTooltip = () => {
+    this.setState(prevState => ({
+      resetPasswordTooltipOpen: !prevState.resetPasswordTooltipOpen
+    }));
+  };
 
   render() {
     return (
@@ -22,15 +29,31 @@ class ResetPasswordButton extends React.PureComponent {
           onClose={this.resetPopupClose}
           onReset={this.resetPassword}
         />
-        <Button
-          {...(this.props.darkMode ? { outline: false } : {outline: true})}
-          color="primary"
-          className={'btn  btn-outline-success mr-1' + (this.props.isSmallButton ? ' btn-sm' : '')}
-          style={this.props.darkMode ? {boxShadow: "0 0 0 0", minWidth: '115px', fontWeight: "bold"} : { ...boxStyle, minWidth: '115px' }}
-          onClick={this.onResetClick}
-        >
-          {'Reset Password'}
-        </Button>
+        <>
+          {
+            !this.props.canResetPassword ?
+            <Tooltip 
+                placement="bottom"
+                isOpen={this.state.resetPasswordTooltipOpen}
+                target={"btn-reset-password-"+this.props.user._id}
+                toggle={this.toggleResetPasswordTooltip}
+              >
+                You don't have permission to reset the password
+              </Tooltip>
+              : ""
+          }
+          <Button
+            {...(this.props.darkMode ? { outline: false } : {outline: true})}
+            color="primary"
+            className={'btn  btn-outline-success mr-1' + (this.props.isSmallButton ? ' btn-sm' : '')}
+            style={this.props.darkMode ? {boxShadow: "0 0 0 0", minWidth: '115px', fontWeight: "bold"} : { ...boxStyle, minWidth: '115px' }}
+            onClick={this.onResetClick}
+            id={'btn-reset-password-'+this.props.user._id}
+            disabled={!this.props.canResetPassword}
+          >
+            {'Reset Password'}
+          </Button>
+        </>
       </React.Fragment>
     );
   }

--- a/src/components/UserManagement/UserSearchPanel.jsx
+++ b/src/components/UserManagement/UserSearchPanel.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { SEARCH, SHOW, CREATE_NEW_USER, SEND_SETUP_LINK } from '../../languages/en/ui';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBell } from '@fortawesome/free-solid-svg-icons';
@@ -6,6 +6,7 @@ import { Tooltip, OverlayTrigger } from 'react-bootstrap';
 import { boxStyle, boxStyleDark } from 'styles';
 import hasPermission from 'utils/permissions';
 import { connect } from 'react-redux';
+import { Tooltip as ReactstrapTooltip } from 'reactstrap';
 
 const setupHistoryTooltip = (
   <Tooltip id="tooltip">
@@ -20,6 +21,9 @@ const setupHistoryTooltip = (
 const UserSearchPanel = ({hasPermission,handleNewUserSetupPopup, handleSetupHistoryPopup, onNewUserClick, searchText, onSearch, onActiveFiter, darkMode}) => {
   // console.log('UserSearchPanel props', props);
   const canCreateUsers = hasPermission('postUserProfile');
+  const [tooltipCreateNewUserOpen, setTooltipCreateNewUserOpen] = useState(false);
+  const toggleCreateNewUserTooltip = () => setTooltipCreateNewUserOpen(!tooltipCreateNewUserOpen);
+  
   return (
     <div className="input-group mt-3" id="new_usermanagement">
       <button type="button" disabled={!canCreateUsers} className="btn btn-info mr-2" onClick={handleNewUserSetupPopup} style={darkMode ? boxStyleDark : boxStyle}>
@@ -35,18 +39,33 @@ const UserSearchPanel = ({hasPermission,handleNewUserSetupPopup, handleSetupHist
       </OverlayTrigger>
 
 
-
-      <button
-        type="button"
-        disabled={!canCreateUsers}
-        className="btn btn-info mr-2"
-        onClick={e => {
-          onNewUserClick();
-        }}
-        style={darkMode ? boxStyleDark : boxStyle}
-      >
-        {CREATE_NEW_USER}
-      </button>
+      <>
+        {
+          !canCreateUsers ? 
+          <ReactstrapTooltip
+            placement="bottom"
+            isOpen={tooltipCreateNewUserOpen}
+            target={"btn-create-new-user"}
+            toggle={toggleCreateNewUserTooltip}
+          >
+            You don't have permission to create a new user
+          </ReactstrapTooltip>
+          : ""
+        }
+        
+        <button
+          type="button"
+          disabled={!canCreateUsers}
+          className="btn btn-info mr-2"
+          onClick={e => {
+            onNewUserClick();
+          }}
+          style={darkMode ? boxStyleDark : boxStyle}
+          id={"btn-create-new-user"}
+        >
+          {CREATE_NEW_USER}
+        </button>
+      </>
       <div className="input-group-prepend">
         <span className="input-group-text">{SEARCH}</span>
       </div>

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -251,7 +251,7 @@ const UserTableData = React.memo(props => {
                 props.onDeleteClick(props.user, 'archive');
               }}
               style={darkMode ? { boxShadow: "0 0 0 0", fontWeight: "bold" } : boxStyle}
-              disabled={props.auth?.user.userid === props.user._i || !canDeleteUsers}
+              disabled={props.auth?.user.userid === props.user._id || !canDeleteUsers}
             >
               {DELETE}
             </button>

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -11,14 +11,24 @@ import { boxStyle, boxStyleDark } from 'styles';
 import { connect } from 'react-redux';
 import { formatDateLocal } from 'utils/formatDate';
 import { cantUpdateDevAdminDetails } from 'utils/permissions';
+import { Tooltip } from 'reactstrap';
 /**
  * The body row of the user table
  */
 const UserTableData = React.memo(props => {
   const darkMode = props.darkMode;
+  const [tooltipDeleteOpen, setTooltipDelete] = useState(false);
+  const [tooltipPauseOpen, setTooltipPause] = useState(false);
+  const [tooltipFinalDayOpen, setTooltipFinalDay] = useState(false);
 
   const [isChanging, onReset] = useState(false);
   const canAddDeleteEditOwners = props.hasPermission('addDeleteEditOwners');
+  const canDeleteUsers = props.hasPermission('deleteUserProfile');
+  const resetPasswordStatus = props.hasPermission('resetPassword');
+  const canChangeUserStatus = props.hasPermission('changeUserStatus');
+  const toggleDeleteTooltip = () => setTooltipDelete(!tooltipDeleteOpen);
+  const togglePauseTooltip = () => setTooltipPause(!tooltipPauseOpen);
+  const toggleFinalDayTooltip = () => setTooltipFinalDay(!tooltipFinalDayOpen);
 
   /**
    * reset the changing state upon rerender with new isActive status
@@ -49,7 +59,7 @@ const UserTableData = React.memo(props => {
       <td className="usermanagement__active--input">
         <ActiveCell
           isActive={props.isActive}
-          canChange={true}
+          canChange={canChangeUserStatus}
           key={`active_cell${props.index}`}
           index={props.index}
           onClick={() => props.onActiveInactiveClick(props.user)}
@@ -91,6 +101,20 @@ const UserTableData = React.memo(props => {
       </td>
       <td>{props.user.weeklycommittedHours}</td>
       <td>
+        <>
+        {
+          !canChangeUserStatus ?
+          <Tooltip
+            placement="bottom"
+            isOpen={tooltipPauseOpen}
+            target={"btn-pause-profile-"+props.user._id}
+            toggle={togglePauseTooltip}
+          >
+            You don't have permission to change user status
+          </Tooltip>
+          :
+          ""
+        } 
         <button
           type="button"
           className={`btn btn-outline-${props.isActive ? 'warning' : 'success'} btn-sm`}
@@ -106,9 +130,12 @@ const UserTableData = React.memo(props => {
             );
           }}
           style={darkMode ? { boxShadow: "0 0 0 0", fontWeight: "bold" } : boxStyle}
+          disabled={!canChangeUserStatus}
+          id={"btn-pause-profile-"+props.user._id}
         >
           {isChanging ? '...' : props.isActive ? PAUSE : RESUME}
         </button>
+        </>
       </td>
       <td className="centered-td">
         <button
@@ -144,6 +171,20 @@ const UserTableData = React.memo(props => {
       </td>
       <td>
         {!isCurrentUser && (
+          <>
+          {
+            !canChangeUserStatus ? 
+              <Tooltip
+                placement="bottom"
+                isOpen={tooltipFinalDayOpen}
+                target={"btn-final-day-"+props.user._id}
+                toggle={toggleFinalDayTooltip}
+              >
+                You don't have permission to change user status
+              </Tooltip>
+            :
+            ""
+          }
           <button
             type="button"
             className={`btn btn-outline-${props.user.endDate ? 'warning' : 'success'} btn-sm`}
@@ -159,9 +200,12 @@ const UserTableData = React.memo(props => {
               );
             }}
             style={darkMode ? { boxShadow: "0 0 0 0", fontWeight: "bold" } : boxStyle}
+            id={"btn-final-day-"+props.user._id}
+            disabled={!canChangeUserStatus}
           >
             {props.user.endDate ? CANCEL : SET_FINAL_DAY}
           </button>
+          </>
         )}
       </td>
       <td>
@@ -185,20 +229,36 @@ const UserTableData = React.memo(props => {
       {checkPermissionsOnOwner() ? null : (
         <td>
           <span className="usermanagement-actions-cell">
+            <>
+            {
+              !canDeleteUsers ?
+              <Tooltip
+                placement="bottom"
+                isOpen={tooltipDeleteOpen}
+                target={"btn-delete-"+props.user._id}
+                toggle={toggleDeleteTooltip}
+              >
+                You don't have permission to delete the user
+              </Tooltip>
+              :
+              ""
+            } 
             <button
               type="button"
+              id={"btn-delete-"+props.user._id}
               className="btn btn-outline-danger btn-sm"
               onClick={e => {
                 props.onDeleteClick(props.user, 'archive');
               }}
               style={darkMode ? { boxShadow: "0 0 0 0", fontWeight: "bold" } : boxStyle}
-              disabled={props.auth?.user.userid === props.user._id}
+              disabled={props.auth?.user.userid === props.user._i || !canDeleteUsers}
             >
               {DELETE}
             </button>
+            </>
           </span>
           <span className="usermanagement-actions-cell">
-            <ResetPasswordButton authEmail={props.authEmail} user={props.user} darkMode={darkMode} isSmallButton />
+            <ResetPasswordButton authEmail={props.authEmail} user={props.user} darkMode={darkMode} isSmallButton canResetPassword={resetPasswordStatus}/>
           </span>
         </td>
       )}

--- a/src/components/UserManagement/__tests__/ResetPasswordButton.test.js
+++ b/src/components/UserManagement/__tests__/ResetPasswordButton.test.js
@@ -16,7 +16,7 @@ describe('reset password button ', () => {
   beforeEach(() => {
     render(
       <Provider store={store}> 
-        <ResetPasswordButton isSmallButton user={userProfileMock} />
+        <ResetPasswordButton isSmallButton user={userProfileMock} canResetPassword={true}/>
       </Provider>
     );
   });

--- a/src/components/UserManagement/__tests__/UserTableData.test.js
+++ b/src/components/UserManagement/__tests__/UserTableData.test.js
@@ -15,6 +15,10 @@ const jaeAccountMock = {
     expiryTimestamp: '2023-08-22T22:51:06.544Z',
     iat: 1597272666,
     userid: '1',
+    permissions: {
+      frontPermissions: ['deleteUserProfile', 'resetPassword', 'changeUserStatus'],
+      backPermissions: []
+    },
     role: 'Administrator',
     email: 'devadmin@hgn.net'
   },
@@ -31,6 +35,10 @@ const nonJaeAccountMock = {
     expiryTimestamp: '2023-08-22T22:51:06.544Z',
     iat: 1597272666,
     userid: '2',
+    permissions: {
+      frontPermissions: ['deleteUserProfile', 'resetPassword', 'changeUserStatus'],
+      backPermissions: []
+    },
     role: 'Administrator',
     email: 'non_jae@hgn.net'
   },
@@ -48,6 +56,10 @@ const ownerAccountMock = {
     expiryTimestamp: '2023-08-22T22:51:06.544Z',
     iat: 1597272666,
     userid: '3',
+    permissions: {
+      frontPermissions: ['deleteUserProfile', 'resetPassword', 'changeUserStatus'],
+      backPermissions: []
+    },
     role: 'Owner',
     email: 'devadmin@hgn.net'
   },
@@ -67,7 +79,14 @@ describe('User Table Data: Non-Jae related Account', () => {
     store = mockStore({
       auth: ownerAccountMock,
       userProfile: nonJaeAccountMock,
-      role: nonJaeAccountMock.role,
+      role: {
+        roles: [
+          { 
+            roleName: nonJaeAccountMock.role, 
+            permissions: ['deleteUserProfile', 'resetPassword', 'changeUserStatus']
+          },
+        ],
+      },
       theme: themeMock,
     });
     onPauseResumeClick = jest.fn();
@@ -160,7 +179,14 @@ describe('User Table Data: Jae protected account record and login as Jae related
     store = mockStore({
       auth: authMock,
       userProfile: jaeAccountMock,
-      role: jaeAccountMock.role
+      role: {
+        roles: [
+          { 
+            roleName: jaeAccountMock.role, 
+            permissions: ['deleteUserProfile', 'resetPassword', 'changeUserStatus'] 
+          },
+        ],
+      },
     });
     onPauseResumeClick = jest.fn();
     onDeleteClick = jest.fn();


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/aa309631-80d4-4c90-8663-1f6d14e62722)
Fixes # (bug list priority low )

## Related PRS (if any):
To test this frontend PR you need to checkout the development in backend repository.

## Main changes explained:
- Modify ResetPasswordButton.jsx to disable the button when the `resetPassword` permission is not enabled for the user, and display a tooltip on the disabled button with the message: "You don't have permission to reset the password."
- Update UserSearchPanel.jsx to show a tooltip with the message: "You don't have permission to create a new user" on the disabled 'create new user' button when the user lacks the `postUserProfile` permission.
- Update UserTableData.jsx to add checks on the delete button when the `deleteUserProfile` permission is not enabled. Also, include checks for the final day, and for the pause/resume button when the `changeUserStatus` permission is not enabled. Tooltips should be displayed on these buttons as well.
- Update test cases in UserTableData.test.js and ResetPasswordButton.test.js accordingly.

## How to test:
1. check into current branch `git checkout ambika-add-permission-user-management`
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as a owner user
5. go to dashboard -> other links → Permissions management
6. Click on manage user permissions
7. Choose your volunteer user name and give permission 'see all users' and scroll at the bottom and click submit button
8. Logout and log as volunteer user name
9. go to dashboard→ other links → User management
10. verify create new user button, active/inactive cell, pause button, set final day button, delete button, reset password button are disabled
11. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

### Screenshots of after implementation
- Disable and Tooltip for create new user
 ![image](https://github.com/user-attachments/assets/40e1ede2-d086-4a0b-8066-0c3ae7d1aa03)

- Disable click on active/inactive active cell
 ![image](https://github.com/user-attachments/assets/930b773e-22b4-4864-878e-5bb03b92a872)

- Disable and Tooltip for Pause button
 ![image](https://github.com/user-attachments/assets/24b673a7-6561-4104-b1d7-c7fba2657c6e)

- Disable and Tooltip for set final day button
 ![image](https://github.com/user-attachments/assets/3676cd57-2bd2-4801-9295-8cb754528eaa)

- Disable and Tooltip for delete button
 ![image](https://github.com/user-attachments/assets/62a559e4-310e-4668-bca5-d07b34df2338)

- Disable and Tooltip for reset password button
 ![image](https://github.com/user-attachments/assets/760c4043-e87e-4ef3-90fd-73c1dbbe4f9c)

## Note:
