### PR TITLE
Newell - Hotfix: timer dark mode modal used in light mode

### DIFF
--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -611,7 +611,7 @@ function Timer({ authUser, darkMode }) {
         </ModalFooter>
       </Modal>
       <Modal
-        className={`${fontColor} dark-mode`}
+        className={cs(fontColor, darkMode ? 'dark-mode' : '')}
         size="md"
         isOpen={inacModal}
         toggle={() => setInacModal(!inacModal)}


### PR DESCRIPTION
# Description
Fix that timer dark mode modal used in light mode.

## Related PRS (if any):
#2219 

## Main changes explained:
Fix that timer dark mode modal used in light mode.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. start the timer.
6. refresh the page and see if modal is showing properly in light mode.
