### PR TITLE
Fixed PR#2197

### DIFF
--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -286,54 +286,52 @@ class UserManagement extends React.PureComponent {
       userTableItems: this.userTableElements(userProfiles, rolesPermissions, timeOffRequests, darkMode, editUser)
     })
   }
-
+  
   filteredUserList = userProfiles => {
     return userProfiles.filter(user => {
-      // Applying the search filters before creating each table data element
-      const search = result => {
-        if (typeof result === 'string') {
-          return result
-            .toLowerCase()
-            .trim()
-            .replace(/\s+/g, '');
-        }
-        const numberToString = String(result)
-          .trim()
-          .replace(/\s+/g, '');
-        const stringToNumber = Number(numberToString);
-        return stringToNumber;
-      };
-
+      
+      const firstNameSearch = this.state.firstNameSearchText || '';
+      const lastNameSearch = this.state.lastNameSearchText || '';
+  
+     
+      const firstName = user.firstName.toLowerCase();
+      const lastName = user.lastName.toLowerCase();
+  
+      
+      const trimmedFirstNameSearch = firstNameSearch.trim().toLowerCase();
+      const trimmedLastNameSearch = lastNameSearch.trim().toLowerCase();
+  
+     
+      const firstNameMatches = trimmedFirstNameSearch
+        ? firstName === trimmedFirstNameSearch // Exact match required
+        : true;
+  
+     
+      const lastNameMatches = trimmedLastNameSearch
+        ? lastName === trimmedLastNameSearch // Exact match required
+        : true;
+  
+      // Combine first name and last name matching logic
+      const nameMatches = (firstNameSearch ? firstNameMatches : true) && (lastNameSearch ? lastNameMatches : true);
+  
+     
       return (
-        // Check if the user matches the search criteria
-        (
-          // Regular search criteria
-          user.firstName.toLowerCase().indexOf(this.state.firstNameSearchText.toLowerCase()) > -1 &&
-          user.lastName.toLowerCase().indexOf(this.state.lastNameSearchText.toLowerCase()) > -1 &&
-          user.role.toLowerCase().indexOf(this.state.roleSearchText.toLowerCase()) > -1 &&
-          user.email.toLowerCase().indexOf(this.state.emailSearchText.toLowerCase()) > -1 &&
-          (this.state.weeklyHrsSearchText === '' || user.weeklycommittedHours === Number(this.state.weeklyHrsSearchText)) &&
-
-          // Check the isActive state only if 'all' is not selected
-          ((this.state.allSelected && true) || (this.state.isActive === undefined || user.isActive === this.state.isActive)) &&
-
-          // Check the isPaused state only if 'all' is not selected
-          ((this.state.allSelected && true) || (this.state.isPaused === false || (user.reactivationDate && new Date(user.reactivationDate) > new Date()))
-          ) &&
-
-          (
-            searchWithAccent(user.firstName, this.state.wildCardSearchText) ||
-            searchWithAccent(user.lastName, this.state.wildCardSearchText) ||
-            user.role.toLowerCase().indexOf(this.state.wildCardSearchText.toLowerCase()) > -1 ||
-            user.email.toLowerCase().indexOf(this.state.wildCardSearchText.toLowerCase()) > -1 ||
-            user.weeklycommittedHours === Number(this.state.wildCardSearchText)
-          )
-        )
+        nameMatches &&
+        user.role.toLowerCase().includes(this.state.roleSearchText.toLowerCase()) &&
+        user.email.toLowerCase().includes(this.state.emailSearchText.toLowerCase()) &&
+        (this.state.weeklyHrsSearchText === '' || user.weeklycommittedHours === Number(this.state.weeklyHrsSearchText)) &&
+       
+        ((this.state.allSelected && true) || (this.state.isActive === undefined || user.isActive === this.state.isActive)) &&
+    
+        ((this.state.allSelected && true) || (this.state.isPaused === false || (user.reactivationDate && new Date(user.reactivationDate) > new Date())))
       );
     });
   };
+  
 
+  
   /**
+   * 
    * reload user list and close user creation popup
    */
   userCreated = () => {
@@ -614,6 +612,8 @@ class UserManagement extends React.PureComponent {
       selectedPage: 1,
     });
   };
+
+ 
 
   /**
    * call back for active/inactive search filter


### PR DESCRIPTION
# Description

This pull request resolves an issue in the User Management search functionality, where adding a space after a search term (e.g., "Li ") was intended to limit the search to exact matches for that term, rather than partial matches. Previously, the system returned all names containing the search term, even if an exact match with a trailing space was entered (e.g., entering "test " would incorrectly return names like "testuser" instead of just "test").

# Fix Details
Modified the search function in UserManagement.jsx to handle trailing spaces correctly.
Now, when a user enters a search term with a space at the end, the search is limited to names that exactly match the given term, rather than including partial matches.
This ensures that entering "Li " will only return names that are exactly "Li", providing more precise search results as requested.

Fixes #2197 
<img width="806" alt="Task" src="https://github.com/user-attachments/assets/821f1afa-6180-431b-92ed-3dad8e775a1f">


## Main changes explained:

Updated the search functionality in User Management to support exact-match searches when a trailing space is added to the FirstName/ LastName. Now, entering "test " will return only users with the exact name "test", instead of including partial matches like "testuser". This improves search accuracy as requested.

## How to test:
1. check into current branch
2. do npm start to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links -> User Management

6. Verify Functionality behaves as expected with the new exact-match functionality in First Name and Last Name Columns.  Please see the attached screenshot for confirmation

## Screenshots of changes:
# Before Pictures:
<img width="1470" alt="Before 1" src="https://github.com/user-attachments/assets/33405e27-7c67-4c7f-909d-b3b86dd49624">
<img width="1470" alt="Before 2" src="https://github.com/user-attachments/assets/8c9dba50-0c05-442e-af28-ce4f89cc6458">



# After Pictures:
<img width="1470" alt="After 1" src="https://github.com/user-attachments/assets/107cee4d-9e52-4cb0-88f5-3492426caa8e">
<img width="1470" alt="After2" src="https://github.com/user-attachments/assets/7823e09a-3715-4e14-a624-8a7799dc08aa">
