### PR TITLE
Swathi Add a button to display paused tasks on the top of the table.

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -65,6 +65,8 @@ function WBSTasks(props) {
       case 'active': return tasks.filter(task => ['Active', 'Started'].includes(task.status))
       case 'inactive': return tasks.filter(task => ['Not Started', 'Paused'].includes(task.status))
       case 'complete': return tasks.filter(task => task.status === 'Complete')
+      case 'paused': return tasks.filter(task => task.status === 'Paused');
+
     }
   }
 
@@ -278,6 +280,16 @@ function WBSTasks(props) {
           >
             Active
           </Button>
+        
+          <Button
+         color="info"
+        size="sm"
+        onClick={() => setFilterState('paused')}
+       className="ml-2"
+       style={darkMode ? boxStyleDark : boxStyle}
+        >
+          Paused
+        </Button>
           <Button
             color="warning"
             size="sm"


### PR DESCRIPTION
# Description
This PR introduces a button to display paused tasks at the top of the table in the tasks view. 


## Related PRS (if any):
This frontend PR is related to the development backend 


## Main changes explained:

- Add button to task view: Added a button in the task UI to filter and display paused tasks.
- Update filter logic in file: Updated the filter function in the tasks component to handle paused tasks status.
- Modify styling and layout: Adjusted styling and layout to maintain consistency and ensure the button aligns with the existing UI.

## How to test:

-  Check into current branch
- Run npm install to ensure dependencies are up-to-date.
- Clear your browser’s site data and cache to avoid any stored data conflicts.
- Log in as an admin user.
- Navigate to Other Links>Projects>Click WBS Icon>Choose WBS>Add Task
- Add or Edit a new task and set its status to "Paused".
- Click the new "Paused" button and verify that only paused tasks are displayed.
- Confirm that the feature functions correctly in both light and dark mode.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/950f4f38-decf-4011-9096-dd76994748ed

![image](https://github.com/user-attachments/assets/f61902af-e2ad-4e47-be40-26ff273ed01e)

