### PR TITLE
Crystal fix tasks of members are hidden when teams toggle is off 

### DIFF
--- a/src/components/Teams/InfoModal.jsx
+++ b/src/components/Teams/InfoModal.jsx
@@ -7,7 +7,7 @@ function InfoModal ({ isOpen, toggle }) {
         <ModalHeader toggle={toggle}>Restrict the team member visiblity</ModalHeader>
         <ModalBody>
           <p>
-            By default a user can see all the members on their team. Disable it if you want to restrict the user's visibility and make it so that they cannot see other members on the same team.
+            By default a user can see all the members on their team. Disable it if you want to restrict the user’s visibility and make it so that they cannot see other members on the same team. This toggle does NOT reduce visibility for Owner, Admin or Core Team roles.
           </p>
         </ModalBody>
         <ModalFooter>


### PR DESCRIPTION
# Description
<img width="621" alt="image" src="https://github.com/user-attachments/assets/d7bdf403-9930-4424-8c8f-81375ee5e615">

## Related PRS (if any):
This frontend PR is related to the [crystal-followup-fix-so-tasks-of-members-are-hidden-with-the-teams-toggle](https://github.com/OneCommunityGlobal/HGNRest/pull/1127) backend PR.

## Main changes explained:
- Frontend changes: Updated info modal message
- Backend changes: Implement condition so that users (besides Owner/Admin/Core Team) cannot view team's tasks when their team toggle visibility is off 

## How to test:
1. Check into current branch: `git checkout crystal-followup-fix-so-tasks-of-members-are-hidden-with-the-teams-toggle-frontend`
2. Do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. Log as admin user
5. Go to Dashboard → Other Links → Teams → Select a team -> click on 'i' icon
6. Verify that the 'i' icon message is updated to 
> By default a user can see all the members on their team. Disable it if you want to restrict the user’s visibility and make it so that they cannot see other members on the same team. This toggle does NOT reduce visibility for Owner, Admin or Core Team roles.
7. Verify backend changes: https://github.com/OneCommunityGlobal/HGNRest/pull/1127

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/1c16627f-1098-4e03-93f8-3feb77402057)

https://github.com/user-attachments/assets/ae04c209-6682-477c-a94e-00916a55024b

