### PR TITLE
Deepthi fixed the earned dates at 1025px and below

### DIFF
--- a/src/components/Badge/BadgeReport.css
+++ b/src/components/Badge/BadgeReport.css
@@ -2,6 +2,10 @@
   display: none;
 }
 
+.desktop {
+  display: block;
+}
+
 @media (max-width: 1024px) {
   .desktop {
     display: none;
@@ -11,6 +15,20 @@
     display: block;
   }
 }
+
+ /* Adjust column widths */
+ .tablet th:nth-child(2), /* Name column */
+ .tablet th:nth-child(3), /* Modified column */
+ .tablet td:nth-child(2), /* Name cell */
+ .tablet td:nth-child(3) /* Modified cell */ {
+   width: 80px; 
+   padding: 0 8px; 
+ }
+
+ /* Apply dark background */
+ .dark-mode .tablet thead {
+   background-color: #1C2541 !important;
+ }
 
 .badge_dropdown {
   max-height: 150px; /* Limits the dropdown height */

--- a/src/components/Badge/BadgeReport.css
+++ b/src/components/Badge/BadgeReport.css
@@ -35,3 +35,15 @@
   overflow-y: auto;  /* Allows scrolling if needed */
   height: auto;      /* Allows height to adjust based on content */
 }
+
+/* Show "Earned Dates" for all screen sizes */
+th[data-testid="desktop-earned-dates"] {
+  display: table-cell;
+}
+
+/* Adjust layout for smaller screens */
+@media (max-width: 1024px) {
+  th[data-testid="desktop-earned-dates"] {
+    display: table-cell; /* adjust width or alignment here */
+  }
+}

--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -44,6 +44,8 @@ function BadgeReport(props) {
   const [badgeToDelete, setBadgeToDelete] = useState([]);
   const [savingChanges, setSavingChanges] = useState(false);
 
+
+
   const canDeleteBadges = props.hasPermission('deleteBadges');
   const canUpdateBadges = props.hasPermission('updateBadges');
 
@@ -364,11 +366,8 @@ function BadgeReport(props) {
               <tr style={{ zIndex: '10' }}>
                 <th style={{ width: '90px' }}>Badge</th>
                 <th>Name</th>
-                <th style={{ width: '110px' }}>Modified</th>
-                {/* Desktop view - visible only on larger screens */}
-                {window.innerWidth > 1024 && (
-                  <th style={{ width: '110px' }} data-testid="desktop-earned-dates">Earned Dates</th>
-                )}
+                <th style={{ width: '110px' }}>Modified</th>                             
+                <th style={{ width: '110px' }} data-testid="desktop-earned-dates">Earned Dates</th> {/* Earned dates for desktop view */}
                 <th style={{ width: '90px' }}>Count</th>
                 {canDeleteBadges ? <th>Delete</th> : []}
                 <th style={{ width: '70px', zIndex: '1' }}>Featured</th>
@@ -557,10 +556,7 @@ function BadgeReport(props) {
                 <th style={{ width: '93px' }}>Badge</th>
                 <th>Name</th>
                 <th style={{ width: '110px' }}>Modified</th>
-                {/*Tablet view - visible only on smaller screens*/}
-                {window.innerWidth <= 1024 && (
-                  <th style={{ width: '110px' }} data-testid="tablet-earned-dates">Earned Dates</th>
-                )}
+                <th style={{ width: '110px' }} data-testid="tablet-earned-dates">Earned Dates</th> {/*Earned dates for tablet view*/}
                 <th style={{ width: '80px' }}></th> {/* Ensure Options column is included here */}
               </tr>
             </thead>

--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -365,7 +365,10 @@ function BadgeReport(props) {
                 <th style={{ width: '90px' }}>Badge</th>
                 <th>Name</th>
                 <th style={{ width: '110px' }}>Modified</th>
-                <th style={{ width: '110px' }}>Earned Dates</th>
+                {/* Desktop view - visible only on larger screens */}
+                {window.innerWidth > 1024 && (
+                  <th style={{ width: '110px' }} data-testid="desktop-earned-dates">Earned Dates</th>
+                )}
                 <th style={{ width: '90px' }}>Count</th>
                 {canDeleteBadges ? <th>Delete</th> : []}
                 <th style={{ width: '70px', zIndex: '1' }}>Featured</th>
@@ -554,7 +557,11 @@ function BadgeReport(props) {
                 <th style={{ width: '93px' }}>Badge</th>
                 <th>Name</th>
                 <th style={{ width: '110px' }}>Modified</th>
-                <th style={{ width: '100%', zIndex: '10' }}>Earned</th>
+                {/*Tablet view - visible only on smaller screens*/}
+                {window.innerWidth <= 1024 && (
+                  <th style={{ width: '110px' }} data-testid="tablet-earned-dates">Earned Dates</th>
+                )}
+                <th style={{ width: '80px' }}></th> {/* Ensure Options column is included here */}
               </tr>
             </thead>
             <tbody>
@@ -591,6 +598,28 @@ function BadgeReport(props) {
                             timeZone: 'America/Los_Angeles',
                           })}
                     </td>
+
+                    <td> {/* Add Dates */}
+                      <UncontrolledDropdown className="me-2" direction="down">
+                        <DropdownToggle
+                          caret
+                          color="primary"
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            width: '80px',
+                          }}
+                        >
+                          Dates
+                        </DropdownToggle>
+                        <DropdownMenu className="badge_dropdown">
+                          {value.earnedDate.map((date, i) => (
+                            <DropdownItem key={i}>{date}</DropdownItem>
+                          ))}
+                        </DropdownMenu>
+                      </UncontrolledDropdown>
+                    </td> {/* Add dates */}
 
                     <td>
                       <ButtonGroup style={{ marginLeft: '8px' }}>

--- a/src/components/Badge/__tests__/BadgeReport.test.js
+++ b/src/components/Badge/__tests__/BadgeReport.test.js
@@ -43,12 +43,14 @@ describe('BadgeReport Component', () => {
     const badgeHeaders = screen.getAllByText('Badge');
     const nameHeaders = screen.getAllByText('Name');
     const modifiedHeaders = screen.getAllByText('Modified');
+    const earnedDatesHeaders = screen.getAllByText('Earned Dates'); // Fix for multiple matches
     expect(badgeHeaders).toHaveLength(2);
     expect(nameHeaders).toHaveLength(2);
     expect(modifiedHeaders).toHaveLength(2);
+    expect(earnedDatesHeaders).toHaveLength(2); // One for desktop, one for tablet
 
     //headers only in desktop view
-    expect(screen.getByText('Earned Dates')).toBeInTheDocument();
+  //  expect(screen.getByText('Earned Dates')).toBeInTheDocument();
     expect(screen.getByText('Count')).toBeInTheDocument();
     expect(screen.getByText('Featured')).toBeInTheDocument();
   });


### PR DESCRIPTION
# Description
Below 1025px, the column or option for earned dates is unavailable
 

## Related PRS (if any):
This frontend PR is related to the #2617 
…

## Main changes explained:
- BadgeReport.jsx: "Earned Dates" is now rendered for both desktop and tablet views without conditions. Styling and visibility are handled via CSS.
- BadgeReport.css: Media query to toggle between .tablet and .desktop views, column width adjustments for tablet view, dark mode adjustments for tablet header, dropdown menu styling, to control visibility and layout differences for the "Earned Dates".
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user/ owner user
5. go to dashboard→ view profile→ featured badges→ select featured
6. verify the earned dates column or option is available at 1025px and below

## Screenshots or videos of changes:


https://github.com/user-attachments/assets/792a7686-06c8-4b21-a5d9-c79472d7506b

