### PR TITLE
Pallavi Fixed ability to interact with deadline check-in-box

### DIFF
--- a/src/components/TeamMemberTasks/components/TaskCompletedModal.jsx
+++ b/src/components/TeamMemberTasks/components/TaskCompletedModal.jsx
@@ -26,11 +26,23 @@ const TaskCompletedModal = React.memo(props => {
       }
       return newResource;
     });
-
+  
     const updatedTask = { ...task, resources: newResources };
+  
+    
     props.updateTask(task._id, updatedTask);
+  
+    
+    if (props.setUpdatedTasks) {
+      props.setUpdatedTasks(prevTasks =>
+        prevTasks.map(t => (t._id === task._id ? updatedTask : t))
+      );
+    }
+  
     toast.success("Task is successfully marked as done.");
   };
+  
+  
 
   const removeUserFromTask = task => {
     const newResources = task.resources.filter(item => item.userID !== props.userId);
@@ -40,10 +52,21 @@ const TaskCompletedModal = React.memo(props => {
     toast.success("User has been removed from the task successfully.");
   };
 
-  const handleClick = ()=>{
+ 
+
+  const handleClick = () => {
+    const scrollY = window.scrollY; // Save scroll position
     closeFunction();
-    props.taskModalOption === 'Checkmark' ? removeTaskFromUser(props.task) : removeUserFromTask(props.task);
-  }
+  
+    if (props.taskModalOption === 'Checkmark') {
+      removeTaskFromUser(props.task);
+    } else {
+      removeUserFromTask(props.task);
+    }
+  
+    window.scrollTo(0, scrollY); 
+  };
+  
 
   let isCheckmark = props.taskModalOption === 'Checkmark';
   let modalHeader = isCheckmark ? 'Mark as Done' : 'Remove User from Task';


### PR DESCRIPTION
# Description
This Pull Request addresses an issue with the functionality of the deadline check-in box on the Admin Dashboard > Tasks Tab. Previously, when resolving a task, the deadline check-in box became unresponsive until the page was refreshed. This bug caused an interruption in workflow and a poor user experience.


## Related PRS (if any):
This frontend PR is related to the developement backend PR.

<img width="1194" alt="Task" src="https://github.com/user-attachments/assets/0644ded9-3397-41de-83a7-48d78a027c50">


## Main changes explained:
- Improved the functionality of the handleClick function to preserve the current scroll position when closing the modal and performing actions (Checkmark or user removal). This ensures a smoother user experience and prevents the page from jumping to the top after interactions.
- Enhanced task update logic in removeTaskFromUser by ensuring that the setUpdatedTasks function is only called when it exists, avoiding potential errors in scenarios where setUpdatedTasks is not passed as a prop.


## How to test:
1. check into current branch
2. do npm start to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Admin Login>Dashboard> Tasks Tab>deadline check-in box 
6. Verify that handleClick correctly preserves the scroll position and updates tasks as expected.
7. verify this new feature works in both light and dark mode.

## Screenshots or videos of changes:


https://github.com/user-attachments/assets/0309973d-a342-43c4-94a0-0a8742611df0




