### PR TITLE
ambika hotfix the task name when it's too long

### DIFF
--- a/src/components/Reports/PeopleTableDetails.css
+++ b/src/components/Reports/PeopleTableDetails.css
@@ -246,5 +246,8 @@
 
 .people-report-task-name {
   word-wrap: break-word;
+}
+
+.task-name-word-break {
   word-break: break-all;
 }

--- a/src/components/Reports/PeopleTableDetails.css
+++ b/src/components/Reports/PeopleTableDetails.css
@@ -202,6 +202,7 @@
   background-color: #ffc107;
   color: #fff;
   width: fit-content;
+  margin-left: 5px;
 }
 
 .task-info {
@@ -241,4 +242,9 @@
   height: 30px;
   cursor: pointer;
   margin-left: auto;
+}
+
+.people-report-task-name {
+  word-wrap: break-word;
+  word-break: break-all;
 }

--- a/src/components/Reports/PeopleTableDetails.jsx
+++ b/src/components/Reports/PeopleTableDetails.jsx
@@ -235,7 +235,7 @@ function PeopleTableDetails(props) {
         <div key={value._id} >
           <div className='task-header'>
             <div>
-              <div className='task-title people-report-task-name'>
+              <div className='task-title people-report-task-name task-name-word-break'>
                 {value.taskName}
               </div>  
             </div>

--- a/src/components/Reports/PeopleTableDetails.jsx
+++ b/src/components/Reports/PeopleTableDetails.jsx
@@ -234,9 +234,12 @@ function PeopleTableDetails(props) {
       <div className={`task-card ${darkMode ? 'text-dark' : ''}`}>
         <div key={value._id} >
           <div className='task-header'>
-            <div className='task-title'>
-              {value.taskName}
+            <div>
+              <div className='task-title people-report-task-name'>
+                {value.taskName}
+              </div>  
             </div>
+            
             <div className='task-status'>
               {value.status}
             </div>
@@ -294,7 +297,7 @@ function PeopleTableDetails(props) {
   const renderFilteredTask = value => (
     <div>
       <div key={value._id} className={`people-table-row people-table-body-row ${darkMode ? 'people-table-row-dark' : ''}`}>
-        <div>{value.taskName}</div>
+        <div className='people-report-task-name'>{value.taskName}</div>
         <div>{value.priority}</div>
         <div>{value.status}</div>
         <div>


### PR DESCRIPTION
# Description
Main issue : Still have an overlapping issue. See the second image under bullet 'v.' This image was taken on a widescreen.
![image](https://github.com/user-attachments/assets/18ec20ae-ba9b-4587-8389-48443ff49dfb)

Fixes # (bug list priority high)

## Related PRS (if any):
To test this backend PR you need to checkout the development backend branch.

## Main changes explained:
- added work break css in both cases

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ task→…
6. verify the task name in case of being too long
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

After implementation:
![image](https://github.com/user-attachments/assets/2b0d9ac0-9500-43bc-a26a-8f4b21a6f477)

