### PR TITLE
Aaryaneil Unit Test actionItemsReducer

### DIFF
--- a/src/reducers/__tests__/actionItemsReducer.test.js
+++ b/src/reducers/__tests__/actionItemsReducer.test.js
@@ -5,7 +5,7 @@ test('should return the initial state when no action is provided', () => {
   expect(actionItemsReducer(undefined, {})).toBeNull();
 });
 
-// Test handling of GET_ACTION_ITEMS action
+// Test to handle of GET_ACTION_ITEMS action
 test('should handle GET_ACTION_ITEMS action', () => {
   const initialState = null;
   const action = {

--- a/src/reducers/__tests__/actionItemsReducer.test.js
+++ b/src/reducers/__tests__/actionItemsReducer.test.js
@@ -1,0 +1,26 @@
+import { actionItemsReducer } from '../actionItemsReducer';
+
+// Test initial state
+test('should return the initial state when no action is provided', () => {
+  expect(actionItemsReducer(undefined, {})).toBeNull();
+});
+
+// Test handling of GET_ACTION_ITEMS action
+test('should handle GET_ACTION_ITEMS action', () => {
+  const initialState = null;
+  const action = {
+    type: 'GET_ACTION_ITEMS',
+    payload: [{ id: 1, name: 'Item 1' }, { id: 2, name: 'Item 2' }]
+  };
+  const expectedState = action.payload;
+  
+  expect(actionItemsReducer(initialState, action)).toEqual(expectedState);
+});
+
+// Test with an unknown action type
+test('should return current state for unknown action types', () => {
+  const initialState = [{ id: 1, name: 'Item 1' }];
+  const action = { type: 'UNKNOWN_ACTION' };
+  
+  expect(actionItemsReducer(initialState, action)).toEqual(initialState);
+});


### PR DESCRIPTION
# Description
Unit test for `src/reducers/actionItemsReducer.js`




## Main changes explained:
Added test cases for the following:
1. should return the initial state when no action is provided
2. should handle GET_ACTION_ITEMS action
3. should return current state for unknown action types



## How to test:
1. check into current branch
2. do `npm install` and `npm test actionItemsReducer.test.js` to run this PR locally


## Screenshots or videos of changes:
<img width="1291" alt="Screenshot 2024-12-21 at 5 40 10 AM" src="https://github.com/user-attachments/assets/365b8083-49b4-429d-b2b4-4b1c05b00a3d" />
