### PR TITLE
Yili - Fix Assign/Edit/Delete Blue Squares Permission 

### DIFF
--- a/src/components/UserProfile/BlueSquares/BlueSquare.jsx
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.jsx
@@ -2,13 +2,19 @@ import './BlueSquare.css';
 import hasPermission from 'utils/permissions';
 import { connect } from 'react-redux';
 import { formatCreatedDate, formatDate } from 'utils/formatDate';
+import { useEffect, useState } from 'react';
 
 const BlueSquare = props => {
-  const canAddInfringements = props.hasPermission('addInfringements');
-  const canEditInfringements = props.hasPermission('editInfringements');
-  const canDeleteInfringements = props.hasPermission('deleteInfringements');
+  const [canAddInfringements, setCanAddInfringements] = useState(props.hasPermission('addInfringements'));
+  const [canEditInfringements, setCanEditInfringements] = useState(props.hasPermission('editInfringements'));
+  const [canDeleteInfringements, setDeleteInfringements] = useState(props.hasPermission('deleteInfringements'));
   const isInfringementAuthorizer = canAddInfringements || canEditInfringements || canDeleteInfringements
   const { blueSquares, handleBlueSquare } = props;
+  useEffect(() => {
+  setCanAddInfringements(props.hasPermission('addInfringements', true));
+  setCanEditInfringements(props.hasPermission('editInfringements', true));
+  setDeleteInfringements(props.hasPermission('deleteInfringements', true));
+  }, [props]);
 
   return (
     <div className="blueSquareContainer">

--- a/src/components/UserProfile/BlueSquaresTable/BlueSquaresTable.jsx
+++ b/src/components/UserProfile/BlueSquaresTable/BlueSquaresTable.jsx
@@ -31,11 +31,11 @@ const BlueSquaresTable = ({ userProfile ,canEdit, isPrivate , handleUserProfile 
         )}
       </div>
       {canEdit ? (
-        <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} darkMode={darkMode}/>
+        <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} darkMode={darkMode} userProfile={userProfile}/>
       ) : !isPrivate ? (
         <div className="pl-1">Blue Square Info is Private</div>
       ) : (
-        <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} darkMode={darkMode}/>
+        <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} darkMode={darkMode} userProfile={userProfile}/>
       )}
     </div>
   );

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -60,6 +60,7 @@ import { GiConsoleController } from 'react-icons/gi';
 import { setCurrentUser } from '../../actions/authActions';
 import { getAllTimeOffRequests } from '../../actions/timeOffRequestAction';
 import QuickSetupModal from './QuickSetupModal/QuickSetupModal';
+import { getUserProfile } from '../../actions/userProfile';
 import {
   DEV_ADMIN_ACCOUNT_EMAIL_DEV_ENV_ONLY,
   DEV_ADMIN_ACCOUNT_CUSTOM_WARNING_MESSAGE_DEV_ENV_ONLY,
@@ -168,6 +169,12 @@ function UserProfile(props) {
   useEffect(() => {
     userProfileRef.current = userProfile;
   });
+
+  useEffect(() => {
+    if (userProfile?._id) {
+      dispatch(getUserProfile(userProfile._id));
+    }
+  }, [userProfile]);
 
   useEffect(() => {
     checkIsTeamsEqual();

--- a/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
@@ -46,8 +46,8 @@ const UserProfileModal = props => {
   const darkMode = useSelector(state=>state.theme.darkMode);
 
   const canPutUserProfile = props.hasPermission('putUserProfile');
-  const canEditInfringements = props.hasPermission('editInfringements');
-  const canDeleteInfringements = props.hasPermission('deleteInfringements');
+  const canEditInfringements = props.hasPermission('editInfringements', true);
+  const canDeleteInfringements = props.hasPermission('deleteInfringements', true);
 
   const [linkName, setLinkName] = useState('');
   const [linkURL, setLinkURL] = useState('');


### PR DESCRIPTION
# Description
 
![Fix Assign:Edit:Delete Blue Squares Permissio](https://github.com/user-attachments/assets/cdea15bf-8915-40a7-8e84-d08c04c7fdd8)

## Related PRS (if any):
For backend use development branch

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to > Other Links > Permissions Management > Mange User Permissions > Select a volunteer account > Assign/Edit/Delete Blue Squares > Click on `Submit`
6. log as the volunteer user with the granted permission
7. go to another volunteer's dashboard > view profile > Blue Square
9. Verify the following:
    - The volunteer can see the '+' sign to add a Blue Square.
    - The volunteer can open the option to assign a Blue Square.
    - After creating a new Blue Square and clicking the 'Submit' button, ensure the newly created Blue Square icon remains visible and does not disappear.
    - The volunteer can successfully edit and delete an existing Blue Square.

## Screenshots or videos of changes:


https://github.com/user-attachments/assets/8b3f7efc-60aa-468f-8752-f41553769514
![1](https://github.com/user-attachments/assets/66df57c4-bdd4-4801-b682-94c6f492a7be)
![2](https://github.com/user-attachments/assets/5c2d9ba9-f695-47bf-ba03-317f6e0e3121)


