### PR TITLE
Supriya-Add-User-Role-below-their-name-in-Tasks-Tab

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -204,6 +204,14 @@ const TeamMemberTask = React.memo(
                               fontSize: '20px'
                             }}
                           >{`${user.name}`}</Link>
+
+                       
+                            {user.role !== 'Volunteer' && (
+                              <div className="user-role" style={{ fontSize: '14px', color: darkMode ? 'lightgray' : 'gray' }}>
+                                {user.role}
+                              </div>
+                            )}
+
                           {canGetWeeklySummaries && <GoogleDocIcon link={userGoogleDocLink} />}
 
                           <Warning


### PR DESCRIPTION
# Description
The role of the user was added in the Tasks tab 

## Related PRS (if any):
No related PRs
…

## Main changes explained:
Added the role of the user(except Volunteer) below their names and above tracking in TeamMemberTask.jsx  for both Light mode and dark mode

<img width="541" alt="image" src="https://github.com/user-attachments/assets/6035ecd3-74f3-4eab-8cb8-0fd201fd8534">


…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ Tasks→ task→…
6. verify you can see the role under their name
7. verify this new feature works in [dark mode]

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/70ea7538-27ab-4208-a2d4-2dcf1e8604ed


## Note:
Test for different modes and with different roles