### PR TITLE
Delete tags from Lesson List

### DIFF
--- a/src/components/BMDashboard/LessonList/LessonListForm.css
+++ b/src/components/BMDashboard/LessonList/LessonListForm.css
@@ -1,5 +1,6 @@
 
 .form-container{
+  
   .form-control {
    max-width: unset !important;
    font-size: small !important;
@@ -7,8 +8,21 @@
  .form-label{
   margin: 5px 0;
   font-size: small;
+  }
 }
+
+.form-control-delete {
+  margin-left: 10px;
+  font-size: small !important;
+  max-width: 100%;
 }
+
+.tag .delete-tag {
+  margin-left: 10px;
+  background-color: red;
+  
+}
+
 .main-container{
  display: flex;
  flex-direction: column;
@@ -42,39 +56,90 @@
   background-color: #F2F2F266 !important;
 
 }
+
 .tag-container {
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
   padding: 5px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  
+  margin-top: 10px;
+}
+
+.delete-input-wrapper {
+  position: relative;
+  flex: 1;
+}
+
+.form-control-delete {
+  width: 100%;
+  margin-left: 0;
+  font-size: small !important;
+}
+
+.tags-input-container {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
 }
 
 .tag {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  background-color: #F2F2F266 !important;
+  background-color: #F2F2F266;
   border-radius: 5px;
-  margin-right: 5px;
+  padding: 2px 5px;
+  margin: 2px;
   font-size: small;
-  word-break: break-all;
-  overflow: hidden;
+  gap: 5px;
+  min-height: 24px;
 }
 
 .tag .close {
   margin-left: 5px;
   cursor: pointer;
 } 
-.close-button {
-  border: none !important;
-  background-color: transparent !important;
-} 
 
+.tag .button-close {
+  background-color: #F2F2F266;
+  border-color: #F2F2F266;
+  color: black;
+}
+
+.tags-input-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.tags-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+
+.tag-dropdown {
+  position: absolute;
+  background: white;
+  border: 1px solid #ccc;
+  max-height: 200px;
+  overflow-y: auto;
+  z-index: 1000;
+  width: 100%;
+}
+
+.tag-dropdown-item {
+  padding: 8px;
+  cursor: pointer;
+}
+
+.tag-dropdown-item:hover {
+  background-color: #f0f0f0;
+}
 
   @media (max-width: 570px) {
    .form-select-container {
      flex-direction: column;
    }
   }
+

--- a/src/components/BMDashboard/LessonList/LessonListForm.jsx
+++ b/src/components/BMDashboard/LessonList/LessonListForm.jsx
@@ -3,20 +3,74 @@ import { connect } from 'react-redux';
 import { Form, FormControl, InputGroup, Button } from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './LessonListForm.css';
+import { toast } from 'react-toastify';
+import axios from 'axios';
+import { ENDPOINTS } from 'utils/URL';
 import { fetchBMLessons } from 'actions/bmdashboard/lessonsAction';
 import Lessons from './Lessons';
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+} from 'reactstrap';
 
 function LessonList(props) {
   const { lessons, dispatch } = props;
   const [tags, setTags] = useState([]);
   const [inputValue, setInputValue] = useState('');
+  const [deleteValue, setDeleteInputValue] = useState('');
   const [filteredLessons, setFilteredLessons] = useState(lessons);
   const [filterOption, setFilterOption] = useState('1');
   const [sortOption, setSortOption] = useState('1');
+  const [availableTags, setAvailableTags] = useState([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [showDeleteDropdown, setShowDeleteDropdown] = useState(false);
+  const [tagsToDelete, setTagsToDelete] = useState([]);
+  const [showConfirmModal, setConfirmModal] = useState(false);
 
+  
   useEffect(() => {
-    dispatch(fetchBMLessons());
+    const fetchData = async () => {
+      try {
+        // Fetch both lessons and tags in parallel
+        const [lessonsResponse, tagsResponse] = await Promise.all([
+          axios.get(`${ENDPOINTS.BM_LESSONS}`),
+          axios.get(`${ENDPOINTS.BM_TAGS}`)
+        ]);
+  
+        // Update Redux store 
+        dispatch({
+          type: 'SET_LESSONS',
+          payload: lessonsResponse.data
+        });
+  
+        // Update available tags
+        setAvailableTags(tagsResponse.data);
+        
+        // Update filtered lessons
+        setFilteredLessons(lessonsResponse.data);
+  
+      } catch (error) {
+        console.error('Error fetching data:', error);
+        toast.error('Failed to load data');
+      }
+    };
+  
+    fetchData();
   }, []);
+
+  const getFilteredTags = () => {
+    return availableTags.filter(tag => 
+      tag.toLowerCase().includes(inputValue.toLowerCase()) && 
+      !tags.includes(tag)
+    );
+  };
+
+  const getFilteredTagsToDelete = () => {
+    return availableTags.filter(tag => 
+      tag.toLowerCase().includes(deleteValue.toLowerCase())
+    );
+  }
 
   const getWeekNumber = date => {
     const currentDate = new Date(date);
@@ -33,6 +87,25 @@ function LessonList(props) {
 
     return weekNumber;
   };
+
+  const ConfirmationModal = () => (
+    <Modal isOpen={showConfirmModal} toggle={() => setConfirmModal(false)}>
+      <ModalBody>
+        <p>Whoa tiger! This is a very aggressive move… please confirm you are SURE you want to do this. Deleting tags cannot be undone and removes them from every lesson that uses them, not just this one.</p>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="danger" onClick={() => {
+          handleDeleteTags();
+          setConfirmModal(false);
+        }}>
+          Yep, I'm sure, scratch them!
+        </Button>
+        <Button color="secondary" onClick={() => setConfirmModal(false)}>
+          No, take me back!
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
 
   const isInThisWeek = date => {
     // Convert the date string to a Date object with consistent formatting
@@ -77,6 +150,21 @@ function LessonList(props) {
       });
     });
   }, [lessons]);
+
+  useEffect(() => {
+    const handleClickOutside = event => {
+      if (!event.target.closest('.tags-input-container')) {
+        setShowDropdown(false);
+        setShowDeleteDropdown(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, []);
 
   useEffect(() => {
     const filterAndSort = () => {
@@ -129,6 +217,15 @@ function LessonList(props) {
     }
     setInputValue('');
   };
+
+  const addDeleteTag = tag => {
+    if (!tagsToDelete.includes(tag)) {
+      setTagsToDelete(prev => [...prev, tag]);
+    }
+    setDeleteInputValue('');
+    setShowDeleteDropdown(false);
+  }
+
   const handleInputKeyDown = event => {
     if (event.key === 'Enter' || event.key === ',') {
       event.preventDefault();
@@ -136,26 +233,108 @@ function LessonList(props) {
     }
   };
 
+  const handleDeleteKeyDown = event => {
+    if (event.key === 'Enter' && deleteValue.trim()) {
+      addDeleteTag(deleteValue.trim());
+    }
+  };
+
+  const handleDeleteButtonClick = () => {
+    setConfirmModal(true);
+  }
+
+  const handleDeleteTags = async() => {
+    try {
+      const tagExistsChecks = tagsToDelete.map(tag => 
+        availableTags.includes(tag)
+      );
+
+      if (tagExistsChecks.includes(false)) {
+        toast.error("One or more tags don't exist");
+        return;
+      }
+      
+      const deletePromises = tagsToDelete.map(tag => 
+        axios.delete(`${ENDPOINTS.BM_TAGS}/${tag}`)
+      );
+      
+      // Wait for all deletions to process
+      await Promise.all(deletePromises);
+      
+      const lessonsResponse = await axios.get(`${ENDPOINTS.BM_LESSONS}`);
+      
+      // Update Redux store 
+      dispatch({
+        type: 'SET_LESSONS',
+        payload: lessonsResponse.data
+      });
+      
+      // filter lessons
+      setFilteredLessons(lessonsResponse.data);
+
+      // Update available tags
+      const updatedTagsResponse = await axios.get(`${ENDPOINTS.BM_TAGS}`);
+      setAvailableTags(updatedTagsResponse.data);
+      
+      setTagsToDelete([]);
+      setConfirmModal(false);
+      toast.success('Tags deleted successfully');
+      
+    } catch (error) {
+      console.error('Error deleting tags: ', error);
+      toast.error('Failed to delete tags');
+    }
+  }
+
   const removeTag = index => {
     const newTags = [...tags];
     newTags.splice(index, 1);
     setTags(newTags);
   };
   const filterLessonsByTags = () => {
-    if (tags.length === 0) {
-      // No tags to filter, show all lessons
-      setFilteredLessons(lessons);
-    } else {
-      // Filter lessons based on tags
-      setFilteredLessons(
-        lessons.filter(lesson => lesson.tags && tags.some(tag => lesson.tags.includes(tag))),
+    let filtered = [...lessons];
+  
+    // If tags exist
+    if (tags.length > 0) {
+      filtered = filtered.filter(lesson => 
+        lesson.tags && tags.every(tag => lesson.tags.includes(tag))
       );
     }
+  
+    //  date filtering
+    switch (filterOption) {
+      case '2':
+        filtered = filtered.filter(item => isInThisYear(item.date));
+        break;
+      case '3':
+        filtered = filtered.filter(item => isInThisMonth(item.date));
+        break;
+      case '4':
+        filtered = filtered.filter(item => isInThisWeek(item.date));
+        break;
+    }
+  
+    //  apply sorting
+    switch (sortOption) {
+      case '1':
+        filtered.sort((a, b) => new Date(a.date) - new Date(b.date));
+        break;
+      case '2':
+        filtered.sort((a, b) => new Date(b.date) - new Date(a.date));
+        break;
+      case '3':
+        filtered.sort((a, b) => b.totalLikes - a.totalLikes);
+        break;
+    }
+  
+    setFilteredLessons(filtered);
   };
+  
 
   useEffect(() => {
     filterLessonsByTags();
-  }, [tags, lessons]);
+  }, [tags, lessons, filterOption, sortOption]);
+  
 
   return (
     <div className="main-container">
@@ -202,29 +381,111 @@ function LessonList(props) {
             </div>
           </div>
           <Form.Group controlId="tagInput">
-            <Form.Label>Tags:</Form.Label>
-            <InputGroup className="mb-3">
-              {tags.length > 0 &&
-                tags.map((tag, index) => (
-                  <div key={tag} className="tag">
+          <Form.Label>Tags:</Form.Label>
+          <div className="tags-input-container">
+            <InputGroup className="tags-wrapper">
+              <input
+                type="text"
+                placeholder="Select tag"
+                value={inputValue}
+                onChange={(e) => {
+                  setInputValue(e.target.value);
+                  setShowDropdown(true);
+                }}
+                onFocus={() => setShowDropdown(true)}
+                className="form-control"
+              />
+              {showDropdown && inputValue && (
+                <div className="tag-dropdown">
+                  {getFilteredTags().map(tag => (
+                    <div
+                      key={tag}
+                      className="tag-dropdown-item"
+                      onClick={() => {
+                        addTag(tag);
+                        setShowDropdown(false);
+                      }}
+                    >
+                      {tag}
+                    </div>
+                  ))}
+                </div>
+              )}
+              
+            </InputGroup>
+            <div className="tag-container">
+              {tags.map((tag, index) => (
+                <div key={index} className="tag">
+                  <span>{tag}</span>
+                  <Button
+                    className = "button-close"
+                    onClick={() => removeTag(index)}
+                  >
+                    x
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <Form.Label>Delete Tags (Press enter to add a tag to delete): </Form.Label>
+          <div className="tags-input-container">
+            <div className="delete-input-wrapper">
+              <input
+                    type="text"
+                    placeholder="Search tag to delete"
+                    value={deleteValue}
+                    className="form-control-delete"
+                    onChange={(e) => {
+                      setDeleteInputValue(e.target.value);
+                      setShowDeleteDropdown(true);
+                    }}
+                    onFocus ={()=>setShowDeleteDropdown(true)}
+                    onKeyDown={handleDeleteKeyDown}
+              />
+              {showDeleteDropdown && deleteValue && (
+                <div className="tag-dropdown">
+                  {getFilteredTagsToDelete().map(tag => (
+                    <div
+                      key={tag}
+                      className="tag-dropdown-item"
+                      onClick={() => addDeleteTag(tag)}
+                    >
+                      {tag}
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="tag-container">
+                {tagsToDelete.map((tag, index) => (
+                  <div key={index} className="tag">
                     <span>{tag}</span>
                     <Button
-                      variant="light"
-                      className="close-button"
-                      onClick={() => removeTag(index)}
+                      className="button-close"
+                      onClick={() => {
+                        const newTags = tagsToDelete.filter((_, i) => i !== index);
+                        setTagsToDelete(newTags);
+                      }}
                     >
-                      &times;
+                      x
                     </Button>
                   </div>
                 ))}
-              <FormControl
-                placeholder="Add tags"
-                value={inputValue}
-                onKeyDown={handleInputKeyDown}
-                onChange={e => setInputValue(e.target.value)}
-              />
-            </InputGroup>
-          </Form.Group>
+              </div>
+            </div>
+            {tagsToDelete.length > 0 && (
+                <Button 
+                  style={{ backgroundColor: 'red', marginLeft: '10px' }}
+                  onClick={handleDeleteButtonClick}
+                >
+                  Delete
+                </Button>
+              )}
+
+              <ConfirmationModal />
+          </div>
+          
+        </Form.Group>
         </Form>
         <Lessons
           filteredLessons={filteredLessons}
@@ -242,3 +503,4 @@ const mapStateToProps = state => ({
 });
 
 export default connect(mapStateToProps)(LessonList);
+

--- a/src/components/BMDashboard/Projects/ProjectSelectForm.jsx
+++ b/src/components/BMDashboard/Projects/ProjectSelectForm.jsx
@@ -5,7 +5,7 @@ import { Form, FormGroup, Col, Row, Label, Input, Button } from 'reactstrap';
 import ErrorAlert from '../ErrorAlert';
 
 function ProjectSelectForm() {
-  const projects = useSelector(state => state.bmProjects);
+  const projects = useSelector(state => state.bmProjects) || [];
   const history = useHistory();
   const [selectedProjectId, setSelectedProjectId] = useState('');
   const [error, setError] = useState(false);

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -1,3 +1,4 @@
+
 const APIEndpoint =
   process.env.REACT_APP_APIENDPOINT || 'https://hgn-rest-beta.azurewebsites.net/api';
 
@@ -7,13 +8,9 @@ export const ENDPOINTS = {
   USER_PROFILE_PROPERTY: userId => `${APIEndpoint}/userprofile/${userId}/property`,
   USER_PROFILES: `${APIEndpoint}/userprofile/`,
   UPDATE_REHIREABLE_STATUS: userId => `${APIEndpoint}/userprofile/${userId}/rehireable`,
-  USER_PROFILE_UPDATE: `${APIEndpoint}/userprofile/update`,
   ADD_BLUE_SQUARE: userId => `${APIEndpoint}/userprofile/${userId}/addInfringement`,
-  MODIFY_BLUE_SQUARE: (userId, blueSquareId) =>
-    `${APIEndpoint}/userprofile/${userId}/infringements/${blueSquareId}`,
-  USERS_ALLTEAMCODE_CHANGE: `${APIEndpoint}/AllTeamCodeChanges`,
-  USER_PROFILE_BASIC_INFO: `${APIEndpoint}/userProfile/basicInfo`,
-  USER_AUTOCOMPLETE: searchText => `${APIEndpoint}/userProfile/autocomplete/${searchText}`,
+  MODIFY_BLUE_SQUARE: (userId, blueSquareId) => `${APIEndpoint}/userprofile/${userId}/infringements/${blueSquareId}`,
+  USERS_ALLTEAMCODE_CHANGE : `${APIEndpoint}/AllTeamCodeChanges`,
 
   INFO_COLLECTIONS: `${APIEndpoint}/informations`,
   INFO_COLLECTION: infoId => `${APIEndpoint}/informations/${infoId}`,
@@ -42,8 +39,6 @@ export const ENDPOINTS = {
     `${APIEndpoint}/TimeEntry/user/${userId}/${fromDate}/${toDate}`,
   TIME_ENTRIES_USER_LIST: `${APIEndpoint}/TimeEntry/users`,
   TIME_ENTRIES_REPORTS: `${APIEndpoint}/TimeEntry/reports`,
-  TIME_ENTRIES_REPORTS_TOTAL_PROJECT_REPORT: `${APIEndpoint}/TimeEntry/reports/projects`,
-  TIME_ENTRIES_REPORTS_TOTAL_PEOPLE_REPORT: `${APIEndpoint}/TimeEntry/reports/people`,
   TIME_ENTRIES_LOST_USER_LIST: `${APIEndpoint}/TimeEntry/lostUsers`,
   TIME_ENTRIES_LOST_PROJ_LIST: `${APIEndpoint}/TimeEntry/lostProjects`,
   TIME_ENTRIES_LOST_TEAM_LIST: `${APIEndpoint}/TimeEntry/lostTeams`,
@@ -70,14 +65,11 @@ export const ENDPOINTS = {
   UPDATE_PARENT_TASKS: wbsId => `${APIEndpoint}/task/updateAllParents/${wbsId}`,
   MOVE_TASKS: wbsId => `${APIEndpoint}/tasks/moveTasks/${wbsId}`,
   WEEKLY_SUMMARIES_REPORT: () => `${APIEndpoint}/reports/weeklysummaries`,
-  SAVE_SUMMARY_RECEPIENTS: userid => `${APIEndpoint}/reports/recepients/${userid}`,
+  SAVE_SUMMARY_RECEPIENTS: (userid) => `${APIEndpoint}/reports/recepients/${userid}`,
   GET_SUMMARY_RECEPIENTS: () => `${APIEndpoint}/reports/getrecepients`,
-  AUTHORIZE_WEEKLY_SUMMARY_REPORTS: () =>
-    `${APIEndpoint}/userProfile/authorizeUser/weeeklySummaries`,
-  TOTAL_ORG_SUMMARY: (startDate, endDate) =>
-    `${APIEndpoint}/reports/volunteerstats?startDate=${startDate}&endDate=${endDate}`,
-  HOURS_TOTAL_ORG_SUMMARY: (startDate, endDate) =>
-    `${APIEndpoint}/reports/overviewsummaries/taskandprojectstats?startDate=${startDate}&endDate=${endDate}`,
+  AUTHORIZE_WEEKLY_SUMMARY_REPORTS: () => `${APIEndpoint}/userProfile/authorizeUser/weeeklySummaries`,
+  TOTAL_ORG_SUMMARY: (startDate, endDate) => `${APIEndpoint}/reports/volunteerstats?startDate=${startDate}&endDate=${endDate}`,
+  HOURS_TOTAL_ORG_SUMMARY: (startDate,endDate) => `${APIEndpoint}/reports/overviewsummaries/taskandprojectstats?startDate=${startDate}&endDate=${endDate}`,
 
   POPUP_EDITORS: `${APIEndpoint}/popupeditors/`,
   POPUP_EDITOR_BY_ID: id => `${APIEndpoint}/popupeditor/${id}`,
@@ -100,12 +92,12 @@ export const ENDPOINTS = {
   DELETE_TASK_NOTIFICATION: taskNotificationId =>
     `${APIEndpoint}/tasknotification/${taskNotificationId}`,
 
-  // titles endpoints
+  //titles endpoints
   TITLES: () => `${APIEndpoint}/title`,
   // TITLES: () => `${APIEndpoint}/title/deleteAll`,
   TITLE_BY_ID: titleId => `${APIEndpoint}/title/${titleId}`,
   CREATE_NEW_TITLE: () => `${APIEndpoint}/title`,
-  EDIT_OLD_TITLE: () => `${APIEndpoint}/title/update`,
+  EDIT_OLD_TITLE:  ()=>`${APIEndpoint}/title/update`,
   DELETE_TITLE_BY_ID: titleId => `${APIEndpoint}/title/${titleId}`,
 
   DELETE_TASK_NOTIFICATION_BY_USER_ID: (taskId, userId) =>
@@ -115,7 +107,7 @@ export const ENDPOINTS = {
     `${APIEndpoint}/taskeditsuggestion/${taskEditSuggestionId}`,
 
   TIMER_SERVICE: `${APIEndpoint.replace('http', 'ws').replace('api', 'timer-service')}`,
-  TIMEZONE_LOCATION: location => `${APIEndpoint}/timezone/${location}`,
+  TIMEZONE_LOCATION: (location) => `${APIEndpoint}/timezone/${location}`,
 
   ROLES: () => `${APIEndpoint}/roles`,
   ROLES_BY_ID: roleId => `${APIEndpoint}/roles/${roleId}`,
@@ -142,7 +134,24 @@ export const ENDPOINTS = {
   NON_HGN_EMAIL_SUBSCRIPTION: `${APIEndpoint}/add-non-hgn-email-subscription`,
   CONFIRM_EMAIL_SUBSCRIPTION: `${APIEndpoint}/confirm-non-hgn-email-subscription`,
   REMOVE_EMAIL_SUBSCRIPTION: `${APIEndpoint}/remove-non-hgn-email-subscription`,
-  // reasons endpoints
+  //reasons endpoints
+  CREATEREASON: () => {
+    return `${APIEndpoint}/reason/`;
+  },
+  GETALLUSERREASONS: userId => {
+    return `${APIEndpoint}/reason/${userId}`;
+  },
+  GETSINGLEREASONBYID: userId => {
+    return `${APIEndpoint}/reason/single/${userId}`;
+  },
+  PATCHUSERREASONBYID: userId => {
+    return `${APIEndpoint}/reason/${userId}`;
+  },
+  DELETEUSERREASONBYID: userId => {
+    return `${APIEndpoint}/reason/${userId}`;
+  },
+
+  //reasons endpoints
   CREATEREASON: () => {
     return `${APIEndpoint}/reason/`;
   },
@@ -166,8 +175,9 @@ export const ENDPOINTS = {
   GET_TOTAL_COUNTRY_COUNT: () => `${APIEndpoint}/getTotalCountryCount`,
 
   GET_ALL_FOLLOWUPS: () => `${APIEndpoint}/followup`,
+
   SET_USER_FOLLOWUP: (userId, taskId) => `${APIEndpoint}/followup/${userId}/${taskId}`,
-  GET_PROJECT_BY_PERSON: searchName => `${APIEndpoint}/userProfile/projects/${searchName}`,
+  GET_PROJECT_BY_PERSON: (searchName) => `${APIEndpoint}/userProfile/projects/${searchName}`,
 
   // bm dashboard endpoints
   BM_LOGIN: `${APIEndpoint}/bm/login`,
@@ -199,10 +209,17 @@ export const ENDPOINTS = {
   BM_LESSON_LIKES: lessonId => `${APIEndpoint}/bm/lesson/${lessonId}/like`,
   BM_INVENTORY_UNITS: `${APIEndpoint}/bm/inventoryUnits`,
   BM_INVTYPE_ROOT: `${APIEndpoint}/bm/invtypes`,
+  BM_TOOLS: `${APIEndpoint}/bm/tools/`,
   BM_TOOL_BY_ID: singleToolId => `${APIEndpoint}/bm/tools/${singleToolId}`,
   BM_LOG_TOOLS: `${APIEndpoint}/bm/tools/log`,
   BM_EQUIPMENT_BY_ID: singleEquipmentId => `${APIEndpoint}/bm/equipment/${singleEquipmentId}`,
+  BM_EQUIPMENTS: `${APIEndpoint}/bm/equipments`,
   BM_INVTYPE_TYPE: type => `${APIEndpoint}/bm/invtypes/${type}`,
+  BM_UPDATE_MATERIAL_BULK: `${APIEndpoint}/bm/updateMaterialRecordBulk`,
+  BM_PROJECTS: `${APIEndpoint}/bm/projects`,
+  BM_TAGS: `${APIEndpoint}/bm/tags`,
+  BM_TAG_ADD: `${APIEndpoint}/bm/tags`,
+  BM_TAGS_DELETE: `${APIEndpoint}/bm/tags`,
   GET_TIME_OFF_REQUESTS: () => `${APIEndpoint}/getTimeOffRequests`,
   ADD_TIME_OFF_REQUEST: () => `${APIEndpoint}/setTimeOffRequest`,
   UPDATE_TIME_OFF_REQUEST: id => `${APIEndpoint}/updateTimeOffRequest/${id}`,


### PR DESCRIPTION
# Description
Gives users the ability to delete tags in the Lesson List page.
This is part of the Phase 2 Implementation. 

## Related PRS (if any):
This frontend PR is related to the #1159  backend PR.
…

## Main changes explained:
- Created a delete tag input area that allows users to search through existing tags.
- Added some changes to the backend to fetch tags from the database and to remove tags.
- Modal popup before deleting tags from database.
- Erases tags from lesson cards after deletion.
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. go to http://localhost:3000/bmdashboard/lessonlist
5. verify the delete input area searches for tags in databases 
6. verify tags can be added below the input area 
7. check that the modal popup shows up after pressing delete button 
8. once user ensures that they want the tag deleted, the tags selected to be deleted must also be removed from the lesson cards.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/dcf696ec-52f3-4008-9c2a-236381b16d56

