### PR TITLE
Vijay Anand - Hotfix for badge assignment popup UI issue in dark mode.

### DIFF
--- a/src/actions/badgeManagement.js
+++ b/src/actions/badgeManagement.js
@@ -243,7 +243,7 @@ export const assignBadgesByUserID = (userId, selectedBadges) => {
       );
       setTimeout(() => {
         dispatch(closeAlert());
-      }, 6000);
+      }, 600000);
     } catch (e) {
       dispatch(getMessage('Oops, something is wrong!', 'danger'));
       setTimeout(() => {

--- a/src/actions/badgeManagement.js
+++ b/src/actions/badgeManagement.js
@@ -243,7 +243,7 @@ export const assignBadgesByUserID = (userId, selectedBadges) => {
       );
       setTimeout(() => {
         dispatch(closeAlert());
-      }, 600000);
+      }, 6000);
     } catch (e) {
       dispatch(getMessage('Oops, something is wrong!', 'danger'));
       setTimeout(() => {

--- a/src/components/Badge/BadgeDevelopmentTable.jsx
+++ b/src/components/Badge/BadgeDevelopmentTable.jsx
@@ -271,14 +271,28 @@ function BadgeDevelopmentTable(props) {
         className={darkMode ? 'text-light' : ''}
       >
         <ModalBody
-          className={`badge-message-background-${props.color} ${darkMode ? 'bg-yinmn-blue' : ''}`}
+          className={`${darkMode ? 'bg-yinmn-blue' : `badge-message-background-${props.color}`} ${
+            props.color === 'success' ? 'border-success' : 'border-danger'
+          } border`}
         >
-          <p className={darkMode ? 'text-light' : `badge-message-text-${props.color}`}>
+          <p
+            className={`${
+              props.color === 'success'
+                ? darkMode
+                  ? 'text-success'
+                  : 'text-success'
+                : darkMode
+                ? 'text-danger'
+                : 'text-danger'
+            } font-weight-bold mb-0`}
+          >
             {props.message}
           </p>
         </ModalBody>
         <ModalFooter
-          className={`badge-message-background-${props.color} ${darkMode ? 'bg-space-cadet' : ''}`}
+          className={`${darkMode ? 'bg-space-cadet' : `badge-message-background-${props.color}`} ${
+            props.color === 'success' ? 'border-success' : 'border-danger'
+          } border-top-0`}
         >
           <Button color="secondary" size="sm" onClick={() => props.closeAlert()}>
             OK

--- a/src/components/Badge/BadgeDevelopmentTable.jsx
+++ b/src/components/Badge/BadgeDevelopmentTable.jsx
@@ -273,7 +273,9 @@ function BadgeDevelopmentTable(props) {
         <ModalBody
           className={`badge-message-background-${props.color} ${darkMode ? 'bg-yinmn-blue' : ''}`}
         >
-          <p className={`badge-message-text-${props.color}`}>{props.message}</p>
+          <p className={darkMode ? 'text-light' : `badge-message-text-${props.color}`}>
+            {props.message}
+          </p>
         </ModalBody>
         <ModalFooter
           className={`badge-message-background-${props.color} ${darkMode ? 'bg-space-cadet' : ''}`}


### PR DESCRIPTION
# Description
Badge assignment popup message was not clear in dark mode.

Fixes # (bug list priority high/medium/low x.y.z)
Or Implements # (WBS) 
Fixed the UI to display the message clear in both dark and light mode.

## Related PRS (if any):
To test this frontend PR you need to checkout the development branch for backend

## Main changes explained:
- Modified the styles in the BadgeDevelopmentTable component to display the success and failure message in dark mode.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ Other Links→Badge Management → Badge Assignment tab.
6. verify if the user is able to search name and select a name and assign a badge and click on confirm button.
7. verify if the success/failure popup modal message is clear and visible in both light and dark mode. 

## Screenshots or videos of changes:
**Before:**
![image](https://github.com/user-attachments/assets/dcdeac98-7362-4ac2-bdff-3012eec22e02)

**After/How to test:**
https://www.loom.com/share/8773832eafc948bbb713b7f1642a79c1?sid=537e5b95-89b0-4b87-a166-7b05a62c4978

## Note:
This is not a functional change. It affects only the style of the popup modal.
