### PR TITLE
Ambika hotfix Owner account should update Password of another account

### DIFF
--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -25,6 +25,7 @@ const UserTableData = React.memo(props => {
   const canAddDeleteEditOwners = props.hasPermission('addDeleteEditOwners');
   const canDeleteUsers = props.hasPermission('deleteUserProfile');
   const resetPasswordStatus = props.hasPermission('resetPassword');
+  const updatePasswordStatus = props.hasPermission('updatePassword');
   const canChangeUserStatus = props.hasPermission('changeUserStatus');
   const toggleDeleteTooltip = () => setTooltipDelete(!tooltipDeleteOpen);
   const togglePauseTooltip = () => setTooltipPause(!tooltipPauseOpen);
@@ -258,7 +259,7 @@ const UserTableData = React.memo(props => {
             </>
           </span>
           <span className="usermanagement-actions-cell">
-            <ResetPasswordButton authEmail={props.authEmail} user={props.user} darkMode={darkMode} isSmallButton canResetPassword={resetPasswordStatus}/>
+            <ResetPasswordButton authEmail={props.authEmail} user={props.user} darkMode={darkMode} isSmallButton canResetPassword={resetPasswordStatus || updatePasswordStatus}/>
           </span>
         </td>
       )}

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -1272,6 +1272,7 @@ function UserProfile(props) {
                   className="mr-1 btn-bottom"
                   user={userProfile}
                   authEmail={authEmail}
+                  canResetPassword={true}
                 />
               )}
               {isUserSelf && (activeTab === '1' || canPutUserProfile) && (
@@ -1401,6 +1402,7 @@ function UserProfile(props) {
                           className="mr-1 btn-bottom"
                           user={userProfile}
                           authEmail={authEmail}
+                          canResetPassword={true}
                         />
                       )}
                       {isUserSelf && (activeTab == '1' || canPutUserProfile) && (


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/16134a00-ea86-4ee3-aec3-3683945aec38)

Fixes # (bug list priority high)

## Related PRS (if any):
N/A

## Main changes explained:
- Update UserProfile.jsx file for ResetPasswordButton with canResetPassword prop as true 

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to Dashboard->Otherlinks->User Management-> Reset Password
6. verify the Owner account is able to change the password from the User Management page.
7. go to Leaderboard->click on account name->update Password
8. verify the Owner account is able to change the password from the Profile page
9. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

## Note:

