### PR TITLE
Aditya-Added-Tests-For-Badges

### DIFF
--- a/src/components/UserProfile/__tests__/Badges.test.jsx
+++ b/src/components/UserProfile/__tests__/Badges.test.jsx
@@ -1,12 +1,18 @@
+// Badges.test.jsx
 import React from 'react';
-import Badges from './Badges';
-import { renderWithEnzymeProvider as renderWithProvider } from '../../__tests__/utils';
-import { authMock, userProfileMock, rolesMock } from '../../__tests__/mockStates';
+import Badges from '../Badges';
+import { renderWithEnzymeProvider as renderWithProvider } from '../../../__tests__/utils';
+import { authMock, userProfileMock, rolesMock } from '../../../__tests__/mockStates';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 
-const mockStore = configureStore([thunk]);
+// Mock useLayoutEffect to useEffect to avoid SSR warnings in test environment
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useLayoutEffect: jest.requireActual('react').useEffect,
+}));
 
+const mockStore = configureStore([thunk]);
 
 describe('Badges Component', () => {
   let store;
@@ -14,9 +20,10 @@ describe('Badges Component', () => {
     store = mockStore({
       auth: authMock,
       userProfile: userProfileMock,
-      role: rolesMock.role
+      role: rolesMock.role,
     });
-  })
+  });
+
   const badgeProps = {
     isUserSelf: false,
     userProfile: {
@@ -32,6 +39,7 @@ describe('Badges Component', () => {
     handleSubmit: jest.fn(),
     userPermissions: [],
   };
+
   describe('Card Footer Text', () => {
     describe('When viewing your own profile', () => {
       it('should display the correct text when you have no badges', () => {
@@ -69,9 +77,8 @@ describe('Badges Component', () => {
         const renderedBadges = renderWithProvider(<Badges {...props} />, {
           store,
         });
-        // This uses a regular expression that matches all postive numbers > 1.
         expect(renderedBadges.find('.card-footer').text()).toMatch(
-          /Bravo! You have earned ([1-9]\d+|[2-9]) badges!/,
+          /Bravo! You have earned ([1-9]\d+|[2-9]) badges!/
         );
       });
     });
@@ -87,13 +94,13 @@ describe('Badges Component', () => {
       it('should display the correct text when they have exactly 1 badge', () => {
         const props = {
           ...badgeProps,
-          userProfile: { ...badgeProps.userProfile, badgeCollection: [ { count: 1 }] },
+          userProfile: { ...badgeProps.userProfile, badgeCollection: [{ count: 1 }] },
         };
         const renderedBadges = renderWithProvider(<Badges {...props} />, {
           store,
         });
         expect(renderedBadges.find('.card-footer').text()).toBe(
-          'Bravo! This person has earned 1 badge!',
+          'Bravo! This person has earned 1 badge!'
         );
       });
 
@@ -105,12 +112,11 @@ describe('Badges Component', () => {
             badgeCollection: [{ count: 1 }, { count: 2 }, { count: 3 }],
           },
         };
-
         const renderedBadges = renderWithProvider(<Badges {...props} />, {
           store,
         });
         expect(renderedBadges.find('.card-footer').text()).toMatch(
-          /Bravo! This person has earned ([1-9]\d+|[2-9]) badges!/,
+          /Bravo! This person has earned ([1-9]\d+|[2-9]) badges!/
         );
       });
     });


### PR DESCRIPTION
# Description
This PR introduces unit tests for the `Badges` component to verify the correct display of badge-related messages. These tests ensure that both the number of badges and the context (whether the user is viewing their own profile or another user's profile) are handled accurately.

## Main changes explained:
- **Created** `Badges.test.jsx` to introduce unit tests for the `Badges` component.
- **Mock** Redux store to simulate authentication, user profile, and role states.
- **Implemented** tests for badge display logic, ensuring the component correctly displays:
  - No badges,
  - One badge,
  - Multiple badges,
  - Contextual messages depending on whether the user is viewing their own or another user's profile.

## How to test:
1. Check into the current branch.
2. Run `npm install` to install dependencies.
3. Run `npm test Badges.test.jsx` to execute the unit tests.
4. Verify that all tests pass, and the text for badge displays matches the expected values for each scenario.

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/5827e927-31df-43c3-a814-0952ea479177)

## Note:
Ensure that the badge display logic behaves correctly under different user contexts and badge collection states. Also, check for edge cases like an empty badge collection or large numbers of badges.