### PR TITLE
Manager Account able to submit summary for Admin User

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -238,6 +238,37 @@ function LeaderBoard({
     showTimeOffRequestModal(request);
   };
 
+  const manager = 'Manager';
+  const adm = 'Administrator';
+  const owner = 'Owner';
+
+  const handleDashboardAccess = item => {
+    // check the logged in user is manager and if the dashboard is admin and owner
+    if (loggedInUser.role === manager && [adm, owner].includes(item.role)) {
+      // check the logged in user is admin and if dashboard is owner
+      toast.error("Oops! You don't have the permission to access this user's dashboard!");
+    } else if (loggedInUser.role === adm && [owner].includes(item.role)) {
+      toast.error("Oops! You don't have the permission to access this user's dashboard!");
+    }
+    // check the logged in user isn't manager, administrator or owner and if they can access the dashboard
+    else if (
+      loggedInUser.role !== manager &&
+      loggedInUser.role !== adm &&
+      loggedInUser.role !== owner
+    ) {
+      if ([manager, adm, owner].includes(item.role)) {
+        // prevent access
+        toast.error("Oops! You don't have the permission to access this user's dashboard!");
+      } else {
+        // allow access to the painel
+        dashboardToggle(item);
+      }
+    } else {
+      // allow access to the painel
+      dashboardToggle(item);
+    }
+  };
+
   const teamName = (name, maxLength) =>
     setSelectedTeamName(maxLength > 15 ? `${name.substring(0, 15)}...` : name);
 
@@ -470,7 +501,9 @@ function LeaderBoard({
                         Jump to personal Dashboard
                       </ModalHeader>
                       <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
-                        <p>Are you sure you wish to view this {item.name} dashboard?</p>
+                        <p className="title-dashboard">
+                          Are you sure you wish to view the dashboard for {item.name}?
+                        </p>
                       </ModalBody>
                       <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
                         <Button variant="primary" onClick={() => showDashboard(item)}>
@@ -494,11 +527,11 @@ function LeaderBoard({
                       role="button"
                       tabIndex={0}
                       onClick={() => {
-                        dashboardToggle(item);
+                        handleDashboardAccess(item);
                       }}
                       onKeyDown={e => {
                         if (e.key === 'Enter') {
-                          dashboardToggle(item);
+                          handleDashboardAccess(item);
                         }
                       }}
                     >


### PR DESCRIPTION
# Description
This is a continuation for [PR 1966 ](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1966)

<img width="721" alt="Screenshot 2024-09-13 at 11 13 33 AM" src="https://github.com/user-attachments/assets/275b9258-0e7b-4fb8-8c39-8779035eb833">

## Related PRS (if any):
This frontend PR is related to the latest backend branch.
…

## Main changes explained:
- Added a logical condition to allow the managers can't access administrators or owners dashboard.
- Added a logical condition to allow the administrators can't owners dashboard.
- Added a logical condition to allow no users can access administrators, managers or owners dashboard
- Added toast functions to allow the UI messages
- Replaced the phrase "in this dashboard {item.name}" for "the dashboard for {item.name}"
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as manager user, go to dashboard, go to Leaderboard, click status button, verify the following conditionals: 
                  Managers and above (administrators and owners) can access others dashboards
                  Managers can't be able to access Admin/Owner dashboard
5. log as administrator user, go to dashboard, go to Leaderboard, click status button, verify the following conditionals:
                  Administrators and above (managers and owners) can access others dashboards
                  Aministrators can't be able to access Owners dashboard
6. log as owner user, go to dashboard, go to Leaderboard, click status button, verify the following conditionals:
                  Owners and above (administrators and owners) can be able to access all dashboards
7. log as any user (without being administrators, owners and managers) go to dashboards, go to Leaderboard, click status button, verify the following conditionals:
                   All users (without being administrators, owners and managers) can access others dashboards, but they can't be able to administrators, owners and managers

## Screenshots or videos of changes:
Admin check:
https://github.com/user-attachments/assets/19bdc0be-6982-4bcc-8fea-e7a2fece5055

Manager check:
https://github.com/user-attachments/assets/531c7ef8-dbdf-4bb4-bad9-9248582fcd19

Owner check:
https://github.com/user-attachments/assets/e089095d-e241-4713-996a-5f9f20135af9

Other user check:
https://github.com/user-attachments/assets/c662a6e8-7c56-4899-96af-827826b7fb18

