### PR TITLE
ziyan_fix_userProfile_start_date

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -333,6 +333,13 @@ function UserProfile(props) {
 
       const startDate = newUserProfile?.startDate.split('T')[0];
       // Validate team and project data. Remove incorrect data which may lead to page crash. E.g teams: [null]
+      const createdDate = newUserProfile?.createdDate ? newUserProfile.createdDate.split('T')[0] : null;
+
+
+      if (startDate && createdDate && new Date(startDate) < new Date(createdDate)) {
+        newUserProfile.startDate = createdDate;
+      }
+      //if start date is earlier than createdDate, update it to createdDate
       newUserProfile.teams = newUserProfile.teams.filter(team => team !== null);
       newUserProfile.projects = newUserProfile.projects.filter(project => project !== null);
       setTeams(newUserProfile.teams);


### PR DESCRIPTION
# Description
Some users are unable to update their basic information because the "Save Changes" button is disabled. This issue occurs when a user’s startDate is set to a date prior to their account created date, which triggers the button to remain disabled.
![image](https://github.com/user-attachments/assets/2dd5c44d-99c8-458a-8457-8acad316de12)

See video for specific describe:
https://www.loom.com/share/fc8c9f31a4c6401a96cc5a2de1d448ea?sid=e57c40f5-8207-46d6-997f-7c30a3713334

## Related PRS (if any):
This frontend PR is related to the development branch of the [backend](https://github.com/OneCommunityGlobal/HGNRest) repository.

## Main changes explained:
-Update startDate to match createdDate if set earlier: Automatically adjusts startDate to ensure it is not earlier than createdDate, maintaining logical consistency within user profile data.
-Remove invalid data: Filters out null values in teams and projects arrays to prevent potential errors from invalid data entries.

## How to test:
1. check into current branch
2. do `npm install` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Navigate to Leaderboard: Go to Dashboard → Leaderboard (located on the right side of the dashboard) → Click on a user profile (note: the owner account cannot be modified).
6. Verify "Save Changes" Button: Edit any user information and check if the "Save Changes" button is enabled. Confirm that changes can be saved successfully.
7. Go to the Volunteering Time tab and verify that the start date is either the same as or later than the account created date.

## Screenshots or videos of changes:
**Start Date Automatically Updated:** The start date is now automatically set to the same day as the account created date:
![image](https://github.com/user-attachments/assets/7c9015bf-75bc-419a-b3d8-413ba4653540)

After the start date is updated, we can save changes successfully:
![image](https://github.com/user-attachments/assets/a8f8538f-2c15-4db1-9dd5-5ba0c26b8d83)

