### PR TITLE
Rishitha fix purchase request

### DIFF
--- a/src/components/BMDashboard/ItemList/RecordsModal.jsx
+++ b/src/components/BMDashboard/ItemList/RecordsModal.jsx
@@ -82,7 +82,7 @@ export function Record({ record, recordType }) {
           </tr>
         </thead>
         <tbody>
-          {record?.purchaseRecord && record?.purchaseRecord.length ? (
+          {record && record?.length ? (
             record.map(({ _id, date, status, brandPref, priority, quantity, requestedBy }) => {
               return (
                 <tr key={_id}>

--- a/src/components/BMDashboard/PurchaseRequests/PurchaseForm.jsx
+++ b/src/components/BMDashboard/PurchaseRequests/PurchaseForm.jsx
@@ -84,6 +84,7 @@ function PurchaseForm({
       setUnit('');
       setPriority('Low');
       setBrand('');
+      history.push('/bmdashboard/materials');
     } else {
       toast.error(`Error: ${response?.statusText || 'Unknown error'}`);
     }
@@ -209,7 +210,7 @@ function PurchaseForm({
             style={boxStyle}
             disabled={!primaryId || !secondaryId || !quantity || !priority || !!validationError}
           >
-            Submit
+            Purchase Request
           </Button>
         </div>
       </Form>

--- a/src/components/BMDashboard/PurchaseRequests/PurchaseForm.jsx
+++ b/src/components/BMDashboard/PurchaseRequests/PurchaseForm.jsx
@@ -48,6 +48,10 @@ function PurchaseForm({
     setUnit(selectedType ? selectedType.unit : '');
   }, [secondaryId, secondaryData]);
 
+  useEffect(() => {
+    if (validationError) setValidationError('');
+  }, [primaryId, secondaryId, quantity, priority, brand]);
+
   // Form validation logic
   const validateForm = () =>
     Joi.object({


### PR DESCRIPTION
# Description
Fixed material purchase request form to display requests under Purchases in the Materials List and automatically redirect to the Material List upon submission.

<img width="391" alt="image" src="https://github.com/user-attachments/assets/321008da-f853-40b2-a476-6c5f9a5fd0c8">

## Related PRS (if any):
This frontend PR is related to the development backend PR.
…

## Main changes explained:
Updated RecordModal.jsx for displaying material purchase requests under the Purchases section in the Materials List.
Updated PurchaseForm.jsx for implementing automatic redirection to the Material List after a purchase request is submitted and changed button from submit to Purchase Request.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an admin user.
5. Navigate to http://localhost:3000/bmdashboard and log in as an admin again.
6. Go to http://localhost:3000/bmdashboard/materials/purchase
7. Verify that the button is labeled "Purchase Request."
8. Confirm that purchase requests are successfully submitted and that upon successful submission, you are redirected to the Material List at http://localhost:3000/bmdashboard/materials
9. On the Material List page, click "View" under Purchases and ensure that all purchase records are displayed along with the preferred brand (if available).

## Screenshots or videos of changes:
Before:
https://github.com/user-attachments/assets/7e516c94-2172-4460-a918-ee786dc118e1

After:
https://github.com/user-attachments/assets/7c1e8b31-d55f-4bc2-a98a-b2cfca7bff40

## Note:
This is a phase 2 bug.
