### PR TITLE
Xiaolu fix the extra spin arrows in Firefox

### DIFF
--- a/src/components/Timer/Countdown.module.css
+++ b/src/components/Timer/Countdown.module.css
@@ -177,6 +177,16 @@
   margin: 0;
 }
 
+/* Remove arrows in number input for Firefox and other browsers */
+input[type='number'] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+/* Hide spin buttons in number input for Firefox */
+input[type='number']::-moz-inner-spin-button {
+  display: none;
+}
+
 .bottom .goal input:focus {
   outline: none;
   box-shadow: none;


### PR DESCRIPTION
# Description
Resolved a display issue in the Firefox browser where extra up and down arrows appeared next to the time numbers in the Initial Goal section of the Timer. This problem did not occur in Chrome, leading to inconsistencies in user experience across different browsers.

## Related PRS (if any):
To test this frontend PR you need to checkout the development branch of backend.

## Main changes explained:
1. Update the Countdown.module.css 

## How to test:
1. Check into current branch
2. Do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. Log In as User and Admin in Firefox
5. Go to the Dashboard →  Timer → Initial Goal
6. Ensure that there are no extra up and down arrows appearing next to the time numbers under the Initial Goal section of the Timer. (feel free to include screenshot here)
7. Verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
Before:
<img width="762" alt="Screenshot 2024-10-18 at 14 31 50" src="https://github.com/user-attachments/assets/448d7f81-b5a3-4d09-85a4-794d3767a871">

After:
![Screenshot 2024-10-18 at 14 30 06](https://github.com/user-attachments/assets/d00fbcdd-921e-4e0b-b64d-8de691f5adaf)

## Note:
Include the information the reviewers need to know.
