### PR TITLE
Ambika fix make editing Team name auto-refresh page

### DIFF
--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -403,12 +403,18 @@ class Teams extends React.PureComponent {
         toast.error(postResponse);
       }
     }
-    this.setState({
+
+    this.setState(prevState => ({
+      teams: prevState.teams.map(team => 
+        team.props.teamId === this.state.selectedTeamId
+        ? { ...team, props: { ...team.props, name: name, active: this.state.isActive, teamCode: this.state.selectedTeamCode } }
+        : team
+      ),
       selectedTeamId: undefined,
       selectedTeam: '',
       isEdit: false,
       createNewTeamPopupOpen: false,
-    });
+    }));
   };
   /**
    * callback for deleting a team


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/0053f6b4-5eed-4608-ba48-4e1d77ab3cd0)

Fixes # (bug list priority medium)

## Related PRS (if any):
To test this frontend PR you need to checkout the development branch of backend.

## Main changes explained:
- Update file src/components/Teams/Teams.jsx for updating state of teams

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to other links→ Teams
6. Choose any team and click on edit button of that team
7.  Make changes in name of team and click of Ok button
8. verify that team name is updated in table without refreshing the page
9. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
## Note:
