### PR TITLE
Deepthi add title with info icon to Teams page

### DIFF
--- a/src/components/Teams/Team.css
+++ b/src/components/Teams/Team.css
@@ -35,9 +35,9 @@ thead {
   text-align: start;
 }
 
-.teams__overview--top {
+/*.teams__overview--top {
   background: gray;
-}
+} */
 
 .teams__overview--top .card {
   width: 200px;

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -124,7 +124,7 @@ class Teams extends React.PureComponent {
                   areaTitle="Teams"
                   fontSize={30}
                   isPermissionPage={true}
-                  role={this.props.state.userProfile.role}
+                  role={this.props.state?.auth?.user?.role}
                 />
               
               <TeamOverview

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -25,6 +25,7 @@ import CreateNewTeamPopup from './CreateNewTeamPopup';
 import DeleteTeamPopup from './DeleteTeamPopup';
 import TeamStatusPopup from './TeamStatusPopup';
 import lo from 'lodash';
+import EditableInfoModal from '../UserProfile/EditableModal/EditableInfoModal';
 
 class Teams extends React.PureComponent {
   constructor(props) {
@@ -116,10 +117,21 @@ class Teams extends React.PureComponent {
           <React.Fragment>
             <div className="container mt-3">
               {this.teampopupElements(allTeams)}
+              <div className="d-flex align-items-center">
+                <h3 style={{ display: 'inline-block', marginRight: 10 }}>Teams</h3>
+                <EditableInfoModal
+                  areaName="teamsInfoModal"
+                  areaTitle="Teams"
+                  fontSize={30}
+                  isPermissionPage={true}
+                  role={this.props.state.userProfile.role}
+                />
+              
               <TeamOverview
                 numberOfTeams={numberOfTeams}
                 numberOfActiveTeams={numberOfActiveTeams}
               />
+              </div>
               <TeamTableSearchPanel
                 onSearch={this.onWildCardSearch}
                 onCreateNewTeamClick={this.onCreateNewTeamShow}


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/e4c3eddc-770d-4ee4-bee0-5c4484dbda16)

…

## Main changes explained:
- Updated Teams page JSX: Added the Teams title and an EditableInfoModal with the info icon next to it.
- Updated Teams page CSS: Commented out the background: gray; rule in the .teams__overview--top class to remove the grey background affecting the Total Teams and Active Teams buttons for a cleaner layout.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ other links→ teams→…
6. verify The Teams title and the info icon are displayed correctly

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/3a79ee92-786c-4726-b189-a37f78c8d917)



