### PR TITLE
Vijay Anand - Unit test total org summary reducer

### DIFF
--- a/src/reducers/__tests__/totalOrgSummary.test.js
+++ b/src/reducers/__tests__/totalOrgSummary.test.js
@@ -1,0 +1,53 @@
+import { totalOrgSummaryReducer } from '../totalOrgSummaryReducer';
+import * as actions from '../../constants/totalOrgSummary';
+
+describe('totalOrgSummaryReducer', () => {
+  const initialState = {
+    volunteerstats: [],
+    volunteerOverview: [],
+    loading: false,
+    error: null,
+    fetchingError: null,
+  };
+
+  it('should return the initial state when no action is provided', () => {
+    const newState = totalOrgSummaryReducer(undefined, {});
+    expect(newState).toEqual(initialState);
+  });
+
+  it('should handle FETCH_TOTAL_ORG_SUMMARY_BEGIN', () => {
+    const action = { type: actions.FETCH_TOTAL_ORG_SUMMARY_BEGIN };
+    const newState = totalOrgSummaryReducer(initialState, action);
+    expect(newState).toEqual({
+      ...initialState,
+      loading: true,
+      error: null,
+    });
+  });
+
+  it('should handle FETCH_TOTAL_ORG_SUMMARY_SUCCESS', () => {
+    const action = {
+      type: actions.FETCH_TOTAL_ORG_SUMMARY_SUCCESS,
+      payload: { volunteerstats: [{ id: 1, name: 'John Doe' }] },
+    };
+    const newState = totalOrgSummaryReducer(initialState, action);
+    expect(newState).toEqual({
+      ...initialState,
+      loading: false,
+      volunteerstats: [{ id: 1, name: 'John Doe' }],
+    });
+  });
+
+  it('should handle FETCH_TOTAL_ORG_SUMMARY_ERROR', () => {
+    const action = {
+      type: actions.FETCH_TOTAL_ORG_SUMMARY_ERROR,
+      payload: { error: 'Unable to fetch data' },
+    };
+    const newState = totalOrgSummaryReducer(initialState, action);
+    expect(newState).toEqual({
+      ...initialState,
+      loading: false,
+      error: 'Unable to fetch data',
+    });
+  });
+});

--- a/src/reducers/__tests__/totalOrgSummaryReducer.test.js
+++ b/src/reducers/__tests__/totalOrgSummaryReducer.test.js
@@ -50,4 +50,30 @@ describe('totalOrgSummaryReducer', () => {
       error: 'Unable to fetch data',
     });
   });
+
+  it('should handle FETCH_TOTAL_ORG_SUMMARY_DATA_SUCCESS', () => {
+    const action = {
+      type: actions.FETCH_TOTAL_ORG_SUMMARY_DATA_SUCCESS,
+      payload: { volunteerOverview: [{ id: 2, name: 'Jane Doe' }] },
+    };
+    const newState = totalOrgSummaryReducer(initialState, action);
+    expect(newState).toEqual({
+      ...initialState,
+      loading: false,
+      volunteerOverview: [{ id: 2, name: 'Jane Doe' }],
+    });
+  });
+
+  it('should handle FETCH_TOTAL_ORG_SUMMARY_DATA_ERROR', () => {
+    const action = {
+      type: actions.FETCH_TOTAL_ORG_SUMMARY_DATA_ERROR,
+      payload: { fetchingError: 'Unable to fetch overview data' },
+    };
+    const newState = totalOrgSummaryReducer(initialState, action);
+    expect(newState).toEqual({
+      ...initialState,
+      loading: false,
+      fetchingError: 'Unable to fetch overview data',
+    });
+  });
 });


### PR DESCRIPTION
# Description
Added unit tests for the totalOrgSummaryReducer.

## Related PRS (if any):
No related PRs.

## Main changes explained:
- Created a new test file totalOrgSummaryReducer.test.js under the tests directory.
- Covered the following scenarios:
  - Returns the initial state when no state is provided.
  - Handles FETCH_TOTAL_ORG_SUMMARY_BEGIN by setting loading to true and clearing errors.
  - Handles FETCH_TOTAL_ORG_SUMMARY_SUCCESS by updating the volunteerstats array and stopping the loading state.
  - Handles FETCH_TOTAL_ORG_SUMMARY_ERROR by setting error with the provided error message and stopping the loading state.
  - Handles FETCH_TOTAL_ORG_SUMMARY_DATA_SUCCESS by updating the volunteerOverview array and stopping the loading state.
  - Handles FETCH_TOTAL_ORG_SUMMARY_DATA_ERROR by setting fetchingError with the provided error message and stopping the loading state.

## How to test:
1. Check out the current branch.
2. Run npm install if necessary.
3. Execute npm test totalOrgSummaryReducer.test.js.
4. Verify that all test cases pass successfully without any errors.

## Screenshots or videos of changes:
<img width="789" alt="image" src="https://github.com/user-attachments/assets/2a7731a7-a15b-48e1-b5b5-105595ffb6ce" />

## Note:
Include the information the reviewers need to know.
