### PR TITLE
howie team scrollbar hotfix

### DIFF
--- a/src/components/Teams/Team.css
+++ b/src/components/Teams/Team.css
@@ -131,3 +131,7 @@ tr:hover {
     overflow-y: auto;
   }
 }
+
+.overflow-container table {
+  min-width: 600px; 
+}

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -129,7 +129,7 @@ class Teams extends React.PureComponent {
                         darkMode={darkMode}
                       />
                     </thead>
-                    <tbody className={`fixed-scrollbar ${darkMode ? 'dark-mode' : ''}`}>
+                    <tbody className={darkMode ? 'dark-mode' : ''}> 
                       {this.state.sortedTeams}
                     </tbody>
                   </table>


### PR DESCRIPTION
# Description
Team horizontal scrollbar disspears under ~600px 

## Related PRS (if any):
This frontend PR is related to the #2492 PR 
just a hotfix for it

## Main changes explained:
added a CSS rule for the table under to set a min-width so that the inner contents are scrollable

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links → Teams 
6. verify the Teams table resizes and a horizontal scrollbar exists at ALL widths
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/894994ee-0600-4497-8454-e9870ff57c51


## Note:
Include the information the reviewers need to know.
