### PR TITLE
Aishwarya - Create way to see 6 months & yearly anniversaries

### DIFF
--- a/src/actions/leaderBoardData.js
+++ b/src/actions/leaderBoardData.js
@@ -3,6 +3,7 @@ import { ENDPOINTS } from '../utils/URL';
 import {
   getOrgData as getOrgDataActionCreator,
   getLeaderBoardData as getLeaderBoardDataActionCreator,
+  postLeaderboardData as postLeaderboardDataActionCreator,
 } from '../constants/leaderBoardData';
 
 export const getLeaderboardData = userId => {
@@ -24,3 +25,23 @@ export const getOrgData = () => {
     await dispatch(getOrgDataActionCreator(res.data));
   };
 };
+
+export const postLeaderboardData = (userId, trophyFollowedUp, userProfile) => {
+  
+  return async dispatch => {
+    try {
+      const url = ENDPOINTS.TROPHY_ICON(userId, trophyFollowedUp);
+      
+      // Attempt to post the data
+      const res = await httpService.post(url, userProfile);
+
+      // Dispatch the action with the user profile
+      await dispatch(postLeaderboardDataActionCreator(userProfile));
+    } catch (error) {
+      // Handle any errors that occur
+      console.error('Error posting leaderboard data:', error);
+
+    }
+  };
+};
+

--- a/src/components/LeaderBoard/LeaderBoard.container.jsx
+++ b/src/components/LeaderBoard/LeaderBoard.container.jsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { get, round, maxBy } from 'lodash';
-import { getLeaderboardData, getOrgData } from '../../actions/leaderBoardData';
+import { getLeaderboardData, postLeaderboardData, getOrgData } from '../../actions/leaderBoardData';
 import Leaderboard from './Leaderboard';
 import { getcolor, getprogress, getProgressValue } from '../../utils/effortColors';
 import { getMouseoverText } from '../../actions/mouseoverTextAction';
