### PR TITLE
Ambika - hotfix task done popup on task board issue

### DIFF
--- a/src/components/Teams/Team.css
+++ b/src/components/Teams/Team.css
@@ -131,7 +131,7 @@ tr:hover {
   }
 }
 
-body.modal-open {
+body.open-team-members-popup-modal {
   overflow: hidden;
   position: fixed;
   width: 100%;

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -190,7 +190,7 @@ export const TeamMembersPopup = React.memo(props => {
         toggle={closePopup}
         autoFocus={false}
         size="lg"
-        className={darkMode ? 'dark-mode text-light' : ''}
+        className={`${darkMode ? 'dark-mode text-light' : ''} ${props.open ? ' open-team-members-popup-modal' : ''}`}
       >
         <ModalHeader
           className={darkMode ? 'bg-space-cadet' : ''}


### PR DESCRIPTION
# Description
Hotfix for the task completion popup that was causing the page to scroll to the top, preventing users from staying in their current section on the task board within the dashboard.

Fixes # (bug list priority high)

## Related PRS (if any):
N/A

## Main changes explained:
- The issue arises from CSS modifications made to the modal-open [generic] class in PR #2718.
- Resolved by creating a custom class specifically for the modal when it opens and updating the corresponding CSS file to apply the new class.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Navigate to Dashboard → Tasks → Choose any member and resolve Task by click on the green checkmark → A modal will open, then close.
6. Confirm that the page remains at the previously scrolled position.
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

## Note:

