### PR TITLE
Adding z-index to button

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/TeamsAndProjects.css
+++ b/src/components/UserProfile/TeamsAndProjects/TeamsAndProjects.css
@@ -31,6 +31,7 @@
   width: 100%;
   margin-bottom: 10px;
   outline: none;
+  z-index: 10;
 }
 
 .teams-span,


### PR DESCRIPTION
# Description
The issue is related to the UI of the "Assign Team" button in the User Profile, where it intermittently responds to clicks.
Fixes # Increased the z-index of the "Assign Team" button to ensure it appears above overlapping elements, resolving an intermittent clickability issue.

## Related PRS (if any):
This frontend PR is related to the Development backend PR.

## Main changes explained:
- Update TeamAndProjects.css to add z-index

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Profile → Teams → Check "Assign Team" button click
6. verify it in different resolutions.
7. verify if this works in [dark mode]

## Screenshots or videos of changes:
Before: 


https://github.com/user-attachments/assets/29ff9358-b827-4e09-a9da-dd3f10503577



After: Button clicking working as expected

