### PR TITLE
Strallia: Add workflow for closing PRs from forks

### DIFF
--- a/.github/workflows/close-fork-pr.yml
+++ b/.github/workflows/close-fork-pr.yml
@@ -1,0 +1,39 @@
+name: Close PRs from Forks
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  check-fork:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check if PR is from a fork
+        id: check
+        run: |
+          echo "PR head repo: ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "Base repo: ${{ github.event.repository.full_name }}"
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.repository.full_name }}" ]]; then
+            echo "PR is from a fork"
+            echo "is_fork=true" >> $GITHUB_ENV
+          else
+            echo "PR is not from a fork"
+            echo "is_fork=false" >> $GITHUB_ENV
+          fi
+
+      - name: Close PR and add comment
+        if: env.is_fork == 'true'
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          GH_REPO=${{ github.repository }}
+          echo "Closing PR #$PR_NUMBER in repository $GH_REPO"
+          gh pr close \
+            "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --comment "This PR has been closed because PRs from forks are not allowed. Please create a branch directly off the origin repository and resubmit your PR."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

This PR adds a GitHub Actions workflow to automatically close pull requests originating from forked repositories. This change prevents unnecessary alerts triggered by Netlify build requests for such PRs, reducing noise in the CI/CD process.

## Main changes:
- Add new workflow in `close-fork-pr.yml`

## How to test:
The workflow has all ready been tested in PRs #2899 and #2898. Further tests are not recommended as to avoid cluttering the PR page. However, please review the code changes, especially if you are familiar with yaml and workflow files.
