### PR TITLE
Yili - Fix the issue for non-Owner/Admin accounts that have the 'Edit Team 4-Digit Codes' permission, allowing them to edit the team code

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -1442,7 +1442,7 @@ function UserProfile(props) {
                   </Button>
                 </Link>
               )}
-              {canEdit && activeTab && (
+              {(canEdit && activeTab || canEditTeamCode) && (
                 <>
                   <SaveButton
                     className="mr-1 btn-bottom"


### PR DESCRIPTION
# Description
![Fix the issue for non-Owner:Admin accounts that have the 'Edit Team 4-Digit Codes' permission, allowing them to edit the team code](https://github.com/user-attachments/assets/1b0fd9ae-e151-43c6-8af8-01001508a14c)

## Related PRS (if any):
This frontend PR is related to the backend [PR #1172](https://github.com/OneCommunityGlobal/HGNRest/pull/1172)

## How to test:

1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to Other Links -> Permissions Management -> Manage User Permissions -> Choose a volunteer user -> Permissions  -> Reports  -> `Edit Team 4-Digit Codes`  -> Click on "Add" -> Click on "save changes"
6. log as the volunteer user with permission
7. go to another volunteer's profile
8. verify that the user who was given the permission is now able to edit edit team codes on other users' profiles


## Screenshots or videos of changes:

https://github.com/user-attachments/assets/60b3c307-35d3-4922-abf3-27c8f138e4ad

<img width="659" alt="1" src="https://github.com/user-attachments/assets/baa0b7a5-e6b7-4f9b-8196-ced181cff57d">
<img width="516" alt="2" src="https://github.com/user-attachments/assets/fa67345e-7f94-4c77-8683-bb906f8b0930">
