### PR TITLE
Vijay Anand - confirm button enable/disable in badge popup component based on selection

### DIFF
--- a/src/actions/badgeManagement.js
+++ b/src/actions/badgeManagement.js
@@ -118,7 +118,7 @@ export const validateBadges = (firstName, lastName) => {
     if (!firstName || !lastName) {
       dispatch(
         getMessage(
-          'The Name Find function does not work without entering first and last name. Nice try though.',
+          'The Name Find function does not work without entering a name. Nice try though.',
           'danger',
         ),
       );
@@ -243,7 +243,7 @@ export const assignBadgesByUserID = (userId, selectedBadges) => {
       );
       setTimeout(() => {
         dispatch(closeAlert());
-      }, 6000);
+      }, 600000);
     } catch (e) {
       dispatch(getMessage('Oops, something is wrong!', 'danger'));
       setTimeout(() => {

--- a/src/components/Badge/AssignBadgePopup.jsx
+++ b/src/components/Badge/AssignBadgePopup.jsx
@@ -1,28 +1,35 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Table, Button, UncontrolledTooltip } from 'reactstrap';
+import { useSelector, useDispatch } from 'react-redux';
 import AssignTableRow from './AssignTableRow';
-import { useSelector } from 'react-redux';
 import './AssignBadgePopup.css';
+import { clearSelected } from '../../actions/badgeManagement';
 
 function AssignBadgePopup(props) {
   const darkMode = useSelector(state => state.theme.darkMode);
+  const selectedBadges = useSelector(state => state.badge.selectedBadges);
   const [searchedName, setSearchedName] = useState('');
+  const dispatch = useDispatch();
+
+  useEffect(() => {}, [selectedBadges]);
 
   const onSearch = text => {
     setSearchedName(text);
   };
 
   const filterBadges = allBadges => {
-    const filteredList = allBadges.filter(badge => {
-      if (badge.badgeName.toLowerCase().indexOf(searchedName.toLowerCase()) > -1) {
-        return badge;
-      }
-      return 0;
-    });
-    return filteredList;
+    return allBadges.filter(badge =>
+      badge.badgeName.toLowerCase().includes(searchedName.toLowerCase()),
+    );
+  };
+
+  const handleSubmit = () => {
+    props.submit();
+    dispatch(clearSelected());
   };
 
   const filteredBadges = filterBadges(props.allBadgeData);
+  const isAnyBadgeSelected = selectedBadges.length > 0;
 
   return (
     <div>
@@ -30,9 +37,7 @@ function AssignBadgePopup(props) {
         type="text"
         className="form-control assign_badge_search_box mb-3"
         placeholder="Search Badge Name"
-        onChange={e => {
-          onSearch(e.target.value);
-        }}
+        onChange={e => onSearch(e.target.value)}
       />
       <div className={`overflow-auto mb-2 max-h-300 ${darkMode ? 'bg-dark text-light' : ''}`}>
         <Table className={darkMode ? 'table-dark' : ''}>
@@ -48,13 +53,11 @@ function AssignBadgePopup(props) {
                   className="bg-secondary text-light"
                 >
                   <p className="badge_info_icon_text">
-                    Hmmm, little blank boxes... what could they mean? Yep, you guessed it, check those
-                    boxes to select the badges you wish to assign a person. Click the
-                    &quot;Confirm&quot; button at the bottom when you&apos;ve selected all you wish to
-                    add.
+                    Check those boxes to select the badges you wish to assign a person. Click the
+                    "Confirm" button at the bottom when you've selected all you wish to add.
                   </p>
                   <p className="badge_info_icon_text">
-                    Want to assign multiple of the same badge to a person? Repeat the process!!
+                    Want to assign multiple of the same badge to a person? Repeat the process!
                   </p>
                 </UncontrolledTooltip>
               </th>
@@ -66,15 +69,18 @@ function AssignBadgePopup(props) {
                 badge={value}
                 index={index}
                 key={index}
-                selectedBadges={props.selectedBadges}
+                selectedBadges={selectedBadges}
               />
             ))}
           </tbody>
         </Table>
       </div>
       <Button
-        className={`btn btn-success float-right ${darkMode ? 'bg-dark text-light' : 'bg-success text-white'}`}
-        onClick={props.submit}
+        className={`btn btn-success float-right ${
+          darkMode ? 'bg-dark text-light' : 'bg-success text-white'
+        }`}
+        onClick={handleSubmit}
+        disabled={!isAnyBadgeSelected}
       >
         Confirm
       </Button>

--- a/src/components/Badge/AssignTableRow.jsx
+++ b/src/components/Badge/AssignTableRow.jsx
@@ -1,16 +1,19 @@
 import { useState, useEffect } from 'react';
 import { Card, CardBody, CardImg, CardText, Popover, CustomInput } from 'reactstrap';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { addSelectBadge, removeSelectBadge } from '../../actions/badgeManagement';
 
-function AssignTableRow(props) {
+function AssignTableRow({ badge, index }) {
   const [isOpen, setOpen] = useState(false);
   const [isSelect, setSelect] = useState(false);
   const dispatch = useDispatch();
+  const selectedBadges = useSelector(state => state.badge?.selectedBadges) || [];
 
   useEffect(() => {
-    setSelect(props.selectedBadges.includes(`assign-badge-${props.badge._id}`));
-  }, [props.selectedBadges, props.badge._id]);
+    if (Array.isArray(selectedBadges)) {
+      setSelect(selectedBadges.includes(`assign-badge-${badge._id}`));
+    }
+  }, [selectedBadges, badge._id]);
 
   const toggle = () => setOpen(prevIsOpen => !prevIsOpen);
 
@@ -18,35 +21,35 @@ function AssignTableRow(props) {
     const isChecked = e.target.checked;
     setSelect(isChecked);
     if (isChecked) {
-      dispatch(addSelectBadge(`assign-badge-${props.badge._id}`));
+      dispatch(addSelectBadge(`assign-badge-${badge._id}`));
     } else {
-      dispatch(removeSelectBadge(`assign-badge-${props.badge._id}`));
+      dispatch(removeSelectBadge(`assign-badge-${badge._id}`));
     }
   };
 
   return (
     <tr>
       <td className="badge_image_mini">
-        <img src={props.badge.imageUrl} id={`popover_${props.index.toString()}`} alt="" />
+        <img src={badge.imageUrl} id={`popover_${index?.toString()}`} alt="" />
         <Popover
           trigger="hover"
           isOpen={isOpen}
           toggle={toggle}
-          target={`popover_${props.index.toString()}`}
+          target={`popover_${index?.toString()}`}
         >
           <Card className="text-center">
-            <CardImg className="badge_image_lg" src={props.badge.imageUrl} />
+            <CardImg className="badge_image_lg" src={badge.imageUrl} />
             <CardBody>
-              <CardText>{props.badge.description}</CardText>
+              <CardText>{badge.description}</CardText>
             </CardBody>
           </Card>
         </Popover>
       </td>
-      <td>{props.badge.badgeName}</td>
+      <td>{badge.badgeName}</td>
       <td>
         <CustomInput
           type="checkbox"
-          id={`assign-badge-${props.badge._id}`}
+          id={`assign-badge-${badge._id}`}
           onChange={handleCheckBoxChange}
           checked={isSelect}
         />

--- a/src/components/Badge/AssignTableRow.jsx
+++ b/src/components/Badge/AssignTableRow.jsx
@@ -1,36 +1,32 @@
 import { useState, useEffect } from 'react';
 import { Card, CardBody, CardImg, CardText, Popover, CustomInput } from 'reactstrap';
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { addSelectBadge, removeSelectBadge } from '../../actions/badgeManagement';
 
 function AssignTableRow(props) {
   const [isOpen, setOpen] = useState(false);
   const [isSelect, setSelect] = useState(false);
+  const dispatch = useDispatch();
 
   useEffect(() => {
-    if (props.selectedBadges && props.selectedBadges.includes(`assign-badge-${props.badge._id}`)) {
-      setSelect(true);
-    } else {
-      setSelect(false);
-    }
+    setSelect(props.selectedBadges.includes(`assign-badge-${props.badge._id}`));
   }, [props.selectedBadges, props.badge._id]);
 
   const toggle = () => setOpen(prevIsOpen => !prevIsOpen);
 
   const handleCheckBoxChange = e => {
-    if (e.target.checked) {
-      props.addSelectBadge(e.target.id);
-      setSelect(true);
+    const isChecked = e.target.checked;
+    setSelect(isChecked);
+    if (isChecked) {
+      dispatch(addSelectBadge(`assign-badge-${props.badge._id}`));
     } else {
-      props.removeSelectBadge(e.target.id);
-      setSelect(false);
+      dispatch(removeSelectBadge(`assign-badge-${props.badge._id}`));
     }
   };
 
   return (
     <tr>
       <td className="badge_image_mini">
-        {' '}
         <img src={props.badge.imageUrl} id={`popover_${props.index.toString()}`} alt="" />
         <Popover
           trigger="hover"
@@ -59,9 +55,4 @@ function AssignTableRow(props) {
   );
 }
 
-const mapDispatchToProps = dispatch => ({
-  addSelectBadge: badgeId => dispatch(addSelectBadge(badgeId)),
-  removeSelectBadge: badgeId => dispatch(removeSelectBadge(badgeId)),
-});
-
-export default connect(null, mapDispatchToProps)(AssignTableRow);
+export default AssignTableRow;

--- a/src/components/Badge/__tests__/AssignBadgePopup.test.js
+++ b/src/components/Badge/__tests__/AssignBadgePopup.test.js
@@ -9,8 +9,6 @@ import { themeMock } from '../../../__tests__/mockStates';
 
 const mockStore = configureStore([thunk]);
 
-// Added mock badge data and can be changed according to your test.
-
 const mockallBadgeData = [
   { _id: '1', badgeName: '30 HOURS 3-WEEK STREAK' },
   { _id: '2', badgeName: 'LEAD A TEAM OF 40+ (Trailblazer) ' },
@@ -22,9 +20,9 @@ const mockallBadgeData = [
 
 const mockSubmit = jest.fn();
 
-const renderComponent = () => {
+const renderComponent = (initialSelectedBadges = []) => {
   const store = mockStore({
-    badge: { allBadgeData: mockallBadgeData },
+    badge: { allBadgeData: mockallBadgeData, selectedBadges: initialSelectedBadges },
     theme: themeMock,
   });
 
@@ -37,12 +35,12 @@ const renderComponent = () => {
 
 describe('AssignBadgePopup component', () => {
   it('Renders without crashing', () => {
-    // check if component is rendering without a crash
     renderComponent();
+    expect(screen.getByText('Badge')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
   });
-  it('Check if search box for badges rendering correct results', () => {
-    // When searched for a particular text, the results should change and the ones that do not match the keyword should be null
 
+  it('Check if search box for badges rendering correct results', () => {
     renderComponent();
     const searchInput = screen.getByPlaceholderText('Search Badge Name');
     fireEvent.change(searchInput, { target: { value: 'hours' } });
@@ -55,16 +53,14 @@ describe('AssignBadgePopup component', () => {
     expect(screen.queryByText('LEAD A TEAM OF 40+ (Trailblazer)')).toBeNull();
     expect(screen.queryByText('NO BLUE SQUARE FOR 3 MONTHS')).toBeNull();
   });
-  it('Verify Badge and Name column is present', () => {
-    // Badge and Name column should be present in the document
 
+  it('Verify Badge and Name column is present', () => {
     renderComponent();
     expect(screen.getByText('Badge')).toBeInTheDocument();
     expect(screen.getByText('Name')).toBeInTheDocument();
   });
-  it('Check if tool tip renders the text when hovered', async () => {
-    // Added mouse events to check if the tool tip shows the text when hovered over it and should not show any text if mouse is not hovered over it.
 
+  it('Check if tool tip renders the text when hovered', async () => {
     const { container } = renderComponent();
     const iconElement = container.querySelector('.fa.fa-info-circle');
 
@@ -73,10 +69,10 @@ describe('AssignBadgePopup component', () => {
     await waitFor(() => {
       const updatedText = screen.getByRole('tooltip');
       expect(updatedText.textContent).toContain(
-        'Hmmm, little blank boxes... what could they mean? Yep, you guessed it, check those boxes to select the badges you wish to assign a person. Click the "Confirm" button at the bottom when you\'ve selected all you wish to add.',
+        'Check those boxes to select the badges you wish to assign a person. Click the "Confirm" button at the bottom when you\'ve selected all you wish to add.',
       );
       expect(updatedText.textContent).toContain(
-        'Want to assign multiple of the same badge to a person? Repeat the process!!',
+        'Want to assign multiple of the same badge to a person? Repeat the process!',
       );
     });
 
@@ -86,18 +82,28 @@ describe('AssignBadgePopup component', () => {
       expect(updatedText).toBeNull();
     });
   });
-  it('Check filtered badges', () => {
-    // check the length of rows displayed from filteredBadges
 
+  it('Check filtered badges', () => {
     renderComponent();
     const assignTableRows = screen.getAllByRole('row');
     expect(assignTableRows.length).toBe(mockallBadgeData.length + 1);
   });
-  it('Check if confirm button works as expected', () => {
-    // simulated confirm button event to check if it works as expected
 
+  it('Check if confirm button is disabled when no badges are selected', () => {
     renderComponent();
-    const buttonElement = screen.getByRole('button');
+    const buttonElement = screen.getByRole('button', { name: /confirm/i });
+    expect(buttonElement).toBeDisabled();
+  });
+
+  it('Check if confirm button is enabled when badges are selected', () => {
+    renderComponent(['assign-badge-1']);
+    const buttonElement = screen.getByRole('button', { name: /confirm/i });
+    expect(buttonElement).not.toBeDisabled();
+  });
+
+  it('Check if confirm button works as expected when enabled', () => {
+    renderComponent(['assign-badge-1']);
+    const buttonElement = screen.getByRole('button', { name: /confirm/i });
     fireEvent.click(buttonElement);
     expect(mockSubmit).toHaveBeenCalled();
   });

--- a/src/reducers/badgeReducer.js
+++ b/src/reducers/badgeReducer.js
@@ -10,7 +10,7 @@ import {
   GET_MESSAGE,
   CLOSE_ALERT,
   GET_BADGE_COUNT,
-  RESET_BADGE_COUNT
+  RESET_BADGE_COUNT,
 } from '../constants/badge';
 
 const badgeInitial = {
@@ -30,13 +30,15 @@ export const badgeReducer = (state = badgeInitial, action) => {
     case GET_ALL_BADGE_DATA:
       return { ...state, allBadgeData: action.allBadges };
     case ADD_SELECT_BADGE:
-      const toAdd = state.selectedBadges;
-      toAdd.push(action.badgeId);
-      return { ...state, selectedBadges: toAdd };
+      return {
+        ...state,
+        selectedBadges: [...state.selectedBadges, action.badgeId],
+      };
     case REMOVE_SELECT_BADGE:
-      const toRemove = state.selectedBadges;
-      toRemove.splice(toRemove.indexOf(action.badgeId), 1);
-      return { ...state, selectedBadges: toRemove };
+      return {
+        ...state,
+        selectedBadges: state.selectedBadges.filter(id => id !== action.badgeId),
+      };
     case GET_BADGE_COUNT:
       return {
         ...state,


### PR DESCRIPTION
# Description
Confirm button in AssignBadgePopup was causing error when user try to click confirm button and restart again from user selection step in badge assingment.

Fixes # (bug list priority high/medium/low x.y.z)
Or Implements # (WBS) 
Made confirm button to get enabled only when the user selects at least one badge.

## Related PRS (if any):
To test this frontend PR you need to checkout the development branch for backend.

## Main changes explained:
- Improved Redux state management in the badgeReducer, ensuring immutability when adding or removing selected badges.
- Updated AssignBadgePopup to use Redux state directly via useSelector, and implemented a proper check for enabling the Confirm button.
- Modified AssignTableRow to dispatch Redux actions directly using useDispatch, ensuring consistent state updates.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links→ Badge Management→ Badge Assignment
6. Search for a user and select a user and then click Assign Badge button.
7. verify if the "Confirm" Button is disabled when no badge is selected and gets enabled only when at least one badge is selected.
8. verify if it gets disabled again if no badges are selected.

## Screenshots or videos of changes:
**Before**
https://drive.google.com/file/d/1tzsavAocJK-0v-H1i5fB3jJkvlVYcOjp/view?usp=sharing

**After/How to test**
https://www.loom.com/share/08c369d54beb420e9bb210f61bf73790?sid=ea1c5473-6ebc-4ad2-95fd-6bc41e6dffb7


## Note:
Include the information the reviewers need to know.
