### PR TITLE
Rishitha Fix blue square summary format and date 

### DIFF
--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -21,6 +21,7 @@
 
 .summary {
   padding: 5px;
+  white-space: pre-wrap;
 }
 
 .blueSquareContainer {

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -505,10 +505,11 @@ function UserProfile(props) {
         const newBlueSquare = {
           date: dateStamp,
           description: summary,
-          createdDate: moment
-            .tz('America/Los_Angeles')
-            .toISOString()
-            .split('T')[0],
+          // createdDate: moment
+          //   .tz('America/Los_Angeles')
+          //   .toISOString()
+          //   .split('T')[0],
+          createdDate: moment().format('YYYY-MM-DD'),
         };
         setModalTitle('Blue Square');
         await axios


### PR DESCRIPTION
# Description
(PRIORITY MEDIUM) Jae: Fix blue square summary formatting and date tag (WIP Rishitha)
Admin/Owner Login>Profile Page>Blue Squares>”+”
When assigning a blue square, the date it is assigned  shows up at the beginning of the description… this date is a day later than it should be
The summary is also eliminating line spaces. They are missing in pic right and that makes the reason harder to read. 

## Related PRS (if any):
This frontend PR is related to the development backend PR.

## Main changes explained:
- Update src/components/UserProfile/BlueSquares/BlueSquare.css for including line spaces
- Update src/components/UserProfile/UserProfile.jsx to correct the date

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ others links -> user management 
6. select a user profile to assign blue square
7. in user profile page -> blue squares -> "+"
8. assign the blue square
9. verify the date is correct and shows the date it is assigned on
11. verify the line spacing provided in the summary while assiging blue square is not eliminated.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/e90e9baa-ba1f-460f-9aba-6d41f3a18a41
