### PR TITLE
Dashboard-table-text-ui-color-fix

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.css
+++ b/src/components/LeaderBoard/Leaderboard.css
@@ -67,7 +67,7 @@
 }
 
 .leaderboard-totals-title {
-  color: #007bff;
+  color: #339CFF;
   font-weight: bold;
 }
 

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -558,7 +558,7 @@ function LeaderBoard({
                         ) &&
                         currentDate.isBefore(moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ'))
                           ? 'rgba(128, 128, 128, 0.5)'
-                          : '#007BFF',
+                          : '#339CFF',
                     }}
                   >
                     {item.name}

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -164,7 +164,7 @@ const TeamMemberTask = React.memo(
                           ) &&
                           currentDate.isBefore(moment(user.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ'))
                             ? 'rgba(128, 128, 128, 0.5)'
-                            : darkMode ? "#007BFF" : undefined,
+                            : darkMode ? "#339CFF" : undefined,
                         fontSize: '20px'
                       }}
                     >{`${user.name}`}</Link>
@@ -180,7 +180,7 @@ const TeamMemberTask = React.memo(
                     />
                   </td>
                   <td data-label="Time" className={`team-clocks ${darkMode ? "text-light" : ""}`}>
-                    <u className={darkMode ? "text-azure" : ""}>{user.weeklycommittedHours ? user.weeklycommittedHours : 0}</u> /
+                    <u className={darkMode ? "dashboard-team-clocks" : ""}>{user.weeklycommittedHours ? user.weeklycommittedHours : 0}</u> /
                     <font color="green"> {thisWeekHours ? thisWeekHours.toFixed(1) : 0}</font> /
                     <font color="red"> {totalHoursRemaining.toFixed(1)}</font>
                   </td>
@@ -201,7 +201,7 @@ const TeamMemberTask = React.memo(
                               className='team-member-tasks-content-link'
                               to={task.projectId ? `/wbs/tasks/${task._id}` : '/'}
                               data-testid={`${task.taskName}`}
-                              style={{ color: darkMode ? '#007BFF' : undefined }}
+                              style={{ color: darkMode ? '#339CFF' : undefined }}
                             >
                               <span>{`${task.num} ${task.taskName}`} </span>
                             </Link>

--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -105,6 +105,9 @@
   justify-content: space-around;
 }
 
+.dashboard-team-clocks{
+  color: #339CFF !important;
+}
 
 .team-clocks-header {
   height: 73.5px;


### PR DESCRIPTION
# Description
Fix Font Color in Dark Mode on Dashboard(WIP Pavan)
The Current Font Color is Difficult to View in Dark Mode
Make it a slightly lighter shade of blue for those links

## Related PRS (if any):
This frontend PR is not related to any backend PR.

## Main changes explained:
-changed text color to #339CFF, which is a slightly lighter color than previous ones.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user and toggle dark mode
5. go to dashboard→ Tasks→ check color of text in leaderboard and team member tasks
6. verify function mentioned above


## Screenshots or videos of changes:
<img width="750" alt="Screenshot 2024-09-13 at 1 56 49 PM" src="https://github.com/user-attachments/assets/f45120d5-0c3d-41a0-b9cf-36a42d9813a9">
<img width="739" alt="Screenshot 2024-09-13 at 1 56 58 PM" src="https://github.com/user-attachments/assets/e81b955b-f17c-4aea-b16e-9c2eed75b102">
<img width="728" alt="Screenshot 2024-09-13 at 1 57 03 PM" src="https://github.com/user-attachments/assets/1cf03d2c-edd9-4df9-9986-78cf15c55b1f">
<img width="815" alt="Screenshot 2024-09-13 at 1 57 24 PM" src="https://github.com/user-attachments/assets/cee6059b-f34a-4372-a625-0be83c6daaab">

https://github.com/user-attachments/assets/60b1ecbd-d486-4d07-ab88-2033445e70f0


