### PR TITLE
Fix deactivation date logic and ensure proper behavior

### DIFF
--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -74,7 +74,7 @@ export const getTimeEntriesForPeriod = (userId, fromDate, toDate) => {
 export const getTimeEndDateEntriesByPeriod = (userId, fromDate, toDate) => { //Find last week of work in date
   toDate = moment(toDate)
     .endOf('day')
-    .format('YYYY-MM-DD');
+    .format('YYYY-MM-DDTHH:mm:ss');
   const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate,toDate);
   return async dispatch => {
     let loggedOut = false;

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -661,12 +661,12 @@ function UserProfile(props) {
     });
   };
 
-  const setActiveInactive = isActive => {
+  const setActiveInactive = async isActive => {
     let endDate;
 
     if (!isActive) {
-      endDate = dispatch(
-        getTimeEndDateEntriesByPeriod(userProfile._id, userProfile.createdDate, userProfile.toDate),
+      endDate = await dispatch(
+        getTimeEndDateEntriesByPeriod(userProfile._id, userProfile.createdDate, userProfile.toDate)
       );
       if (endDate == 'N/A') {
         endDate = userProfile.createdDate;
@@ -679,7 +679,7 @@ function UserProfile(props) {
     };
 
     try {
-      props.updateUserStatus(
+      await props.updateUserStatus(
         newUserProfile,
         isActive ? UserStatus.Active : UserStatus.InActive,
         undefined,


### PR DESCRIPTION
### **Description**
Fixes the issue where the deactivation date on the profile page is incorrectly displayed as "Invalid date" when the green button is clicked to deactivate an account. Now, the deactivation date will correctly show the last day the user logged time.

### **Fixes:**

Bug priority: Medium
Related task: "Fix deactivation date not showing when the green button is clicked on the profile page."
Main Changes Explained
Updated the logic for fetching and displaying the deactivation date:
Integrated a backend call to retrieve the last logged time for the user.
Ensured the End Date field displays the correct last logged time when the account is deactivated.
Adjusted fallback behavior:
If no logged time is available, the End Date will now default to the account creation date.
Verified display functionality in both light mode and dark mode.
**### How to Test**
Switch to this branch: Cillian_fix_deactivation_date_bug.
Run the project locally:
Clear browser cache and site data to ensure no stale data interferes with testing.
Steps to Test: a. Log in as an admin user. b. Navigate to the profile page of a user. c. Click the green button to deactivate the account. d. Verify that the End Date field correctly displays the last day the user logged time. e. Reactivate the account, then deactivate again to ensure consistency. f. Test this functionality in dark mode to ensure proper visibility.

**### Screenshots/Videos of Changes**
Include screenshots or a link to a video showing the following:
![image](https://github.com/user-attachments/assets/52a9f542-effd-4111-9474-5e72c76945f4)

The End Date correctly displaying the last logged time in both light and dark modes.
**### Notes**
This PR addresses the issue in the frontend; ensure the backend endpoint /time-entries returns accurate data for the user's last logged time.
The End Date logic falls back to the account creation date (createdDate) if no logged time is found.