### PR TITLE
Vijay Anand - Add unit test for weeklySummaryRecipientsReducer

### DIFF
--- a/src/reducers/__tests__/weeklySummaryRecipientsReducer.test.js
+++ b/src/reducers/__tests__/weeklySummaryRecipientsReducer.test.js
@@ -1,0 +1,90 @@
+import * as actions from '../../constants/weeklySummariesReport';
+import { weeklySummaryRecipientsReducer } from '../weeklySummaryRecipientsReducer';
+
+describe('weeklySummaryRecipientsReducer', () => {
+  const initialState = {
+    user: {},
+    recepientsArr: [],
+    err: null,
+  };
+
+  it('should return the initial state', () => {
+    expect(weeklySummaryRecipientsReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should handle DELETE_WEEKLY_SUMMARIES_RECIPIENTS', () => {
+    const action = {
+      type: actions.DELETE_WEEKLY_SUMMARIES_RECIPIENTS,
+      payload: { userid: '123' },
+    };
+    const state = {
+      ...initialState,
+      recepientsArr: [{ _id: '123' }, { _id: '456' }],
+    };
+    const expectedState = {
+      ...initialState,
+      recepientsArr: [{ _id: '456' }],
+    };
+
+    expect(weeklySummaryRecipientsReducer(state, action)).toEqual(expectedState);
+  });
+
+  it('should handle AUTHORIZE_WEEKLY_SUMMARY_REPORTS', () => {
+    const action = {
+      type: actions.AUTHORIZE_WEEKLY_SUMMARY_REPORTS,
+      payload: true,
+    };
+    const expectedState = {
+      ...initialState,
+      passwordMatch: true,
+    };
+
+    expect(weeklySummaryRecipientsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle AUTHORIZE_WEEKLYSUMMARIES_REPORTS_ERROR', () => {
+    const action = {
+      type: actions.AUTHORIZE_WEEKLYSUMMARIES_REPORTS_ERROR,
+      payload: 'Password mismatch',
+    };
+    const expectedState = {
+      ...initialState,
+      passwordMatchErr: 'Password mismatch',
+    };
+
+    expect(weeklySummaryRecipientsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle GET_SUMMARY_RECIPIENTS', () => {
+    const action = {
+      type: actions.GET_SUMMARY_RECIPIENTS,
+      recepientsArr: [{ _id: '123' }, { _id: '456' }],
+    };
+    const expectedState = {
+      ...initialState,
+      recepientsArr: [{ _id: '123' }, { _id: '456' }],
+    };
+
+    expect(weeklySummaryRecipientsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle GET_SUMMARY_RECIPIENTS_ERROR', () => {
+    const action = {
+      type: actions.GET_SUMMARY_RECIPIENTS_ERROR,
+      payload: { err: 'Failed to fetch recipients' },
+    };
+    const expectedState = {
+      ...initialState,
+      getRecepientsErr: 'Failed to fetch recipients',
+    };
+
+    expect(weeklySummaryRecipientsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should return the current state for unknown actions', () => {
+    const action = { type: 'UNKNOWN_ACTION' };
+    const state = { ...initialState, recepientsArr: [{ _id: '123' }] };
+
+    expect(weeklySummaryRecipientsReducer(state, action)).toEqual(state);
+  });
+});


### PR DESCRIPTION
# Description
Added unit tests for the weeklySummaryRecipientsReducer

## Related PRS (if any):
No related PRs.

## Main changes explained:

- Added a new test file weeklySummaryRecipientsReducer.test.js under the __tests__ directory.
- Test cases include:
  - Returns the initial state when no state is provided.
  - Handles DELETE_WEEKLY_SUMMARIES_RECIPIENTS by removing the recipient with the specified _id.
  - Handles AUTHORIZE_WEEKLY_SUMMARY_REPORTS by updating the passwordMatch state.
  - Handles AUTHORIZE_WEEKLYSUMMARIES_REPORTS_ERROR by updating the passwordMatchErr field.
  - Handles GET_SUMMARY_RECIPIENTS by populating the recepientsArr.
  - Handles GET_SUMMARY_RECIPIENTS_ERROR by updating getRecepientsErr with the error message.
  - Returns the current state for unknown action types.

## How to test:
Check out the current branch.
Run npm install if needed, then execute npm test weeklySummaryRecipientsReducer.test.js.
Verify all test cases pass without any errors.

## Screenshots or videos of changes:
<img width="858" alt="image" src="https://github.com/user-attachments/assets/d2ff2c26-6e19-4c89-9928-751296095389">

## Note:
Include the information the reviewers need to know.
