### PR TITLE
Ajay - fix date mismatch on reports and user management

### DIFF
--- a/src/components/Reports/PeopleTable.js
+++ b/src/components/Reports/PeopleTable.js
@@ -45,10 +45,10 @@ function PeopleTable({ userProfiles, darkMode }) {
             </div>
           </td>
           <td className={`${darkMode ? 'text-light' : ''}`} style={{ width: '110px' }}>
-            {moment(person.startDate).format('MM-DD-YY')}
+            {moment.utc(person.startDate).format('MM-DD-YY')}
           </td>
           <td className={`${darkMode ? 'text-light' : ''}`} style={{ width: '110px' }}>
-          {person.endDate ? moment(person.endDate).format('MM-DD-YY') : 'N/A'}
+          {person.endDate ? moment.utc(person.endDate).format('MM-DD-YY') : 'N/A'}
           </td>
         </tr>
       ));

--- a/src/components/Reports/PeopleTable.js
+++ b/src/components/Reports/PeopleTable.js
@@ -45,9 +45,11 @@ function PeopleTable({ userProfiles, darkMode }) {
             </div>
           </td>
           <td className={`${darkMode ? 'text-light' : ''}`} style={{ width: '110px' }}>
+            {/* Format the start date in Coordinated Universal Time (UTC) to 'MM-DD-YY' format */}
             {moment.utc(person.startDate).format('MM-DD-YY')}
           </td>
           <td className={`${darkMode ? 'text-light' : ''}`} style={{ width: '110px' }}>
+            {/* If endDate exists, format it in UTC; otherwise, display 'N/A' */}
           {person.endDate ? moment.utc(person.endDate).format('MM-DD-YY') : 'N/A'}
           </td>
         </tr>


### PR DESCRIPTION
# Description
This pull request addresses the one-day difference in start dates between the **user management** page and the **reports** page, particularly affecting accounts with no time logged. We ensure consistent date displays across both pages by using moment.utc() for date formatting and adding explanatory comments about UTC. This fix maintains the use of moment.js to prevent disruptions in other components that rely on it. The added comments clarify the purpose of using UTC, aiding future maintenance and preventing similar issues. To verify the fix worked, I used Python scripts to extract user data from the reports page and compared it with the JSON data.

Fixes # (PRIORITY LOW) Howie: Some accounts have an off by one start date inaccuracy for some reason

## Related PRS (if any):
This frontend PR is related to the [development](https://github.com/OneCommunityGlobal/HGNRest) branch of the backend repository.
…

## Main changes explained:
- Updated **PeopleTable.jsx** to use moment.utc() for date formatting
…

## How to test:
1. Check into the current frontend branch and the development backend branch.
2. Do npm install and npm run start:local to run this PR locally.
3. Clear site data/cache.
4. Log in as an owner-user.
5. Go to Dashboard → Reports → Reports → People.
6. ![image](https://github.com/user-attachments/assets/2748bdb8-43f3-4cd2-bcb7-6aede95ca07c)
7. Open Dashboard → Other Links → User Management [in a new tab].
8. ![image](https://github.com/user-attachments/assets/e70f4547-b631-4284-8792-5c69506c6d8f)
9. Verify the start date matches on both the pages [reports page and the user management page] for the users.
