### PR TITLE
Added sorting functionality to equipment table

### DIFF
--- a/src/components/BMDashboard/Equipment/List/EquipmentsTable.jsx
+++ b/src/components/BMDashboard/Equipment/List/EquipmentsTable.jsx
@@ -18,8 +18,18 @@ function EquipmentsTable({ equipment, project }) {
   const [recordType, setRecordType] = useState(null);
   const [modal, setModal] = useState(false);
   const [selectedRow, setSelectedRow] = useState(null);
-  const [sortOrder, setSortOrder] = useState({ project: 'asc', itemType: 'asc' });
-  const [iconToDisplay, setIconToDisplay] = useState({ project: faSortUp, itemType: faSortUp });
+  const [sortOrder, setSortOrder] = useState({
+    project: 'asc',
+    itemType: 'asc',
+    rentedOn: 'asc',
+    rentedDue: 'asc',
+  });
+  const [iconToDisplay, setIconToDisplay] = useState({
+    project: faSortUp,
+    itemType: faSortUp,
+    rentedOn: faSortUp,
+    rentedDue: faSortUp,
+  });
   const [equipmentsViewData, setEquipmentsViewData] = useState(null);
 
   useEffect(() => {
@@ -73,6 +83,32 @@ function EquipmentsTable({ equipment, project }) {
         setEquipmentsViewData(_equipmentsViewData);
         break;
       }
+      case 'rentedOn': {
+        setSortOrder({ ...sortOrder, rentedOn: sortOrder.rentedOn === 'asc' ? 'desc' : 'asc' });
+        setIconToDisplay({
+          ...iconToDisplay,
+          rentedOn: iconToDisplay.rentedOn === faSortUp ? faSortDown : faSortUp,
+        });
+        const factor = sortOrder.rentedOn === 'asc' ? 1 : -1;
+        _equipmentsViewData = [..._equipments].sort((a, b) => {
+          return factor * (new Date(b.rentedOnDate) - new Date(a.rentedOnDate));
+        });
+        setEquipmentsViewData(_equipmentsViewData);
+        break;
+      }
+      case 'rentedDue': {
+        setSortOrder({ ...sortOrder, rentedDue: sortOrder.rentedDue === 'asc' ? 'desc' : 'asc' });
+        setIconToDisplay({
+          ...iconToDisplay,
+          rentedDue: iconToDisplay.rentedDue === faSortUp ? faSortDown : faSortUp,
+        });
+        const factor = sortOrder.rentedDue === 'asc' ? 1 : -1;
+        _equipmentsViewData = [..._equipments].sort((a, b) => {
+          return factor * (new Date(b.rentalDueDate) - new Date(a.rentalDueDate));
+        });
+        setEquipmentsViewData(_equipmentsViewData);
+        break;
+      }
       default: {
         break;
       }
@@ -93,7 +129,6 @@ function EquipmentsTable({ equipment, project }) {
       setEquipmentsViewData([...equipments]);
     }
   }, [project]);
-
   useEffect(() => {
     let _equipments;
     if (project.value === '0' && equipment.value === '0') {
@@ -146,8 +181,26 @@ function EquipmentsTable({ equipment, project }) {
               </th>
               <th>Bought</th>
               <th>Rental</th>
-              <th>Rented On</th>
-              <th>Rental Due</th>
+              <th onClick={() => handleSort('rentedOn')}>
+                <div
+                  data-tip={`Sort Rented On ${sortOrder.rentedOn}`}
+                  className="d-flex align-items-stretch cusorpointer"
+                >
+                  <div>Rented On</div>
+                  <FontAwesomeIcon icon={iconToDisplay.rentedOn} size="lg" />
+                </div>
+                <ReactTooltip />
+              </th>
+              <th onClick={() => handleSort('rentedDue')}>
+                <div
+                  data-tip={`Sort Rental Due ${sortOrder.rentedDue}`}
+                  className="d-flex align-items-stretch cusorpointer"
+                >
+                  <div>Rental Due</div>
+                  <FontAwesomeIcon icon={iconToDisplay.rentedDue} size="lg" />
+                </div>
+                <ReactTooltip />
+              </th>
               <th>Updates</th>
               <th>Purchases</th>
             </tr>
@@ -207,5 +260,4 @@ function EquipmentsTable({ equipment, project }) {
     </div>
   );
 }
-
 export default EquipmentsTable;


### PR DESCRIPTION
# Description
This is part of the Phase 2 implementation. Sorting functionality was added to the equipment table under "Rented On" and "Rental Due"

## Related PRS (if any):
This frontend PR is related to the backend development branch.
...
## Main changes explained:
- Added a sorting icon to match the existing sorting icons in the other column headers.
- Sorting functionality added to sort dates under Rented On and Rental Due
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to http://localhost:3000/bmdashboard/equipment
6. verify sorting functionality works under Rented On and Rental Due

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/7c8404da-85ca-4787-b817-b0044195ba7b


