### PR TITLE
Huijie fix add lost hours editing deleting

### DIFF
--- a/src/components/Reports/LostTime/AddLostTime.jsx
+++ b/src/components/Reports/LostTime/AddLostTime.jsx
@@ -50,7 +50,7 @@ const AddLostTime = props => {
 
   const [entryType, setEntryType] = useState('');
   const [isSubmitting, setSubmitting] = useState(false);
-  const [inputs, setInputs] = useState(initialForm);
+  const [inputs, setInputs] = useState(initialForm); //-----------------------------------------
   
   const [selectedTeam, setSelectTeam] = useState(undefined);
   const [selectedProject, setSelectProject] = useState(undefined);
@@ -110,6 +110,7 @@ const AddLostTime = props => {
   };
 
   const handleFormContent = () => {
+    console.log("inputs", inputs);
     if (entryType == 'project') {
       return (
         <FormGroup>
@@ -148,11 +149,12 @@ const AddLostTime = props => {
     } else if (entryType == 'team') {
       return (
         <FormGroup>
-          <Label className={fontColor}>Team Name</Label>
+          <Label className={fontColor}>Team Name</Label> 
           <AddTeamsAutoComplete
             teamsData={{allTeams: props.teams}}
             onDropDownSelect={selectTeam}
             setNewTeamName={setNewTeamName} 
+            setInputs={setInputs}
             newTeamName={newTeamName}
             selectedTeam={selectedTeam}
             searchText={searchTeamText}
@@ -244,6 +246,7 @@ const AddLostTime = props => {
       result.personId = 'Person is required';
     }
     if (entryType == 'team' && inputs.teamId == undefined) {
+      console.log("inputs", inputs);
       result.teamId = 'Team is required';
     }
 

--- a/src/components/Reports/LostTime/AddLostTime.jsx
+++ b/src/components/Reports/LostTime/AddLostTime.jsx
@@ -50,7 +50,7 @@ const AddLostTime = props => {
 
   const [entryType, setEntryType] = useState('');
   const [isSubmitting, setSubmitting] = useState(false);
-  const [inputs, setInputs] = useState(initialForm); //-----------------------------------------
+  const [inputs, setInputs] = useState(initialForm);
   
   const [selectedTeam, setSelectTeam] = useState(undefined);
   const [selectedProject, setSelectProject] = useState(undefined);
@@ -110,7 +110,6 @@ const AddLostTime = props => {
   };
 
   const handleFormContent = () => {
-    console.log("inputs", inputs);
     if (entryType == 'project') {
       return (
         <FormGroup>
@@ -246,7 +245,6 @@ const AddLostTime = props => {
       result.personId = 'Person is required';
     }
     if (entryType == 'team' && inputs.teamId == undefined) {
-      console.log("inputs", inputs);
       result.teamId = 'Team is required';
     }
 

--- a/src/components/Reports/LostTime/EditHistoryModal.jsx
+++ b/src/components/Reports/LostTime/EditHistoryModal.jsx
@@ -177,7 +177,6 @@ const EditHistoryModal = props => {
       result.personId = 'Person is required';
     }
     if (props.entryType == 'team' && inputs.teamId == undefined) {
-      console.log("EditHistory");
       result.teamId = 'Team is required';
     }
 

--- a/src/components/Reports/LostTime/EditHistoryModal.jsx
+++ b/src/components/Reports/LostTime/EditHistoryModal.jsx
@@ -177,6 +177,7 @@ const EditHistoryModal = props => {
       result.personId = 'Person is required';
     }
     if (props.entryType == 'team' && inputs.teamId == undefined) {
+      console.log("EditHistory");
       result.teamId = 'Team is required';
     }
 

--- a/src/components/UserProfile/TeamsAndProjects/AddTeamsAutoComplete.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/AddTeamsAutoComplete.jsx
@@ -46,6 +46,10 @@ const AddTeamsAutoComplete = React.memo(props => {
                     className="team-auto-complete"
                     onClick={() => {
                       props.setSearchText(item.teamName);
+                      props.setInputs(inputs => ({
+                        ...inputs,
+                        teamId: item._id,
+                      }))
                       toggle(false);
                     }}
                   >

--- a/src/components/UserProfile/TeamsAndProjects/__tests__/AddTeamsAutoComplete.test.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/__tests__/AddTeamsAutoComplete.test.jsx
@@ -13,6 +13,7 @@ jest.mock('react-toastify', () => ({
 describe('AddTeamsAutoComplete Component', () => {
   const mockSetSearchText = jest.fn();
   const mockOnCreateNewTeam = jest.fn();
+  const mockSetInputs = jest.fn();
   const teamsData = {
     allTeams: [
       { _id: '1', teamName: 'Engineering' },
@@ -30,6 +31,7 @@ describe('AddTeamsAutoComplete Component', () => {
       <AddTeamsAutoComplete
         searchText=""
         setSearchText={mockSetSearchText}
+        setInputs={mockSetInputs}
         teamsData={teamsData}
         onCreateNewTeam={mockOnCreateNewTeam}
       />
@@ -162,14 +164,23 @@ describe('AddTeamsAutoComplete Component', () => {
       <AddTeamsAutoComplete
         searchText="Eng"
         setSearchText={mockSetSearchText}
+        setInputs={mockSetInputs}
         teamsData={teamsData}
         onCreateNewTeam={mockOnCreateNewTeam}
       />
     );
 
     fireEvent.click(screen.getByText('Engineering'));
-
     expect(mockSetSearchText).toHaveBeenCalledWith('Engineering');
+
+    expect(mockSetInputs).toHaveBeenCalledWith(expect.any(Function));
+    const updateFn = mockSetInputs.mock.calls[0][0];
+    const initialInputs = { testKey: 'testValue' };
+    const updatedInputs = updateFn(initialInputs);
+    expect(updatedInputs).toEqual({
+      testKey: 'testValue',
+      teamId: '1',
+    });
   });
 
   test('creates a new team when no match is found', () => {


### PR DESCRIPTION
# Description
![1](https://github.com/user-attachments/assets/9a6a66b4-3332-49eb-8cc2-5db6e9a24865)

## Related PRS (if any):
This frontend PR is related to the backend PR 1115(https://github.com/OneCommunityGlobal/HGNRest/pull/1115).
Please check the backend PR for more details. 

## Main changes explained:
Fix the error that owner user cannot add lost time for teams.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin or owner user
5. go to Reports -> Reports -> Add Lost Time, or Show Person Lost Time, verify that the errors in adding, updating and deleting lost hours do not occur. Please check the backend PR for more details. Thank you!