### PR TITLE
Swathi-fix-task-view-and-the-dots-with-initials

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/wbs.css
+++ b/src/components/Projects/WBS/WBSDetail/wbs.css
@@ -40,26 +40,27 @@
 .load {
   position: relative;
 }
-
 .dot {
   height: 24px;
   width: 24px;
   background-color: #bbb;
   border-radius: 50%;
-  display: inline-block;
+  display: flex;
+  justify-content: center; /* Center horizontally */
+  align-items: center;
   font-size: 10px;
   font-weight: 700;
-  text-align: center;
   text-transform: uppercase;
-  padding: 4px 0;
-  margin-top: 3px;
+  
 }
 
 .img-circle {
   border-radius: 50%;
-  border-radius: 50%;
   height: 24px;
   width: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .task-hour {
@@ -85,7 +86,7 @@
 }
 
 .wbsTask {
-  line-height: 28px;
+  line-height: 22px;
 }
 /* Ensured task-action-buttons has a flex display to properly align the buttons */
 .task-action-buttons {
@@ -117,7 +118,9 @@
 }
 
 .table td {
-  padding: 0.45rem;
+  padding: 4px 8px;
+  line-height: 1.2;
+  height: 40px
 }
 
 .taskNum {
@@ -125,8 +128,7 @@
 }
 
 .taskName {
-  width: 300px;
-  height: 80px;
+  height: auto;
 }
 
 .taskDrop {
@@ -140,13 +142,16 @@
 }
 
 .resourceMoreToggle {
-  cursor: pointer;
-  color: white;
-  font-size: 14px;
+  display: flex;
+  justify-content: center; /* Centers horizontally */
+  align-items: center; /* Centers vertically */
+  height: 100%; /* Ensures it takes up the full height of the cell */
 }
 
 .resourceMore {
   display: none;
+  justify-content: center; /* Centers the element horizontally */
+  align-items: center;
 }
 
 .warning {
@@ -190,7 +195,9 @@
   }
 
   .table td {
-    padding: 5px !important;
+    padding: 5px;
+    line-height: 1.2;
+    height: 40px
   }
 }
 
@@ -227,7 +234,7 @@
   padding-left: .25em;
 }
 .tasks-detail-task-name { /* task column height and width changes*/
-  width: 40%; 
+  
   height: auto; 
 }
 


### PR DESCRIPTION
# Description
Fix alignment of task view and the dots with initials

## Related PRS (if any):
This frontend PR is related to the development backend PR.

## Main changes explained:
- Updated `.dot` class in the CSS to ensure initials are centered inside the circle.
- Adjusted row height using `padding` and `line-height` to ensure consistent row sizes across the table.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to Other Links>Projects>Click WBS Icon>Choose WBS>Edit
6. Ensure that the initials in the resource column are centered both horizontally and vertically.
7. Verify that the row height remains consistent and is not affected by the initials' centering.

## Screenshots changes:

Video :  https://www.loom.com/share/46318b96e901490ca23e989a896aca03?sid=7ded15d3-e004-4524-ab42-915c793e0549
Before changes : 
![image](https://github.com/user-attachments/assets/b9c26ace-c4a0-4ad2-93b8-cfa59600e03e)
After :
![UI Change_Task View](https://github.com/user-attachments/assets/e5543fd5-9f31-44d6-bc3b-62b35ed4c188)
