### PR TITLE
Ziyu-add-unit-test-for-QuickSetupModal

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/__mock__/mockData.js
+++ b/src/components/UserProfile/QuickSetupModal/__mock__/mockData.js
@@ -1,0 +1,25 @@
+export const mockUserProfile = {
+    id: 1,
+    name: 'Ziyu Chu',
+    email: 'ziyuchu@example.com',
+    role: 'Admin'
+};
+
+export const mockTeamsData = {
+    allTeams: [
+      { teamId: 1, teamName: '2021 Test new' },
+      { teamId: 2, teamName: 'Development Team' },
+    ]
+};
+
+export const mockTitles = [
+    { _id: 1, name: 'Title1', permissions: ['edit'] },
+    { _id: 2, name: 'Title2', permissions: ['assign'] },
+    { _id: 3, name: 'Title3', permissions: ['edit', 'assign'] }
+];
+  
+export const mockUserPermissions = {
+    canEditTitle: true,
+    canAddTitle: true,
+    canAssignTitle: true
+};  

--- a/src/components/UserProfile/QuickSetupModal/__test__/QuickSetupModal.test.js
+++ b/src/components/UserProfile/QuickSetupModal/__test__/QuickSetupModal.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import QuickSetupModal from '../QuickSetupModal';
+import { getAllTitle } from '../../../../actions/title';
+import { mockTeamsData, mockUserProfile, mockTitles, mockUserPermissions } from '../__mock__/mockData';
+
+jest.mock('../../../../actions/title', () => ({
+  getAllTitle: jest.fn()
+}));
+
+jest.mock('../../../../utils/permissions', () => ({
+  hasPermission: jest.fn(permission => mockUserPermissions[permission])
+}));
+
+const mockStore = configureStore([]);
+
+describe('QuickSetupModal Component', () => {
+  let store;
+
+  beforeEach(() => {
+    store = mockStore({
+      theme: { darkMode: false },
+    });
+    getAllTitle.mockResolvedValue({ data: mockTitles });
+  });
+
+  test('renders "Add New QST" button when user has addTitle permission', async () => {
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <QuickSetupModal userProfile={mockUserProfile} hasPermission={() => true} />
+        </Provider>
+      );
+    });
+
+    const addButton = screen.getByText('Add New QST');
+    expect(addButton).toBeInTheDocument();
+    expect(addButton).toBeEnabled();
+  });
+
+  test('opens AddNewTitleModal when "Add New QST" button is clicked', async () => {
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <QuickSetupModal 
+            userProfile={mockUserProfile} 
+            hasPermission={() => true} 
+            teamsData={mockTeamsData} 
+          />
+        </Provider>
+      );
+    });
+
+    fireEvent.click(screen.getByText('Add New QST'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Add A New Title')).toBeInTheDocument();
+    });
+  });
+
+  test('renders Edit and Save buttons conditionally', async () => {
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <QuickSetupModal userProfile={mockUserProfile} hasPermission={() => true} />
+        </Provider>
+      );
+    });
+
+    const editButton = screen.getByText('Edit');
+    expect(editButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+
+    const saveButton = screen.getByText('Save');
+    expect(saveButton).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Description
This pull request enhances the QuickSetupModal component to ensure it behaves correctly based on user permissions and dynamically renders modals for title management. It adds comprehensive unit tests to validate conditional rendering of buttons, modals, and user interactions within the component.


## Related PRS (if any):
This frontend PR is related to the development backend PR.
…

## Main changes explained:
- Updated the QuickSetupModal component to render the “Add New QST” button only if the user has the appropriate addTitle permission.
- Added unit tests to confirm that the “Add New QST” button is enabled and functional when permissions allow, and triggers the AddNewTitleModal correctly.
- Ensured the component displays the “Edit” button initially and replaces it with a “Save” button upon clicking, validating conditional rendering and functionality.
- Added mock data to simulate various user permissions and store configurations, providing consistent test scenarios.
- Verified that the component handles state changes accurately and displays modals and interactive elements as expected

## How to test:
1. Check into the current branch.
2. Run npm install.
3. Execute npm test QuickSetupModal.test.js to run the unit tests.

## Screenshots or videos of changes:
![Screenshot 2024-11-01 at 3 01 26 PM](https://github.com/user-attachments/assets/e330ec21-52be-403c-8675-297b13a4e92b)


## Note:
Include the information the reviewers need to know.
