### PR TITLE
Jinxiong fix timer layout change

### DIFF
--- a/src/components/Reports/reportsPage.css
+++ b/src/components/Reports/reportsPage.css
@@ -1,7 +1,6 @@
 * {
   box-sizing: border-box;
   margin: 0;
-  padding: 0;
 }
 
 .container-component-wrapper {


### PR DESCRIPTION
# Description
Fix the timer layout change in navigator after clicking into “Reports” 
When entering index page for the first time, the layout of timer buttons are normal. After clicking “Reports” tab, the buttons layout become much more narrower, and will never change back if you click into other page. The inconsistency should be solved.


## Related PRS (if any):
This frontend PR is related to the development backend.

## Main changes explained:
Update reportsPage.css to edit the layout of header.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports → Reports
6. verify the timer layout did not change after clicking into "Reports" (feel free to include screenshot here)
7. verify this new feature works in [dark mode]

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/f2a3f932-02b4-48a6-a9ee-d2b410f8cf23)
![image](https://github.com/user-attachments/assets/a5d7b788-d113-43e1-9ab7-b821bc2b9a20)

