### PR TITLE
Ajay - fix verified the user data and fixed the UI/UX issues of the user list.

### DIFF
--- a/src/components/TeamLocations/ListUsersPopUp.jsx
+++ b/src/components/TeamLocations/ListUsersPopUp.jsx
@@ -1,15 +1,50 @@
+import React, {useState} from 'react';
 import { useSelector } from 'react-redux';
 import { Button, Modal, ModalHeader, ModalFooter, ModalBody } from 'reactstrap';
 import { boxStyle, boxStyleDark } from 'styles';
-import '../Header/DarkMode.css'
+import '../Header/DarkMode.css';
 
 function ListUsersPopUp({ open, onClose, userProfiles, removeUser, setEdit }) {
   const darkMode = useSelector(state => state.theme.darkMode)
+  // State to manage sorting
+  const [sortConfig, setSortConfig] = useState({ key: 'name', direction: 'ascending' });
+
+  // Function to handle sorting
+  const sortedProfiles = [...userProfiles].sort((a, b) => {
+    let aValue = '', bValue = '';
+    
+    // Get sorting values based on the key (name or location)
+    if (sortConfig.key === 'name') {
+      aValue = a.firstName && a.lastName ? `${a.firstName} ${a.lastName}` : a.firstName || a.lastName || '-';
+      bValue = b.firstName && b.lastName ? `${b.firstName} ${b.lastName}` : b.firstName || b.lastName || '-';
+    } else if (sortConfig.key === 'location') {
+      aValue = `${a.location.city ? `${a.location.city}, ` : ''}${a.location.country}`;
+      bValue = `${b.location.city ? `${b.location.city}, ` : ''}${b.location.country}`;
+    }
+  
+    // Convert values to lowercase for case-insensitive comparison
+    aValue = aValue.toLowerCase();
+    bValue = bValue.toLowerCase();
+  
+    if (aValue < bValue) return sortConfig.direction === 'ascending' ? -1 : 1;
+    if (aValue > bValue) return sortConfig.direction === 'ascending' ? 1 : -1;
+    return 0;
+  });
+  
+
+  // Function to handle sorting click
+  const handleSort = key => {
+    let direction = 'ascending';
+    if (sortConfig.key === key && sortConfig.direction === 'ascending') {
+      direction = 'descending';
+    }
+    setSortConfig({ key, direction });
+  };
 
   return (
     <Modal isOpen={open} toggle={onClose} className={`modal-dialog modal-lg ${darkMode ? 'text-light dark-mode' : ''}`}>
       <ModalHeader className={darkMode ? 'bg-space-cadet' : ''} toggle={onClose} cssModule={{ 'modal-title': 'w-100 text-center my-auto pl-2' }}>
-        Add New User Location
+        Users' Location List
       </ModalHeader>
       <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
         <div style={{ maxHeight: '300px', overflow: 'auto', margin: '4px' }}>
@@ -18,13 +53,17 @@ function ListUsersPopUp({ open, onClose, userProfiles, removeUser, setEdit }) {
               <thead>
                 <tr className={darkMode ? 'bg-space-cadet' : ''}>
                   <th style={{ width: '70px' }}>#</th>
-                  <th>Name</th>
-                  <th>Location</th>
+                  <th onClick={() => handleSort('name')} style={{ cursor: 'pointer' }}>
+                    Name {sortConfig.key === 'name' && (sortConfig.direction === 'ascending' ? '▲' : '▼')}
+                  </th>
+                  <th onClick={() => handleSort('location')} style={{ cursor: 'pointer' }}>
+                    Location {sortConfig.key === 'location' && (sortConfig.direction === 'ascending' ? '▲' : '▼')}
+                  </th>
                   <th>Action</th>
                 </tr>
               </thead>
               <tbody>
-                {userProfiles.map((user, index) => {
+                {sortedProfiles.map((user, index) => {
                   let userName = '';
                   if (user.firstName && user.lastName) {
                     userName = `${user.firstName} ${user.lastName}`;

--- a/src/components/TeamLocations/TeamLocations.css
+++ b/src/components/TeamLocations/TeamLocations.css
@@ -12,6 +12,7 @@
   z-index: 10;
   overflow: hidden;
   max-height: 300px;
+  width: auto;
 }
 
 #map-container {

--- a/src/components/TeamLocations/TeamLocations.jsx
+++ b/src/components/TeamLocations/TeamLocations.jsx
@@ -239,7 +239,7 @@ function TeamLocations() {
                 />
               </div>
               {dropdown && (
-                <div className="position-absolute map-dropdown-table w-100">
+                <div className="position-absolute map-dropdown-table">
                   <div
                     className="overflow-auto pr-3"
                     style={{ height: '300px' }}


### PR DESCRIPTION
# Description
This pull request fixes the issue where the Team Locations search results did not display all columns properly by widening the search list box to show all three columns (Name, Email, Location). It also adds sorting functionality to the "User List," allowing users to sort by Name or Location in ascending and descending order. These changes address previously reported usability issues and enhance the overall user experience. Related problems are from previous [PR2276](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2276) and reported search issues on the Team Locations page.

Fixes # (PRIORITY HIGH)  Tatyana → Fix TeamLoc option Search

## Related PRS (if any):
This frontend PR is related to the development backend branch.

## Main changes explained:
- Updated ListUsersPopUp.jsx: Added sorting functionality and state management to allow sorting user profiles by Name/Location.
- Updated TeamLocations.css: Adjusted the table width to auto to ensure all columns are displayed properly.
- Updated TeamLocations.jsx: Removed unnecessary class that was affecting the layout.

## How to test:
1. Check into the current frontend branch and the development backend branch.
2. Do npm install and npm run start:local to run this PR locally.
3. Clear site data/cache.
4. Log in as an owner-user.
5. Go to dashboard→ Reports → Team Locations.
6. Verify that the search bar is working fine by typing a name, and the user list suggestions are rendered properly with the correct width.
7. 
![image](https://github.com/user-attachments/assets/503d2c29-ef46-404f-bac3-6bee96bd0f1c)
9. Next, verify that the User List is working fine by clicking on the User List button beside the search bar and the users' location list is rendered properly.
10. 
![image](https://github.com/user-attachments/assets/640b2af8-07da-4bf5-a4ed-681d0b7c3667)
12. Finally, verify the sorting function is working on the users' location list for name and location by clicking on Name/ Location.
13. 
![image](https://github.com/user-attachments/assets/2226ae3e-2f13-4510-bb83-e1ff84bb2248)