### PR TITLE
Cillian: Add invisibility indicator to Team members page

### DIFF
--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -15,6 +15,8 @@ import InfoModal from './InfoModal';
 export const TeamMembersPopup = React.memo(props => {
   const darkMode = useSelector(state => state.theme.darkMode);
 
+  const hasVisibilityIconPermission = hasPermission('seeVisibilityIcon');
+
   const [selectedUser, setSelectedUser] = useState(undefined);
   const [isValidUser, setIsValidUser] = useState(true);
   const [searchText, setSearchText] = useState('');
@@ -276,6 +278,9 @@ export const TeamMembersPopup = React.memo(props => {
                             {user.firstName} {user.lastName} ({user.role})
                           </span>
                         )}{' '}
+                        {hasVisibilityIconPermission && !user.isVisible && (
+                          <i className="fa fa-eye-slash" title="User is invisible" />
+                        )}
                       </td>
                       {/* <td>{user}</td> */}
                       <td>{moment(user.addDateTime).format('MMM-DD-YY')}</td>


### PR DESCRIPTION

![Screenshot 2024-09-20 180226](https://github.com/user-attachments/assets/58e0f5d8-b598-4813-8b8e-f8108d64d71a)

Description:
Added an invisibility indicator to the Teams page to clearly show which members are invisible. The indicator is displayed as a hidden eye icon (👁‍🗨) next to the names of invisible members.

Modified TeamMembersPopup.jsx to include the hidden eye icon for members marked as invisible, allowing team members to quickly differentiate between visible and invisible members.
This addresses the need for quickly identifying who is invisible or visible on a team, as outlined in the feature request.
Fixes # (high priority bug)

Related PRS (if any):
No related backend PR.

Main changes explained:
Updated TeamMembersPopup.jsx to add a hidden eye icon (👁‍🗨) next to invisible members.
The visibility status is set via the user’s profile settings (Profile > Teams > Visible/Invisible).
How to test:
Check into the current branch (Cillian_impl_invisibility_indicator).
Run npm install to ensure all dependencies are installed.
Clear site data/cache before testing.
Log in as an admin user.
Navigate to Teams > select a team to view the list of team members.
Confirm that invisible members have the hidden eye icon (👁‍🗨) next to their names, while visible members do not have the icon.
Test the functionality in both light and dark modes to ensure the visibility indicator is displayed clearly in both.
Screenshots or videos of changes:
![Screenshot 2024-09-20 174959](https://github.com/user-attachments/assets/3985e225-748a-46c9-ac34-f9c83ff9e1c7)
![Screenshot 2024-09-20 174903](https://github.com/user-attachments/assets/d836664d-8687-4232-a702-19a81d2966c3)

Note:

This PR implements the invisibility indicator for team members. Reviewers should check if the icon appears correctly and verify that the invisible status is set via the user profile settings (Profile > Teams > Visible/Invisible).
