### PR TITLE
Jingyi fix add new project load icon

### DIFF
--- a/src/components/Projects/AddProject/AddProject.jsx
+++ b/src/components/Projects/AddProject/AddProject.jsx
@@ -93,6 +93,8 @@ const AddProject = (props) => {
         //assing project to members in member list
         membersList.map((member =>  props.assignProject(projectId, member._id, 'Assign', member.firstName, member.lastName)));
         
+        props.onProjectAdded()
+        
         toggleModal();
         setNewName('');
         setNewCategory('Unspecified');

--- a/src/components/Projects/AddProject/AddProject.jsx
+++ b/src/components/Projects/AddProject/AddProject.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import Select from 'react-select';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import { connect } from 'react-redux';
 import '../../Header/DarkMode.css';
@@ -10,7 +9,7 @@ import { findUserProfiles, assignProject } from './../../../actions/projectMembe
 const AddProject = (props) => {
   const [modal, setModal] = useState(false);
   const [newName, setNewName] = useState('');
-  const [newCategory, setNewCategory] = useState({ value: 'Unspecified', label: 'Select Category' });
+  const [newCategory, setNewCategory] = useState('Unspecified');
   const [showAddButton, setShowAddButton] = useState(false);
   const [wbsName, setWbsName] = useState('');
   const [wbsList, setWbsList] = useState([]);
@@ -23,17 +22,6 @@ const AddProject = (props) => {
   const [lastTimeoutId, setLastTimeoutId] = useState(null); 
   // toggle modal open/close
   const toggleModal = () => setModal(!modal);
-
-  const options = [
-    { value: 'Food', label: 'Food' },
-    { value: 'Energy', label: 'Energy' },
-    { value: 'Housing', label: 'Housing' },
-    { value: 'Education', label: 'Education' },
-    { value: 'Society', label: 'Society' },
-    { value: 'Economics', label: 'Economics' },
-    { value: 'Stewardship', label: 'Stewardship' },
-    { value: 'Other', label: 'Other' }
-  ];
 
   //  project name change and show/hide add button
   const changeNewName = (name) => {
@@ -155,11 +143,22 @@ const AddProject = (props) => {
 
           <div className="form-group">
             <label htmlFor="category" className={darkMode ? "text-light":" "}>Select Category</label>
-            <Select
-            value={newCategory}
-            onChange={setNewCategory}
-            options={options}
-          />
+            <select
+              className="form-control"
+              id="category"
+              value={newCategory}
+              onChange={(e) => setNewCategory(e.target.value)}
+            >
+              <option value="Unspecified">Unspecified</option>
+              <option value="Food">Food</option>
+              <option value="Energy">Energy</option>
+              <option value="Housing">Housing</option>
+              <option value="Education">Education</option>
+              <option value="Society">Society</option>
+              <option value="Economics">Economics</option>
+              <option value="Stewardship">Stewardship</option>
+              <option value="Other">Other</option>
+            </select>
           </div>
 
           {canPostWBS ?

--- a/src/components/Projects/AddProject/AddProject.jsx
+++ b/src/components/Projects/AddProject/AddProject.jsx
@@ -4,11 +4,24 @@
  * This component is used to add more project into the database
  ********************************************************************************/
 import React, { useState } from 'react';
+import Select from 'react-select';
 
 const AddProject = props => {
   const [showAddButton, setShowAddButton] = useState(false);
   const [newName, setNewName] = useState('');
-  const [newCategory, setNewCategory] = useState('Unspecified');
+  const [newCategory, setNewCategory] = useState({ value: 'Unspecified', label: 'Select Category' });
+
+  const options = [
+    { value: 'Unspecified', label: 'Select Category' },
+    { value: 'Food', label: 'Food' },
+    { value: 'Energy', label: 'Energy' },
+    { value: 'Housing', label: 'Housing' },
+    { value: 'Education', label: 'Education' },
+    { value: 'Society', label: 'Society' },
+    { value: 'Economics', label: 'Economics' },
+    { value: 'Stewardship', label: 'Stewardship' },
+    { value: 'Other', label: 'Other' }
+  ];
 
   const changeNewName = newName => {
     if (newName.length !== 0) {
@@ -32,19 +45,11 @@ const AddProject = props => {
         onChange={e => changeNewName(e.target.value)}
       />
       <div className="input-group-append">
-        <select onChange={e => setNewCategory(e.target.value)}>
-          <option default value="Unspecified">
-            Select Category
-          </option>
-          <option value="Food">Food</option>
-          <option value="Energy">Energy</option>
-          <option value="Housing">Housing</option>
-          <option value="Education">Education</option>
-          <option value="Society">Society</option>
-          <option value="Economics">Economics</option>
-          <option value="Stewardship">Stewardship</option>
-          <option value="Other">Other</option>
-        </select>
+        <Select
+          value={newCategory}
+          onChange={setNewCategory}
+          options={options}
+        />
       </div>
       <div className="input-group-append">
         {showAddButton ? (

--- a/src/components/Projects/AddProject/AddProject.jsx
+++ b/src/components/Projects/AddProject/AddProject.jsx
@@ -1,10 +1,22 @@
  import React, { useState } from 'react';
+ import Select from 'react-select';
 
  const AddProject = props => {
    const [showAddButton, setShowAddButton] = useState(false);
    const [newName, setNewName] = useState('');
-   const [newCategory, setNewCategory] = useState('Unspecified');
+   const [newCategory, setNewCategory] = useState({ value: 'Unspecified', label: 'Select Category' });
    const [loading, setLoading] = useState(false);
+
+   const options = [
+     { value: 'Food', label: 'Food' },
+     { value: 'Energy', label: 'Energy' },
+     { value: 'Housing', label: 'Housing' },
+     { value: 'Education', label: 'Education' },
+     { value: 'Society', label: 'Society' },
+     { value: 'Economics', label: 'Economics' },
+     { value: 'Stewardship', label: 'Stewardship' },
+     { value: 'Other', label: 'Other' }
+   ];
  
    const changeNewName = name => {
      if (name.length !== 0) {
@@ -17,7 +29,7 @@
  
    const handleAddProject = () => {
      setLoading(true); // Start loading
-     Promise.resolve(props.onAddNewProject(newName, newCategory))
+     Promise.resolve(props.onAddNewProject(newName, newCategory.value))
     .then(() => {
       // Reset fields after the project is added
       setNewName('');
@@ -44,23 +56,11 @@
          disabled={loading}
        />
        <div className="input-group-append">
-         <select
-           value={newCategory}
-           onChange={e => setNewCategory(e.target.value)}
-           disabled={loading}
-         >
-           <option default value="Unspecified">
-             Select Category
-           </option>
-           <option value="Food">Food</option>
-           <option value="Energy">Energy</option>
-           <option value="Housing">Housing</option>
-           <option value="Education">Education</option>
-           <option value="Society">Society</option>
-           <option value="Economics">Economics</option>
-           <option value="Stewardship">Stewardship</option>
-           <option value="Other">Other</option>
-         </select>
+        <Select
+          value={newCategory}
+          onChange={setNewCategory}
+          options={options}
+        />
        </div>
        <div className="input-group-append">
          {showAddButton && (

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -19,7 +19,6 @@ import Loading from '../common/Loading';
 import hasPermission from '../../utils/permissions';
 import EditableInfoModal from '../UserProfile/EditableModal/EditableInfoModal';
 import SearchProjectByPerson from 'components/SearchProjectByPerson/SearchProjectByPerson';
-import ProjectsList from 'components/BMDashboard/Projects/ProjectsList';
 
 const Projects = function(props) {
   const role = props.state.userProfile.role;

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -119,6 +119,7 @@ const Projects = function(props) {
 
   const postProject = async (name, category) => {
     await props.postNewProject(name, category);
+    await props.fetchAllProjects();
   };
 
   const generateProjectList = (categorySelectedForSort, showStatus, sortedByName) => {

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -216,7 +216,7 @@ const Projects = function(props) {
             />
             <Overview numberOfProjects={numberOfProjects} numberOfActive={numberOfActive} />
 
-            {canPostProject ? <AddProject hasPermission={hasPermission} /> : null}
+            {canPostProject ? <AddProject hasPermission={hasPermission} onProjectAdded={refreshProjects}/> : null}
           </div>
 
           <SearchProjectByPerson onSearch={handleSearchName} />


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/aec3a27e-394a-4fac-a83a-7936bef1a181)

## Related PRS (if any):
This frontend PR is related to development backend PR.

## Main changes explained:
- Updated Projects.js to include a callback that triggers the fetchAllProjects() method post project addition, ensuring the project list updates immediately.
- Modified AddProject.js to handle post-submission UI behavior, disabling the loading icon once the server response is received.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an admin/owner user.
5. Go to dashboard → Other Links → Projects.
6. Try adding a new project and observe that the loading icon disappears as soon as the project is added without needing to refresh the page.
7. Verify this new feature works in [dark mode].

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/041a8eb5-baad-45ea-b714-848ccccff143


