### PR TITLE
Strallia: Fix non-interactive tasks list on dashboard in Safari

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -123,7 +123,7 @@ const TeamMemberTask = React.memo(
       <>
         <tr ref={ref} className={`table-row ${darkMode ? "bg-yinmn-blue" : ""}`}  key={user.personId}>
           {/* green if member has met committed hours for the week, red if not */}
-          <td colSpan={1} className={`${darkMode ? "bg-yinmn-blue" : ""}`}>
+          <td colSpan={1}>
             <div style={{ display: 'flex', alignItems: 'center' }}>
               <div className="committed-hours-circle">
                 <FontAwesomeIcon

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -344,32 +344,32 @@ const TeamMemberTask = React.memo(
               ) : (
                 <div className="taking-time-off-content-div">
                   <button
-                    className="compress-time-off-detail-button"
-                    onClick={() => {
-                      setExpandTimeOffIndicator(prev => ({ ...prev, [user.personId]: true }));
-                    }}
-                  >
-                    <FontAwesomeIcon icon={faCompressArrowsAlt} data-testid="icon" />
+                      className="compress-time-off-detail-button"
+                      onClick={() => {
+                        setExpandTimeOffIndicator(prev => ({ ...prev, [user.personId]: true }));
+                      }}
+                    >
+                      <FontAwesomeIcon icon={faCompressArrowsAlt} data-testid="icon" />
                   </button>
-
-                  <span className="taking-time-off-content-text">
-                    {onTimeOff
-                      ? `${user.name} Is Not Available this Week`
-                      : `${user.name} Is Not Available Next Week`}
-                  </span>
-                  <button
-                    type="button"
-                    className="taking-time-off-content-btn"
-                    onClick={() => {
-                      const request = onTimeOff
-                        ? { ...onTimeOff, onVacation: true, name: user.name }
-                        : { ...goingOnTimeOff, onVacation: false, name: user.name };
-
-                      openDetailModal(request);
-                    }}
-                  >
-                    Details ?
-                  </button>
+                  <div className="taking-time-off-content-alignment">
+                    <span className="taking-time-off-content-text">
+                      {onTimeOff
+                        ? `${user.name} Is Not Available this Week`
+                        : `${user.name} Is Not Available Next Week`}
+                    </span>
+                    <button
+                      type="button"
+                      className="taking-time-off-content-btn"
+                      onClick={() => {
+                        const request = onTimeOff
+                          ? { ...onTimeOff, onVacation: true, name: user.name }
+                          : { ...goingOnTimeOff, onVacation: false, name: user.name };
+                        openDetailModal(request);
+                      }}
+                    >
+                      Details ?
+                    </button>
+                  </div>
                 </div>
               ))}
           </td>

--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -156,20 +156,32 @@
 .right-padding-temp-fix {
   padding-right: 0px !important;
 }
+
 .table-row {
-  position: relative;
+  /* These rules serve as a replacement to `position: relative` which 
+  does not work as expected on table elements in Safari */
+  transform: translate(0);
+  clip-path: inset(0);
 }
 
 .taking-time-off-content-div {
   background-color: rgba(0, 0, 25, 0.7);
   position: absolute;
   width: 100%;
-  height: calc(100% - 2px);
+  height: 100%;
   top: 1px;
   left: 0;
   display: flex;
   justify-content: center;
+}
+
+.taking-time-off-content-alignment {
+  display: flex;
   align-items: center;
+  height: min-content;
+  margin-top: 40px;
+  margin-right: 20px;
+  margin-left: 20px;
 }
 
 .taking-time-off-table-div:hover {
@@ -246,6 +258,7 @@
   border: 1px solid white;
   padding: 7px;
   border-radius: 6px;
+  text-wrap: nowrap;
 }
 
 .taking-time-off-content-btn:hover {
@@ -287,7 +300,7 @@
   color: white;
   position: absolute;
   right: 1px;
-  bottom: 1px;
+  top: 1px;
   border: none;
   background-color: transparent;
   border-radius: 5px;
@@ -301,7 +314,7 @@
   color: white;
   position: absolute;
   right: 1px;
-  bottom: 1px;
+  top: 1px;
   background-color: rgba(0, 0, 25, 0.7);
   border-radius: 5px;
 }


### PR DESCRIPTION
# Description

This PR fixes the blacked-out, non-interactive tasks list in Safari.

Before any changes, the overlays showing when a user is taking time off works as expected in Chrome, covering only a single row in the table. But in Safari, the overlay covers the entire table. See reference:
(Safari on right, Chrome left)

https://github.com/user-attachments/assets/d8028439-a8a1-48a8-a6f6-4868de89abef

The issue originates from `position: relative` not working on table elements in Safari, so the absolutely positioned overlay renders incorrectly.

After making changes:
(Safari on right, Chrome left)

https://github.com/user-attachments/assets/d9f4e907-4be2-42a9-a85d-18f3415de4d0

I've tested the changes on Safari version 17.6, Chrome v128.0.6613.138, and Firefox v130.0.1.

## Related PRS (if any):
n/a

## Main changes explained:
- In style.css:
  - Replace use of `position: relative` on table rows with rules that work for both Safari and Chrome
  - Make minor changes to the layout of the overlay's content
- In TeamMemberTask.jsx:
  - Add div with taking-time-off-content-alignment class to re-align content of overlay

## How to test:
1. check into current branch
2. do `npm install` and `npm start` to run this PR locally
3. clear site data/cache
4. open Safari and Chrome
5. login as any user (The user will need to have a team member who has time-off scheduled in the system to test this PR)
6. go to `Dashboard` → `Tasks and Timelogs` pane → `Tasks` tab
7. verify the overlay only covers a single row
8. verify all the buttons in the overlay still work
9. verify the overlay works as expected in both Safari and Chrome

## Screenshots or videos of changes:
(included above)

## Note:
n/a