### PR TITLE
Yashwanth - Edited mouseover text in assign team

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
@@ -197,8 +197,7 @@ const UserTeamsTable = props => {
                         target="teamCodeAssign"
                         toggle={toggleTeamCodeExplainTooltip}
                       >
-                        This team code should only used by admin/owner, and has nothing to do with
-                        the team data model.
+                        This team code should only be used by Admins/Owners, and has nothing to do with the team data model.
                       </Tooltip>
                     </>
                   )}


### PR DESCRIPTION
# Description
Applying a hotfix to edit the text displayed on mouseover for the "Assign Teams" feature.

## Main changes explained:
- Before my changes the mouseover text was "This team code should only used by admins/Owner, and has nothing to do with the team data model."
- After Changes "This team code should only be used by Admins/Owners, and has nothing to do with the team data model."
- Edited UserTeamsTable.jsx file
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Profile page>Teams>Assign Team mouseover


## Screenshots or videos of changes:
![hotfix1](https://github.com/user-attachments/assets/11db0f8f-eeea-493a-86a1-9c0b88261a24)


