### PR TITLE
Xiaolu add the unit test of PasswordInputModal

### DIFF
--- a/src/components/WeeklySummariesReport/PasswordInputModal.jsx
+++ b/src/components/WeeklySummariesReport/PasswordInputModal.jsx
@@ -109,6 +109,7 @@ export default function PasswordInputModal({
               id="passwordField"
               value={passwordField}
               onChange={onChangeFunc}
+              data-testid="password-input"
             />
             {showPassword ? (
               <FontAwesomeIcon

--- a/src/components/WeeklySummariesReport/__tests__/PasswordInputModal.test.js
+++ b/src/components/WeeklySummariesReport/__tests__/PasswordInputModal.test.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import PasswordInputModal from '../PasswordInputModal';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import axios from 'axios';
+import { toast } from 'react-toastify';
+
+jest.mock('axios');
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: jest.fn(),
+  },
+}));
+
+const mockStore = configureStore([]);
+const mockOnClose = jest.fn();
+const mockCheckForValidPwd = jest.fn();
+const mockSetSummaryRecepientsPopup = jest.fn();
+const mockSetAuthpassword = jest.fn();
+
+describe('PasswordInputModal', () => {
+  let store;
+
+  beforeEach(() => {
+    store = mockStore({
+      theme: { darkMode: false },
+    });
+  });
+
+  const renderComponent = () =>
+    render(
+      <Provider store={store}>
+        <PasswordInputModal
+          onClose={mockOnClose}
+          open={true}
+          checkForValidPwd={mockCheckForValidPwd}
+          isValidPwd={false}
+          setSummaryRecepientsPopup={mockSetSummaryRecepientsPopup}
+          setAuthpassword={mockSetAuthpassword}
+          authEmailWeeklySummaryRecipient="test@example.com"
+        />
+      </Provider>
+    );
+
+  test('renders the modal with input field and buttons', () => {
+    renderComponent();
+
+    expect(screen.getByText(/Password to Authorise User/i)).toBeInTheDocument();
+    expect(screen.getByTestId('password-input')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Authorize/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
+  });
+
+  test('toggles password visibility when eye icon is clicked', () => {
+    renderComponent();
+
+    const passwordInput = screen.getByTestId('password-input');
+    const eyeIcon = screen.getByRole('img', { hidden: true });
+
+    expect(passwordInput).toHaveAttribute('type', 'password');
+
+    fireEvent.click(eyeIcon);
+    expect(passwordInput).toHaveAttribute('type', 'text');
+
+    fireEvent.click(eyeIcon);
+    expect(passwordInput).toHaveAttribute('type', 'password');
+  });
+
+  test('calls onClose when Cancel button is clicked', () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls success flow when the password is correct', async () => {
+    axios.post.mockResolvedValueOnce({
+      status: 200,
+      data: { message: 'Success', password: 'correctPassword' },
+    });
+
+    renderComponent();
+
+    const passwordInput = screen.getByTestId('password-input');
+    const authorizeButton = screen.getByRole('button', { name: /Authorize/i });
+
+    userEvent.type(passwordInput, 'correctPassword');
+    fireEvent.click(authorizeButton);
+
+    await waitFor(() => {
+      expect(mockCheckForValidPwd).toHaveBeenCalledWith(true);
+      expect(mockSetAuthpassword).toHaveBeenCalledWith('correctPassword');
+      expect(mockSetSummaryRecepientsPopup).toHaveBeenCalledWith(true);
+      expect(mockOnClose).toHaveBeenCalled();
+      expect(toast.success).toHaveBeenCalledWith(
+        'Authorization successful! Please wait to see Recipients table!'
+      );
+    });
+  });
+});

--- a/src/components/WeeklySummariesReport/__tests__/PasswordInputModal.test.js
+++ b/src/components/WeeklySummariesReport/__tests__/PasswordInputModal.test.js
@@ -42,7 +42,7 @@ describe('PasswordInputModal', () => {
           setAuthpassword={mockSetAuthpassword}
           authEmailWeeklySummaryRecipient="test@example.com"
         />
-      </Provider>
+      </Provider>,
     );
 
   test('renders the modal with input field and buttons', () => {
@@ -96,7 +96,7 @@ describe('PasswordInputModal', () => {
       expect(mockSetSummaryRecepientsPopup).toHaveBeenCalledWith(true);
       expect(mockOnClose).toHaveBeenCalled();
       expect(toast.success).toHaveBeenCalledWith(
-        'Authorization successful! Please wait to see Recipients table!'
+        'Authorization successful! Please wait to see Recipients table!',
       );
     });
   });


### PR DESCRIPTION
# Description
Unit test for PasswordInputModal

## Related PRS (if any):
No related PRs

## Main changes explained:
- Added test cases in PasswordInputModal.test.js to cover all functionalities of PasswordInputModal.
- Validated the following scenarios:
   Verifies that the title, input field, "Authorize," and "Cancel" buttons render correctly.
   Confirms that clicking the eye icon toggles the password input visibility.
   Ensures the onClose function is called when the "Cancel" button is clicked
   After entering the correct password, checks that: checkForValidPwd is called. The authorized password is set. A success notification appears. The modal closes.


## How to test:
1. Check into current branch
2. Do npm install
3. Execute npm test PasswordInputModal.test.js
4. Verify all test cases pass without errors.


## Screenshots or videos of changes:
![Screenshot 2024-12-06 at 17 37 03](https://github.com/user-attachments/assets/84f7519d-85f9-4d36-9476-b87ef8b1d6de)

