### PR TITLE
Ambika fix Create new Badge permission in badge management

### DIFF
--- a/src/components/Badge/BadgeDevelopment.jsx
+++ b/src/components/Badge/BadgeDevelopment.jsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
+import { connect } from 'react-redux';
 import { Button, Modal, ModalHeader, ModalBody } from 'reactstrap';
 import { boxStyle, boxStyleDark } from 'styles';
 import BadgeDevelopmentTable from './BadgeDevelopmentTable';
 import CreateNewBadgePopup from './CreateNewBadgePopup';
+import hasPermission from '../../utils/permissions';
 import '../Header/DarkMode.css';
 
 function BadgeDevelopment(props) {
@@ -12,11 +14,14 @@ function BadgeDevelopment(props) {
 
   const toggle = () => setCreateNewBadgePopupOpen(prevIsOpen => !prevIsOpen);
 
+  const canCreateBadge = props.hasPermission('createBadges');
+
   return (
     <div className={darkMode ? 'bg-yinmn-blue text-light' : ''}>
       <Button
         className="btn--dark-sea-green"
         onClick={toggle}
+        disabled={!canCreateBadge}
         style={darkMode ? { ...boxStyleDark, margin: 20 } : { ...boxStyle, margin: 20 }}
       >
         Create New Badge
@@ -39,4 +44,12 @@ function BadgeDevelopment(props) {
   );
 }
 
-export default BadgeDevelopment;
+const mapStateToProps = state => ({
+  darkMode: state.theme.darkMode,
+});
+
+const mapDispatchToProps = dispatch => ({
+  hasPermission: permission => dispatch(hasPermission(permission)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(BadgeDevelopment);

--- a/src/components/Badge/__tests__/BadgeDevelopment.test.js
+++ b/src/components/Badge/__tests__/BadgeDevelopment.test.js
@@ -3,6 +3,7 @@ import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import BadgeDevelopment from '../BadgeDevelopment';
 import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { themeMock } from '__tests__/mockStates';
 
@@ -11,51 +12,62 @@ jest.mock('components/Badge/BadgeDevelopmentTable', () => () => <div>BadgeDevelo
 jest.mock('components/Badge/CreateNewBadgePopup', () => () => <div>CreateNewBadgePopup</div>);
 
 describe('BadgeDevelopment Component', () => {
-  const mockStore = configureStore([]);
-  const initialState = {
-    theme: themeMock,
-  };
-  let store;
-
-  beforeEach(() => {
-    store = mockStore(initialState);
-  });
-
-  it('Should render without crashing', () => {
-    render(
+  const mockStore = configureStore([thunk]);
+ 
+  const renderComponent = () => {
+    const store = mockStore({
+      allProjects: {
+        projects: [],
+      },
+      auth: {
+        isAuthenticated: true,
+        user: {
+          userid: '123',
+          role: 'Owner',
+          firstName: 'John',
+          profilePic: '/path/to/image.jpg',
+          permissions: {
+            frontPermissions: ['updateBadges', 'deleteBadges', 'createBadges'],
+            backPermissions: [],
+          },
+        },
+      },
+      userProfile: {
+        email: 'test@example.com',
+      },
+      taskEditSuggestionCount: 0,
+      role: {
+        roles: ['Owner'],
+      },
+      theme: themeMock,
+    });
+  
+    return render(
       <Provider store={store}>
         <BadgeDevelopment />
       </Provider>,
     );
+  };
+
+  it('Should render without crashing', () => {
+    renderComponent();
     expect(screen.getByText('Create New Badge')).toBeInTheDocument();
   });
 
   it('Should open the create new badge popup when the button is clicked', () => {
-    render(
-      <Provider store={store}>
-        <BadgeDevelopment />
-      </Provider>,
-    );
+    renderComponent();
     fireEvent.click(screen.getByText('Create New Badge'));
     expect(screen.getByText('New Badge')).toBeInTheDocument();
   });
 
   it('should render the BadgeDevelopmentTable component', () => {
-    render(
-      <Provider store={store}>
-        <BadgeDevelopment />
-      </Provider>,
-    );
+    renderComponent();
     const table = document.querySelector('.table');
     expect(table);
   });
 
   it('should close the New Badge popup when the button is clicked', () => {
-    render(
-      <Provider store={store}>
-        <BadgeDevelopment />
-      </Provider>,
-    );
+    renderComponent();
     fireEvent.click(screen.getByText('Create New Badge'));
     expect(screen.getByText('New Badge')).toBeInTheDocument();
     fireEvent.click(screen.getByText('New Badge'));


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/ebb80683-3ee4-45a3-8bac-51f544d69b27)
![image](https://github.com/user-attachments/assets/45bd7b7d-223b-4201-bd31-70a8f195c3bc)

**Bug addressed in this PR is:**
a user does not have 'Create New Badge' permission, the user is still able to create badges. I have shown this in the attached loom.

Loom video: [https://www.loom.com/share/fff6792c51e142488c4a99f09056bc30](https://www.google.com/url?q=https://www.loom.com/share/fff6792c51e142488c4a99f09056bc30&sa=D&source=docs&ust=1728526418031297&usg=AOvVaw1dEezR2btiLZyO2-lzKC78) 

Fixes # (bug list priority medium)

## Related PRS (if any):
To test this frontend PR you need to checkout the development branch of backend PR.

## Main changes explained:
- Update src/components/Badge/BadgeDevelopment.jsx file for adding permission check on button "Create new Badge", permission name is 'createBadges'
- Update src/components/Badge/__tests__/BadgeDevelopment.test.js file test cases by providing user with relevant permission with owner role 

## How to test:
1. check into current branch, git checkout ambika-fix-create-new-badge-permission
2. do npm install and npm run start:local to run this PR locally
3. Clear site data/cache
4. To test this bug you will use two roles, owner and volunteer
5. You can create a new volunteer role if needed
6. Log in as an owner user (a user who has access to the permission management menu).
7. Navigate to Dashboard → Other Links → Permission Management.
8. Click on Manage User Permissions button
9. Search for your user with a volunteer role, grant two permissions, "See badges", "Create Badge" permission.
10. Log in as the volunteer user you just modified.
11. Go to Dashboard → Other Links → Badge Management.
12. Navigate to the Badge Development button and observe the behavior of the Create new badge button.
13. Verify that the Create button is enabled because create badge permission was given
14. Repeat the above steps, this time remove "Create Badge" permission for the volunteer user.
15. Log out as a volunteer user if already logged in
16. Log in again as a volunteer user
17. Verify that the 'Create new badge' button in the Badge Development accurately reflect the permissions granted to the user.
18. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:


## Note:

