### PR TITLE
nikhil-fixed project page UI issues

### DIFF
--- a/src/components/Reports/ProjectReport/ProjectReport.jsx
+++ b/src/components/Reports/ProjectReport/ProjectReport.jsx
@@ -2,11 +2,11 @@ import React, { useEffect, useState } from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
 import { useDispatch, useSelector } from 'react-redux';
 import { FiBox } from 'react-icons/fi';
-import {WbsPieChart}  from './WbsPiechart/WbsPieChart';
+import { WbsPieChart } from './WbsPiechart/WbsPieChart';
 import { getProjectDetail } from '../../../actions/project';
-import {getTimeEntryByProjectSpecifiedPeriod} from '../../../actions/index'
+import { getTimeEntryByProjectSpecifiedPeriod } from '../../../actions/index'
 import { fetchAllMembers, getProjectActiveUser } from '../../../actions/projectMembers';
-import { fetchAllTasks} from '../../../actions/task';
+import { fetchAllTasks } from '../../../actions/task';
 import { fetchAllWBS } from '../../../actions/wbs';
 import { ProjectMemberTable } from '../ProjectMemberTable';
 import { ReportPage } from '../sharedComponents/ReportPage';
@@ -18,11 +18,8 @@ import viewWBSpermissionsRequired from '../../../utils/viewWBSpermissionsRequire
 import { projectReportViewData } from './selectors';
 import '../../Teams/Team.css';
 import './ProjectReport.css';
-import { boxStyle, boxStyleDark } from '../../../styles';
 import { PieChartByProject } from './PiechartByProject/PieChartByProject';
 
