### PR TITLE
pavanswaroop-fixed-hours-section-to-lessen-vertical-space

### DIFF
--- a/src/components/Projects/WBS/SingleTask/SingleTask.js
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.js
@@ -20,14 +20,6 @@ import { getPopupById } from '../../../../actions/popupEditorAction';
 import { TASK_DELETE_POPUP_ID } from '../../../../constants/popupId';
 import { formatDate } from 'utils/formatDate';
 
-const hoursContainerStyle = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr)', // 3 columns in 1 row
-  gap: '1rem', // Spacing between items
-  justifyContent: 'space-between',
-  alignItems: 'center', // Align items vertically to the center
-};
-
 const TINY_MCE_INIT_OPTIONS = 
   {
     license_key: 'gpl',

--- a/src/components/Projects/WBS/SingleTask/SingleTask.js
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.js
@@ -20,6 +20,14 @@ import { getPopupById } from '../../../../actions/popupEditorAction';
 import { TASK_DELETE_POPUP_ID } from '../../../../constants/popupId';
 import { formatDate } from 'utils/formatDate';
 
+const hoursContainerStyle = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)', // 3 columns in 1 row
+  gap: '1rem', // Spacing between items
+  justifyContent: 'space-between',
+  alignItems: 'center', // Align items vertically to the center
+};
+
 const TINY_MCE_INIT_OPTIONS = 
   {
     license_key: 'gpl',
@@ -149,6 +157,7 @@ function SingleTask(props) {
           <tbody className={darkMode ? 'bg-yinmn-blue' : ''}>
             <tr>
               <th scope="row">
+                <div className="d-flex">
                 <EditTaskModal
                   key={`editTask_${task._id}`}
                   parentNum={task.num}
@@ -168,7 +177,7 @@ function SingleTask(props) {
                       <Button
                         type="button"
                         size="sm"
-                        className="btn btn-danger mt-1"
+                        className="btn btn-danger"
                         onClick={() => showUpDeleteModal()}
                         style={darkMode ? boxStyleDark : boxStyle}
                       >
@@ -188,6 +197,7 @@ function SingleTask(props) {
                       />
                     </>
                   )}
+                  </div>
               </th>
               <th scope="row">{task.num}</th>
               <td>{task.taskName}</td>

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -57,6 +57,10 @@ function EditTaskModal(props) {
   const [dateWarning, setDateWarning] = useState(false);
   const [currentMode, setCurrentMode] = useState("");
 
+  const hoursGridStyle = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px', alignItems: 'center',};
+  const inputStyle = { width: '80px', margin: '0 5px', padding: '2px',};
+  const labelStyle = { margin: '0', padding: '0 5px 0 0',};
+
   const res = [...(resourceItems || [])];
   const categoryOptions = [
     { value: 'Unspecified', label: 'Unspecified' },
@@ -455,96 +459,86 @@ function EditTaskModal(props) {
                   Hours
                 </td>
                 <td scope="col" className="w-100">
-                  <div className="py-2 flex-responsive">
-                    <label htmlFor="bestCase" className={`text-nowrap w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
-                      Best-case
-                    </label>
-                    {ReadOnlySectionWrapper(
-                      <input
-                        type="number"
-                        min="0"
-                        max="500"
-                        value={hoursBest}
-                        onChange={e => setHoursBest(e.target.value)}
-                        onBlur={() => calHoursEstimate()}
-                        id="bestCase"
-                        className="m-auto"
-                      />,
-                      editable,
-                      hoursBest,
-                      {componentOnly:true}
-                    )}
-                  </div>
-                  <div className="warning">
-                    {hoursWarning
-                      ? 'The number of hours must be less than other cases'
-                      : ''}
-                  </div>
-                  <div className="py-2 flex-responsive">
-                    <label htmlFor="worstCase" className={`text-nowrap w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
-                      Worst-case
-                    </label>
-                    {ReadOnlySectionWrapper(
-                      <input
-                        type="number"
-                        min={hoursBest}
-                        max="500"
-                        value={hoursWorst}
-                        onChange={e => setHoursWorst(e.target.value)}
-                        onBlur={() => calHoursEstimate('hoursWorst')}
-                        className="m-auto"
-                      />,
-                      editable,
-                      hoursWorst,
-                      {componentOnly:true}
-                    )}
-                  </div>
-                  <div className="warning">
-                    {hoursWarning
-                      ? 'The number of hours must be higher than other cases'
-                      : ''}
-                  </div>
-                  <div className="py-2 flex-responsive">
-                    <label htmlFor="mostCase" className={`text-nowrap w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
-                      Most-case
-                    </label>
-                    {ReadOnlySectionWrapper(
-                      <input
-                        type="number"
-                        min="0"
-                        max="500"
-                        value={hoursMost}
-                        onChange={e => setHoursMost(e.target.value)}
-                        onBlur={() => calHoursEstimate('hoursMost')}
-                        className="m-auto"
-                      />,
-                      editable,
-                      hoursMost,
-                      {componentOnly:true}
-                    )}
-                  </div>
-                  <div className="warning">
-                    {hoursWarning
-                      ? 'The number of hours must range between best and worst cases'
-                      : ''}
-                  </div>
-                  <div className="py-2 flex-responsive">
-                    <label htmlFor="Estimated" className={`text-nowrap w-25 mr-4 ${darkMode ? 'text-light' : ''}`}>
-                      Estimated
-                    </label>
-                    {ReadOnlySectionWrapper(
-                      <input
-                        type="number"
-                        min="0"
-                        max="500"
-                        value={hoursEstimate}
-                        onChange={e => setHoursEstimate(e.target.value)}
-                        className="m-auto"
-                      />,
-                      editable,
-                      hoursEstimate,
-                      {componentOnly:true}
-                    )}
+                  <div style={hoursGridStyle}>
+                    <div>
+                      <label htmlFor="bestCase" style={labelStyle} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
+                        Best-case
+                      </label>
+                      {ReadOnlySectionWrapper(
+                        <input
+                          type="number"
+                          min="0"
+                          max="500"
+                          value={hoursBest}
+                          onChange={e => setHoursBest(e.target.value)}
+                          onBlur={() => calHoursEstimate()}
+                          id="bestCase"
+                          style={inputStyle}
+                        />,
+                        editable,
+                        hoursBest,
+                        { componentOnly: true }
+                      )}
+                      {hoursWarning && <div className="warning">Must be less than others</div>}
+                    </div>
+                    <div>
+                      <label htmlFor="worstCase" style={labelStyle} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
+                        Worst-case
+                      </label>
+                      {ReadOnlySectionWrapper(
+                        <input
+                          type="number"
+                          min={hoursBest}
+                          max="500"
+                          value={hoursWorst}
+                          onChange={e => setHoursWorst(e.target.value)}
+                          onBlur={() => calHoursEstimate('hoursWorst')}
+                          style={inputStyle}
+                        />,
+                        editable,
+                        hoursWorst,
+                        { componentOnly: true }
+                      )}
+                      {hoursWarning && <div className="warning">Must be higher than others</div>}
+                    </div>
+                    <div>
+                      <label htmlFor="mostCase" style={labelStyle} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
+                        Most-case
+                      </label>
+                      {ReadOnlySectionWrapper(
+                        <input
+                          type="number"
+                          min="0"
+                          max="500"
+                          value={hoursMost}
+                          onChange={e => setHoursMost(e.target.value)}
+                          onBlur={() => calHoursEstimate('hoursMost')}
+                          style={inputStyle}
+                        />,
+                        editable,
+                        hoursMost,
+                        { componentOnly: true }
+                      )}
+                      {hoursWarning && <div className="warning">Must be between best and worst</div>}
+                    </div>
+                    <div>
+                      <label htmlFor="Estimated" style={labelStyle} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
+                        Estimated
+                      </label>
+                      {ReadOnlySectionWrapper(
+                        <input
+                          type="number"
+                          min="0"
+                          max="500"
+                          value={hoursEstimate}
+                          onChange={e => setHoursEstimate(e.target.value)}
+                          style={inputStyle}
+                        />,
+                        editable,
+                        hoursEstimate,
+                        { componentOnly: true }
+                      )}
+                    </div>
                   </div>
                 </td>
               </tr>

--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -57,10 +57,6 @@ function EditTaskModal(props) {
   const [dateWarning, setDateWarning] = useState(false);
   const [currentMode, setCurrentMode] = useState("");
 
-  const hoursGridStyle = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px', alignItems: 'center',};
-  const inputStyle = { width: '80px', margin: '0 5px', padding: '2px',};
-  const labelStyle = { margin: '0', padding: '0 5px 0 0',};
-
   const res = [...(resourceItems || [])];
   const categoryOptions = [
     { value: 'Unspecified', label: 'Unspecified' },
@@ -459,86 +455,99 @@ function EditTaskModal(props) {
                   Hours
                 </td>
                 <td scope="col" className="w-100">
-                  <div style={hoursGridStyle}>
-                    <div>
-                      <label htmlFor="bestCase" style={labelStyle} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
-                        Best-case
-                      </label>
-                      {ReadOnlySectionWrapper(
-                        <input
-                          type="number"
-                          min="0"
-                          max="500"
-                          value={hoursBest}
-                          onChange={e => setHoursBest(e.target.value)}
-                          onBlur={() => calHoursEstimate()}
-                          id="bestCase"
-                          style={inputStyle}
-                        />,
-                        editable,
-                        hoursBest,
-                        { componentOnly: true }
-                      )}
-                      {hoursWarning && <div className="warning">Must be less than others</div>}
-                    </div>
-                    <div>
-                      <label htmlFor="worstCase" style={labelStyle} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
-                        Worst-case
-                      </label>
-                      {ReadOnlySectionWrapper(
-                        <input
-                          type="number"
-                          min={hoursBest}
-                          max="500"
-                          value={hoursWorst}
-                          onChange={e => setHoursWorst(e.target.value)}
-                          onBlur={() => calHoursEstimate('hoursWorst')}
-                          style={inputStyle}
-                        />,
-                        editable,
-                        hoursWorst,
-                        { componentOnly: true }
-                      )}
-                      {hoursWarning && <div className="warning">Must be higher than others</div>}
-                    </div>
-                    <div>
-                      <label htmlFor="mostCase" style={labelStyle} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
-                        Most-case
-                      </label>
-                      {ReadOnlySectionWrapper(
-                        <input
-                          type="number"
-                          min="0"
-                          max="500"
-                          value={hoursMost}
-                          onChange={e => setHoursMost(e.target.value)}
-                          onBlur={() => calHoursEstimate('hoursMost')}
-                          style={inputStyle}
-                        />,
-                        editable,
-                        hoursMost,
-                        { componentOnly: true }
-                      )}
-                      {hoursWarning && <div className="warning">Must be between best and worst</div>}
-                    </div>
-                    <div>
-                      <label htmlFor="Estimated" style={labelStyle} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
-                        Estimated
-                      </label>
-                      {ReadOnlySectionWrapper(
-                        <input
-                          type="number"
-                          min="0"
-                          max="500"
-                          value={hoursEstimate}
-                          onChange={e => setHoursEstimate(e.target.value)}
-                          style={inputStyle}
-                        />,
-                        editable,
-                        hoursEstimate,
-                        { componentOnly: true }
-                      )}
-                    </div>
+                  <div className="py-1 flex-responsive">
+                    <label htmlFor="bestCase" style={{ width: '100px', marginRight: '2px' }} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
+                      Best-case
+                    </label>
+                    {ReadOnlySectionWrapper(
+                      <input
+                        type="number"
+                        min="0"
+                        max="500"
+                        value={hoursBest}
+                        onChange={e => setHoursBest(e.target.value)}
+                        onBlur={() => calHoursEstimate()}
+                        id="bestCase"
+                        className="m-auto"
+                      />,
+                      editable,
+                      hoursBest,
+                      {componentOnly:true}
+                    )}
+                  </div>
+                  {hoursWarning && (
+                  <div className="warning mb-3">
+                    {hoursWarning
+                      ? 'The number of hours must be less than other cases'
+                      : ''}
+                  </div>)}
+                  <div className="py-1 flex-responsive">
+                    <label htmlFor="worstCase" style={{ width: '100px', marginRight: '2px' }} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
+                      Worst-case
+                    </label>
+                    {ReadOnlySectionWrapper(
+                      <input
+                        type="number"
+                        min={hoursBest}
+                        max="500"
+                        value={hoursWorst}
+                        onChange={e => setHoursWorst(e.target.value)}
+                        onBlur={() => calHoursEstimate('hoursWorst')}
+                        className="m-auto"
+                      />,
+                      editable,
+                      hoursWorst,
+                      {componentOnly:true}
+                    )}
+                  </div>
+                  {hoursWarning && (
+                  <div className="warning mb-3">
+                    {hoursWarning
+                      ? 'The number of hours must be higher than other cases'
+                      : ''}
+                  </div>)}
+                  <div className="py-1 flex-responsive">
+                    <label htmlFor="mostCase" style={{ width: '100px', marginRight: '2px' }} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
+                      Most-case
+                    </label>
+                    {ReadOnlySectionWrapper(
+                      <input
+                        type="number"
+                        min="0"
+                        max="500"
+                        value={hoursMost}
+                        onChange={e => setHoursMost(e.target.value)}
+                        onBlur={() => calHoursEstimate('hoursMost')}
+                        className="m-auto"
+                      />,
+                      editable,
+                      hoursMost,
+                      {componentOnly:true}
+                    )}
+                  </div>
+                  {hoursWarning && (
+                  <div className="warning mb-3">
+                    {hoursWarning
+                      ? 'The number of hours must range between best and worst cases'
+                      : ''}
+                  </div>)}
+                  <div className="py-1 flex-responsive">
+                    <label htmlFor="Estimated" style={{ width: '100px', marginRight: '2px' }} className={`text-nowrap ${darkMode ? 'text-light' : ''}`}>
+                      Estimated
+                    </label>
+                    {ReadOnlySectionWrapper(
+                      <input
+                        type="number"
+                        min="0"
+                        max="500"
+                        value={hoursEstimate}
+                        onChange={e => setHoursEstimate(e.target.value)}
+                        className="m-auto"
+                      />,
+                      editable,
+                      hoursEstimate,
+                      {componentOnly:true}
+                    )}
                   </div>
                 </td>
               </tr>


### PR DESCRIPTION
# Description
Fix Dashboard>Task>Edit formatting so it takes up way less vertical space

## Related PRS (if any):
This frontend PR is not related to any backend PR.

## Main changes explained:
Modified Hours cases from a vertical alignment to a 2x2 grid with flexible animations

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ select a Task -> Edit -> Hours Section
6. verify functions for Hours modifications.
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/eb0e2093-09b2-4b08-806a-fffc590c4d59

<img width="305" alt="Screenshot 2024-10-04 at 9 21 40 PM" src="https://github.com/user-attachments/assets/ffc954cb-fd27-4138-896e-ca82e1acaf89">

