### PR TITLE
Crystal fix teams toggle 

### DIFF
--- a/src/actions/allTeamsAction.js
+++ b/src/actions/allTeamsAction.js
@@ -98,7 +98,7 @@ export const teamMemberDeleteAction = member => ({
 });
 
 /*
-delete team member action
+add team member action
 */
 export const teamMemberAddAction = member => ({
   type: TEAM_MEMBER_ADD,

--- a/src/components/Teams/InfoModal.jsx
+++ b/src/components/Teams/InfoModal.jsx
@@ -1,13 +1,13 @@
 import { Modal, ModalBody, ModalHeader, ModalFooter, Button } from 'reactstrap';
 
-function InfoModal({ isOpen, toggle }) {
+function InfoModal ({ isOpen, toggle }) {
   return (
     <div>
       <Modal isOpen={isOpen} toggle={toggle}>
         <ModalHeader toggle={toggle}>Restrict the team member visiblity</ModalHeader>
         <ModalBody>
           <p>
-            By default a user can see all the team members. Disable it if you want to restrict the user's visibility
+            By default a user can see all the members on their team. Disable it if you want to restrict the user's visibility and make it so that they cannot see other members on the same team.
           </p>
         </ModalBody>
         <ModalFooter>

--- a/src/components/Teams/MembersAutoComplete.jsx
+++ b/src/components/Teams/MembersAutoComplete.jsx
@@ -20,6 +20,19 @@ export const MemberAutoComplete = props => {
       .replace(/\s+/g, '');
   };
 
+  const filteredUsers = validation
+    .filter(user => {
+      const fullName = user.firstName + user.lastName;
+      if (
+        user.isActive &&
+        // prettier-ignore
+        filterInputAutoComplete(fullName).indexOf(filterInputAutoComplete(props.searchText)) > -1
+      ) {
+        return user;
+      }
+    })
+    .slice(0, 10);
+
   return (
     <Dropdown
       isOpen={isOpen}
@@ -126,19 +139,10 @@ export const MemberAutoComplete = props => {
               className={`dropdown-menu${isOpen ? ' show' : ''}`}
               style={{ marginTop: '0px', width: '100%' }}
             >
-              {validation
-                .filter(user => {
-                  const fullName = user.firstName + user.lastName;
-                  if (
-                    user.isActive &&
-                    // prettier-ignore
-                    filterInputAutoComplete(fullName).indexOf(filterInputAutoComplete(props.searchText)) > -1
-                  ) {
-                    return user;
-                  }
-                })
-                .slice(0, 10)
-                .map((item, idx) => (
+
+              {!filteredUsers.length ?
+                <div className='empty-data-message'>No matching users are found</div> :
+                filteredUsers.map((item, idx) => (
                   <div
                     key={idx}
                     className="user-auto-cpmplete"
@@ -150,7 +154,8 @@ export const MemberAutoComplete = props => {
                   >
                     {`${item.firstName} ${item.lastName}`}
                   </div>
-                ))}
+                ))
+              }
             </div>
           ) : (
             <></>

--- a/src/components/Teams/MembersAutoComplete.jsx
+++ b/src/components/Teams/MembersAutoComplete.jsx
@@ -20,8 +20,7 @@ export const MemberAutoComplete = props => {
       .replace(/\s+/g, '');
   };
 
-  const filteredUsers = validation
-    .filter(user => {
+  const filteredUsers = validation?.filter(user => {
       const fullName = user.firstName + user.lastName;
       if (
         user.isActive &&

--- a/src/components/Teams/MembersAutoComplete.jsx
+++ b/src/components/Teams/MembersAutoComplete.jsx
@@ -138,8 +138,9 @@ export const MemberAutoComplete = props => {
                   }
                 })
                 .slice(0, 10)
-                .map(item => (
+                .map((item, idx) => (
                   <div
+                    key={idx}
                     className="user-auto-cpmplete"
                     onClick={() => {
                       props.setSearchText(`${item.firstName} ${item.lastName}`);

--- a/src/components/Teams/Team.css
+++ b/src/components/Teams/Team.css
@@ -83,12 +83,12 @@ thead {
 
 .isActive i {
   color: lawngreen;
-  margin-top: 10px;
+  margin-top: 0px;
 }
 
 .isNotActive i {
   color: #dee2e6;
-  margin-top: 10px;
+  margin-top: 0px;
 
 }
 
@@ -130,4 +130,30 @@ tr:hover {
     max-height: 80vh;
     overflow-y: auto;
   }
+}
+
+body.modal-open {
+  overflow: hidden;
+  position: fixed;
+  width: 100%;
+  padding-right: 15px !important;
+}
+
+.modal-content {
+  max-height: 95vh;
+  overflow: auto;
+}
+
+.table td {
+  vertical-align: middle !important;
+}
+
+table .ToggleSwitch_switchSection__3twC9 {
+  justify-content: center;
+}
+
+.empty-data-message {
+  color: grey;
+  margin: auto;
+  text-align: center;
 }

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Container, Alert } from 'reactstrap';
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter, Container, Alert, Spinner } from 'reactstrap';
 import hasPermission from 'utils/permissions';
 import { boxStyle, boxStyleDark } from 'styles';
 import '../Header/DarkMode.css';
@@ -163,7 +163,7 @@ export const TeamMembersPopup = React.memo(props => {
     sortList(sortOrder);
     const newMemberVisibility = getMemberVisibility();
     setMemberVisibility(newMemberVisibility);
-  }, [validation, sortOrder, props.teamData]);
+  }, [validation, sortOrder]);
 
   useEffect(() => {
     setIsValidUser(true);
@@ -178,6 +178,8 @@ export const TeamMembersPopup = React.memo(props => {
   const toggleInfoModal = () => {
     setInfoModal(!infoModal);
   };
+
+  const emptyState = (<tr><td colSpan={6} className='empty-data-message'>There are no users on this team.</td></tr>);
 
   return (
     <Container fluid>
@@ -223,9 +225,8 @@ export const TeamMembersPopup = React.memo(props => {
           )}
 
           <table
-            className={`table table-bordered table-responsive-sm ${
-              darkMode ? 'dark-mode text-light' : ''
-            }`}
+            className={`table table-bordered table-responsive-xlg ${darkMode ? 'dark-mode text-light' : ''
+              }`}
           >
             <thead>
               <tr className={darkMode ? 'bg-space-cadet' : ''}>
@@ -251,57 +252,61 @@ export const TeamMembersPopup = React.memo(props => {
               </tr>
             </thead>
             <tbody>
-              {((Array.isArray(props.members.teamMembers) &&
-                props.members.teamMembers.length > 0) ||
-                (typeof props.members.fetching === 'boolean' &&
-                  !props.members.fetching &&
-                  props.members.teamMembers) ||
-                (Array.isArray(props.members) && props.members.length > 0)) &&
-                memberList.toSorted().map((user, index) => {
-                  return (
-                    <tr key={`${props.selectedTeamName}-${user.id}-${index}`}>
-                      <td>
-                        <span className={user.isActive ? 'isActive' : 'isNotActive'}>
-                          <i className="fa fa-circle" aria-hidden="true" />
-                        </span>
-                      </td>
-                      <td>{index + 1}</td>
-                      <td>
-                        {returnUserRole(user) ? (
-                          <b>
-                            {user.firstName} {user.lastName} ({user.role})
-                          </b>
-                        ) : (
-                          <span>
-                            {user.firstName} {user.lastName} ({user.role})
-                          </span>
-                        )}{' '}
-                      </td>
-                      {/* <td>{user}</td> */}
-                      <td>{moment(user.addDateTime).format('MMM-DD-YY')}</td>
-                      <td>
-                        <ToggleSwitch
-                          key={`${props.selectedTeamName}-${user._id}`}
-                          switchType="limit-visibility"
-                          userId={user._id}
-                          choice={memberVisibility[user._id]}
-                          UpdateTeamMembersVisibility={UpdateTeamMembersVisibility}
-                        />
-                      </td>
-                      {canAssignTeamToUsers && (
+              {props.fetching ?
+                <tr><td align='center' colSpan={6}><Spinner  color={`${darkMode ? 'light' : 'dark'}`} animation="border" size="sm" /></td></tr> :
+                !memberList.length ?
+                  emptyState :
+                  ((Array.isArray(props.members.teamMembers) &&
+                    props.members.teamMembers.length > 0) ||
+                    (typeof props.members.fetching === 'boolean' &&
+                      !props.members.fetching &&
+                      props.members.teamMembers) ||
+                    (Array.isArray(props.members) && props.members.length > 0)) &&
+                  memberList.toSorted().map((user, index) => {
+                    return (
+                      <tr key={`${props.selectedTeamName}-${user.id}-${index}`}>
                         <td>
-                          <Button
-                            color="danger"
-                            onClick={() => handleDelete(user._id)}
-                            style={darkMode ? boxStyleDark : boxStyle}
-                          >
-                            Delete
-                          </Button>
+                          <div className={user.isActive ? 'isActive' : 'isNotActive'}>
+                            <i className="fa fa-circle" aria-hidden="true" />
+                          </div>
                         </td>
-                      )}
-                    </tr>
-                  );
-                })}
+                        <td>{index + 1}</td>
+                        <td>
+                          {returnUserRole(user) ? (
+                            <b>
+                              {user.firstName} {user.lastName} ({user.role})
+                            </b>
+                          ) : (
+                            <span>
+                              {user.firstName} {user.lastName} ({user.role})
+                            </span>
+                          )}{' '}
+                        </td>
+                        {/* <td>{user}</td> */}
+                        <td>{moment(user.addDateTime).format('MMM-DD-YY')}</td>
+                        <td>
+                          <ToggleSwitch
+                            key={`${props.selectedTeamName}-${user._id}`}
+                            switchType="limit-visibility"
+                            userId={user._id}
+                            choice={memberVisibility[user._id]}
+                            UpdateTeamMembersVisibility={UpdateTeamMembersVisibility}
+                          />
+                        </td>
+                        {canAssignTeamToUsers && (
+                          <td>
+                            <Button
+                              color="danger"
+                              onClick={() => handleDelete(user._id)}
+                              style={darkMode ? boxStyleDark : boxStyle}
+                            >
+                              Delete
+                            </Button>
+                          </td>
+                        )}
+                      </tr>
+                    );
+                  })}
             </tbody>
           </table>
         </ModalBody>

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -55,6 +55,10 @@ class Teams extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    if (!lo.isEqual(this.props.state.teamsTeamMembers.teamMembers, prevProps.state.teamsTeamMembers.teamMembers)) {
+      this.props.getAllUserTeams();
+      this.props.getAllUserProfile();
+    }
     if (
       !lo.isEqual(prevProps.state.allTeamsData.allTeams, this.props.state.allTeamsData.allTeams) || 
       prevState.teamNameSearchText !== this.state.teamNameSearchText || 

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -53,19 +53,16 @@ class Teams extends React.PureComponent {
     this.props.getAllUserTeams();
     this.props.getAllUserProfile();
   }
-
+  
   componentDidUpdate(prevProps, prevState) {
-    if (!lo.isEqual(this.props.state.teamsTeamMembers.teamMembers, prevProps.state.teamsTeamMembers.teamMembers)) {
-      this.props.getAllUserTeams();
-      this.props.getAllUserProfile();
-    }
     if (
       !lo.isEqual(prevProps.state.allTeamsData.allTeams, this.props.state.allTeamsData.allTeams) || 
       prevState.teamNameSearchText !== this.state.teamNameSearchText || 
       prevState.wildCardSearchText !== this.state.wildCardSearchText
     ) {
-     this.setState({ teams: this.teamTableElements(this.props.state.allTeamsData.allTeams) });
-    }
+      this.setState({ teams: this.teamTableElements(this.props.state.allTeamsData.allTeams) });
+    } 
+    
     if (
       prevState.teams !== this.state.teams || 
       prevState.sortTeamNameState !== this.state.sortTeamNameState || 
@@ -73,6 +70,7 @@ class Teams extends React.PureComponent {
     ) {
       this.sortTeams();
     }
+
     if (
       (prevProps.state.allTeamsData.allTeams && prevProps.state.allTeamsData.allTeams.length) !== (this.props.state.allTeamsData.allTeams && this.props.state.allTeamsData.allTeams.length)
     ) {
@@ -93,6 +91,11 @@ class Teams extends React.PureComponent {
 
       if (teamsChanged) {
         // Teams have changed, update or re-fetch them
+        this.props.getAllUserTeams();
+        this.props.getAllUserProfile();
+      }
+      if (!lo.isEqual(this.props.state.teamsTeamMembers.teamMembers, prevProps.state.teamsTeamMembers.teamMembers)) {
+        // Members have changed, update or re-fetch them
         this.props.getAllUserTeams();
         this.props.getAllUserProfile();
       }
@@ -206,6 +209,7 @@ class Teams extends React.PureComponent {
    */
 
   teampopupElements = (allTeams) => {
+    //WHERE ARE THE MEMBERS COMING
     const members = this.props.state ? this.props.state.teamsTeamMembers : [];
     const selectedTeamData= allTeams? allTeams.filter(team => team.teamName === this.state.selectedTeam) : [];
     return (
@@ -255,15 +259,18 @@ class Teams extends React.PureComponent {
     );
   };
 
-  onAddUser = user => {
-    this.props.addTeamMember(this.state.selectedTeamId, user._id, user.firstName, user.lastName, user.role, Date.now());
+  // CNOTE: ADD USER HERE
+  onAddUser = async user => {
+    await this.props.addTeamMember(this.state.selectedTeamId, user._id, user.firstName, user.lastName, user.role, Date.now());
+    // this.props.getTeamMembers(this.state.selectedTeamId);
   };
 
    /** NEW CODE
    * Update Team member visibility by making a Redux action call
    */
-   onUpdateTeamMemberVisibility = (userid, visibility) => {
-    this.props.updateTeamMemeberVisibility(this.state.selectedTeamId, userid, visibility);
+  onUpdateTeamMemberVisibility = async (userid, visibility) => {
+    await this.props.updateTeamMemeberVisibility(this.state.selectedTeamId, userid, visibility);
+    // this.props.getTeamMembers(this.state.selectedTeamId);
   };
 
   /**

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -209,9 +209,8 @@ class Teams extends React.PureComponent {
    */
 
   teampopupElements = (allTeams) => {
-    //WHERE ARE THE MEMBERS COMING
-    const members = this.props.state ? this.props.state.teamsTeamMembers : [];
-    const selectedTeamData= allTeams? allTeams.filter(team => team.teamName === this.state.selectedTeam) : [];
+    const { teamMembers: members, fetching } = this.props.state.teamsTeamMembers;
+    const selectedTeamData = allTeams ? allTeams.filter(team => team.teamName === this.state.selectedTeam) : [];
     return (
       <>
         <TeamMembersPopup
@@ -221,9 +220,10 @@ class Teams extends React.PureComponent {
           onDeleteClick={this.onDeleteTeamMember}
           usersdata={this.props.state ? this.props.state.allUserProfiles : []}
           onAddUser={this.onAddUser}
-          teamData= {selectedTeamData}
+          teamData={selectedTeamData}
           onUpdateTeamMemberVisibility={this.onUpdateTeamMemberVisibility}
           selectedTeamName={this.state.selectedTeam}
+          fetching={fetching}
         />
         <CreateNewTeamPopup
           open={this.state.createNewTeamPopupOpen}
@@ -259,18 +259,15 @@ class Teams extends React.PureComponent {
     );
   };
 
-  // CNOTE: ADD USER HERE
-  onAddUser = async user => {
-    await this.props.addTeamMember(this.state.selectedTeamId, user._id, user.firstName, user.lastName, user.role, Date.now());
-    // this.props.getTeamMembers(this.state.selectedTeamId);
+  onAddUser = user => {
+    this.props.addTeamMember(this.state.selectedTeamId, user._id, user.firstName, user.lastName, user.role, Date.now());
   };
 
-   /** NEW CODE
-   * Update Team member visibility by making a Redux action call
-   */
-  onUpdateTeamMemberVisibility = async (userid, visibility) => {
-    await this.props.updateTeamMemeberVisibility(this.state.selectedTeamId, userid, visibility);
-    // this.props.getTeamMembers(this.state.selectedTeamId);
+  /** NEW CODE
+  * Update Team member visibility by making a Redux action call
+  */
+  onUpdateTeamMemberVisibility = (userid, visibility) => {
+    this.props.updateTeamMemeberVisibility(this.state.selectedTeamId, userid, visibility);
   };
 
   /**

--- a/src/components/Teams/ToggleSwitch/ToggleSwitch.jsx
+++ b/src/components/Teams/ToggleSwitch/ToggleSwitch.jsx
@@ -1,9 +1,18 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import style from './ToggleSwitch.module.scss';
 
-function ToggleSwitch({ switchType, UpdateTeamMembersVisibility, userId, choice }) {    
-  const [visibility, setVisibility] = useState(choice); 
-  
+const DEFAULT_VISIBILITY = true;
+
+function ToggleSwitch ({ switchType, UpdateTeamMembersVisibility, userId, choice }) {
+
+  const [visibility, setVisibility] = useState(choice !== undefined ? choice : DEFAULT_VISIBILITY);
+
+  const toggleVisibility = () => {
+    const isChecked = !visibility;
+    setVisibility(isChecked);
+    UpdateTeamMembersVisibility(userId, isChecked);
+  };
+
   switch (switchType) {
     case 'limit-visibility':
       return (
@@ -14,11 +23,7 @@ function ToggleSwitch({ switchType, UpdateTeamMembersVisibility, userId, choice 
               type="checkbox"
               className={style.toggleTeamsVisibility}
               checked={visibility} // Assuming visibility is a string
-              onChange={event => {
-                const isChecked = !visibility;
-                setVisibility(isChecked);
-                UpdateTeamMembersVisibility(userId, isChecked);
-              }}
+              onChange={toggleVisibility}
             />
           </div>
         </div>


### PR DESCRIPTION
# Description
<img width="673" alt="image" src="https://github.com/user-attachments/assets/1b534ddf-b5a7-408c-b625-188213449448">

Bug priority urgent

## Related PRS (if any):
This frontend PR is related to the development branch on the backend.

## Main changes explained:
- Updated the default visibility setting for newly added team members from "toggle off" to "toggle on."
- Implemented a condition to retrieve the updated team members list after a new user is added.
- Added a loading spinner to indicate when team member data is being retrieved.
- Added a message to display on the team members table when no team members are present.
- Added a message to display in the dropdown options when no users match the search input.

## How to test:
1. Check into current branch: `git checkout crystal-fix-teams-toggle`
2. Do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. Log as admin user
5. Go to Dashboard→ Other Links→ Team→…
6. Verify newly added users to a team have the default visibility toggle set to "on."
7. Verify when closing and reopening the modal, the team members list displays the correct and updated team members.

## Screenshots or videos of changes:

Before changes (refer to video link below):
https://www.loom.com/share/a00fb6d198ac4a37b32e52d046d8eee0?sid=7889af68-36f7-418c-9c2c-481e28473512

New changes reflecting newly added users to a team have the default visibility toggle set to "on." (refer to video below)

https://github.com/user-attachments/assets/dc0b3d81-2ffe-42eb-b247-e3e5e5981c7f

New changes reflecting when closing and reopening the modal, the team members list displays the correct and updated team members. (refer to video below)

https://github.com/user-attachments/assets/b06495ac-0c60-441e-9273-f5d83f2d18ab

