### PR TITLE
Anirudh - Equipment add page Redirects to equipments page changes

### DIFF
--- a/src/components/BMDashboard/Equipment/Add/AddTypeForm.jsx
+++ b/src/components/BMDashboard/Equipment/Add/AddTypeForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Form, FormGroup, FormFeedback, Label, Input, Button } from 'reactstrap';
 import Joi from 'joi';
 import { toast } from 'react-toastify';
@@ -30,6 +30,13 @@ export default function AddTypeForm() {
   const [fuel, setFuel] = useState(FuelTypes.dies);
   const [errInput, setErrInput] = useState('');
   const [errType, setErrType] = useState('');
+  const [isRedirected, setIsRedirected] = useState(false);
+
+  useEffect(() => {
+    if (isRedirected) {
+      history.push('/bmdashboard/equipment');
+    }
+  }, [isRedirected, history]);
 
   const handleChange = event => {
     setErrInput('');
@@ -55,6 +62,7 @@ export default function AddTypeForm() {
     const response = await addEquipmentType({ name, desc, fuel });
     if (response.status === 201) {
       toast.success('Success: new equipment type added.');
+      setIsRedirected(true);
     } else if (response.status === 409) {
       toast.error(`Error: that type already exists.`);
     } else if (response.status >= 400) {


### PR DESCRIPTION
# Description
![Screen Shot 2024-10-05 at 2 31 27 AM](https://github.com/user-attachments/assets/dc7e6dc1-a9a9-4db1-908a-f93bac085e1b)

## Related PRS (if any):

## Main changes explained:
- Changes to file AddTypeForm.jsx. 
- Upon clicking submit button in Add equipment page (/bmdashboard/equipment/add), the details are saved and the page redirects to the equipments page (/bmdashboard/equipment). 

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in any user
5. go to "/bmdashboard/equipment/add"
6. enter details in the form and submit it. 
7. the page should redirect to "/bmdashboard/equipment"

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/50962eca-3f25-4ef8-9bb6-94cb2e25e9ac
