### PR TITLE
Yili - Fix the Tasks “Active” column filter

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -63,7 +63,7 @@ function WBSTasks(props) {
       case 'assigned': return tasks.filter(task => task.isAssigned === true)
       case 'unassigned': return tasks.filter(task => task.isAssigned === false)
       case 'active': return tasks.filter(task => ['Active', 'Started'].includes(task.status))
-      case 'inactive': return tasks.filter(task => task.status === 'Not Started')
+      case 'inactive': return tasks.filter(task => ['Not Started', 'Paused'].includes(task.status))
       case 'complete': return tasks.filter(task => task.status === 'Complete')
     }
   }


### PR DESCRIPTION
# Description
![Fix the Tasks “Active” column filter](https://github.com/user-attachments/assets/e231b134-cde4-4b88-9c70-b500ce94b3e9)


## Related PRS (if any):
For backend use development branch


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in as admin user
5. Navigate to Other **Links>Projects>Click WBS Icon>Choose WBS**
6. Create tasks with all four statuses: active, not started, paused, and completed.
7.  Click the `Inactive` button
8. Verify that both paused and not started tasks are correctly displayed when `Inactive` is selected.


## Screenshots or videos of changes:


https://github.com/user-attachments/assets/678ff2b9-736e-48bb-9dda-66e837811320

![0](https://github.com/user-attachments/assets/8a454ac4-b059-41d7-b980-f796a36bfb03)