@@ -71,6 +71,7 @@ const mapStateToProps = state => {
 };
 export default connect(mapStateToProps, {
   getLeaderboardData,
+  postLeaderboardData,
   getOrgData,
   getMouseoverText,
   showTimeOffRequestModal,

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -23,6 +23,7 @@ import {
   showStar,
   viewZeroHouraMembers,
 } from 'utils/leaderboardPermissions';
+import { calculateDurationBetweenDates, showTrophyIcon } from 'utils/anniversaryPermissions';
 import hasPermission from 'utils/permissions';
 import MouseoverTextTotalTimeEditButton from 'components/mouseoverText/MouseoverTextTotalTimeEditButton';
 import { toast } from 'react-toastify';
@@ -66,6 +67,7 @@ function displayDaysLeft(lastDay) {
 
 function LeaderBoard({
   getLeaderboardData,
+  postLeaderboardData,
   getOrgData,
   getMouseoverText,
   leaderBoardData,
@@ -85,6 +87,20 @@ function LeaderBoard({
   const hasVisibilityIconPermission = hasPermission('seeVisibilityIcon'); // ??? this permission doesn't exist?
   const isOwner = ['Owner'].includes(loggedInUser.role);
   const currentDate = moment.tz('America/Los_Angeles').startOf('day');
+  const todaysDate = moment()
+    .tz('America/Los_Angeles')
+    .endOf('week')
+    .format('YYYY-MM-DD');
+
+  useEffect(() => {
+    for (let i = 0; i < leaderBoardData.length; i += 1) {
+      const createDate = leaderBoardData[i].createdDate?.split('T')[0];
+      const showTrophy = showTrophyIcon(todaysDate, createDate);
+      if (!showTrophy && leaderBoardData[i].trophyFollowedUp) {
+        postLeaderboardData(leaderBoardData[i].personId, false);
+      }
+    }
+  }, []);
 
   const [mouseoverTextValue, setMouseoverTextValue] = useState(totalTimeMouseoverText);
   const dispatch = useDispatch();
@@ -237,6 +253,34 @@ function LeaderBoard({
 
   const handleTimeOffModalOpen = request => {
     showTimeOffRequestModal(request);
+  };
+
+  // For Monthly and yearly anniversaries
+  const [modalOpen, setModalOpen] = useState(false);
+
+  // opening the modal
+  const trophyIconToggle = item => {
+    if (loggedInUser.role === 'Owner' || loggedInUser.role === 'Administrator') {
+      setModalOpen(item.personId);
+    }
+  };
+
+  // deleting the icon from only that user
+  const handleChangingTrophyIcon = async (item, trophyFollowedUp) => {
+    setModalOpen(false);
+    await postLeaderboardData(item.personId, trophyFollowedUp);
+    // Update leaderboard data after posting
+    await getLeaderboardData(userId);
+  };
+
+  const handleIconContent = durationSinceStarted => {
+    if (durationSinceStarted.months >= 5.8 && durationSinceStarted.months <= 6.2) {
+      return '6M';
+    }
+    if (durationSinceStarted.years >= 0.9) {
+      return `${Math.round(durationSinceStarted.years)}Y`;
+    }
+    return 'N/A';
   };
 
   const teamName = (name, maxLength) =>
@@ -412,208 +456,256 @@ function LeaderBoard({
                 </span>
               </td>
             </tr>
-            {teamsUsers.map(item => (
-              <tr key={item.personId}>
-                <td className="align-middle">
-                  <div>
-                    <Modal
-                      isOpen={isDashboardOpen === item.personId}
-                      toggle={dashboardToggle}
-                      className={darkMode ? 'text-light dark-mode' : ''}
-                      style={darkMode ? boxStyleDark : {}}
-                    >
-                      <ModalHeader
+            {teamsUsers.map(item => {
+              const createDate = item?.createdDate?.split('T')[0];
+              const durationSinceStarted = calculateDurationBetweenDates(todaysDate, createDate);
+              const iconContent = handleIconContent(durationSinceStarted, item);
+              const showTrophy = showTrophyIcon(todaysDate, createDate);
+              return (
+                <tr key={item.personId}>
+                  <td className="align-middle">
+                    <div>
+                      <Modal
+                        isOpen={isDashboardOpen === item.personId}
                         toggle={dashboardToggle}
-                        className={darkMode ? 'bg-space-cadet' : ''}
+                        className={darkMode ? 'text-light dark-mode' : ''}
+                        style={darkMode ? boxStyleDark : {}}
                       >
-                        Jump to personal Dashboard
-                      </ModalHeader>
-                      <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
-                        <p>Are you sure you wish to view this {item.name} dashboard?</p>
-                      </ModalBody>
-                      <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
-                        <Button variant="primary" onClick={() => showDashboard(item)}>
-                          Ok
-                        </Button>{' '}
-                        <Button variant="secondary" onClick={dashboardToggle}>
-                          Cancel
-                        </Button>
-                      </ModalFooter>
-                    </Modal>
-                  </div>
-                  <div
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: hasSummaryIndicatorPermission ? 'space-between' : 'center',
-                    }}
-                  >
-                    {/* <Link to={`/dashboard/${item.personId}`}> */}
+                        <ModalHeader
+                          toggle={dashboardToggle}
+                          className={darkMode ? 'bg-space-cadet' : ''}
+                        >
+                          Jump to personal Dashboard
+                        </ModalHeader>
+                        <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
+                          <p>Are you sure you wish to view this {item.name} dashboard?</p>
+                        </ModalBody>
+                        <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
+                          <Button variant="primary" onClick={() => showDashboard(item)}>
+                            Ok
+                          </Button>{' '}
+                          <Button variant="secondary" onClick={dashboardToggle}>
+                            Cancel
+                          </Button>
+                        </ModalFooter>
+                      </Modal>
+                    </div>
                     <div
-                      role="button"
-                      tabIndex={0}
-                      onClick={() => {
-                        dashboardToggle(item);
-                      }}
-                      onKeyDown={e => {
-                        if (e.key === 'Enter') {
-                          dashboardToggle(item);
-                        }
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: hasSummaryIndicatorPermission ? 'space-between' : 'center',
                       }}
                     >
-                      {hasLeaderboardPermissions(item.role) &&
-                      showStar(item.tangibletime, item.weeklycommittedHours) ? (
-                        <i
-                          className="fa fa-star"
-                          title={`Weekly Committed: ${item.weeklycommittedHours} hours\nClick to view their Dashboard`}
-                          style={{
-                            color: assignStarDotColors(
-                              item.tangibletime,
-                              item.weeklycommittedHours,
-                            ),
-                            fontSize: '20px',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                          }}
-                        />
-                      ) : (
+                      {/* <Link to={`/dashboard/${item.personId}`}> */}
+                      <div
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => {
+                          dashboardToggle(item);
+                        }}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') {
+                            dashboardToggle(item);
+                          }
+                        }}
+                      >
+                        {hasLeaderboardPermissions(item.role) &&
+                        showStar(item.tangibletime, item.weeklycommittedHours) ? (
+                          <i
+                            className="fa fa-star"
+                            title={`Weekly Committed: ${item.weeklycommittedHours} hours\nClick to view their Dashboard`}
+                            style={{
+                              color: assignStarDotColors(
+                                item.tangibletime,
+                                item.weeklycommittedHours,
+                              ),
+                              fontSize: '20px',
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                            }}
+                          />
+                        ) : (
+                          <div
+                            title={`Weekly Committed: ${item.weeklycommittedHours} hours\nClick to view their Dashboard`}
+                            style={{
+                              backgroundColor:
+                                item.tangibletime >= item.weeklycommittedHours ? '#32CD32' : 'red',
+                              width: 15,
+                              height: 15,
+                              borderRadius: 7.5,
+                              margin: 'auto',
+                              verticalAlign: 'middle',
+                            }}
+                          />
+                        )}
+                      </div>
+                      {hasSummaryIndicatorPermission && item.hasSummary && (
                         <div
-                          title={`Weekly Committed: ${item.weeklycommittedHours} hours\nClick to view their Dashboard`}
+                          title="Weekly Summary Submitted"
                           style={{
-                            backgroundColor:
-                              item.tangibletime >= item.weeklycommittedHours ? '#32CD32' : 'red',
-                            width: 15,
-                            height: 15,
-                            borderRadius: 7.5,
-                            margin: 'auto',
-                            verticalAlign: 'middle',
+                            color: '#32a518',
+                            cursor: 'default',
                           }}
-                        />
+                        >
+                          <strong>✓</strong>
+                        </div>
                       )}
                     </div>
-                    {hasSummaryIndicatorPermission && item.hasSummary && (
-                      <div
-                        title="Weekly Summary Submitted"
-                        style={{
-                          color: '#32a518',
-                          cursor: 'default',
-                        }}
-                      >
-                        <strong>✓</strong>
-                      </div>
+                    {/* </Link> */}
+                  </td>
+                  <th scope="row" className="align-middle">
+                    <Link
+                      to={`/userprofile/${item.personId}`}
+                      title="View Profile"
+                      style={{
+                        color:
+                          currentDate.isSameOrAfter(
+                            moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'),
+                          ) &&
+                          currentDate.isBefore(moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ'))
+                            ? 'rgba(128, 128, 128, 0.5)'
+                            : '#007BFF',
+                      }}
+                    >
+                      {item.name}
+                      {currentDate.isSameOrAfter(
+                        moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'),
+                      ) &&
+                      currentDate.isBefore(moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ')) &&
+                      Math.floor(
+                        moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ')
+                          .subtract(1, 'day')
+                          .diff(moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'), 'weeks'),
+                      ) > 0 ? (
+                        <sup>
+                          {' '}
+                          +
+                          {Math.floor(
+                            moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ')
+                              .subtract(1, 'day')
+                              .diff(moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'), 'weeks'),
+                          )}
+                        </sup>
+                      ) : null}
+                    </Link>
+                    &nbsp;&nbsp;&nbsp;
+                    {hasVisibilityIconPermission && !item.isVisible && (
+                      <i className="fa fa-eye-slash" title="User is invisible" />
                     )}
-                  </div>
-                  {/* </Link> */}
-                </td>
-                <th scope="row" className="align-middle">
-                  <Link
-                    to={`/userprofile/${item.personId}`}
-                    title="View Profile"
-                    style={{
-                      color:
-                        currentDate.isSameOrAfter(
-                          moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'),
-                        ) &&
-                        currentDate.isBefore(moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ'))
-                          ? 'rgba(128, 128, 128, 0.5)'
-                          : '#007BFF',
-                    }}
-                  >
-                    {item.name}
-                    {currentDate.isSameOrAfter(
-                      moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'),
-                    ) &&
-                    currentDate.isBefore(moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ')) &&
-                    Math.floor(
-                      moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ')
-                        .subtract(1, 'day')
-                        .diff(moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'), 'weeks'),
-                    ) > 0 ? (
-                      <sup>
-                        {' '}
-                        +
-                        {Math.floor(
-                          moment(item.timeOffTill, 'YYYY-MM-DDTHH:mm:ss.SSSZ')
-                            .subtract(1, 'day')
-                            .diff(moment(item.timeOffFrom, 'YYYY-MM-DDTHH:mm:ss.SSSZ'), 'weeks'),
-                        )}
-                      </sup>
-                    ) : null}
-                  </Link>
-                  &nbsp;&nbsp;&nbsp;
-                  {hasVisibilityIconPermission && !item.isVisible && (
-                    <i className="fa fa-eye-slash" title="User is invisible" />
-                  )}
-                </th>
-                <td className="align-middle">
-                  <span title={mouseoverTextValue} id="Days left" style={{ color: 'red' }}>
-                    {displayDaysLeft(item.endDate)}
-                  </span>
-                </td>
-                <td className="align-middle">
-                  {allRequests && allRequests[item.personId]?.length > 0 && (
-                    <div>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const data = {
-                            requests: [...allRequests[item.personId]],
-                            name: item.name,
-                            leaderboard: true,
-                          };
-                          handleTimeOffModalOpen(data);
+                    {/* Model for trophy */}
+                    &nbsp;&nbsp;&nbsp;
+                    {hasLeaderboardPermissions(loggedInUser.role) && showTrophy && (
+                      <i
+                        role="button"
+                        tabIndex={0}
+                        className="fa fa-trophy"
+                        style={{
+                          fontSize: '18px',
+                          color: item?.trophyFollowedUp === false ? '#FF0800' : '#ffbb00',
                         }}
-                        style={{ width: '35px', height: 'auto' }}
-                        aria-label="View Time Off Requests"
+                        onClick={() => trophyIconToggle(item)}
+                        onKeyDown={() => trophyIconToggle(item)}
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="22"
-                          height="19"
-                          viewBox="0 0 448 512"
-                          className="show-time-off-calender-svg"
+                        <p style={{ fontSize: '10px', marginLeft: '1px' }}>
+                          <strong>{iconContent}</strong>
+                        </p>
+                      </i>
+                    )}
+                    <div>
+                      <Modal isOpen={modalOpen === item.personId} toggle={trophyIconToggle}>
+                        <ModalHeader toggle={trophyIconToggle}>Followed Up?</ModalHeader>
+                        <ModalBody>
+                          <p>Are you sure you have followed up this icon?</p>
+                        </ModalBody>
+                        <ModalFooter>
+                          <Button variant="secondary" onClick={trophyIconToggle}>
+                            Cancel
+                          </Button>{' '}
+                          <Button
+                            color="primary"
+                            onClick={() => {
+                              handleChangingTrophyIcon(item, true);
+                            }}
+                          >
+                            Confirm
+                          </Button>
+                        </ModalFooter>
+                      </Modal>
+                    </div>
+                  </th>
+                  <td className="align-middle">
+                    <span title={mouseoverTextValue} id="Days left" style={{ color: 'red' }}>
+                      {displayDaysLeft(item.endDate)}
+                    </span>
+                  </td>
+                  <td className="align-middle">
+                    {allRequests && allRequests[item.personId]?.length > 0 && (
+                      <div>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            const data = {
+                              requests: [...allRequests[item.personId]],
+                              name: item.name,
+                              leaderboard: true,
+                            };
+                            handleTimeOffModalOpen(data);
+                          }}
+                          style={{ width: '35px', height: 'auto' }}
+                          aria-label="View Time Off Requests"
                         >
-                          <path d="M128 0c17.7 0 32 14.3 32 32V64H288V32c0-17.7 14.3-32 32-32s32 14.3 32 32V64h48c26.5 0 48 21.5 48 48v48H0V112C0 85.5 21.5 64 48 64H96V32c0-17.7 14.3-32 32-32zM0 192H448V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V192zm64 80v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V272c0-8.8-7.2-16-16-16H80c-8.8 0-16 7.2-16 16zm128 0v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V272c0-8.8-7.2-16-16-16H208c-8.8 0-16 7.2-16 16zm144-16c-8.8 0-16 7.2-16 16v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V272c0-8.8-7.2-16-16-16H336zM64 400v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V400c0-8.8-7.2-16-16-16H80c-8.8 0-16 7.2-16 16zm144-16c-8.8 0-16 7.2-16 16v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V400c0-8.8-7.2-16-16-16H208zm112 16v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V400c0-8.8-7.2-16-16-16H336c-8.8 0-16 7.2-16 16z" />
-                        </svg>
-
-                        <i className="show-time-off-icon">
                           <svg
                             xmlns="http://www.w3.org/2000/svg"
-                            width="18"
-                            height="18"
-                            viewBox="0 0 512 512"
-                            className="show-time-off-icon-svg"
+                            width="22"
+                            height="19"
+                            viewBox="0 0 448 512"
+                            className="show-time-off-calender-svg"
                           >
-                            <path d="M464 256A208 208 0 1 1 48 256a208 208 0 1 1 416 0zM0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM232 120V256c0 8 4 15.5 10.7 20l96 64c11 7.4 25.9 4.4 33.3-6.7s4.4-25.9-6.7-33.3L280 243.2V120c0-13.3-10.7-24-24-24s-24 10.7-24 24z" />
+                            <path d="M128 0c17.7 0 32 14.3 32 32V64H288V32c0-17.7 14.3-32 32-32s32 14.3 32 32V64h48c26.5 0 48 21.5 48 48v48H0V112C0 85.5 21.5 64 48 64H96V32c0-17.7 14.3-32 32-32zM0 192H448V464c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V192zm64 80v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V272c0-8.8-7.2-16-16-16H80c-8.8 0-16 7.2-16 16zm128 0v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V272c0-8.8-7.2-16-16-16H208c-8.8 0-16 7.2-16 16zm144-16c-8.8 0-16 7.2-16 16v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V272c0-8.8-7.2-16-16-16H336zM64 400v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V400c0-8.8-7.2-16-16-16H80c-8.8 0-16 7.2-16 16zm144-16c-8.8 0-16 7.2-16 16v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V400c0-8.8-7.2-16-16-16H208zm112 16v32c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16V400c0-8.8-7.2-16-16-16H336c-8.8 0-16 7.2-16 16z" />
                           </svg>
-                        </i>
-                      </button>
-                    </div>
-                  )}
-                </td>
-                <td className="align-middle" id={`id${item.personId}`}>
-                  <span title="Tangible time">{item.tangibletime}</span>
-                </td>
-                <td className="align-middle" aria-label="Description or purpose of the cell">
-                  <Link
-                    to={`/timelog/${item.personId}`}
-                    title={`TangibleEffort: ${item.tangibletime} hours`}
-                  >
-                    <Progress value={item.barprogress} color={item.barcolor} />
-                  </Link>
-                </td>
-                <td className="align-middle">
-                  <span
-                    title={mouseoverTextValue}
-                    id="Total time"
-                    className={item.totalintangibletime_hrs > 0 ? 'leaderboard-totals-title' : null}
-                  >
-                    {item.totaltime}
-                  </span>
-                </td>
-              </tr>
-            ))}
+
+                          <i className="show-time-off-icon">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              width="18"
+                              height="18"
+                              viewBox="0 0 512 512"
+                              className="show-time-off-icon-svg"
+                            >
+                              <path d="M464 256A208 208 0 1 1 48 256a208 208 0 1 1 416 0zM0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM232 120V256c0 8 4 15.5 10.7 20l96 64c11 7.4 25.9 4.4 33.3-6.7s4.4-25.9-6.7-33.3L280 243.2V120c0-13.3-10.7-24-24-24s-24 10.7-24 24z" />
+                            </svg>
+                          </i>
+                        </button>
+                      </div>
+                    )}
+                  </td>
+                  <td className="align-middle" id={`id${item.personId}`}>
+                    <span title="Tangible time">{item.tangibletime}</span>
+                  </td>
+                  <td className="align-middle" aria-label="Description or purpose of the cell">
+                    <Link
+                      to={`/timelog/${item.personId}`}
+                      title={`TangibleEffort: ${item.tangibletime} hours`}
+                    >
+                      <Progress value={item.barprogress} color={item.barcolor} />
+                    </Link>
+                  </td>
+                  <td className="align-middle">
+                    <span
+                      title={mouseoverTextValue}
+                      id="Total time"
+                      className={
+                        item.totalintangibletime_hrs > 0 ? 'leaderboard-totals-title' : null
+                      }
+                    >
+                      {item.totaltime}
+                    </span>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </Table>
       </div>

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -723,6 +723,7 @@ class UserProfileAdd extends Component {
       allowsDuplicateName: allowsDuplicateName,
       createdDate: createdDate,
       teamCode: this.state.teamCode,
+      trophyFollowedUp: false,
       actualEmail: actualEmail,
       actualPassword: actualPassword,
       startDate: startDate,

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -14,6 +14,7 @@ import { faCopy } from '@fortawesome/free-solid-svg-icons';
 
 import { assignStarDotColors, showStar } from 'utils/leaderboardPermissions';
 import { updateOneSummaryReport } from 'actions/weeklySummariesReport';
+import { calculateDurationBetweenDates, showTrophyIcon } from 'utils/anniversaryPermissions';
 import RoleInfoModal from 'components/UserProfile/EditableModal/RoleInfoModal';
 import {
   Input,
@@ -644,6 +645,27 @@ function Index({ summary, weekIndex, allRoleInfo, auth }) {
     return targetLink;
   }, undefined);
 
+  const summarySubmissionDate = moment()
+    .tz('America/Los_Angeles')
+    .endOf('week')
+    .subtract(weekIndex, 'week')
+    .format('YYYY-MM-DD');
+
+  const durationSinceStarted = calculateDurationBetweenDates(
+    summarySubmissionDate,
+    summary?.createdDate.split('T')[0],
+  );
+
+  const handleIconContent = duration => {
+    if (duration.months >= 5.8 && duration.months <= 6.2) {
+      return '6M';
+    }
+    if (duration.years >= 0.9) {
+      return `${Math.round(duration.years)}Y`;
+    }
+    return null;
+  };
+
   return (
     <>
       <b>Name: </b>
@@ -673,6 +695,13 @@ function Index({ summary, weekIndex, allRoleInfo, auth }) {
               info={allRoleInfo.find(item => item.infoName === `${summary.role}Info`)}
               auth={auth}
             />
+          )}
+          {showTrophyIcon(summarySubmissionDate, summary?.createdDate.split('T')[0]) && (
+            <i className="fa fa-trophy" style={{ marginLeft: '10px', fontSize: '25px' }}>
+              <p style={{ fontSize: '10px', marginLeft: '5px' }}>
+                {handleIconContent(durationSinceStarted)}
+              </p>
+            </i>
           )}
         </div>
       </div>

--- a/src/constants/leaderBoardData.js
+++ b/src/constants/leaderBoardData.js
@@ -1,4 +1,5 @@
 export const GET_LEADERBOARD_DATA = 'GET_LEADERBOARD_DATA';
+export const POST_LEADERBOARD_DATA = 'POST_LEADERBOARD_DATA';
 
 export const GET_ORG_DATA = 'GET_ORG_DATA';
 
@@ -9,5 +10,10 @@ export const getLeaderBoardData = data => ({
 
 export const getOrgData = data => ({
   type: GET_ORG_DATA,
+  payload: data,
+});
+
+export const postLeaderboardData = data => ({
+  type: POST_LEADERBOARD_DATA,
   payload: data,
 });

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -33,6 +33,7 @@ export const ENDPOINTS = {
   FORCE_PASSWORD: `${APIEndpoint}/forcepassword`,
   LEADER_BOARD: userId => `${APIEndpoint}/dashboard/leaderboard/${userId}`,
   ORG_DATA: `${APIEndpoint}/dashboard/leaderboard/org/data`,
+  TROPHY_ICON: (userId, trophyFollowedUp) => `${APIEndpoint}/dashboard/leaderboard/trophyIcon/${userId}/${trophyFollowedUp}`,
   TIME_ENTRIES_PERIOD: (userId, fromDate, toDate) =>
     `${APIEndpoint}/TimeEntry/user/${userId}/${fromDate}/${toDate}`,
   TIME_ENTRIES_USER_LIST: `${APIEndpoint}/TimeEntry/users`,

--- a/src/utils/anniversaryPermissions.js
+++ b/src/utils/anniversaryPermissions.js
@@ -1,0 +1,146 @@
+export const calculateAnniversaryDate = (createdDate) => {
+    let dt = new Date(createdDate)
+    const sixMonthAnniversary = dt.setMonth(dt.getMonth() + 6)
+    const oneWeekAfter6M = new Date(sixMonthAnniversary).getTime() + 7 * 24 * 60 * 60 * 1000 + 1
+  
+    dt = new Date(createdDate)
+    const oneYearAnniversary = dt.setFullYear(dt.getFullYear() + 1)
+    const oneWeekAfter1Y = new Date(oneYearAnniversary).getTime() + 7 * 24 * 60 * 60 * 1000 + 1
+  
+    dt = new Date(createdDate)
+    const twoYearAnniversary = dt.setFullYear(dt.getFullYear() + 2)
+    const oneWeekAfter2Y = new Date(twoYearAnniversary).getTime() + 7 * 24 * 60 * 60 * 1000 + 1
+  
+    dt = new Date(createdDate)
+    const threeYearAnniversary = dt.setFullYear(dt.getFullYear() + 3)
+    const oneWeekAfter3Y = new Date(threeYearAnniversary).getTime() + 7 * 24 * 60 * 60 * 1000 + 1
+  
+    dt = new Date(createdDate)
+    const fourYearAnniversary = dt.setFullYear(dt.getFullYear() + 4)
+    const oneWeekAfter4Y = new Date(fourYearAnniversary).getTime() + 7 * 24 * 60 * 60 * 1000 + 1
+  
+    dt = new Date(createdDate)
+    const fiveYearAnniversary = dt.setFullYear(dt.getFullYear() + 5)
+    const oneWeekAfter5Y = new Date(fiveYearAnniversary).getTime() + 7 * 24 * 60 * 60 * 1000 + 1
+  
+    dt = new Date(createdDate)
+    const sixYearAnniversary = dt.setFullYear(dt.getFullYear() + 6)
+    const oneWeekAfter6Y = new Date(sixYearAnniversary).getTime() + 7 * 24 * 60 * 60 * 1000 + 1
+  
+    dt = new Date(createdDate)
+    const sevenYearAnniversary = dt.setFullYear(dt.getFullYear() + 7)
+    const oneWeekAfter7Y = new Date(sevenYearAnniversary).getTime() + 7 * 24 * 60 * 60 * 1000 + 1
+  
+    dt = new Date(createdDate)
+    const eightYearAnniversary = dt.setFullYear(dt.getFullYear() + 8)
+    const oneWeekAfter8Y = new Date(eightYearAnniversary).getTime() + 7 * 24 * 60 * 60 * 1000 + 1
+  
+    dt = new Date(createdDate)
+    const nineYearAnniversary = dt.setFullYear(dt.getFullYear() + 9)
+    const oneWeekAfter9Y = new Date(nineYearAnniversary).getTime() + 7 * 24 * 60 * 60 * 1000 + 1
+  
+    dt = new Date(createdDate)
+    const tenYearAnniversary = dt.setFullYear(dt.getFullYear() + 10)
+    const oneWeekAfter10Y = new Date(tenYearAnniversary).getTime() + 7 * 24 * 60 * 60 * 1000 + 1
+  
+    let anniversaryDates = {
+      sixMonthAnniversary: new Date(sixMonthAnniversary),
+      oneWeekAfter6M: new Date(oneWeekAfter6M),
+  
+      oneYearAnniversary: new Date(oneYearAnniversary),
+      oneWeekAfter1Y: new Date(oneWeekAfter1Y),
+  
+      twoYearAnniversary: new Date(twoYearAnniversary),
+      oneWeekAfter2Y: new Date(oneWeekAfter2Y),
+  
+      threeYearAnniversary: new Date(threeYearAnniversary),
+      oneWeekAfter3Y: new Date(oneWeekAfter3Y),
+  
+      fourYearAnniversary: new Date(fourYearAnniversary),
+      oneWeekAfter4Y: new Date(oneWeekAfter4Y),
+  
+      fiveYearAnniversary: new Date(fiveYearAnniversary),
+      oneWeekAfter5Y: new Date(oneWeekAfter5Y),
+  
+      sixYearAnniversary: new Date(sixYearAnniversary),
+      oneWeekAfter6Y: new Date(oneWeekAfter6Y),
+  
+      sevenYearAnniversary: new Date(sevenYearAnniversary),
+      oneWeekAfter7Y: new Date(oneWeekAfter7Y),
+  
+      eightYearAnniversary: new Date(eightYearAnniversary),
+      oneWeekAfter8Y: new Date(oneWeekAfter8Y),
+  
+      nineYearAnniversary: new Date(nineYearAnniversary),
+      oneWeekAfter9Y: new Date(oneWeekAfter9Y),
+  
+      tenYearAnniversary: new Date(tenYearAnniversary),
+      oneWeekAfter10Y: new Date(oneWeekAfter10Y),
+    };
+  
+    return anniversaryDates;
+  }
+  
+  export const calculateDurationBetweenDates = (endDate, createdDate) => {
+  
+    let endDateObject = new Date(endDate)
+    let createdDateObject = new Date(createdDate)
+    let durationSinceStarted = {
+      months: 0,
+      years: 0
+    }
+    if (endDate > createdDate) {
+      var diff = Math.floor(endDateObject.getTime() - createdDateObject.getTime());
+      var day = 1000 * 60 * 60 * 24;
+  
+      var days = (diff / day);
+      var months = (days / 31);
+      var yearsSinceStarted = (months / 12);
+      durationSinceStarted = {
+        months: months,
+        years: yearsSinceStarted
+      }
+    }
+    else {
+      durationSinceStarted = {
+        months: 0,
+        years: 0
+      }
+    }
+    return durationSinceStarted
+  }
+  
+  export const showTrophyIcon = (endDate, createdDate) => {
+  
+    const calculateAnniversaryDateResults = calculateAnniversaryDate(createdDate)
+  
+    if (createdDate < endDate) {
+      switch (true) {
+        case calculateAnniversaryDateResults.tenYearAnniversary.toISOString().split('T')[0] <= endDate && calculateAnniversaryDateResults.oneWeekAfter10Y.toISOString().split('T')[0] > endDate:
+          return true;
+        case calculateAnniversaryDateResults.nineYearAnniversary.toISOString().split('T')[0] <= endDate && calculateAnniversaryDateResults.oneWeekAfter9Y.toISOString().split('T')[0] > endDate:
+          return true;
+        case calculateAnniversaryDateResults.eightYearAnniversary.toISOString().split('T')[0] <= endDate && calculateAnniversaryDateResults.oneWeekAfter8Y.toISOString().split('T')[0] > endDate:
+          return true;
+        case calculateAnniversaryDateResults.sevenYearAnniversary.toISOString().split('T')[0] <= endDate && calculateAnniversaryDateResults.oneWeekAfter7Y.toISOString().split('T')[0] > endDate:
+          return true;
+        case calculateAnniversaryDateResults.sixYearAnniversary.toISOString().split('T')[0] <= endDate && calculateAnniversaryDateResults.oneWeekAfter6Y.toISOString().split('T')[0] > endDate:
+          return true;
+        case calculateAnniversaryDateResults.fiveYearAnniversary.toISOString().split('T')[0] <= endDate && calculateAnniversaryDateResults.oneWeekAfter5Y.toISOString().split('T')[0] > endDate:
+          return true;
+        case calculateAnniversaryDateResults.fourYearAnniversary.toISOString().split('T')[0] <= endDate && calculateAnniversaryDateResults.oneWeekAfter4Y.toISOString().split('T')[0] > endDate:
+          return true;
+        case calculateAnniversaryDateResults.threeYearAnniversary.toISOString().split('T')[0] <= endDate && calculateAnniversaryDateResults.oneWeekAfter3Y.toISOString().split('T')[0] > endDate:
+          return true;
+        case calculateAnniversaryDateResults.twoYearAnniversary.toISOString().split('T')[0] <= endDate && calculateAnniversaryDateResults.oneWeekAfter2Y.toISOString().split('T')[0] > endDate:
+          return true;
+        case calculateAnniversaryDateResults.oneYearAnniversary.toISOString().split('T')[0] <= endDate && calculateAnniversaryDateResults.oneWeekAfter1Y.toISOString().split('T')[0] > endDate:
+          return true;
+        case calculateAnniversaryDateResults.sixMonthAnniversary.toISOString().split('T')[0] <= endDate && calculateAnniversaryDateResults.oneWeekAfter6M.toISOString().split('T')[0] > endDate:
+          return true;
+        default:
+          false
+      }
+    }
+    return false;
+  }


### PR DESCRIPTION
Code Changes to display Trophy Icon for Anniversaries

# Description
This PR is about adding a trophy icon for 6M, 1Y, 2Y, 3Y, etc. work anniversaries to the Leaderboard and Weekly Summaries Report.

## Related PRS (if any):
To test this frontend PR you need to checkout the [#1180](https://github.com/OneCommunityGlobal/HGNRest/pull/1180) backend PR.
…

## Main changes explained:
- Update LeaderBoard.jsx and WeeklySummaryReport.jsx B for the display trophy functionality
- Create anniversaryPermissions.js for calculating the anniversary to display the trophy icon on the UI
…

## How to test:
1. check into current branch
2. do `npm install` and run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard and check for the Trophy Icon on the Leaderboard Tab, Click on the Trophy Icon to see the follow up page and then click confirm after this please verify the trophy icon color changes from red to yellow.
6. On to the Dashboard go to Reports -> Weekly Summary Reports Page and check for the trophy Icon.
7. verify this new feature works in dark mode

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/bc35ef8c-dfcb-4df4-956d-330f8326c84c

Please refer the video to check the PR Functionality

## Note:
The issue I could not fix/figure out is that some of the users who have trophy icon on the dashboard do not have trophy icon on the weekly summary report page, there was a mismatch and I could not fix it. 
