### PR TITLE
Rishitha - Fix purchase request form for tools

### DIFF
--- a/src/components/BMDashboard/ToolItemList/ToolItemsTable.jsx
+++ b/src/components/BMDashboard/ToolItemList/ToolItemsTable.jsx
@@ -126,14 +126,14 @@ export default function ToolItemsTable({
                     <td>{el.itemType?.name}</td>
                     <td>{el.purchaseStatus === 'Purchased' ? 'Yes' : 'No'}</td>
                     <td>
-                      {el.itemType.using.includes(el._id) ? (
+                      {el.itemType?.using?.includes(el._id) ? (
                         <FontAwesomeIcon icon={faCheck} size="lg" color="green" />
                       ) : (
                         <FontAwesomeIcon icon={faTimes} size="lg" color="red" />
                       )}
                     </td>
                     <td>
-                      {el.itemType.available.includes(el._id) &&
+                      {el.itemType?.available?.includes(el._id) &&
                       el.condition !== 'Lost' &&
                       el.condition !== 'Needs Replacing' ? (
                         <FontAwesomeIcon icon={faCheck} size="lg" color="green" />

--- a/src/components/BMDashboard/ToolPurchaseRequest/PurchaseForm.jsx
+++ b/src/components/BMDashboard/ToolPurchaseRequest/PurchaseForm.jsx
@@ -42,7 +42,7 @@ export default function PurchaseForm() {
 
   const handleSubmit = async e => {
     e.preventDefault();
-    const validate = schema.validate({
+    const { error } = schema.validate({
       projectId,
       toolId,
       quantity,
@@ -51,11 +51,14 @@ export default function PurchaseForm() {
       desc,
       makeModel,
     });
-    // TODO: provide specific validation info to the user
-    if (validate.error) {
-      setValidationError('Invalid form data. Please try again.');
+    if (error) {
+      // Display the first validation error message
+      setValidationError(
+        error.details[0]?.message || 'Invalid form data. Please review your inputs.',
+      );
       return;
     }
+    setValidationError('');
     const body = {
       projectId,
       toolId,
@@ -76,6 +79,7 @@ export default function PurchaseForm() {
 
     if (response.status === 201) {
       toast.success('Success: your purchase request has been logged.');
+      history.push('/bmdashboard/tools');
     } else if (response.status >= 400) {
       toast.error(`Error: ${response.status} ${response.statusText}.`);
     } else toast.warning(`Warning: unexpected status ${response.status}.`);


### PR DESCRIPTION
# Description
Fixed tool purchase request form to display requests under Purchases in the tools List and automatically redirect to the tools List upon submission.

<img width="412" alt="image" src="https://github.com/user-attachments/assets/42867df5-c337-47a3-ad47-edc6235eba58">

## Related PRS (if any):
This frontend PR is related to the development backend PR.
…

## Main changes explained:
Updated ToolItemsTable.jsx for displaying tools purchase requests under the Purchases section in the tools List correctly.
Updated PurchaseForm.jsx for implementing automatic redirection to the tools List after a purchase request is submitted.
…

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. Log in as an admin user.
5. Navigate to http://localhost:3000/bmdashboard and log in as an admin again.
6. Go to http://localhost:3000/bmdashboard/tools/purchase
7. Confirm that purchase requests are successfully submitted and that upon successful submission, you are redirected to the tools List at http://localhost:3000/bmdashboard/tools
8. On the tools List page, click "View" under Purchases and ensure that all purchase records are displayed correctly.

## Screenshots or videos of changes:

Before Changes:
https://github.com/user-attachments/assets/a69d8fdd-5ef9-4fdd-b8ba-612e3b35abe5

After Changes:
https://github.com/user-attachments/assets/7e7de253-2a7c-4029-a93e-cfb737572f41

## Note:
This is a phase 2 bug.
