### PR TITLE
WBS table UI changes for task and action columns

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -302,13 +302,13 @@ function WBSTasks(props) {
         <table className={`table table-bordered tasks-table ${darkMode ? 'text-light' : ''}`} ref={myRef}>
           <thead>
             <tr className={darkMode ? 'bg-space-cadet' : ''}>
-              <th scope="col" data-tip="Action" colSpan="2">
+              <th scope="col" className="tasks-detail-actions" data-tip="Action" colSpan="2">
                 Action
               </th>
               <th scope="col" data-tip="WBS ID" colSpan="1">
                 #
               </th>
-              <th scope="col" data-tip="Task Name" className="task-name">
+              <th scope="col" data-tip="Task Name" className="tasks-detail-task-name task-name">
                 Task
               </th>
               <th scope="col" data-tip="Priority">

--- a/src/components/Projects/WBS/WBSDetail/wbs.css
+++ b/src/components/Projects/WBS/WBSDetail/wbs.css
@@ -214,3 +214,11 @@
   border-left: 1px solid #bbb;
   padding-left: .25em;
 }
+.tasks-detail-task-name { /* task column height and width changes*/
+  width: 40%; 
+  height: auto; 
+}
+
+.tasks-detail-actions {  /* action column width reduced */
+  width: 6%; 
+}


### PR DESCRIPTION
**Description**
The bug relates to the UI of the task table where the width of the actions column is too large, and the task column width and height need to be increased for better visibility. This change addresses these UI issues by adjusting the column sizes to improve the table's overall layout.

**Main changes explained:**
Reduced the width of the actions column in the task table.
Increased the width and height of the task column for better readability.
**How to test:**
Check into the current branch.
Run npm install to install dependencies.
Clear site data/cache.
Log in as an admin user.
Go to Projects → WBS Icon → Choose WBS.
Verify that the actions column width is reduced and the task column width and height are increased.
(Note: The height of the task column will automatically increase if the task name exceeds the expected size, ensuring the full task name is visible without overflow)

Screenshots:
Before:
![Screenshot 2024-09-11 194629](https://github.com/user-attachments/assets/9ccae7c7-5e55-41e0-8447-6f40c6cc80e9)

After:
<img width="947" alt="action column and task column" src="https://github.com/user-attachments/assets/ac1a7e7d-f31e-4a8c-a06f-c1e1b1eff5da">
<img width="946" alt="height of task column" src="https://github.com/user-attachments/assets/af43c423-c6f7-454d-9bf1-3241699245a2">
