### PR TITLE
Ashish_Fix_Rehireable_Status

### DIFF
--- a/src/actions/userManagement.js
+++ b/src/actions/userManagement.js
@@ -85,15 +85,15 @@ export const updateUserStatus = (user, status, reactivationDate) => {
  * @param{boolean} isRehireable - the new rehireable status
  */
 export const updateRehireableStatus = (user, isRehireable) => {
-  const userProfile = { ...user };
-  userProfile.isRehireable = isRehireable
-  const requestData = { isRehireable };
-  
-  const updateProfilePromise = axios.patch(ENDPOINTS.UPDATE_REHIREABLE_STATUS(user._id), requestData)
   return async dispatch => {
-    updateProfilePromise.then(res => {
+    const userProfile = { ...user, isRehireable };
+    const requestData = { isRehireable };
+    try {
+      await axios.patch(ENDPOINTS.UPDATE_REHIREABLE_STATUS(user._id), requestData);
       dispatch(userProfileUpdateAction(userProfile));
-    });
+    } catch (err) {
+      throw err;
+    }
   };
 };
 

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -695,16 +695,20 @@ function UserProfile(props) {
     setShowConfirmDialog(true);
   };
 
-  const handleConfirmChange = () => {
+  const handleConfirmChange = async () => {
     setShowConfirmDialog(false);
     const updatedUserProfile = {
       ...userProfile,
       isRehireable: pendingRehireableStatus,
     };
-    updateRehireableStatus(updatedUserProfile, pendingRehireableStatus);
-    setIsRehireable(pendingRehireableStatus);
-    setUserProfile(updatedUserProfile);
-    setOriginalUserProfile(updatedUserProfile);
+    try{
+      await dispatch(updateRehireableStatus(updatedUserProfile, pendingRehireableStatus));
+      setIsRehireable(pendingRehireableStatus);
+      setUserProfile(updatedUserProfile);
+      setOriginalUserProfile(updatedUserProfile);
+    }catch(error){
+      toast.error('Unable change rehireable status');
+    }
   };
 
   const handleCancelChange = () => {


### PR DESCRIPTION
# Description
Fix Rehireable status is updated in the frontend regardless of the response status
![image](https://github.com/user-attachments/assets/728f38f3-1815-4c9b-850a-6aeaf36f5ff5)


## Related PRS (if any):
This PR is related to the backend [PR# 1148](https://github.com/OneCommunityGlobal/HGNRest/pull/1148).
…

## Main changes explained:
- Updated updateRehireableStatus function in actions/userManagement.js
- Update userProfile.js to display error if backend doesn't return 200 status when updating rehireable status
…

## How to test:
Complete the backend steps first
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user/ user with Change Rehireable Status permission
5. go to dashboard→ User Management → search for the protected accounts
'[jae@onecommunityglobal.org], '[one.community@me.com]', '[jsabol@me.com]', '[devadmin@hgn.net]' , and access their profile.
6. verify you can't update the Rehireable status of any of the protected accounts.

## Screenshots or videos of changes:
Video in the link:
https://www.loom.com/share/1fc5f26e99ba44828e7cd7151b1453d5?sid=6d1fc2c9-4f35-4e3a-874b-711ee5d6c57f

![Screenshot 2024-11-08 224731](https://github.com/user-attachments/assets/58f241c4-7e58-4c79-85d9-4d33388cb9f9)


