### PR TITLE
Jingyi_fix_timeoff_indicator_add_tooltip

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -16,6 +16,7 @@ import {
   DropdownItem,
   Spinner,
 } from 'reactstrap';
+import ReactTooltip from 'react-tooltip';
 import Alert from 'reactstrap/lib/Alert';
 import {
   hasLeaderboardPermissions,
@@ -252,12 +253,19 @@ function LeaderBoard({
       sortedRequests.find(request => moment().isBefore(moment(request.endingDate), 'day')) ||
       sortedRequests[0];
 
-    const isCurrentlyOff = moment().isBetween(
-      moment(mostRecentRequest.startingDate),
-      moment(mostRecentRequest.endingDate),
-      null,
-      '[]',
-    );
+    const startOfWeek = moment().startOf('week');
+    const endOfWeek = moment().endOf('week');
+
+    const isCurrentlyOff =
+      moment(mostRecentRequest.startingDate).isBefore(endOfWeek) &&
+      moment(mostRecentRequest.endingDate).isSameOrAfter(startOfWeek);
+
+    // const isCurrentlyOff = moment().isBetween(
+    //   moment(mostRecentRequest.startingDate),
+    //   moment(mostRecentRequest.endingDate),
+    //   null,
+    //   '[]',
+    // );
 
     let additionalWeeks = 0;
     // additional weeks until back
@@ -621,13 +629,18 @@ function LeaderBoard({
                           fontSize: '15px',
                           justifyItems: 'center',
                         }}
-                        title={
-                          isCurrentlyOff
-                            ? `${additionalWeeks} additional weeks off`
-                            : `${additionalWeeks} weeks until next time off`
-                        }
                       >
                         {isCurrentlyOff ? `+${additionalWeeks}` : additionalWeeks}
+                        <i
+                          className="fa fa-info-circle"
+                          style={{ marginLeft: '5px', cursor: 'pointer' }}
+                          data-tip={
+                            isCurrentlyOff
+                              ? `${additionalWeeks} additional weeks off`
+                              : `${additionalWeeks} weeks until next time off`
+                          }
+                        />
+                        <ReactTooltip place="top" type="dark" effect="solid" />
                       </span>
                     )}
                   </th>


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/da61f7fa-c9eb-4df4-9326-f7b730d0a896)
![image](https://github.com/user-attachments/assets/f3693fda-02f0-4dfc-8098-cb3f701d8cd7)

## Related PRS (if any):
This frontend PR is related to the development backend PR.

## Main changes explained:
- Fix calculation logic in Leaderboard.jsx file
- Add a tooltip icon to explain the number

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. login as **different users** in **one team** then schedule the timeoff currently and in the future.
5. Log in as owner/admin/manager user, navigate to the dashboard, and then to the leaderboard section to view the time off indicators.
6. Verify that names are grayed out for users who are currently on time off for the current week, especially on the day before the return day.
![Screenshot 2024-10-04 173454](https://github.com/user-attachments/assets/3f64f7ec-2492-4400-a9a9-f46338562230)
![Screenshot 2024-10-04 173440](https://github.com/user-attachments/assets/53093593-50f9-465d-9a57-2a55fd2aa86c)
7. Click on the icon next to the number to view a tooltip explaining what the number represents.
![Screenshot 2024-10-04 173512](https://github.com/user-attachments/assets/b954dbeb-9d28-445e-9573-d1748ba4c5e0)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/cfdbe3e0-a902-4078-9b7f-152ac0cd83cd