### PR TITLE
fix: extra container outline in QuickSetupModal.jsx

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
@@ -57,7 +57,7 @@ function QuickSetupModal(props) {
   };
 
   return (
-    <div className="container pt-3">
+    <div>
       {canAssignTitle || canEditTitle || canAddTitle ? (
         <QuickSetupCodes
           setSaved={props.setSaved}


### PR DESCRIPTION
Removed extra container outline in QuickSetupModal.jsx.

# Description
Fixed extra container outline in QuickSetupModal.jsx.

## Related PRS (if any):
#2235 

## Main changes explained:
- Fixed extra container outline in QuickSetupModal.jsx.

## How to test:
1. Netlify down below
