### PR TITLE
Yashwanth fix: labels

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -185,7 +185,7 @@ class UserProfileAdd extends Component {
               <Form>
                 <Row className="user-add-row">
                   <Col md={{ size: 2, offset: 2 }} className="text-md-right my-2">
-                    <Label className={fontColor}>Name</Label>
+                    <Label className={fontColor} >Name <span style={{ color: 'red' }}>*</span> </Label>
                   </Col>
                   <Col md="3">
                     <FormGroup>
@@ -196,9 +196,13 @@ class UserProfileAdd extends Component {
                         value={firstName}
                         onChange={(e) => this.handleUserProfile(e)}
                         placeholder="First Name"
-                        invalid={!!this.state.formErrors.firstName}
+                        invalid={!!(this.state.formSubmitted && this.state.formErrors.firstName)}
                       />
-                      <FormFeedback className={fontWeight}>{this.state.formErrors.firstName}</FormFeedback>
+                       {this.state.formSubmitted && this.state.formErrors.firstName && (
+    <FormFeedback className={fontWeight}>
+      {this.state.formErrors.firstName}
+    </FormFeedback>
+  )}
                     </FormGroup>
                   </Col>
                   <Col md="3">
@@ -210,15 +214,19 @@ class UserProfileAdd extends Component {
                         value={lastName}
                         onChange={(e) => this.handleUserProfile(e)}
                         placeholder="Last Name"
-                        invalid={!!this.state.formErrors.lastName}
+                        invalid={!!(this.state.formSubmitted && this.state.formErrors.lastName)}
                       />
-                      <FormFeedback className={fontWeight}>{this.state.formErrors.lastName}</FormFeedback>
+                      {this.state.formSubmitted && this.state.formErrors.lastName && (
+    <FormFeedback className={fontWeight}>
+      {this.state.formErrors.lastName}
+    </FormFeedback>
+  )}
                     </FormGroup>
                   </Col>
                 </Row>
                 <Row className="user-add-row">
                   <Col md={{ size: 3, offset: 1 }} className="text-md-right my-2">
-                    <Label className={fontColor}>Job Title</Label>
+                    <Label className={fontColor}>Job Title <span style={{ color: 'red' }}>*</span> </Label>
                   </Col>
                   <Col md={{ size: 6 }}>
                     <FormGroup>
@@ -229,15 +237,18 @@ class UserProfileAdd extends Component {
                         value={jobTitle}
                         onChange={(e) => this.handleUserProfile(e)}
                         placeholder="Job Title"
-                        invalid={!!this.state.formErrors.jobTitle}
+                        invalid={!!(this.state.formSubmitted && this.state.formErrors.jobTitle)}
                       />
-                      <FormFeedback className={fontWeight}>{this.state.formErrors.jobTitle}</FormFeedback>
+                      {this.state.formSubmitted && this.state.formErrors.jobTitle && (
+    <FormFeedback className={fontWeight}>
+      {this.state.formErrors.jobTitle}
+    </FormFeedback>)}
                     </FormGroup>
                   </Col>
                 </Row>
                 <Row className="user-add-row">
                   <Col md={{ size: 2, offset: 2 }} className="text-md-right my-2">
-                    <Label className={fontColor}>Email</Label>
+                    <Label className={fontColor}>Email <span style={{ color: 'red' }}>*</span> </Label>
                   </Col>
                   <Col md="6">
                     <FormGroup>
@@ -248,9 +259,12 @@ class UserProfileAdd extends Component {
                         value={email}
                         onChange={(e) => this.handleUserProfile(e)}
                         placeholder="Email"
-                        invalid={!!this.state.formErrors.email}
+                        invalid={!!(this.state.formSubmitted && this.state.formErrors.email)}
                       />
-                      <FormFeedback className={fontWeight}>{this.state.formErrors.email}</FormFeedback>
+                      {this.state.formSubmitted && this.state.formErrors.email && (
+    <FormFeedback className={fontWeight}>
+      {this.state.formErrors.email}
+    </FormFeedback>)}
                       <ToggleSwitch
                         switchType="email"
                         state={this.state.userProfile.privacySettings?.email}
@@ -261,7 +275,7 @@ class UserProfileAdd extends Component {
                 </Row>
                 <Row className="user-add-row">
                   <Col md={{ size: 2, offset: 2 }} className="text-md-right my-2">
-                    <Label className={fontColor}>Phone</Label>
+                    <Label className={fontColor}>Phone <span style={{ color: 'red' }}>*</span> </Label>
                   </Col>
                   <Col md="6">
                     <FormGroup>
@@ -272,7 +286,7 @@ class UserProfileAdd extends Component {
                         value={phoneNumber}
                         onChange={phone => this.phoneChange(phone)}
                       />
-                      {phoneNumberEntered && (
+                      {phoneNumberEntered && this.state.formSubmitted && (
                         <div className={`required-user-field ${fontWeight}`}>
                           {this.state.formErrors.phoneNumber}
                         </div>
@@ -287,7 +301,7 @@ class UserProfileAdd extends Component {
                 </Row>
                 <Row className="user-add-row">
                   <Col md={{ size: 4 }} className="text-md-right my-2">
-                    <Label className={fontColor}>Weekly Committed Hours</Label>
+                    <Label className={fontColor}>Weekly Committed Hours <span style={{ color: 'red' }}>*</span></Label>
                   </Col>
                   <Col md="6">
                     <FormGroup>


### PR DESCRIPTION
# Description
This pull request resolves the issue with error labels being preloaded on the "Create New User" form. Now, error labels will only be displayed when a user makes an error or leaves a required field empty. Additionally, asterisks (*) have been added next to required fields to make it clear which fields are mandatory.

![bg1](https://github.com/user-attachments/assets/74c36681-8219-4acf-8b0c-83d98de231af)

## Main changes explained:
- Added Asterisks to required fields 
- Utilized state of form submission to display form errors

…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links → User Management→ Create new user
6. verify that no errors labels are displayed unless and until you click on submit 


## Screenshots or videos of changes:
![bgchange1](https://github.com/user-attachments/assets/0cacba0b-e7c8-47ee-8db4-3ac396514cbe)
![bgchange2](https://github.com/user-attachments/assets/6285982a-bd7e-4b07-b1b7-5f80ff498bb6)

