### PR TITLE
Vijay Anand - Add unit tests for weeklySummariesReducer

### DIFF
--- a/src/reducers/__tests__/weeklySummariesReducer.test.js
+++ b/src/reducers/__tests__/weeklySummariesReducer.test.js
@@ -1,0 +1,57 @@
+import { weeklySummariesReducer } from '../weeklySummariesReducer';
+import * as actions from '../../constants/weeklySummaries';
+
+describe('weeklySummariesReducer', () => {
+  const initialState = {
+    summaries: {},
+    loading: false,
+    fetchError: null,
+  };
+
+  it('should return the initial state when no action is provided', () => {
+    expect(weeklySummariesReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should handle FETCH_WEEKLY_SUMMARIES_BEGIN', () => {
+    const action = { type: actions.FETCH_WEEKLY_SUMMARIES_BEGIN };
+    const expectedState = {
+      ...initialState,
+      loading: true,
+      fetchError: null,
+    };
+    expect(weeklySummariesReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle FETCH_WEEKLY_SUMMARIES_SUCCESS', () => {
+    const mockData = {
+      weeklySummariesData: {
+        week1: { summary: 'Test Summary 1' },
+        week2: { summary: 'Test Summary 2' },
+      },
+    };
+    const action = {
+      type: actions.FETCH_WEEKLY_SUMMARIES_SUCCESS,
+      payload: mockData,
+    };
+    const expectedState = {
+      ...initialState,
+      loading: false,
+      summaries: mockData.weeklySummariesData,
+    };
+    expect(weeklySummariesReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle FETCH_WEEKLY_SUMMARIES_ERROR', () => {
+    const mockError = new Error('Failed to fetch data');
+    const action = {
+      type: actions.FETCH_WEEKLY_SUMMARIES_ERROR,
+      payload: { error: mockError },
+    };
+    const expectedState = {
+      ...initialState,
+      loading: false,
+      fetchError: mockError,
+    };
+    expect(weeklySummariesReducer(initialState, action)).toEqual(expectedState);
+  });
+});


### PR DESCRIPTION
# Description
Added unit tests for the weeklySummariesReducer file.

## Related PRS (if any):
No related PRs.

## Main changes explained:
- Added a new test file weeklySummariesReducer.test.js under the tests directory.
- Test cases include:
  - Initial State: Ensures the reducer returns the default initial state when no valid action is provided.
  - FETCH_WEEKLY_SUMMARIES_BEGIN: Tests that the loading state is set to true and the fetchError field is cleared when a fetch operation begins.
  - FETCH_WEEKLY_SUMMARIES_SUCCESS: Tests that the summaries field is populated with data from the action payload and loading is set to false after a successful fetch.
  - FETCH_WEEKLY_SUMMARIES_ERROR: Tests that the fetchError is populated with the error from the action payload and loading is set to false after a failed fetch.

## How to test:
1. Check out the current branch.
2. Run npm install if necessary.
3. Execute npm test weeklySummariesReducer.test.js.
4. Verify that all test cases pass without any errors.

## Screenshots or videos of changes:
<img width="899" alt="Screenshot 2024-12-02 at 11 07 42 PM" src="https://github.com/user-attachments/assets/7d1064c3-f9be-445a-ad02-299aea47d17e">

## Note:
Include the information the reviewers need to know.
