### PR TITLE
Sharadha Ready for Review Dropdown is Cropped 

### DIFF
--- a/src/components/TeamMemberTasks/reviewButton.css
+++ b/src/components/TeamMemberTasks/reviewButton.css
@@ -3,6 +3,13 @@
   height: auto; /* Allow the height to adjust based on content */
   white-space: normal; /* Allow content to wrap within the button */
   overflow: hidden; /* Hide any overflowing content */
+  z-index: 1000;
+}
+
+.dropdown-menu {
+  overflow-y: auto; /* enable scrolling if the dropdown is too long*/
+  z-index: 1000;
+
 }
 
 .dark-mode-btn:hover{
@@ -15,11 +22,40 @@
     padding: 5px !important;
     font-size: 0.75rem !important;
   }
+  .dropdown-menu{
+    max-height: 200px;
+  }
 }
 
 @media screen and (max-width: 1151px) and (min-width: 992px) {
   .reviewBtn {
     padding: 2px !important;
     font-size: 0.75rem !important;
+  }
+  .dropdown-menu{
+    max-height: 150px;
+    width: 100%
+  }
+}
+@media screen and (max-width: 991px) {
+  .reviewBtn {
+    padding: 2px !important;
+    font-size: 0.75rem !important;
+    width: 100%
+  }
+  .dropdown-menu{
+    max-height: 150px;
+    width: 100%
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .reviewBtn {
+    padding: 2px !important;
+    font-size: 0.65rem !important;
+  }
+  .dropdown-menu{
+    max-height: 120px;
+    width: 100%
   }
 }


### PR DESCRIPTION
# Description
a. In the Dashboard component, the dropdown from the Ready for Review button in the Team Member Tasks section for some team members is getting cropped.
b. The dropdown should be fully visible and accessible for all team members without any cropping.
c. Expected behavior is that the dropdown from the Ready for Review button appears clearly and completely visible, improving readability and accessibility.
d. Below is the screenshot of the bug.

<img width="642" alt="image" src="https://github.com/user-attachments/assets/e4a15c0e-72de-4119-a584-2218d77ecf96">

## Related PRS (if any):
This frontend PR is not related to any backend PR
…

## Main changes explained:
- Made changes to the review button css file.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/manager user
5. go to dashboard→ Tasks
6. verify that the dropdown from ready to review button is completely visible and is not getting cropped.
7. Verify in both light and dark mode

## Screenshots or videos of changes:
<img width="1362" alt="image" src="https://github.com/user-attachments/assets/d4ba158c-82af-452e-9a2f-53cce3ceb902">

