### PR TITLE
Vijay Anand - Add unit test for projectReportReducer file

### DIFF
--- a/src/reducers/__tests__/projectReportReducer.test.js
+++ b/src/reducers/__tests__/projectReportReducer.test.js
@@ -1,0 +1,46 @@
+import { projectReportReducer } from '../projectReportReducer';
+import {
+  GET_PROJECT_REPORT_BEGIN,
+  GET_PROJECT_REPORT_END,
+} from '../../components/Reports/ProjectReport/actions';
+
+describe('projectReportReducer', () => {
+  it('should return the initial state', () => {
+    const initialState = {
+      project: null, // Updated to match reducer
+      isLoading: false,
+    };
+
+    expect(projectReportReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should handle GET_PROJECT_REPORT_BEGIN by setting isLoading to true', () => {
+    const action = { type: GET_PROJECT_REPORT_BEGIN };
+    const initialState = {
+      project: null, // Updated to match reducer
+      isLoading: false,
+    };
+
+    const expectedState = {
+      project: null, // Updated to match reducer
+      isLoading: true,
+    };
+
+    expect(projectReportReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle GET_PROJECT_REPORT_END by setting isLoading to false', () => {
+    const action = { type: GET_PROJECT_REPORT_END };
+    const initialState = {
+      project: null, // Updated to match reducer
+      isLoading: true,
+    };
+
+    const expectedState = {
+      project: null, // Updated to match reducer
+      isLoading: false,
+    };
+
+    expect(projectReportReducer(initialState, action)).toEqual(expectedState);
+  });
+});


### PR DESCRIPTION
# Description
Added unit tests for projectReportReducer.

## Related PRS (if any):
No related PRs.

## Main changes explained:
- Added test cases in projectReportReducer.test.js to cover all functionalities of projectReportReducer.
- Validated the following scenarios:
  - Returns the initial state when no action is provided.
  - Handles GET_PROJECT_REPORT_BEGIN by setting isLoading to true.
  - Handles GET_PROJECT_REPORT_END by setting isLoading to false.

## How to test:
1. Check out the current branch.
2. Run npm install if needed.
3. Execute npm test projectReportReducer.test.js.
4. Verify all test cases pass without errors.

## Screenshots or videos of changes:
<img width="905" alt="image" src="https://github.com/user-attachments/assets/8632d280-cae2-413e-8648-5fc005878a8f">

