### PR TITLE
Ambika hotfix blank user profile for every user and resolve console errors

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
@@ -36,6 +36,13 @@ function AssignSetUpModal ({ isOpen, setIsOpen, title, userProfile, setUserProfi
     }
 
     if (validation.volunteerAgree && googleDoc.length !== 0) {
+      const originalTeamId = userProfile.teams.map(team => team._id);
+      const originalProjectId = userProfile.projects.map(project => project._id);
+      // If the title has team assigned, add the team to the user profile. Remove duplicate teams
+      const teamsAssigned = title.teamAssiged ? originalTeamId.includes(title?.teamAssiged._id) ? userProfile.teams : [...userProfile.teams, title.teamAssiged] : userProfile.teams;
+      // If the title has project assigned, add the project to the user profile. Remove duplicate projects
+      const projectAssigned = title.projectAssigned ? originalProjectId.includes(title?.projectAssigned._id) ? userProfile.projects : [...userProfile.projects, title.projectAssigned] : userProfile.projects;
+      
       // Ensure adminLinks is not undefined or null
       const updatedAdminLinks = (userProfile.adminLinks || []).map(obj => {
         if (obj.Name === "Media Folder") obj.Link = mediaFolder || '';

--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
@@ -7,23 +7,16 @@ import { getAllTitle } from '../../../actions/title';
 
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import './QuickSetupModal.css';
-import '../../Header/DarkMode.css';
-import { connect,useSelector } from 'react-redux';
+import '../../Header/DarkMode.css'
+import { connect, useSelector } from 'react-redux';
 import { boxStyle, boxStyleDark } from 'styles';
 import hasPermission from 'utils/permissions';
 
-function QuickSetupModal({
-  canAddTitle,
-  canAssignTitle,
-  teamsData,
-  projectsData,
-  userProfile,
-  setUserProfile,
-  handleSubmit,
-  setSaved,
-}) {
-  const darkMode = useSelector(state => state.theme.darkMode);
-
+function QuickSetupModal(props) {
+  const darkMode = useSelector(state => state.theme.darkMode)
+  const canEditTitle=props.hasPermission('editTitle')
+  const canAddTitle=props.hasPermission('addNewTitle')
+  const canAssignTitle=props.hasPermission('assignTitle')
   const [showAddTitle, setShowAddTitle] = useState(false);
   const [showAssignModal, setShowAssignModal] = useState(false);
   const [titles, setTitles] = useState([]);
@@ -48,8 +41,8 @@ function QuickSetupModal({
     getAllTitle()
       .then(res => {
         setTitles(res.data);
-        setUserProfile(userProfile)
-        setUserProfile(prev => ({ ...prev,adminLinks: adminLinks }));
+        props.setUserProfile(props.userProfile)
+        props.setUserProfile(prev => ({ ...prev,adminLinks: adminLinks }));
       })
       .catch(err => console.log(err));
   };
@@ -84,9 +77,10 @@ function QuickSetupModal({
        <div className="col text-center mt-3 flex">
         {canAddTitle ? (
           <Button
-            color="primary"
-            onClick={() => setShowAddTitle(true)}
-            style={darkMode ? boxStyleDark : boxStyle}
+          color="primary"
+          onClick={() => setShowAddTitle(true)}
+          style={darkMode ? boxStyleDark : boxStyle}
+          disabled={editMode==true?true:false}
           >
             Add A New Title
           </Button>
@@ -169,8 +163,8 @@ function QuickSetupModal({
             </Button>
           </ModalFooter>
         </Modal>
-      )}
-    </div>
+      )} 
+    </div> 
   );
 }
 


### PR DESCRIPTION
# Description
Hotfix for PR #2688

User profile is blank for each user and console errors appears.

Fixes # (bug list priority high)

## Related PRS (if any):
To test this frontend PR you need to checkout the development branch of backend PR.

## Main changes explained:
- Updated file src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx, resolved merge conflicts as the variables were missing after merge in PR 2688
- Update file src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx, resolved merge conflicts for props and way of accessing and calling methods and states

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to user profile
6. verify that PR 2688 is working fine and also user profile is loading fully with all information without any errors
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
Before implementation:
![image](https://github.com/user-attachments/assets/1a609804-8bbe-4c60-8491-cfc5cc199a03)

After implementation:
![image](https://github.com/user-attachments/assets/c139cd42-8a0b-43d3-8d6f-decc40cee952)

## Note:
