### PR TITLE
Niketha - Fix Category column on Projects page

### DIFF
--- a/src/components/Projects/Project/Project.jsx
+++ b/src/components/Projects/Project/Project.jsx
@@ -12,8 +12,9 @@ const Project = props => {
   const { darkMode, index } = props;
   const [firstLoad, setFirstLoad] = useState(true);
   const [projectData, setProjectData] = useState(props.projectData);
-  const { projectName, category, isActive, _id: projectId } = projectData;
+  const { projectName, isActive, _id: projectId } = projectData;
   const [displayName, setDisplayName] = useState(projectName);
+  const [category, setCategory] = useState(props.category || 'Unspecified'); // Initialize with props or default
 
   const canPutProject = props.hasPermission('putProject');
   const canDeleteProject = props.hasPermission('deleteProject');
@@ -47,8 +48,9 @@ const Project = props => {
   }
 
   const onUpdateProjectCategory = (e) => {
-    updateProject('category', e.target.value);
-  }
+    setCategory(e.target.value);
+    updateProject('category', e.target.value); // Update the projectData state
+  };
 
   const onArchiveProject = () => {
     props.onClickArchiveBtn(projectData);
@@ -59,6 +61,9 @@ const Project = props => {
       setFirstLoad(false);
     } else {
       props.onUpdateProject(projectData)
+    }
+    if (props.projectData.category) {
+      setCategory(props.projectData.category);
     }
   }, [projectData]);
 
@@ -92,7 +97,7 @@ const Project = props => {
           <select
 
             data-testid="projects__category--input" //added for unit test
-            value={props.category}
+            value={category}
             onChange={e => {
               setCategory(e.target.value);
             }}
@@ -114,7 +119,6 @@ const Project = props => {
           category
         )}
       </td>
-
 
       {/* <td className="projects__active--input" data-testid="project-active" onClick={canPutProject ? updateActive : null}>
         {props.active ? ( */}

--- a/src/components/Projects/Project/Project.jsx
+++ b/src/components/Projects/Project/Project.jsx
@@ -119,13 +119,10 @@ const Project = props => {
           category
         )}
       </td>
-
       {/* <td className="projects__active--input" data-testid="project-active" onClick={canPutProject ? updateActive : null}>
         {props.active ? ( */}
           <td className="projects__active--input" data-testid="project-active" onClick={canEditCategoryAndStatus || canPutProject ? onUpdateProjectActive : null}>
               {isActive ? (
-
-
           <div className="isActive">
             <i className="fa fa-circle" aria-hidden="true"></i>
           </div>

--- a/src/components/Reports/Reports.jsx
+++ b/src/components/Reports/Reports.jsx
@@ -29,7 +29,6 @@ import ViewReportByDate from './ViewReportsByDate/ViewReportsByDate';
 import ReportFilter from './ReportFilter/ReportFilter';
 
 const DATE_PICKER_MIN_DATE = '01/01/2010';
-
 class ReportsPage extends Component {
   constructor(props) {
     super(props);
@@ -165,7 +164,7 @@ class ReportsPage extends Component {
 
   filteredPeopleList = userProfiles => {
     const filteredList = userProfiles.filter(userProfile => {
-      // Applying the search filters before creating each team table data element
+      // Applying the search filters before creating each team table data element 
       if (
         (userProfile.firstName &&
           searchWithAccent(userProfile.firstName, this.state.teamNameSearchText) &&

--- a/src/components/Reports/Reports.jsx
+++ b/src/components/Reports/Reports.jsx
@@ -27,6 +27,7 @@ import AddLostTime from './LostTime/AddLostTime';
 import LostTimeHistory from './LostTime/LostTimeHistory';
 import ViewReportByDate from './ViewReportsByDate/ViewReportsByDate';
 import ReportFilter from './ReportFilter/ReportFilter';
+import Loading from '../common/Loading';
 
 const DATE_PICKER_MIN_DATE = '01/01/2010';
 class ReportsPage extends Component {
@@ -77,7 +78,7 @@ class ReportsPage extends Component {
       activeTab: '1',
       errors: {},
       fetchError: null,
-      loading: true,
+      loading: false,
       teamSearchData: {},
       peopleSearchData: [],
       projectSearchData: {},
@@ -308,20 +309,49 @@ class ReportsPage extends Component {
   }
 
   showTotalProject() {
-    this.setState(prevState => ({
+    if (this.state.showTotalProject) {
+      this.setState({
+        showTotalProject: false,
+        loading: false,
+      });
+      return;
+    }
+  
+    this.setState({
+      loading: true,
       showProjects: false,
       showPeople: false,
       showTeams: false,
-      showTotalProject: !prevState.showTotalProject,
       showTotalTeam: false,
       showTotalPeople: false,
+      showTotalProject: false,  // Initially hide the report
       showAddTimeForm: false,
       showAddProjHistory: false,
       showAddPersonHistory: false,
       showAddTeamHistory: false,
-    }));
+    }, () => {
+      setTimeout(() => {
+        this.setState({
+          loading: false,
+          showTotalProject: true,  // Show the report after loading completes
+        });
+      }, 2000);  // Adjust the delay as needed
+    });
   }
-
+  // showTotalProject() {
+  //   this.setState(prevState => ({
+  //     showProjects: false,
+  //     showPeople: false,
+  //     showTeams: false,
+  //     showTotalProject: !prevState.showTotalProject,
+  //     showTotalTeam: false,
+  //     showTotalPeople: false,
+  //     showAddTimeForm: false,
+  //     showAddProjHistory: false,
+  //     showAddPersonHistory: false,
+  //     showAddTeamHistory: false,
+  //   }));
+  // }
   showAddProjHistory() {
     this.setState(prevState => ({
       showProjects: false,
@@ -376,6 +406,7 @@ class ReportsPage extends Component {
   }
 
   render() {
+    const { loading, showTotalProject } = this.state;
     const { darkMode } = this.props.state.theme;
     const userRole = this.props.state.userProfile.role;
     const myRole = this.props.state.auth.user.role;
@@ -429,6 +460,12 @@ class ReportsPage extends Component {
         >
           <div className="container-component-category">
             <h2 className="mt-3 mb-5">
+  {/* Loading spinner at the top */}
+  {this.state.loading && (
+  <div className="loading-spinner-top">
+    <Loading align="center" darkMode={darkMode} />
+  </div>
+)}
               <div className="d-flex align-items-center">
                 <span className="mr-2">Reports Page</span>
                 <EditableInfoModal
@@ -555,22 +592,13 @@ class ReportsPage extends Component {
                       />
                     </div>
                   </div>
-                  <div className="total-report-item">
-                    <Button color="info" onClick={this.showTotalTeam}>
-                      {this.state.showTotalTeam
-                        ? 'Hide Total Team Report'
-                        : 'Show Total Team Report'}
-                    </Button>
-                    <div style={{ display: 'inline-block', marginLeft: 10 }}>
-                      <EditableInfoModal
-                        areaName="totalTeamReportInfoPoint"
-                        areaTitle="Total Team Report"
-                        role={userRole}
-                        fontSize={15}
-                        isPermissionPage
-                      />
-                    </div>
-                  </div>
+                  <div>
+          <div className="total-report-item">
+  <Button color="info" onClick={this.showTotalProject}>
+    {this.state.showTotalProject ? 'Hide Total Project Report' : 'Show Total Project Report'}
+  </Button>
+</div>
+</div>
                 </div>
                 {myRole != 'Owner' && (
                   <div className="lost-time-container">
@@ -711,15 +739,6 @@ class ReportsPage extends Component {
             {this.state.showTeams && (
               <TeamTable allTeams={this.state.teamSearchData} darkMode={darkMode} />
             )}
-            {this.state.showTotalProject && (
-              <TotalProjectReport
-                startDate={this.state.startDate}
-                endDate={this.state.endDate}
-                userProfiles={userProfiles}
-                projects={projects}
-                darkMode={darkMode}
-              />
-            )}
             {this.state.showTotalPeople && (
               <TotalPeopleReport
                 startDate={this.state.startDate}
@@ -728,17 +747,15 @@ class ReportsPage extends Component {
                 darkMode={darkMode}
               />
             )}
-            {this.state.showTotalTeam && (
-              <TotalTeamReport
-                startDate={this.state.startDate}
-                endDate={this.state.endDate}
-                userProfiles={userProfiles}
-                allTeamsData={allTeams}
-                passTeamMemberList={this.setTeamMemberList}
-                savedTeamMemberList={this.state.teamMemberList}
-                darkMode={darkMode}
-              />
-            )}
+{!this.state.loading && this.state.showTotalProject && (
+  <TotalProjectReport
+  startDate={this.state.startDate}
+  endDate={this.state.endDate}
+  userProfiles={userProfiles}
+  projects={projects}
+  darkMode={darkMode}
+/>
+)}
             {this.state.showAddTimeForm && myRole === 'Owner' && (
               <AddLostTime
                 isOpen={this.state.showAddTimeForm}

--- a/src/components/Reports/TotalReport/TotalProjectReport.jsx
+++ b/src/components/Reports/TotalReport/TotalProjectReport.jsx
@@ -244,7 +244,7 @@ function TotalProjectReport(props) {
   return (
     <div>
       {!totalProjectReportDataReady ? (
-        <Loading align="center" darkMode={darkMode}/>
+        ""
       ) : (
         <div>
           <div>{totalProjectInfo(allProject)}</div>


### PR DESCRIPTION
# Description
Fix Category column on Projects page 
Other Links>Projects>Category
All projects have an ‘Unspecified’ category by default when all projects are loaded. It should show their actual category. 

Fixes # (bug list priority high/medium/low x.y.z)

## Related PRS (if any):
This frontend PR is related to the Niketha_categorycolumn PR.

## Main changes explained:
- Added category column in projects page

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links→ Project
6. The category name should load automatically. Earlier all the field in the dropdown would load as unspecified.
7. Category name loads as saved in the project details.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/24eecbe6-d041-43c0-9d90-1dfdf1ebba2e

## Note:
Include the information the reviewers need to know.
