### PR TITLE
Strallia: Org Summary Line Chart

### DIFF
--- a/src/actions/totalOrgSummary.js
+++ b/src/actions/totalOrgSummary.js
@@ -28,8 +28,8 @@ export const fetchTotalOrgSummaryReportError = error => ({
   payload: { error },
 });
 
-export const getTotalOrgSummary = (startDate, endDate) => {
-  const url = ENDPOINTS.TOTAL_ORG_SUMMARY(startDate, endDate);
+export const getTotalOrgSummary = (startDate, endDate, comparisionStartDate, comparisionEndDate) => {
+  const url = ENDPOINTS.TOTAL_ORG_SUMMARY(startDate, endDate,comparisionStartDate, comparisionEndDate);
   return async dispatch => {
     dispatch(fetchTotalOrgSummaryReportBegin());
     try {

--- a/src/actions/totalOrgSummary.js
+++ b/src/actions/totalOrgSummary.js
@@ -35,7 +35,7 @@ export const getTotalOrgSummary = (startDate, endDate) => {
     try {
       const response = await axios.get(url);
       dispatch(fetchTotalOrgSummaryReportSuccess(response.data));
-      return {status: response.status, data: response.data};
+      return { status: response.status, data: response.data };
     } catch (error) {
       dispatch(fetchTotalOrgSummaryReportError(error));
       return error.response.status;

--- a/src/components/TotalOrgSummary/DateRangeSelector.jsx
+++ b/src/components/TotalOrgSummary/DateRangeSelector.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import DatePicker from 'react-datepicker';
-import moment from 'moment'; // For date manipulation
+import moment from 'moment';
 import 'react-datepicker/dist/react-datepicker.css';
+import Select from 'react-select';
 
 // Get the start of the current week (Sunday)
 function getStartOfWeek(date) {
@@ -10,20 +11,13 @@ function getStartOfWeek(date) {
     .toDate();
 }
 
-// Get the start and end of last week (Sunday to Saturday)
-// function getLastWeekRange() {
-//   const startOfCurrentWeek = getStartOfWeek(new Date());
-//   const startOfLastWeek = moment(startOfCurrentWeek)
-//     .subtract(7, 'days')
-//     .toDate();
-//   const endOfLastWeek = moment(startOfLastWeek)
-//     .add(6, 'days')
-//     .toDate();
-//   return { startDate: startOfLastWeek, endDate: endOfLastWeek };
-// }
-// filteredData
 function DateRangeSelector({ onDateRangeChange }) {
-  const [selectedOption, setSelectedOption] = useState('Current Week');
+  const options = [
+    { value: 'current', label: 'Current Week (default)' },
+    { value: 'lastweek', label: 'Last Week' },
+    { value: 'custom', label: 'Select Date Range' },
+  ];
+  const [selectedOption, setSelectedOption] = useState(options[0]);
   const [startDate, setStartDate] = useState(getStartOfWeek(new Date()));
   const [endDate, setEndDate] = useState(
     moment()
@@ -37,29 +31,20 @@ function DateRangeSelector({ onDateRangeChange }) {
     onDateRangeChange({ startDate: start, endDate: end });
   };
 
-  // Handle option change (Current Week, Last Week, Custom)
-  const handleOptionChange = ({ target: { value } }) => {
-    setSelectedOption(value);
+  // Handle option change
+  // const handleOptionChange = (selected) => {
+  //   setSelectedOption(selected);
+  // };
 
-    // if (value === 'Current Week') {
-    //   // start date: last sunday
-    //   // end date: last sunday + 6days
-    //   updateDates(
-    //     getStartOfWeek(new Date()),
-    //     moment()
-    //       .endOf('day')
-    //       .toDate(),
-    //   );
-    // } else if (value === 'Last Week') {
-    //   // start date: last to last sunday
-    //   // end date: last to last sunday + 6days
-    //   const { startLastWeek, endLastWeek } = getLastWeekRange();
-    //   updateDates(startLastWeek, endLastWeek);
-    // } else {
-    //   updateDates(null, null);
-    // }
+  const handleOptionChange = selected => {
+    if (!selected) {
+      console.error('No option selected');
+      return;
+    }
 
-    if (value === 'Current Week') {
+    setSelectedOption(selected);
+
+    if (selected.value === 'current') {
       updateDates(
         moment()
           .startOf('week')
@@ -68,7 +53,7 @@ function DateRangeSelector({ onDateRangeChange }) {
           .endOf('week')
           .format('YYYY-MM-DD'),
       );
-    } else if (value === 'Last Week') {
+    } else if (selected.value === 'lastweek') {
       const startLastWeek = moment()
         .subtract(1, 'week')
         .startOf('week')
@@ -93,15 +78,16 @@ function DateRangeSelector({ onDateRangeChange }) {
 
   return (
     <div>
-      <select id="dateRange" value={selectedOption} onChange={handleOptionChange}>
-        <option value="Current Week">Current Week (default)</option>
-        <option value="Last Week">Last Week</option>
-        <option value="Select Date Range">Select Date Range</option>
-      </select>
+      <Select
+        id="dateRange"
+        value={selectedOption}
+        onChange={handleOptionChange}
+        options={options}
+        placeholder="Select..."
+      />
 
-      {selectedOption === 'Select Date Range' && (
-        <div style={{ marginTop: '10px' }}>
-          <label>Date Range: </label>
+      {selectedOption.value === 'custom' && (
+        <div style={{ marginTop: '5px', position: 'absolute' }}>
           <DatePicker
             selected={startDate}
             onChange={handleDateChange}

--- a/src/components/TotalOrgSummary/DateRangeSelector.jsx
+++ b/src/components/TotalOrgSummary/DateRangeSelector.jsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import DatePicker from 'react-datepicker';
+import moment from 'moment'; // For date manipulation
+import 'react-datepicker/dist/react-datepicker.css';
+
+// Get the start of the current week (Sunday)
+function getStartOfWeek(date) {
+  return moment(date)
+    .startOf('week')
+    .toDate();
+}
+
+// Get the start and end of last week (Sunday to Saturday)
+function getLastWeekRange() {
+  const startOfCurrentWeek = getStartOfWeek(new Date());
+  const startOfLastWeek = moment(startOfCurrentWeek)
+    .subtract(7, 'days')
+    .toDate();
+  const endOfLastWeek = moment(startOfLastWeek)
+    .add(6, 'days')
+    .toDate();
+  return { startDate: startOfLastWeek, endDate: endOfLastWeek };
+}
+// filteredData
+function DateRangeSelector({ onDateRangeChange }) {
+  const [selectedOption, setSelectedOption] = useState('Current Week');
+  const [startDate, setStartDate] = useState(getStartOfWeek(new Date()));
+  const [endDate, setEndDate] = useState(
+    moment()
+      .endOf('day')
+      .toDate(),
+  );
+
+  // Update dates and notify parent component
+  const updateDates = (start, end) => {
+    setStartDate(start);
+    setEndDate(end);
+    onDateRangeChange({ startDate: start, endDate: end });
+  };
+
+  // Handle option change (Current Week, Last Week, Custom)
+  const handleOptionChange = ({ target: { value } }) => {
+    // const value = event.target.value;
+    setSelectedOption(value);
+
+    if (value === 'Current Week') {
+      updateDates(
+        getStartOfWeek(new Date()),
+        moment()
+          .endOf('day')
+          .toDate(),
+      );
+    } else if (value === 'Last Week') {
+      const { startLastWeek, endLastWeek } = getLastWeekRange();
+      updateDates(startLastWeek, endLastWeek);
+    } else {
+      updateDates(null, null);
+    }
+  };
+
+  // Update date range when date picker changes
+  const handleDateChange = dates => {
+    const [start, end] = dates;
+    setStartDate(start);
+    setEndDate(end);
+    if (start && end) onDateRangeChange({ startDate: start, endDate: end });
+  };
+
+  return (
+    <div>
+      <select id="dateRange" value={selectedOption} onChange={handleOptionChange}>
+        <option value="Current Week">Current Week (default)</option>
+        <option value="Last Week">Last Week</option>
+        <option value="Select Date Range">Select Date Range</option>
+      </select>
+
+      {selectedOption === 'Select Date Range' && (
+        <div style={{ marginTop: '10px' }}>
+          <label>Date Range: </label>
+          <DatePicker
+            selected={startDate}
+            onChange={handleDateChange}
+            startDate={startDate}
+            endDate={endDate}
+            selectsRange
+            inline
+            dateFormat="MM/dd/yyyy"
+            isClearable
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DateRangeSelector;

--- a/src/components/TotalOrgSummary/DateRangeSelector.jsx
+++ b/src/components/TotalOrgSummary/DateRangeSelector.jsx
@@ -38,7 +38,7 @@ function DateRangeSelector({ onDateRangeChange }) {
 
   const handleOptionChange = selected => {
     if (!selected) {
-      console.error('No option selected');
+      // console.error('No option selected');
       return;
     }
 

--- a/src/components/TotalOrgSummary/DateRangeSelector.jsx
+++ b/src/components/TotalOrgSummary/DateRangeSelector.jsx
@@ -11,16 +11,16 @@ function getStartOfWeek(date) {
 }
 
 // Get the start and end of last week (Sunday to Saturday)
-function getLastWeekRange() {
-  const startOfCurrentWeek = getStartOfWeek(new Date());
-  const startOfLastWeek = moment(startOfCurrentWeek)
-    .subtract(7, 'days')
-    .toDate();
-  const endOfLastWeek = moment(startOfLastWeek)
-    .add(6, 'days')
-    .toDate();
-  return { startDate: startOfLastWeek, endDate: endOfLastWeek };
-}
+// function getLastWeekRange() {
+//   const startOfCurrentWeek = getStartOfWeek(new Date());
+//   const startOfLastWeek = moment(startOfCurrentWeek)
+//     .subtract(7, 'days')
+//     .toDate();
+//   const endOfLastWeek = moment(startOfLastWeek)
+//     .add(6, 'days')
+//     .toDate();
+//   return { startDate: startOfLastWeek, endDate: endOfLastWeek };
+// }
 // filteredData
 function DateRangeSelector({ onDateRangeChange }) {
   const [selectedOption, setSelectedOption] = useState('Current Week');
@@ -31,7 +31,6 @@ function DateRangeSelector({ onDateRangeChange }) {
       .toDate(),
   );
 
-  // Update dates and notify parent component
   const updateDates = (start, end) => {
     setStartDate(start);
     setEndDate(end);
@@ -40,18 +39,44 @@ function DateRangeSelector({ onDateRangeChange }) {
 
   // Handle option change (Current Week, Last Week, Custom)
   const handleOptionChange = ({ target: { value } }) => {
-    // const value = event.target.value;
     setSelectedOption(value);
+
+    // if (value === 'Current Week') {
+    //   // start date: last sunday
+    //   // end date: last sunday + 6days
+    //   updateDates(
+    //     getStartOfWeek(new Date()),
+    //     moment()
+    //       .endOf('day')
+    //       .toDate(),
+    //   );
+    // } else if (value === 'Last Week') {
+    //   // start date: last to last sunday
+    //   // end date: last to last sunday + 6days
+    //   const { startLastWeek, endLastWeek } = getLastWeekRange();
+    //   updateDates(startLastWeek, endLastWeek);
+    // } else {
+    //   updateDates(null, null);
+    // }
 
     if (value === 'Current Week') {
       updateDates(
-        getStartOfWeek(new Date()),
         moment()
-          .endOf('day')
-          .toDate(),
+          .startOf('week')
+          .format('YYYY-MM-DD'),
+        moment()
+          .endOf('week')
+          .format('YYYY-MM-DD'),
       );
     } else if (value === 'Last Week') {
-      const { startLastWeek, endLastWeek } = getLastWeekRange();
+      const startLastWeek = moment()
+        .subtract(1, 'week')
+        .startOf('week')
+        .format('YYYY-MM-DD');
+      const endLastWeek = moment()
+        .subtract(1, 'week')
+        .endOf('week')
+        .format('YYYY-MM-DD');
       updateDates(startLastWeek, endLastWeek);
     } else {
       updateDates(null, null);

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -29,6 +29,7 @@ import HoursWorkList from './HoursWorkList/HoursWorkList';
 import NumbersVolunteerWorked from './NumbersVolunteerWorked/NumbersVolunteerWorked';
 import Loading from '../common/Loading';
 import DateRangeSelector from './DateRangeSelector';
+import VolunteerTrendsByTimeLineChart from './VolunteerTrendsByTimeLineChart/VolunteerTrendsByTimeLineChart';
 
 function calculateFromDate() {
   const currentDate = new Date();
@@ -442,7 +443,7 @@ function TotalOrgSummary(props) {
         <Row>
           <Col lg={{ size: 7 }}>
             <div className="component-container component-border">
-              <VolunteerHoursDistribution />
+              <VolunteerTrendsByTimeLineChart />
             </div>
           </Col>
           <Col lg={{ size: 5 }}>

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -236,7 +236,7 @@ function TotalOrgSummary(props) {
   // }, [selectedDateRange]);
 
   useEffect(() => {
-    props.hasPermission('');
+    // props.hasPermission('');
   }, [selectedDateRange]);
 
   useEffect(() => {
@@ -323,12 +323,12 @@ function TotalOrgSummary(props) {
     <Container
       fluid
       className={`container-total-org-wrapper py-3 mb-5 ${
-        darkMode ? 'bg-oxford-blue text-light' : 'cbg--white-smoke'
+        darkMode ? 'bg-oxford-blue' : 'cbg--white-smoke'
       }`}
     >
       <Row className="d-flex align-items-center justify-content-between">
         <Col xs={12} sm={12} md={4} lg={4} className="d-flex align-items-center mb-sm-3 mb-md-0">
-          <h3 className={darkMode ? 'text-light' : ''}>Weekly Volunteer Summary</h3>
+          <h3>Weekly Volunteer Summary</h3>
         </Col>
 
         <Col
@@ -338,46 +338,22 @@ function TotalOrgSummary(props) {
           lg={8}
           className="d-flex justify-content-end align-items-center mb-0"
         >
-          <div
-            className={darkMode ? 'date-selector-dark' : ''}
-            style={{ marginRight: '15px', width: '214px' }}
-          >
-            <DateRangeSelector
-              onDateRangeChange={handleDateRangeChange}
-              withPortal
-              className="form-control"
-            />
+          <div style={{ marginRight: '15px', width: '250px' }}>
+            <DateRangeSelector onDateRangeChange={handleDateRangeChange} />
           </div>
 
-          <div
-            className={darkMode ? 'select-dark' : ''}
-            style={{ marginRight: '15px', width: '225px' }}
-          >
+          <div style={{ marginRight: '15px', width: '250px' }}>
             <Select
               options={comparisonOptions}
               onChange={handleComparisonPeriodChange}
-              styles={{
-                control: base => ({
-                  ...base,
-                  width: '225px',
-                  height: '40px',
-                }),
-              }}
+              defaultValue={comparisonOptions.find(option => option.value === 'nocomparsion')}
             />
           </div>
 
           <button
             className={darkMode ? 'btn btn-outline-light' : 'btn btn-dark'}
             type="button"
-            style={{
-              borderRadius: '8px',
-              height: '40px',
-              padding: '0 16px',
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              whiteSpace: 'nowrap',
-            }}
+            style={{ whiteSpace: 'nowrap' }}
           >
             Share PDF
           </button>

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -13,6 +13,7 @@ import { getAllUsersTimeEntries } from 'actions/allUsersTimeEntries';
 import { getTimeEntryForOverDate } from 'actions/index';
 import { getTaskAndProjectStats } from 'actions/totalOrgSummary';
 
+// import Select from 'react-select';
 import SkeletonLoading from '../common/SkeletonLoading';
 import '../Header/DarkMode.css';
 import './TotalOrgSummary.css';
@@ -65,7 +66,24 @@ const fromDate = calculateFromDate();
 const toDate = calculateToDate();
 const fromOverDate = calculateFromOverDate();
 const toOverDate = calculateToOverDate();
-
+// const comparisionOptions = [
+//   {
+//     label: 'last week',
+//     value: 'lastweek',
+//   },
+//   {
+//     label: 'Same week last month',
+//     value: 'lastmonth',
+//   },
+//   {
+//     label: 'Same week last year',
+//     value: 'lastyear',
+//   },
+//   {
+//     label: 'Do not show comparision data',
+//     value: 'nocomparision',
+//   },
+// ];
 const aggregateTimeEntries = userTimeEntries => {
   const aggregatedEntries = {};
 
@@ -99,12 +117,21 @@ const aggregateTimeEntries = userTimeEntries => {
 };
 
 function TotalOrgSummary(props) {
+  // const { darkMode, loading, error, allUserProfiles, volunteerstats } = props;
   const { darkMode, loading, error, allUserProfiles } = props;
 
   const [usersId, setUsersId] = useState([]);
   const [usersTimeEntries, setUsersTimeEntries] = useState([]);
   const [usersOverTimeEntries, setUsersOverTimeEntries] = useState([]);
   const [taskProjectHours, setTaskProjectHours] = useState([]);
+  // const [selectedWeek, setDate] = useState({
+  //   startDate: new Date(),
+  //   endDate: new Date(),
+  //   key: 'selection',
+  //   // endDate: new Date().toISOString().split('T')[0],
+  // });
+  // const [comparisionWeek, setComparisionWeek] = useState({ startDate: '', endDate: '' });
+  // console.log(volunteerstats);
 
   const dispatch = useDispatch();
 
@@ -178,6 +205,55 @@ function TotalOrgSummary(props) {
     fetchData();
   }, [fromDate, toDate, fromOverDate, toOverDate]);
 
+  // useEffect(() => {
+  //   props.getTotalOrgSummary(selectedWeek.startDate, selectedWeek.endDate);
+  //   props.hasPermission('');
+  // }, [selectedWeek]);
+
+  // useEffect(() => {
+  //   if (comparisionWeek.startDate !== '') {
+  //     props.getTotalOrgSummary(comparisionWeek.startDate, comparisionWeek.endDate);
+  //   }
+  // }, [comparisionWeek]);
+
+  // this is called on date change and it sets the date range in State
+  // const handleChange = ranges => {
+  //   setDate(ranges.selection);
+  // };
+
+  // sets comparision date based on comparision option and time period selection
+  // const handleComparisionPeriodChange = option => {
+  //   const { startDate, endDate } = selectedWeek;
+  //   const commonStartDate = new Date(startDate);
+  //   const commonEndDate = new Date(endDate);
+  //   switch (option.value) {
+  //     case 'lastweek':
+  //       // Calculate last week's start and end dates
+  //       commonStartDate.setDate(commonStartDate.getDate() - 7 * 2); // Move back 2 weeks
+  //       commonEndDate.setDate(commonEndDate.getDate() - 7 * 2); // Move back 2 weeks
+  //       break;
+
+  //     case 'lastmonth':
+  //       // Set dates to last month
+  //       commonStartDate.setMonth(commonStartDate.getMonth() - 1);
+  //       commonEndDate.setMonth(commonEndDate.getMonth() - 1);
+  //       break;
+
+  //     case 'lastyear':
+  //       // Set dates to last year
+  //       commonStartDate.setFullYear(commonStartDate.getFullYear() - 1);
+  //       commonEndDate.setFullYear(commonEndDate.getFullYear() - 1);
+  //       break;
+
+  //     default:
+  //       throw new Error('Invalid option selected');
+  //   }
+  //   setComparisionWeek({
+  //     startDate: commonStartDate.toISOString().split('T')[0],
+  //     endDate: commonEndDate.toISOString().split('T')[0],
+  //   });
+  // };
+
   if (error) {
     return (
       <Container className={`container-wsr-wrapper ${darkMode ? 'bg-oxford-blue' : ''}`}>
@@ -213,8 +289,29 @@ function TotalOrgSummary(props) {
       }`}
     >
       <Row>
-        <Col lg={{ size: 12 }}>
+        <Col lg={{ size: 6 }}>
           <h3 className="mt-3 mb-5">Total Org Summary</h3>
+        </Col>
+        <Col lg={{ size: 2 }}>
+          <h3 className="mt-3 mb-5">
+            {/* <DateRangePicker
+              className="dateRange"
+              ranges={[selectedWeek]}
+              onChangse={handleChange}
+            /> */}
+            {/* DATE SELECTOR COMPONENT GOES HERE */}
+            {/* use selectedWeek to store dates and handleChange to update dates */}
+          </h3>
+        </Col>
+        <Col lg={{ size: 2 }} style={{ paddingTop: '20px' }}>
+          {/* <Select
+            options={comparisionOptions}
+            onChange={option => handleComparisionPeriodChange(option)}
+            default
+          /> */}
+        </Col>
+        <Col lg={{ size: 2 }}>
+          <h3 className="mt-3 mb-5">PDF Button</h3>
         </Col>
       </Row>
       <hr />
@@ -326,11 +423,11 @@ function TotalOrgSummary(props) {
     </Container>
   );
 }
-
+// totalOrgSummary: state.totalOrgSummary,
 const mapStateToProps = state => ({
   error: state.error,
   loading: state.loading,
-  totalOrgSummary: state.totalOrgSummary,
+  volunteerstats: state.totalOrgSummary.volunteerstats,
   role: state.auth.user.role,
   auth: state.auth,
   darkMode: state.theme.darkMode,
@@ -338,10 +435,11 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  getTotalOrgSummary: () => dispatch(getTotalOrgSummary(fromDate, toDate)),
+  // getTotalOrgSummary: () => dispatch(getTotalOrgSummary(fromDate, toDate)),
   getTaskAndProjectStats: () => dispatch(getTaskAndProjectStats(fromDate, toDate)),
   hasPermission: permission => dispatch(hasPermission(permission)),
   getAllUserProfile: () => dispatch(getAllUserProfile()),
+  getTotalOrgSummary: (startDate, endDate) => dispatch(getTotalOrgSummary(startDate, endDate)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TotalOrgSummary);

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
 import { Alert, Col, Container, Row } from 'reactstrap';
-import { MultiSelect } from 'react-multi-select-component';
+// import { MultiSelect } from 'react-multi-select-component';
 
 import 'moment-timezone';
 import moment from 'moment';
@@ -343,7 +343,7 @@ function TotalOrgSummary(props) {
           >
             <DateRangeSelector
               onDateRangeChange={handleDateRangeChange}
-              withPortal={true}
+              withPortal
               className="form-control"
             />
           </div>
@@ -367,6 +367,7 @@ function TotalOrgSummary(props) {
 
           <button
             className={darkMode ? 'btn btn-outline-light' : 'btn btn-dark'}
+            type="button"
             style={{
               borderRadius: '8px',
               height: '40px',

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -326,17 +326,18 @@ function TotalOrgSummary(props) {
         darkMode ? 'bg-oxford-blue text-light' : 'cbg--white-smoke'
       }`}
     >
-      <Row
-        className="d-flex align-items-center justify-content-between"
-        style={{ padding: '0', margin: '0' }}
-      >
-        <Col sm={4} md={4} lg={4} className="d-flex align-items-center">
-          <h3 className={darkMode ? 'text-light' : ''} style={{ margin: '0', padding: '0' }}>
-            Weekly Volunteer Summary
-          </h3>
+      <Row className="d-flex align-items-center justify-content-between">
+        <Col xs={12} sm={12} md={4} lg={4} className="d-flex align-items-center mb-sm-3 mb-md-0">
+          <h3 className={darkMode ? 'text-light' : ''}>Weekly Volunteer Summary</h3>
         </Col>
 
-        <Col sm={8} md={8} lg={8} className="d-flex justify-content-end align-items-center mb-0">
+        <Col
+          xs={12}
+          sm={12}
+          md={8}
+          lg={8}
+          className="d-flex justify-content-end align-items-center mb-0"
+        >
           <div
             className={darkMode ? 'date-selector-dark' : ''}
             style={{ marginRight: '15px', width: '214px' }}

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -2,6 +2,8 @@ import { connect } from 'react-redux';
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
 import { Alert, Col, Container, Row } from 'reactstrap';
+import { MultiSelect } from 'react-multi-select-component';
+
 import 'moment-timezone';
 import moment from 'moment';
 
@@ -27,9 +29,6 @@ import HoursWorkList from './HoursWorkList/HoursWorkList';
 import NumbersVolunteerWorked from './NumbersVolunteerWorked/NumbersVolunteerWorked';
 import Loading from '../common/Loading';
 import DateRangeSelector from './DateRangeSelector';
-
-// This needed delete
-// import mockVolunteerData from './mockVolunteerData';
 
 function calculateFromDate() {
   const currentDate = new Date();
@@ -71,7 +70,7 @@ const fromDate = calculateFromDate();
 const toDate = calculateToDate();
 const fromOverDate = calculateFromOverDate();
 const toOverDate = calculateToOverDate();
-const comparisionOptions = [
+const comparisonOptions = [
   {
     label: 'Week over week',
     value: 'lastweek',
@@ -85,13 +84,11 @@ const comparisionOptions = [
     value: 'lastyear',
   },
   {
-    label: 'Do not show comparision data',
-    value: 'nocomparision',
+    label: 'Do not show comparison data',
+    value: 'nocomparsion',
   },
 ];
-// const selectedComparisionOption = comparisionOptions.find(
-//   option => option.value === 'nocomparision',
-// );
+
 const aggregateTimeEntries = userTimeEntries => {
   const aggregatedEntries = {};
 
@@ -125,21 +122,16 @@ const aggregateTimeEntries = userTimeEntries => {
 };
 
 function TotalOrgSummary(props) {
-  // volunteerstats
+  // const [comparisonOptions,setcomparisonOptions] = useState(option[0]);
+
   const { darkMode, loading, error, allUserProfiles } = props;
 
   const [usersId, setUsersId] = useState([]);
   const [usersTimeEntries, setUsersTimeEntries] = useState([]);
   const [usersOverTimeEntries, setUsersOverTimeEntries] = useState([]);
   const [taskProjectHours, setTaskProjectHours] = useState([]);
-  // const [selectedWeek, setDate] = useState({
-  //   startDate: new Date(),
-  //   endDate: new Date(),
-  //   key: 'selection',
-  //   // endDate: new Date().toISOString().split('T')[0],
-  // });
-  const [comparisionWeek, setComparisionWeek] = useState({ startDate: null, endDate: null });
-  // console.log(volunteerstats);
+
+  const [comparisonWeek, setComparisonWeek] = useState({ startDate: null, endDate: null });
 
   const dispatch = useDispatch();
 
@@ -155,31 +147,14 @@ function TotalOrgSummary(props) {
       .format('YYYY-MM-DD'),
   });
 
-  // const [filteredData, setFilteredData] = useState([]);
-
   const handleDateRangeChange = ({ startDate, endDate }) => {
+    // console.log('Selected Date Range:', startDate, endDate);
+
     setSelectedDateRange({
       startDate: moment(startDate).format('YYYY-MM-DD'),
       endDate: moment(endDate).format('YYYY-MM-DD'),
     });
   };
-
-  // Filter the mock volunteer data based on the selected date range
-  // useEffect(() => {
-  //   if (selectedDateRange.startDate && selectedDateRange.endDate) {
-  //     const startDate = moment(selectedDateRange.startDate);
-  //     const endDate = moment(selectedDateRange.endDate);
-
-  //     const filtered = mockVolunteerData.filter(volunteer => {
-  //       const volunteerDate = moment(volunteer.date);
-  //       return volunteerDate.isBetween(startDate, endDate, null, '[]');
-  //     });
-
-  //     setFilteredData(filtered);
-  //   } else {
-  //     setFilteredData(mockVolunteerData);
-  //   }
-  // }, [selectedDateRange]);
 
   useEffect(() => {
     dispatch(getAllUserProfile());
@@ -229,6 +204,7 @@ function TotalOrgSummary(props) {
         });
     }
   }, [allUsersTimeEntries, usersId, fromOverDate, toOverDate]);
+
   useEffect(() => {
     async function fetchData() {
       const { taskHours, projectHours } = await props.getTaskAndProjectStats(fromDate, toDate);
@@ -249,81 +225,70 @@ function TotalOrgSummary(props) {
     fetchData();
   }, [fromDate, toDate, fromOverDate, toOverDate]);
 
+  // useEffect(() => {
+  //   props.getTotalOrgSummary(
+  //     selectedDateRange.startDate,
+  //     selectedDateRange.endDate,
+  //     comparisionWeek.startDate,
+  //     comparisionWeek.endDate,
+  //   );
+  //   props.hasPermission('');
+  // }, [selectedDateRange]);
+
   useEffect(() => {
-    props.getTotalOrgSummary(
-      selectedDateRange.startDate,
-      selectedDateRange.endDate,
-      comparisionWeek.startDate,
-      comparisionWeek.endDate,
-    );
     props.hasPermission('');
   }, [selectedDateRange]);
 
   useEffect(() => {
-    if (comparisionWeek.startDate !== null) {
-      props.getTotalOrgSummary(
-        selectedDateRange.startDate,
-        selectedDateRange.endDate,
-        comparisionWeek.startDate,
-        comparisionWeek.endDate,
-      );
-    }
-  }, [comparisionWeek]);
+    // console.log('API Call Params:', {
+    //   startDate: selectedDateRange.startDate,
+    //   endDate: selectedDateRange.endDate,
+    //   comparisonStartDate: comparisonWeek.startDate,
+    //   comparisonEndDate: comparisonWeek.endDate,
+    // });
 
-  // this is called on date change and it sets the date range in State
-  // const handleChange = ranges => {
-  //   setDate(ranges.selection);
-  // };
+    // if (comparisonWeek.startDate && comparisonWeek.endDate) {
 
-  // sets comparision date based on comparision option and time period selection
-  const handleComparisionPeriodChange = option => {
+    // }
+    props.getTotalOrgSummary(
+      selectedDateRange.startDate,
+      selectedDateRange.endDate,
+      comparisonWeek.startDate,
+      comparisonWeek.endDate,
+    );
+  }, [selectedDateRange, comparisonWeek]);
+
+  const handleComparisonPeriodChange = option => {
     const { startDate, endDate } = selectedDateRange;
-    // console.log(selectedDateRange);
-    let commonStartDate = new Date(startDate);
-    let commonEndDate = new Date(endDate);
+    let commonStartDate = moment(startDate);
+    let commonEndDate = moment(endDate);
 
     switch (option.value) {
-      case 'lastweek ':
-        // Calculate last week's start and end dates
-        commonStartDate = moment(startDate)
-          .subtract(1, 'week')
-          .startOf('week'); // Last week's start
-        commonEndDate = moment(endDate)
-          .subtract(1, 'week')
-          .endOf('week'); // Last week's end
+      case 'lastweek':
+        commonStartDate = commonStartDate.subtract(1, 'week').startOf('week');
+        commonEndDate = commonEndDate.subtract(1, 'week').endOf('week');
         break;
-
       case 'lastmonth':
-        // Calculate the entire last month's start and end dates
-        commonStartDate = moment(startDate).subtract(1, 'month');
-        commonEndDate = moment(endDate).subtract(1, 'month');
+        commonStartDate = commonStartDate.subtract(1, 'month').startOf('month');
+        commonEndDate = commonEndDate.subtract(1, 'month').endOf('month');
         break;
-
       case 'lastyear':
-        // Calculate last year's same date range
-        commonStartDate = moment(startDate).subtract(1, 'year');
-        commonEndDate = moment(endDate).subtract(1, 'year');
+        commonStartDate = commonStartDate.subtract(1, 'year').startOf('year');
+        commonEndDate = commonEndDate.subtract(1, 'year').endOf('year');
         break;
-
-      case 'nocomparision':
+      case 'nocomparison':
       default:
-        // If no comparison, set comparison dates to null
-        setComparisionWeek({ startDate: null, endDate: null });
+        setComparisonWeek({ startDate: null, endDate: null });
         return;
     }
 
-    // Set the calculated comparison week with the correct format
-    setComparisionWeek({
+    setComparisonWeek({
       startDate: commonStartDate.format('YYYY-MM-DD'),
       endDate: commonEndDate.format('YYYY-MM-DD'),
     });
-
-    // console.log(commonStartDate.format('YYYY-MM-DD'));
-    // console.log(commonEndDate.format('YYYY-MM-DD'));
-
-    // setComparisionWeek({
-    //   startDate: moment(commonStartDate).format('YYYY-MM-DD'),
-    //   endDate: moment(commonEndDate).format('YYYY-MM-DD'),
+    // console.log('Comparison Week Set:', {
+    //   startDate: commonStartDate.format('YYYY-MM-DD'),
+    //   endDate: commonEndDate.format('YYYY-MM-DD'),
     // });
   };
 
@@ -361,65 +326,62 @@ function TotalOrgSummary(props) {
         darkMode ? 'bg-oxford-blue text-light' : 'cbg--white-smoke'
       }`}
     >
-      <Row>
-        <Col sm={4} md={4} lg={4}>
-          <h3 className="mt-3 mb-5">Total Org Summary</h3>
-        </Col>
-        <Col sm={4} md={4} lg={4}>
-          <h3 className="mt-3 mb-5">
-            <DateRangeSelector onDateRangeChange={handleDateRangeChange} />
+      <Row
+        className="d-flex align-items-center justify-content-between"
+        style={{ padding: '0', margin: '0' }}
+      >
+        <Col sm={4} md={4} lg={4} className="d-flex align-items-center">
+          <h3 className={darkMode ? 'text-light' : ''} style={{ margin: '0', padding: '0' }}>
+            Weekly Volunteer Summary
           </h3>
         </Col>
-        <Col sm={2} md={2} lg={2} style={{ paddingTop: '20px' }}>
-          <Select
-            options={comparisionOptions}
-            onChange={option => handleComparisionPeriodChange(option)}
-            default
-          />
-        </Col>
-        <Col sm={2} md={2} lg={2}>
-          <h3 className="mt-3 mb-5">PDF Button</h3>
+
+        <Col sm={8} md={8} lg={8} className="d-flex justify-content-end align-items-center mb-0">
+          <div
+            className={darkMode ? 'date-selector-dark' : ''}
+            style={{ marginRight: '15px', width: '214px' }}
+          >
+            <DateRangeSelector
+              onDateRangeChange={handleDateRangeChange}
+              withPortal={true}
+              className="form-control"
+            />
+          </div>
+
+          <div
+            className={darkMode ? 'select-dark' : ''}
+            style={{ marginRight: '15px', width: '225px' }}
+          >
+            <Select
+              options={comparisonOptions}
+              onChange={handleComparisonPeriodChange}
+              styles={{
+                control: base => ({
+                  ...base,
+                  width: '225px',
+                  height: '40px',
+                }),
+              }}
+            />
+          </div>
+
+          <button
+            className={darkMode ? 'btn btn-outline-light' : 'btn btn-dark'}
+            style={{
+              borderRadius: '8px',
+              height: '40px',
+              padding: '0 16px',
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Share PDF
+          </button>
         </Col>
       </Row>
 
-      {/* Date Range Selector Component */}
-      {/* <Row>
-        <Col lg={12}>
-          <DateRangeSelector onDateRangeChange={handleDateRangeChange} />
-        </Col>
-      </Row> */}
-
-      <hr />
-
-      {/* Display filtered volunteer data */}
-      {/* <Row>
-        <Col lg={12}>
-          {filteredData.length === 0 ? (
-            <Alert color="warning">No data available for the selected date range.</Alert>
-          ) : (
-            <table className="table table-striped">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Hours Worked</th>
-                  <th>Tasks Completed</th>
-                  <th>Date</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredData.map(volunteer => (
-                  <tr key={volunteer.name + volunteer.date}>
-                    <td>{volunteer.name}</td>
-                    <td>{volunteer.hoursWorked}</td>
-                    <td>{volunteer.tasksCompleted}</td>
-                    <td>{volunteer.date}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-        </Col>
-      </Row> */}
       <hr />
       <AccordianWrapper title="Volunteer Status">
         <Row>
@@ -529,7 +491,7 @@ function TotalOrgSummary(props) {
     </Container>
   );
 }
-// totalOrgSummary: state.totalOrgSummary,
+
 const mapStateToProps = state => ({
   error: state.error,
   loading: state.loading,
@@ -545,8 +507,8 @@ const mapDispatchToProps = dispatch => ({
   getTaskAndProjectStats: () => dispatch(getTaskAndProjectStats(fromDate, toDate)),
   hasPermission: permission => dispatch(hasPermission(permission)),
   getAllUserProfile: () => dispatch(getAllUserProfile()),
-  getTotalOrgSummary: (startDate, endDate, comparisionStartDate, comparisionEndDate) =>
-    dispatch(getTotalOrgSummary(startDate, endDate, comparisionStartDate, comparisionEndDate)),
+  getTotalOrgSummary: (startDate, endDate, comparisonStartDate, comparisonEndDate) =>
+    dispatch(getTotalOrgSummary(startDate, endDate, comparisonStartDate, comparisonEndDate)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TotalOrgSummary);

--- a/src/components/TotalOrgSummary/VolunteerTrendsByTimeLineChart/VolunteerTrendsByTimeLineChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerTrendsByTimeLineChart/VolunteerTrendsByTimeLineChart.jsx
@@ -1,0 +1,56 @@
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts';
+
+const testData = [
+  { xLabel: 'Jan', totalVolunteers: 100 },
+  { xLabel: 'Feb', totalVolunteers: 500 },
+  { xLabel: 'Mar', totalVolunteers: 300 },
+  { xLabel: 'Apr', totalVolunteers: 1000 },
+];
+
+export default function VolunteerTrendsByTimeLineChart() {
+  const latestNumberOfVolunteers = testData[testData.length - 1].totalVolunteers;
+
+  const formatNumber = number => {
+    // Add comma every third digit (e.g. makes 1000 a 1,000)
+    return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  };
+
+  const renderCustomDot = props => {
+    // Highlight and show value of last dot on the line
+    const { cx, cy, index } = props;
+    const isLastPoint = index === testData.length - 1;
+    const formattedNumber = formatNumber(latestNumberOfVolunteers);
+    if (isLastPoint) {
+      return (
+        <>
+          <circle cx={cx} cy={cy} r={24} fill="rgba(0, 0, 0, 0.1)" />
+          <circle cx={cx} cy={cy} r={6} fill="black" />
+          <text x={cx} y={cy - 30} fill="black" textAnchor="middle" fontWeight={600} fontSize={16}>
+            {formattedNumber}
+          </text>
+        </>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div style={{ display: 'grid', justifyContent: 'center', textAlign: 'center' }}>
+      <h5>Volunteer Trends by Time</h5>
+      <LineChart width={600} height={350} data={testData} margin={{ right: 50, top: 50, left: 20 }}>
+        <CartesianGrid stroke="#ccc" vertical={false} />
+        <XAxis dataKey="xLabel" axisLine={false} tickLine={false} />
+        <YAxis tickFormatter={formatNumber} axisLine={false} tickLine={false} />
+        <Line
+          type="linear"
+          dataKey="totalVolunteers"
+          stroke="#328D1B"
+          strokeWidth={4}
+          dot={renderCustomDot}
+          strokeLinecap="round"
+        />
+        <Tooltip />
+      </LineChart>
+    </div>
+  );
+}

--- a/src/components/TotalOrgSummary/mockVolunteerData.js
+++ b/src/components/TotalOrgSummary/mockVolunteerData.js
@@ -1,4 +1,12 @@
 const mockVolunteerData = [
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-24' },
+
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-23' },
+
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-22' },
+
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-21' },
+
   { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-20' },
 
   { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-19' },

--- a/src/components/TotalOrgSummary/mockVolunteerData.js
+++ b/src/components/TotalOrgSummary/mockVolunteerData.js
@@ -1,0 +1,50 @@
+const mockVolunteerData = [
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-20' },
+
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-19' },
+
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-18' },
+
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-17' },
+
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-16' },
+
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-15' },
+
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-14' },
+
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-13' },
+  { name: 'John Doe', hoursWorked: 15, tasksCompleted: 3, date: '2024-09-12' },
+
+  { name: 'Jane Smith', hoursWorked: 20, tasksCompleted: 5, date: '2024-09-11' },
+  { name: 'Sam Wilson', hoursWorked: 12, tasksCompleted: 2, date: '2024-09-10' },
+  { name: 'Alex Johnson', hoursWorked: 18, tasksCompleted: 4, date: '2024-09-09' },
+  { name: 'Chris Lee', hoursWorked: 10, tasksCompleted: 1, date: '2024-09-08' },
+  { name: 'Patricia Wong', hoursWorked: 25, tasksCompleted: 7, date: '2024-09-07' },
+  { name: 'Michael Brown', hoursWorked: 8, tasksCompleted: 2, date: '2024-09-06' },
+  { name: 'Emily Davis', hoursWorked: 16, tasksCompleted: 6, date: '2024-09-05' },
+  { name: 'Daniel Garcia', hoursWorked: 22, tasksCompleted: 3, date: '2024-09-04' },
+  { name: 'Sophia Martinez', hoursWorked: 14, tasksCompleted: 2, date: '2024-09-03' },
+  { name: 'William Taylor', hoursWorked: 9, tasksCompleted: 4, date: '2024-09-02' },
+  { name: 'Isabella Thomas', hoursWorked: 19, tasksCompleted: 5, date: '2024-09-01' },
+  { name: 'James Wilson', hoursWorked: 11, tasksCompleted: 3, date: '2024-08-31' },
+  { name: 'Olivia Moore', hoursWorked: 17, tasksCompleted: 6, date: '2024-08-30' },
+  { name: 'Lucas Clark', hoursWorked: 13, tasksCompleted: 2, date: '2024-08-29' },
+  { name: 'Charlotte Lewis', hoursWorked: 21, tasksCompleted: 4, date: '2024-08-28' },
+  { name: 'Liam Walker', hoursWorked: 24, tasksCompleted: 5, date: '2024-08-27' },
+  { name: 'Mia Young', hoursWorked: 6, tasksCompleted: 1, date: '2024-08-26' },
+  { name: 'Benjamin King', hoursWorked: 23, tasksCompleted: 3, date: '2024-08-25' },
+  { name: 'Emma Scott', hoursWorked: 14, tasksCompleted: 4, date: '2024-08-24' },
+  { name: 'Ethan Green', hoursWorked: 10, tasksCompleted: 2, date: '2024-08-23' },
+  { name: 'Ava Baker', hoursWorked: 7, tasksCompleted: 1, date: '2024-08-22' },
+  { name: 'Noah Adams', hoursWorked: 13, tasksCompleted: 3, date: '2024-08-21' },
+  { name: 'Amelia Nelson', hoursWorked: 5, tasksCompleted: 2, date: '2024-08-20' },
+  { name: 'Mason Carter', hoursWorked: 20, tasksCompleted: 6, date: '2024-08-19' },
+  { name: 'Sophia Reed', hoursWorked: 11, tasksCompleted: 2, date: '2024-08-18' },
+  { name: 'Logan Stewart', hoursWorked: 9, tasksCompleted: 3, date: '2024-08-17' },
+  { name: 'Harper Evans', hoursWorked: 18, tasksCompleted: 5, date: '2024-08-16' },
+  { name: 'Elijah Mitchell', hoursWorked: 14, tasksCompleted: 4, date: '2024-08-15' },
+  { name: 'Ella Rivera', hoursWorked: 15, tasksCompleted: 3, date: '2024-08-14' },
+];
+
+export default mockVolunteerData;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -30,10 +30,10 @@ import { infoCollectionsReducer } from './informationReducer';
 import { weeklySummariesAIPromptReducer } from './weeklySummariesAIPromptReducer';
 import { mouseoverTextReducer } from './mouseoverTextReducer';
 import notificationReducer from './notificationReducer';
-import { weeklySummaryRecipientsReducer } from "./weeklySummaryRecipientsReducer";
-import { followUpReducer } from "./followUpReducer";
+import { weeklySummaryRecipientsReducer } from './weeklySummaryRecipientsReducer';
+import { followUpReducer } from './followUpReducer';
 import { BlueSquareEmailAssignment } from './blueSquareEmailBcc';
-import {userProjectsByUserNameReducer} from './userProjectsByUserNameReducer';
+import { userProjectsByUserNameReducer } from './userProjectsByUserNameReducer';
 
 // bm dashboard
 import { materialsReducer } from './bmdashboard/materialsReducer';
@@ -46,7 +46,7 @@ import { bmInvUnitReducer } from './bmdashboard/inventoryUnitReducer';
 import { consumablesReducer } from './bmdashboard/consumablesReducer';
 import { toolReducer } from './bmdashboard/toolReducer';
 import { equipmentReducer } from './bmdashboard/equipmentReducer';
-import { timeOffRequestsReducer } from "./timeOffRequestReducer";
+import { timeOffRequestsReducer } from './timeOffRequestReducer';
 import { totalOrgSummaryReducer } from './totalOrgSummaryReducer';
 import { allUsersTimeEntriesReducer } from './allUsersTimeEntriesReducer';
 
@@ -73,9 +73,9 @@ const localReducers = {
   ownerMessage: ownerMessageReducer,
   infoCollections: infoCollectionsReducer,
   mouseoverText: mouseoverTextReducer,
-  weeklySummaryRecipients:weeklySummaryRecipientsReducer,
+  weeklySummaryRecipients: weeklySummaryRecipientsReducer,
   notification: notificationReducer,
-  userFollowUp : followUpReducer,
+  userFollowUp: followUpReducer,
   userProjectsByUserNameReducer: userProjectsByUserNameReducer,
   blueSquareEmailAssignment : BlueSquareEmailAssignment,
   totalOrgSummary: totalOrgSummaryReducer,
@@ -93,7 +93,7 @@ const localReducers = {
   bmEquipments: equipmentReducer,
   bmInvUnits: bmInvUnitReducer,
   bmConsumables: consumablesReducer,
-  bmReusables: reusablesReducer
+  bmReusables: reusablesReducer,
 };
 
 const sessionReducers = {

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -68,7 +68,7 @@ export const ENDPOINTS = {
   SAVE_SUMMARY_RECEPIENTS: (userid) => `${APIEndpoint}/reports/recepients/${userid}`,
   GET_SUMMARY_RECEPIENTS: () => `${APIEndpoint}/reports/getrecepients`,
   AUTHORIZE_WEEKLY_SUMMARY_REPORTS: () => `${APIEndpoint}/userProfile/authorizeUser/weeeklySummaries`,
-  TOTAL_ORG_SUMMARY: (startDate, endDate) => `${APIEndpoint}/reports/volunteerstats?startDate=${startDate}&endDate=${endDate}`,
+  TOTAL_ORG_SUMMARY: (startDate, endDate, comparisionStartDate, comparisionEndDate) => `${APIEndpoint}/reports/volunteerstats?startDate=${startDate}&endDate=${endDate}&comparisonStartDate=${comparisionStartDate}&&comparisonEndDate=${comparisionEndDate}`,
   HOURS_TOTAL_ORG_SUMMARY: (startDate,endDate) => `${APIEndpoint}/reports/overviewsummaries/taskandprojectstats?startDate=${startDate}&endDate=${endDate}`,
 
   POPUP_EDITORS: `${APIEndpoint}/popupeditors/`,


### PR DESCRIPTION
# Description
PR for the `Volunteer Trends by Time` line chart component on the `Total Org Summary` page. This component currently uses hard coded data instead of data from the backend.

## Related PRS (if any):
This frontend PR is related to the [#2699 frontend PR](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2699/commits) and  [#1062 backend PR](https://github.com/OneCommunityGlobal/HGNRest/pull/1062).

## Main changes explained:
- Add `VolunteerTrendsByTimeLineChart.jsx` file for the line chart component
- Update `TotalOrgSummary.jsx` to include line chart component

## How to test:
1. check into current branch
2. do `npm install` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Dashboard→ Reports→ Total Org Summary → open the `Volunteer Engagement Trends and Milestone` accordion → view the `Volunteer Trends by Time` chart

## Screenshots or videos of changes:
<img width="1222" alt="Volunteer Engagement Trends and Milestones" src="https://github.com/user-attachments/assets/e9a555a8-90c3-4fd1-858e-a70c5d483455">

## Note:
n/a