### PR TITLE
Haoyue added the hover text for "Add new QST" button

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
@@ -81,6 +81,7 @@ function QuickSetupModal(props) {
             onClick={() => setShowAddTitle(true)}
             style={darkMode ? boxStyleDark : boxStyle}
             disabled={editMode == true}
+            title="Click this to add a new QST"
           >
             Add New QST
           </Button>


### PR DESCRIPTION
# Description
(PRIORITY HIGH) Jae: Quick Setup Tool: Fix Formatting of Created Titles (WIP Haoyue)
Profile page>Add a New Title
“Add A New Title” should be “Add New QST” with mouseover text that says “Click this to add a new Quick Setup Title”

## Related PRS (if any):
This frontend PR is not related to any backend PR.

## Main changes explained:
- Added hover text for "Add New QST" button.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to View Profile→ Add New QST
6. verify the mouseover text of "Click this to add a new Quick Setup Title"

## Screenshots or videos of changes:
<img width="805" alt="Screenshot 2024-10-22 at 12 36 37 PM" src="https://github.com/user-attachments/assets/93e78151-68f5-4812-968a-bc8749e2436e">

