### PR TITLE
Yili - Gives the user permission to Reset and/or Change the password of any user 

### DIFF
--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -159,6 +159,12 @@ export const permissionLabels = [
           'Gives the user permission to change the requirement to the user to submit a summary.',
       },
       {
+        label: 'Reset / Change Password (Others)',
+        key: 'resetPassword',
+        description:
+          'Gives the user permission to Reset and/or Change the password of any user but Owner/Admin classes. ',
+      },
+      {
         label: 'Manage Time Off Requests',
         key: 'manageTimeOffRequests',
         description: 'Gives the user permission to Add/Delete/Edit Time off requests.',

--- a/src/components/PermissionsManagement/PermissionsConst.js
+++ b/src/components/PermissionsManagement/PermissionsConst.js
@@ -159,10 +159,10 @@ export const permissionLabels = [
           'Gives the user permission to change the requirement to the user to submit a summary.',
       },
       {
-        label: 'Reset / Change Password (Others)',
-        key: 'resetPassword',
+        label: 'Update Password (Others)',
+        key: 'updatePassword',
         description:
-          'Gives the user permission to Reset and/or Change the password of any user but Owner/Admin classes. ',
+          'Gives the user permission to update the password of any user but Owner/Admin classes. ',
       },
       {
         label: 'Manage Time Off Requests',

--- a/src/components/UserManagement/ResetPasswordButton.jsx
+++ b/src/components/UserManagement/ResetPasswordButton.jsx
@@ -67,7 +67,7 @@ class ResetPasswordButton extends React.PureComponent {
           onReset={this.resetPassword}
         />
         <>
-          {!this.props.canResetPassword ? (
+          {!this.props.canUpdatePassword ? (
             <Tooltip
               placement="bottom"
               isOpen={this.state.resetPasswordTooltipOpen}
@@ -90,7 +90,7 @@ class ResetPasswordButton extends React.PureComponent {
             }
             onClick={this.onResetClick}
             id={`btn-reset-password-${this.props.user._id}`}
-            disabled={!this.props.canResetPassword}
+            disabled={!this.props.canUpdatePassword}
           >
             Reset Password
           </Button>

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -512,7 +512,7 @@ const UserTableData = React.memo(props => {
               user={props.user}
               darkMode={darkMode}
               isSmallButton
-              canResetPassword={resetPasswordStatus || updatePasswordStatus}
+              canUpdatePassword={resetPasswordStatus || updatePasswordStatus}
             />
           </span>
         </td>

--- a/src/components/UserManagement/__tests__/ResetPasswordButton.test.js
+++ b/src/components/UserManagement/__tests__/ResetPasswordButton.test.js
@@ -17,7 +17,7 @@ describe('reset password button ', () => {
   beforeEach(() => {
     render(
       <Provider store={store}>
-        <ResetPasswordButton isSmallButton user={userProfileMock} canResetPassword />
+        <ResetPasswordButton isSmallButton user={userProfileMock} canUpdatePassword />
       </Provider>,
     );
   });

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -125,7 +125,7 @@ function UserProfile(props) {
   const [showToggleVisibilityModal, setShowToggleVisibilityModal] = useState(false);
   const [pendingRehireableStatus, setPendingRehireableStatus] = useState(null);
   const [isRehireable, setIsRehireable] = useState(null);
-  const [canResetPassword, setCanResetPassword] = useState(false);
+  const [canUpdatePassword, setCanUpdatePassword] = useState(props.hasPermission('updatePassword'));
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [didLinkUpdate, setDidLinkUpdate] = useState(false);
   // Function to toggle the modal
@@ -337,7 +337,7 @@ function UserProfile(props) {
       const response = await axios.get(ENDPOINTS.USER_PROFILE(userId));
       const currentUserEmail = response.data.email;
       dispatch(setCurrentUser({ ...props.auth.user, email: currentUserEmail }));
-      setCanResetPassword(response.data.permissions.frontPermissions.includes('resetPassword'));
+      setCanUpdatePassword(response.data.permissions.frontPermissions.includes('updatePassword'));
     } catch (err) {
       toast.error('Error while getting current logged in user email');
     }
@@ -866,7 +866,6 @@ function UserProfile(props) {
   const canChangeUserStatus = props.hasPermission('changeUserStatus');
   const canAddDeleteEditOwners = props.hasPermission('addDeleteEditOwners');
   const canPutUserProfile = props.hasPermission('putUserProfile');
-  const canUpdatePassword = props.hasPermission('updatePassword');
   const canGetProjectMembers = props.hasPermission('getProjectMembers');
   const canChangeRehireableStatus = props.hasPermission('changeUserRehireableStatus');
   const canUpdateSummaryRequirements = props.hasPermission('updateSummaryRequirements');
@@ -1405,12 +1404,12 @@ function UserProfile(props) {
               </TabPane>
             </TabContent>
             <div className="profileEditButtonContainer">
-              {(canUpdatePassword && canEdit && !isUserSelf || canResetPassword) && (
+              {(canUpdatePassword && canEdit && !isUserSelf) && (
                 <ResetPasswordButton
                   className="mr-1 btn-bottom"
                   user={userProfile}
                   authEmail={authEmail}
-                  canResetPassword
+                  canUpdatePassword
                 />
               )}
               {isUserSelf && (activeTab === '1' || canPutUserProfile) && (
@@ -1541,7 +1540,7 @@ function UserProfile(props) {
                           className="mr-1 btn-bottom"
                           user={userProfile}
                           authEmail={authEmail}
-                          canResetPassword
+                          canUpdatePassword
                         />
                       )}
                       {isUserSelf && (activeTab == '1' || canPutUserProfile) && (

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -125,6 +125,7 @@ function UserProfile(props) {
   const [showToggleVisibilityModal, setShowToggleVisibilityModal] = useState(false);
   const [pendingRehireableStatus, setPendingRehireableStatus] = useState(null);
   const [isRehireable, setIsRehireable] = useState(null);
+  const [canResetPassword, setCanResetPassword] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [didLinkUpdate, setDidLinkUpdate] = useState(false);
   // Function to toggle the modal
@@ -336,6 +337,7 @@ function UserProfile(props) {
       const response = await axios.get(ENDPOINTS.USER_PROFILE(userId));
       const currentUserEmail = response.data.email;
       dispatch(setCurrentUser({ ...props.auth.user, email: currentUserEmail }));
+      setCanResetPassword(response.data.permissions.frontPermissions.includes('resetPassword'));
     } catch (err) {
       toast.error('Error while getting current logged in user email');
     }
@@ -1403,7 +1405,7 @@ function UserProfile(props) {
               </TabPane>
             </TabContent>
             <div className="profileEditButtonContainer">
-              {canUpdatePassword && canEdit && !isUserSelf && (
+              {(canUpdatePassword && canEdit && !isUserSelf || canResetPassword) && (
                 <ResetPasswordButton
                   className="mr-1 btn-bottom"
                   user={userProfile}

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -125,7 +125,6 @@ function UserProfile(props) {
   const [showToggleVisibilityModal, setShowToggleVisibilityModal] = useState(false);
   const [pendingRehireableStatus, setPendingRehireableStatus] = useState(null);
   const [isRehireable, setIsRehireable] = useState(null);
-  const [canUpdatePassword, setCanUpdatePassword] = useState(props.hasPermission('updatePassword'));
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [didLinkUpdate, setDidLinkUpdate] = useState(false);
   // Function to toggle the modal
@@ -336,8 +335,15 @@ function UserProfile(props) {
     try {
       const response = await axios.get(ENDPOINTS.USER_PROFILE(userId));
       const currentUserEmail = response.data.email;
-      dispatch(setCurrentUser({ ...props.auth.user, email: currentUserEmail }));
-      setCanUpdatePassword(response.data.permissions.frontPermissions.includes('updatePassword'));
+      dispatch(setCurrentUser({ ...props.auth.user, email: currentUserEmail, 
+        permissions: {
+          ...props.auth.user.permissions,
+          frontPermissions: [
+            ...(props.auth.user.permissions?.frontPermissions || []),
+            ...(response.data.permissions?.frontPermissions || [])
+          ]
+        }
+      }));
     } catch (err) {
       toast.error('Error while getting current logged in user email');
     }
@@ -866,6 +872,7 @@ function UserProfile(props) {
   const canChangeUserStatus = props.hasPermission('changeUserStatus');
   const canAddDeleteEditOwners = props.hasPermission('addDeleteEditOwners');
   const canPutUserProfile = props.hasPermission('putUserProfile');
+  const canUpdatePassword = props.hasPermission('updatePassword');
   const canGetProjectMembers = props.hasPermission('getProjectMembers');
   const canChangeRehireableStatus = props.hasPermission('changeUserRehireableStatus');
   const canUpdateSummaryRequirements = props.hasPermission('updateSummaryRequirements');
@@ -877,7 +884,7 @@ function UserProfile(props) {
 
   const canEditUserProfile = targetIsDevAdminUneditable
     ? false
-    : userProfile.role === 'Owner'
+    : userProfile.role === 'Owner' || userProfile.role === 'Administrator'
     ? canAddDeleteEditOwners
     : canPutUserProfile;
 


### PR DESCRIPTION
# Description
![Gives the user permission to Reset and:or Change the password of any user but Owner:Admin classes](https://github.com/user-attachments/assets/3ea766df-0511-41bb-be72-7719e68eb876)


## Related PRS 
This frontend PR is related to the backend [PR #1146](https://github.com/OneCommunityGlobal/HGNRest/pull/1146)

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to Other Links -> Permissions Management -> Manage User Permissions -> Choose a volunteer user -> add Reset / Change Password (Others) -> click on "save changes"
6. verify that the user who was given the permission is now able to see the reset password button and reset another volunteer user's password.(make sure to reset your own account for testing) 

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/b3993606-c514-4249-a5b6-295ab4eb817a

![1](https://github.com/user-attachments/assets/943e1f43-ffc1-41e3-9c6e-a0796742393b)
![2](https://github.com/user-attachments/assets/f8c03652-b0be-4c5d-802d-0e2b01de7e59)
![3](https://github.com/user-attachments/assets/6970b9fc-ad8f-4fca-a4ce-75ba49822a90)
