### PR TITLE
Saipreetham_fix/add-new-QST-media-folder-validation of link.

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
@@ -292,10 +292,16 @@ function AddNewTitleModal({
               id="mediafolder"
               value={titleData.mediaFolder}
               onChange={e => {
-                e.persist();
-                setTitleData({ ...titleData, mediaFolder: e.target.value });
+                const inputValue = e.target.value;
+                setTitleData({ ...titleData, mediaFolder: inputValue });
               }}
+              placeholder="Enter a valid URL"
             />
+            {!/^(https?:\/\/[^\s]+)$/.test(titleData.mediaFolder) && titleData.mediaFolder !== '' && (
+              <small style={{ color: 'red', marginTop: '5px', display: 'block' }}>
+                Please enter a valid URL that starts with http:// or https://
+              </small>
+            )}
             <Label className={fontColor}>
               Team Code<span className="qsm-modal-required">*</span>:
             </Label>
@@ -349,7 +355,11 @@ function AddNewTitleModal({
       </ModalBody>
 
       <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
-        <Button color="primary" onClick={() => confirmOnClick()}>
+        <Button 
+          color="primary" 
+          onClick={() => confirmOnClick()}
+          disabled={!/^(https?:\/\/[^\s]+)$/.test(titleData.mediaFolder) || titleData.mediaFolder === ''}
+        >
           Confirm
         </Button>
         <Button color="secondary" onClick={() => setIsOpen(false)}>


### PR DESCRIPTION
# Description
<img width="417" alt="image" src="https://github.com/user-attachments/assets/337f3615-2133-4297-a36f-8e29e53372fc">


## Related PRS (if any):
Please use latest backend development branch for this PR.

## Main changes explained:
 Updated AddNewTitleModal.jsx to add URL validation for the Media Folder input with inline error handling and submission prevention.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ View Profile→ Add New QST
6. Verify the validation logic by entering regular text into the "Media Folder" field. Ensure that the "Confirm" button is disabled and an error message appears below the input field stating, "Please enter a valid URL that starts with http:// or https://."
7. Test the validation for valid URLs by entering a proper URL into the "Media Folder" field. Ensure that the error message disappears, the "Confirm" button is enabled, and the modal can be successfully submitted.
8. Verify that the validation logic works in both the modes.
## Screenshots or videos of changes:

https://github.com/user-attachments/assets/1f7f854b-0836-4935-b75c-b57c24474720


