### PR TITLE
Gmon - Add active/inactive numbers by teams on team page

### DIFF
--- a/src/components/Teams/TeamsOverview.jsx
+++ b/src/components/Teams/TeamsOverview.jsx
@@ -3,8 +3,11 @@ import { TOTAL_TEAMS, ACTIVE_TEAMS } from '../../languages/en/ui';
 import "./TeamsOverview.css"
 
 const TeamsOverview = ({ numberOfTeams, numberOfActiveTeams }) => {
+  const numberOfNonActiveTeams = numberOfTeams - numberOfActiveTeams;
+
   return (
     <div className="teams__overview--top">
+      {/* Total Teams Card */}
       <div className="card" id="card_team" data-testid="card_team">
         <div className="card-body">
           <h6 className="card-text">
@@ -13,10 +16,20 @@ const TeamsOverview = ({ numberOfTeams, numberOfActiveTeams }) => {
         </div>
       </div>
 
+      {/* Active Teams Card */}
       <div className="card" id="card_active" data-testid="card_active">
         <div className="card-body">
           <h6 className="card-text">
             <i className="fa fa-circle fa-circle-isActive" aria-hidden="true"></i> {ACTIVE_TEAMS}: {numberOfActiveTeams}
+          </h6>
+        </div>
+      </div>
+
+      {/* Non-Active Teams Card */}
+      <div className="card" id="card_active" data-testid="card_active">
+        <div className="card-body">
+          <h6 className="card-text">
+            <i className="fa fa-circle fa-circle-Active" aria-hidden="true"></i> Non-Active Teams: {numberOfNonActiveTeams}
           </h6>
         </div>
       </div>


### PR DESCRIPTION
# Description
I am working on the below task
![Task](https://github.com/user-attachments/assets/10248b2d-7211-442f-a4e4-6227d80ccf5a)

Fixes # (bug list priority high/medium/low x.y.z)
Or Implements # (WBS) 

## Related PRS (if any):
[PR 2506](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2506#partial-pull-merging)
…

## Main changes explained:
- I have added the non active members on the page
- checked the responsive of the page

…

## How to test:
1.check into the current branch
2.do npm install and ... to run this PR locally
3.Clear site data/cache
l4.og in as an admin user
5.go to dashboard ->other links → Teams 
6.verify if you are able to see if the non active members on the page
7.Check the responsiveness of the page.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/c44e14c9-c637-47ee-b4aa-777679653013



