### PR TITLE
Vijay Anand - Added unit test for roleReducer.js

### DIFF
--- a/src/reducers/__tests__/roleReducer.test.js
+++ b/src/reducers/__tests__/roleReducer.test.js
@@ -1,0 +1,85 @@
+import { roleReducer } from '../roleReducer';
+import * as types from '../../constants/role';
+
+describe('roleReducer', () => {
+  const initialState = {
+    roles: [],
+  };
+
+  it('should return the initial state when an action type is not passed', () => {
+    expect(roleReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should handle RECEIVE_ROLES by sorting roles based on permissions length', () => {
+    const action = {
+      type: types.RECEIVE_ROLES,
+      roles: [
+        { _id: '1', roleName: 'Role1', permissions: ['p1', 'p2'] },
+        { _id: '2', roleName: 'Role2', permissions: ['p1'] },
+      ],
+    };
+
+    const expectedState = {
+      roles: [
+        { _id: '1', roleName: 'Role1', permissions: ['p1', 'p2'] },
+        { _id: '2', roleName: 'Role2', permissions: ['p1'] },
+      ],
+    };
+
+    expect(roleReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle ADD_NEW_ROLE by adding the new role to the state', () => {
+    const action = {
+      type: types.ADD_NEW_ROLE,
+      payload: { _id: '3', roleName: 'NewRole', permissions: ['p1'] },
+    };
+
+    const initial = {
+      roles: [{ _id: '1', roleName: 'Role1', permissions: ['p1', 'p2'] }],
+    };
+
+    const expectedState = {
+      roles: [
+        { _id: '1', roleName: 'Role1', permissions: ['p1', 'p2'] },
+        { _id: '3', roleName: 'NewRole', permissions: ['p1'] },
+      ],
+    };
+
+    expect(roleReducer(initial, action)).toEqual(expectedState);
+  });
+
+  it('should handle UPDATE_ROLE by updating an existing role in the state', () => {
+    const action = {
+      type: types.UPDATE_ROLE,
+      payload: {
+        roleId: '1',
+        roleName: 'UpdatedRole',
+        permissions: ['p1', 'p3'],
+      },
+    };
+
+    const initial = {
+      roles: [
+        { _id: '1', roleName: 'Role1', permissions: ['p1', 'p2'] },
+        { _id: '2', roleName: 'Role2', permissions: ['p1'] },
+      ],
+    };
+
+    const expectedState = {
+      roles: [
+        { _id: '1', roleName: 'UpdatedRole', permissions: ['p1', 'p3'] },
+        { _id: '2', roleName: 'Role2', permissions: ['p1'] },
+      ],
+    };
+
+    expect(roleReducer(initial, action)).toEqual(expectedState);
+  });
+
+  it('should return the current state for unknown action types', () => {
+    const action = { type: 'UNKNOWN_ACTION' };
+    const currentState = { roles: [{ _id: '1', roleName: 'Role1', permissions: ['p1'] }] };
+
+    expect(roleReducer(currentState, action)).toEqual(currentState);
+  });
+});


### PR DESCRIPTION
# Description
Unit tests for roleReducer.

## Related PRS (if any):
No related PRs

- ## Main changes explained:
- Added a new test file roleReducer.test.js to verify roleReducer functionality.
- The list of test cases for roleReducer includes:
  - returns the initial state when no action type is specified
  - handles RECEIVE_ROLES action by sorting roles based on permissions length
  - handles ADD_NEW_ROLE action by adding a new role to the state
  - handles UPDATE_ROLE action by updating an existing role in the state
  - returns the current state for unknown action types

## How to test:
1. Check out the current branch.
2. Run npm install and npm test roleReducer.test.js.
3. Verify all test cases pass without any errors.

## Screenshots or videos of changes:
<img width="906" alt="image" src="https://github.com/user-attachments/assets/594d9ae6-c01b-4d76-8536-76d9e0193f8f">

## Note:
Include the information the reviewers need to know.
