### PR TITLE
Howie add double confirmation for task link submission 

### DIFF
--- a/src/components/TeamMemberTasks/ReviewButton.jsx
+++ b/src/components/TeamMemberTasks/ReviewButton.jsx
@@ -25,6 +25,7 @@ const ReviewButton = ({
   const [verifyModal, setVerifyModal] = useState(false);
   const [selectedAction, setSelectedAction] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [confirmSubmitModal, setConfirmSubmitModal] = useState(false); // New state for the final confirmation modal
 
   const toggleModal = () => {
     setModal(!modal);
@@ -40,6 +41,10 @@ const ReviewButton = ({
 
   const toggleVerify = () => {
     setVerifyModal(!verifyModal);
+  }
+
+  const toggleConfirmSubmitModal = () => {
+    setConfirmSubmitModal(!confirmSubmitModal); // Toggle for second confirmation modal
   }
 
   const handleLink = (e) => {
@@ -106,6 +111,32 @@ const ReviewButton = ({
     setIsSubmitting(true);
   };
 
+  const submitReviewRequest = (event) => {
+    event.preventDefault();
+    if (validURL(link)) {
+      // Show confirmation modal instead of submitting immediately
+      toggleConfirmSubmitModal();
+    } else {
+      alert('Invalid URL. Please enter a valid URL of at least 20 characters');
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleFinalSubmit = () => {
+    // Submit the review and link after confirming in the second modal
+    updReviewStat("Submitted");
+    toggleConfirmSubmitModal();
+    sendReviewReq();
+  }
+
+  const sendReviewReq = () => {
+    var data = {};
+    data['myUserId'] = myUserId;
+    data['name'] = user.name;
+    data['taskName'] = task.taskName;
+    httpService.post(`${ApiEndpoint}/tasks/reviewreq/${myUserId}`, data);
+  };
+
   const buttonFormat = () => {
     if (user.personId === myUserId && reviewStatus === "Unsubmitted") {
       return <Button className='reviewBtn' color='primary' onClick={toggleModal} style={darkMode ? boxStyleDark : boxStyle} disabled = { isSubmitting }>
@@ -119,20 +150,17 @@ const ReviewButton = ({
               Ready for Review
             </DropdownToggle>
             <DropdownMenu className={darkMode ? 'bg-space-cadet' : ''}>
-            {task.relatedWorkLinks && task.relatedWorkLinks.map((link, index) => (
-              <DropdownItem key={index} href={link} target="_blank" className={darkMode ? 'text-light dark-mode-btn' : ''}>
-                View Link
+              {task.relatedWorkLinks && task.relatedWorkLinks.map((link, index) => (
+                <DropdownItem key={index} href={link} target="_blank" className={darkMode ? 'text-light dark-mode-btn' : ''}>
+                  View Link
+                </DropdownItem>
+              ))}
+              <DropdownItem onClick={() => { setSelectedAction('Complete and Remove'); toggleVerify(); }} className={darkMode ? 'text-light dark-mode-btn' : ''}>
+                <FontAwesomeIcon className="team-member-tasks-done" icon={faCheck} /> as complete and remove task
               </DropdownItem>
-            ))}
-            <DropdownItem onClick={() => { setSelectedAction('Complete and Remove'); toggleVerify(); }} className={darkMode ? 'text-light dark-mode-btn' : ''}>
-              <FontAwesomeIcon
-                className="team-member-tasks-done"
-                icon={faCheck}
-              /> as complete and remove task
-            </DropdownItem>
-            <DropdownItem onClick={() => { setSelectedAction('More Work Needed'); toggleVerify()}} className={darkMode ? 'text-light dark-mode-btn' : ''}>
-              More work needed, reset this button
-            </DropdownItem>
+              <DropdownItem onClick={() => { setSelectedAction('More Work Needed'); toggleVerify() }} className={darkMode ? 'text-light dark-mode-btn' : ''}>
+                More work needed, reset this button
+              </DropdownItem>
             </DropdownMenu>
           </UncontrolledDropdown>
         );
@@ -147,62 +175,32 @@ const ReviewButton = ({
       }
      } else {
       return <></>;
-     }
-    };
-  
-  const sendReviewReq = event => {
-    event.preventDefault();
-    var data = {};
-    data['myUserId'] = myUserId;
-    data['name'] = user.name;
-    data['taskName'] = task.taskName;
-
-    httpService.post(`${ApiEndpoint}/tasks/reviewreq/${myUserId}`, data);
+    }
   };
-
-  const submitReviewRequest = (event) => {
-    // If link is valid, update the review status to submitted and send review request to email
-    if(validURL(link)) {
-      updReviewStat("Submitted");
-      sendReviewReq(event);
-    }
-    else {
-      alert('Invalid URL. Please enter a valid URL of at least 20 characters');
-      setIsSubmitting(false);
-    }
-  }
 
   return (
     <>
-    {/* Verification Modal */}
-    <Modal isOpen={verifyModal} toggle={toggleVerify} className={darkMode ? 'text-light dark-mode' : ''}>
-      <ModalHeader toggle={toggleVerify} className={darkMode ? 'bg-space-cadet' : ''}>
-        {selectedAction === 'Complete and Remove' && 'Are you sure you have completed the review?'}
-        {selectedAction === 'More Work Needed' && 'Are you sure?'}
+      {/* Second Confirmation Modal */}
+      <Modal isOpen={confirmSubmitModal} toggle={toggleConfirmSubmitModal} className={darkMode ? 'text-light dark-mode' : ''}>
+        <ModalHeader toggle={toggleConfirmSubmitModal} className={darkMode ? 'bg-space-cadet' : ''}>
+          Confirm Submission
         </ModalHeader>
-      <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
-      <Button
-            onClick={(e) => {
-              toggleVerify();
-              if (selectedAction === 'More Work Needed') {
-                updReviewStat("Unsubmitted");
-                setIsSubmitting(false);
-              } else if (reviewStatus === "Unsubmitted") {
-                submitReviewRequest(e);
-              } else {
-                updReviewStat("Reviewed");
-              }
-            }}
-            color="primary"
-            className="float-left"
-            style={darkMode ? boxStyleDark : boxStyle}
-          >
-            {reviewStatus === "Unsubmitted"
-              ? `Submit`
-              : `Complete`}
+        <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
+          You are about to submit the following link for review:
+          <div className="mt-2">
+            {/* Hyperlink for the pasted link */}
+            <a href={link} target="_blank" rel="noopener noreferrer">
+              {link}
+            </a>
+          </div>
+          Please confirm if this is the correct link.
+        </ModalBody>
+        <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
+          <Button color="primary" onClick={handleFinalSubmit} style={darkMode ? boxStyleDark : boxStyle}>
+            Confirm and Submit
           </Button>
           <Button
-            onClick={toggleVerify}
+            onClick={toggleConfirmSubmitModal}
             style={darkMode ? boxStyleDark : boxStyle}
           >
             Cancel

--- a/src/components/TeamMemberTasks/ReviewButton.jsx
+++ b/src/components/TeamMemberTasks/ReviewButton.jsx
@@ -187,11 +187,10 @@ const ReviewButton = ({
         </ModalHeader>
         <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
           You are about to submit the following link for review:
-          <div className="mt-2">
-            {/* Hyperlink for the pasted link */}
+          <div className="mt-2" style={{ wordWrap: 'break-word', wordBreak: 'break-all' }}>
             <a href={link} target="_blank" rel="noopener noreferrer">
-              {link}
-            </a>
+                {link}
+              </a>
           </div>
           Please confirm if this is the correct link.
         </ModalBody>
@@ -199,14 +198,12 @@ const ReviewButton = ({
           <Button color="primary" onClick={handleFinalSubmit} style={darkMode ? boxStyleDark : boxStyle}>
             Confirm and Submit
           </Button>
-          <Button
-            onClick={toggleConfirmSubmitModal}
-            style={darkMode ? boxStyleDark : boxStyle}
-          >
+          <Button onClick={toggleConfirmSubmitModal} style={darkMode ? boxStyleDark : boxStyle}>
             Cancel
           </Button>
-      </ModalFooter>
-    </Modal>
+        </ModalFooter>
+      </Modal>
+
 
             {/* Submission Modal */}
       <Modal isOpen={modal} toggle={toggleModal} className={darkMode ? 'text-light dark-mode' : ''}>


### PR DESCRIPTION
# Description
Previously added requirement for a https link with at least 20 characters in the form for a task to be submitted.
There has also now been a second modal added before full submission that allows the user to confirm that the link they are putting in the submission is desired and to reconfirm

## Related PRS (if any):
This frontend PR is related to the #2703 Frontend PR of requiring the link for submission
…

## Main changes explained:
- New confirmSubmitModal State: controls visibility of the second confirmation modal.
- Second Confirmation Modal: Shows the link the user pasted and asks for a final confirmation before submitting
- submitReviewRequest() Update: Instead of submitting directly, it now shows the second confirmation modal.
- handleFinalSubmit(): This handles the final submission after the user confirms in the second modal.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard
6. verify that when submitting a task for completion without a VALID link it blocks you
7. verify that when submitting a task for completion WITH a valid link it asks for you to confirm and shows a working hyperlink to your submission
8. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/4e557700-f604-49c0-9399-1328c843bc57


## Note:
Include the information the reviewers need to know.
