### PR TITLE
Ambika fix reports teams calendar cropping issue

### DIFF
--- a/src/components/Reports/TeamReport/TeamReport.jsx
+++ b/src/components/Reports/TeamReport/TeamReport.jsx
@@ -4,6 +4,7 @@ import { debounce } from 'lodash';
 import { useDispatch, useSelector, connect } from 'react-redux';
 import moment from 'moment';
 import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
 import { FiUsers } from 'react-icons/fi';
 import Dropdown from 'react-bootstrap/Dropdown';
 import axios from 'axios';
@@ -395,7 +396,7 @@ export function TeamReport({ match }) {
                   onChange={event => handleSearchByName(event)}
                 />
               </div>
-              <div className="date-picker-container">
+              <div className={`date-picker-container ${darkMode ? 'dark-mode' : ''}`}>
                 <div id="task_startDate" className="date-picker-item">
                   <div className="d-flex flex-column">
                     {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}

--- a/src/components/Reports/sharedComponents/ReportPage/components/ReportBlock/ReportBlock.css
+++ b/src/components/Reports/sharedComponents/ReportPage/components/ReportBlock/ReportBlock.css
@@ -1,7 +1,6 @@
 .report-block-wrapper {
   border-radius: 12px;
   box-shadow: 0 0 12px #eae1f6;
-  overflow: hidden;
   text-align: center;
 }
 
@@ -13,6 +12,5 @@
 .report-block-wrapper-dark {
   border-radius: 12px;
   box-shadow: 0 0 12px black;
-  overflow: hidden;
   text-align: center;
 }


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/65b16303-bc01-4a43-a920-de1b1d0d9e64)

Fixes # (bug list priority low)

## Related PRS (if any):
To test this frontend PR you need to checkout the development branch of backend.

## Main changes explained:
- Update ReportBlock.css file by removing overflow hidden from wrapper class

## How to test:
1. check into current branch `npm checkout ambika-fix-reports-teams-calendar-cropping`
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ Reports→Teams->choose any team name -> scroll at the bottom
6. verify that the calendars for 'Created After' and 'Modified After' appear not to be cropped
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
After implementation:
![image](https://github.com/user-attachments/assets/40672543-52d4-47e7-9140-4db2b97f2821)
![image](https://github.com/user-attachments/assets/7b2fec78-ca40-4a64-a837-2dcf10a8d6e8)


## Note:

The list of members is not visible in this section because PR #2468 includes a comment that disables the code responsible for displaying the members list.
