### PR TITLE
Peterson_fix_bug_after_being_clicked_outside_the_modal_is_not_closed

### DIFF
--- a/src/components/Badge/BadgeDevelopment.jsx
+++ b/src/components/Badge/BadgeDevelopment.jsx
@@ -24,7 +24,6 @@ function BadgeDevelopment(props) {
       <Modal
         isOpen={isCreateNewBadgePopupOpen}
         toggle={toggle}
-        backdrop="static"
         className={darkMode ? 'text-light dark-mode' : ''}
       >
         <ModalHeader className={darkMode ? 'bg-space-cadet' : ''} toggle={toggle}>


### PR DESCRIPTION
# Description
This pull request has been opened to fix the bug that prevents the modal from closing when the user clicks outside.

## Related PRS (if any):
None.

## Main changes explained:
The BadgeDevelopment component has been modified to fix the bug.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4.Log in as an administrator or owner.
5. Go to Badge Management.
6. Click on the "Create New Badge" button to open the modal.
7. Click outside the modal, and it should close.

## Screenshots or videos of changes:
![gif](https://github.com/user-attachments/assets/75360118-c587-4814-b77c-16d3a7c1d6c6)

## Note:
None.