-
-// eslint-disable-next-line import/prefer-default-export
 export function ProjectReport({ match }) {
   const [memberCount, setMemberCount] = useState(0);
   const [activeMemberCount, setActiveMemberCount] = useState(0);
@@ -45,7 +42,7 @@ export function ProjectReport({ match }) {
 
   let projectId = '';
   if (match && match.params) {
-  projectId = match.params.projectId;
+    projectId = match.params.projectId;
   }
 
   const [projectUsers, setProjectUsers] = useState([]);
@@ -56,21 +53,21 @@ export function ProjectReport({ match }) {
 
   useEffect(() => {
     dispatch(getTimeEntryByProjectSpecifiedPeriod(projectId, fromDate, toDate))
-    .then(response => {
-      if (response && Array.isArray(response)) {
-        setProjectUsers(response);
-      } else {
+      .then(response => {
+        if (response && Array.isArray(response)) {
+          setProjectUsers(response);
+        } else {
+          console.log('error on fetching data');
+        }
+      }).catch(() => {
         console.log('error on fetching data');
-      }
-    }).catch(() => {
-      console.log('error on fetching data');
-    });
+      });
   }, [projectId]);
 
   useEffect(() => {
     const mergedProjectUsers = projectUsers.reduce((acc, curr) => {
       if (curr.personId && !acc[curr.personId._id]) {
-        acc[curr.personId._id] = {...curr};
+        acc[curr.personId._id] = { ...curr };
       } else if (curr.personId) {
         acc[curr.personId._id].totalSeconds += curr.totalSeconds;
       }
@@ -132,44 +129,44 @@ export function ProjectReport({ match }) {
 
   return (
     <div className={`container-project-wrapper ${darkMode ? 'bg-oxford-blue' : ''}`}>
-    <ReportPage
-      renderProfile={() => (
-        <ReportPage.ReportHeader
-          isActive={isActive}
-          avatar={<FiBox />}
-          name={projectName}
-          counts={{ activeMemberCount: activeMemberCount, memberCount: nonActiveMemberCount + activeMemberCount }}
-          hoursCommitted={hoursCommitted.toFixed(0)}
-          darkMode={darkMode}
-        />
-      )}
-      darkMode={darkMode}
-    >
-      <div className={`project-header ${darkMode ? 'bg-yinmn-blue text-light' : ''}`} style={darkMode ? boxStyleDark : boxStyle}>{projectName}</div>
-      <div className="wbs-and-members-blocks-wrapper">
-        <ReportPage.ReportBlock className="wbs-and-members-blocks" darkMode={darkMode}>
-          <Paging totalElementsCount={wbs.WBSItems.length} darkMode={darkMode}>
-            <WbsTable wbs={wbs} match={match} canViewWBS={canViewWBS} darkMode={darkMode}/>
-          </Paging>
-        </ReportPage.ReportBlock>
-        <ReportPage.ReportBlock className="wbs-and-members-blocks" darkMode={darkMode}>
-          <Paging totalElementsCount={memberCount} darkMode={darkMode}>
-            <ProjectMemberTable
-              projectMembers={projectMembers}
-              handleMemberCount={handleMemberCount}
-              darkMode={darkMode}
-              counts={{ activeMemberCount: activeMemberCount, memberCount: nonActiveMemberCount + activeMemberCount }}
-            />
-          </Paging>
-        </ReportPage.ReportBlock>
-      </div>
+      <ReportPage
+        renderProfile={() => (
+          <ReportPage.ReportHeader
+            isActive={isActive}
+            avatar={<FiBox />}
+            name={projectName}
+            counts={{ activeMemberCount: activeMemberCount, memberCount: nonActiveMemberCount + activeMemberCount }}
+            hoursCommitted={hoursCommitted.toFixed(0)}
+            darkMode={darkMode}
+          />
+        )}
+        darkMode={darkMode}
+        projectName={projectName}
+      >
+        <div className="wbs-and-members-blocks-wrapper">
+          <ReportPage.ReportBlock className="wbs-and-members-blocks" darkMode={darkMode}>
+            <Paging totalElementsCount={wbs.WBSItems.length} darkMode={darkMode}>
+              <WbsTable wbs={wbs} match={match} canViewWBS={canViewWBS} darkMode={darkMode} />
+            </Paging>
+          </ReportPage.ReportBlock>
+          <ReportPage.ReportBlock className="wbs-and-members-blocks" darkMode={darkMode}>
+            <Paging totalElementsCount={memberCount} darkMode={darkMode}>
+              <ProjectMemberTable
+                projectMembers={projectMembers}
+                handleMemberCount={handleMemberCount}
+                darkMode={darkMode}
+                counts={{ activeMemberCount: activeMemberCount, memberCount: nonActiveMemberCount + activeMemberCount }}
+              />
+            </Paging>
+          </ReportPage.ReportBlock>
+        </div>
         <ReportPage.ReportBlock darkMode={darkMode}>
-          <TasksTable darkMode={darkMode} tasks={tasks}/>
+          <TasksTable darkMode={darkMode} tasks={tasks} />
         </ReportPage.ReportBlock>
         <ReportPage.ReportBlock darkMode={darkMode}>
-          <PieChartByProject mergedProjectUsersArray={mergedProjectUsersArray} projectName={projectName} darkMode={darkMode}/>
+          <PieChartByProject mergedProjectUsersArray={mergedProjectUsersArray} projectName={projectName} darkMode={darkMode} />
           <hr />
-          <WbsPieChart projectMembers={projectMembers} projectName={projectName} darkMode={darkMode}/>
+          <WbsPieChart projectMembers={projectMembers} projectName={projectName} darkMode={darkMode} />
         </ReportPage.ReportBlock>
       </ReportPage>
     </div>

--- a/src/components/Reports/TasksDetail/TasksDetail.css
+++ b/src/components/Reports/TasksDetail/TasksDetail.css
@@ -4,17 +4,19 @@
   overflow-x: auto;
 }
 
-.tasks-detail-total{
+.tasks-detail-total {
   float: left;
 }
 
 .tasks-detail-table {
   width: 100%;
   border-collapse: collapse;
-  min-width: 800px; /* Minimum width to maintain table layout on smaller screens */
+  min-width: 800px;
+  /* Minimum width to maintain table layout on smaller screens */
 }
 
-.tasks-detail-table th, .tasks-detail-table td {
+.tasks-detail-table th,
+.tasks-detail-table td {
   padding: 5px;
   border: 1px solid #ddd;
   text-align: left;
@@ -23,6 +25,7 @@
 .tasks-detail-table-head {
   background-color: #f8f9fa;
   font-weight: bold;
+  border-radius: 20px;
 }
 
 .tasks-detail-center-cells {
@@ -42,9 +45,10 @@
 }
 
 .dark-mode-row {
-  background-color: #3A506B ;
+  background-color: #3A506B;
   color: #fff;
 }
+
 /* Responsive design */
 @media screen and (max-width: 1100px) {
   .collapse-column {
@@ -57,7 +61,8 @@
     min-width: 600px;
   }
 
-  .tasks-detail-table th, .tasks-detail-table td {
+  .tasks-detail-table th,
+  .tasks-detail-table td {
     padding: 5px;
     font-size: 12px;
   }
@@ -72,7 +77,8 @@
     min-width: 400px;
   }
 
-  .tasks-detail-table th, .tasks-detail-table td {
+  .tasks-detail-table th,
+  .tasks-detail-table td {
     padding: 2px;
     font-size: 10px;
   }

--- a/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
+++ b/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
@@ -1,22 +1,21 @@
 .report-page-wrapper {
   display: grid;
   grid-template-columns: 1fr 256px;
-  grid-template-rows: auto;
-  column-gap: 24px;
   min-height: 100vh;
   background-color: #faf7fd;
-  padding: 40px 0 0 24px;
   align-items: start;
-  padding: 2vh 7vw;
+  padding: 4vh 7vw;
+  grid-template-rows: 70px repeat(2, 3fr);
+  column-gap: 32px;
+  row-gap: 35px;
 }
 
 .report-page-content {
   display: flex;
   flex-direction: column;
-  grid-row-start: 1;
+  grid-row-start: 2;
   row-gap: 32px;
   width: 100%;
-  /* padding-bottom: 24px; */
 }
 
 .report-page-profile {
@@ -25,6 +24,7 @@
   margin-bottom: 10px;
   width: 100%;
 }
+
 .report-page-profile-dark {
   border-top-left-radius: 25px;
   border-radius: 25px;
@@ -32,12 +32,21 @@
   width: 100%;
 }
 
+.project-header {
+  font-size: 32px;
+  padding: 10px 10px;
+  text-align: center;
+  background-color: white;
+  border-radius: 20px;
+  box-shadow: 0 0 12px #eae1f6;
+}
+
 @media (max-width: 1300px) {
   .report-page-wrapper {
     display: flex;
     flex-direction: column;
-    padding: 40px;
     align-items: center;
+    row-gap: 32px;
   }
 }
 
@@ -45,17 +54,23 @@
   .report-page-wrapper {
     display: flex;
     flex-direction: column;
-    padding: 40px;
     align-items: center;
-  }
-
-  .report-page-content {
-    padding: 24px;
+    row-gap: 32px;
   }
 
   .report-page-content {
     justify-content: center;
     align-items: center;
+  }
+
+  .project-header {
+    font-size: 32px;
+    padding: 10px 10px;
+    text-align: center;
+    background-color: white;
+    border-radius: 20px;
+    box-shadow: 0 0 12px #eae1f6;
+    width: 100%;
   }
 }
 
@@ -69,14 +84,4 @@
   .report-page-wrapper {
     padding: 20px;
   }
-}
-
-.project-header{
-  font-size: 32px;
-  padding: 5px 5px;
-  text-align: center;
-  background-color:white;
-  border-radius: 20px;
-  box-shadow: 0 0 12px #eae1f6;
-  width: 100%;
 }

--- a/src/components/Reports/sharedComponents/ReportPage/ReportPage.jsx
+++ b/src/components/Reports/sharedComponents/ReportPage/ReportPage.jsx
@@ -2,10 +2,12 @@ import { ReportHeader } from './components/ReportHeader';
 import { ReportBlock } from './components/ReportBlock';
 import { ReportCard } from './components/ReportCard';
 import './ReportPage.css';
+import { boxStyle, boxStyleDark } from 'styles';
 
-export function ReportPage({ children, renderProfile, contentClassName, darkMode }) {
+export function ReportPage({ children, renderProfile, contentClassName, darkMode, projectName }) {
   return (
     <section className={`report-page-wrapper ${darkMode ? 'bg-oxford-blue' : ''}`}>
+      <div className={`project-header ${darkMode ? 'bg-yinmn-blue text-light' : ''}`} style={darkMode ? boxStyleDark : boxStyle}>{projectName}</div>
       <div className={`${darkMode ? "report-page-profile-dark" : "report-page-profile"}`}>{renderProfile()}</div>
       <div className={`report-page-content ${contentClassName}`}>{children}</div>
     </section>


### PR DESCRIPTION
… Members table don't have any side spacing when 415px and below.

# Description
Fix PROJECT REPORT PAGE UI issues for 375px and up:

When WBS is empty, the stub/placeholder does not function in dark mode.
When 850px and below the title appears in the second row, we want it in the first.'
Tasks table is out of view when 769px and below.
The WBS and Members table don't have any side spacing when 415px and below.
Tasks table header items overlap when between 851px and 1000px.

## Related PRS (if any):
This frontend PR is related to the development backend PR.
…

## Main changes explained:
Changed the following css files: ProjectReport.css, TasksDetails.css.
Changed the following components: ProjectReport.jsx, TasksDetails.jsx.
…

## How to test:
Check into current branch
Do npm install and npm run start:local to run this PR locally
Clear site data/cache
Log as admin/owner user
Go to Dashboard→ Reports → Projects → Select a project → Follow the steps below
Verify if the stub/placeholder works in dark mode
Verify if when 850px and below the title appears in the first row
Verify if when 769px and below tasks table isn't out of view
Verify if WBS and Members table have side spacing when 415px and below
Verify if Tasks table header items don't overlap when between 851px and 1000px

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
