### PR TITLE
Yashwanth : Fix badge deletion

### DIFF
--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -35,7 +35,11 @@ import hasPermission from '../../utils/permissions';
 import { changeBadgesByUserID } from '../../actions/badgeManagement';
 import './BadgeReport.css';
 import { getUserProfile } from '../../actions/userProfile';
+
+
+
 import { PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE } from 'utils/constants';
+import { deleteBadge } from '../../actions/badgeManagement';
 
 pdfMake.vfs = pdfFonts.pdfMake.vfs;
 function BadgeReport(props) {
@@ -327,11 +331,13 @@ function BadgeReport(props) {
       setNumFeatured(prevNumFeatured => prevNumFeatured - 1);
     }
     setSortBadges(newBadges);
+    toast.success('Badges deleted successfully.');
+    saveChanges(newBadges);
     setShowModal(false);
     setBadgeToDelete([]);
   };
 
-  const saveChanges = async () => {
+  const saveChanges = async (sortBadges) => {
     setSavingChanges(true);
     try {
       let newBadgeCollection = JSON.parse(JSON.stringify(sortBadges));
@@ -515,7 +521,7 @@ function BadgeReport(props) {
           style={darkMode ? { ...boxStyleDark, margin: 5 } : { ...boxStyle, margin: 5 }}
           disabled={savingChanges}
           onClick={e => {
-            saveChanges();
+            saveChanges(sortBadges);
           }}
         >
           Save Changes
@@ -538,11 +544,6 @@ function BadgeReport(props) {
         <Modal isOpen={showModal} className={darkMode ? 'text-light' : ''}>
           <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
             <p>Woah, easy tiger! Are you sure you want to delete this badge?</p>
-            <br />
-            <p>
-              Note: Even if you click &quot;Yes, Delete&quot;, this won&apos;t be fully deleted
-              until you click the &quot;Save Changes&quot; button below.
-            </p>
           </ModalBody>
           <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
             <Button onClick={() => handleCancel()} style={darkMode ? boxStyleDark : boxStyle}>
@@ -716,7 +717,7 @@ function BadgeReport(props) {
               if (props.isRecordBelongsToJaeAndUneditable) {
                 alert(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
               }
-              saveChanges();
+              saveChanges(sortBadges);
             }}
           >
             <span>Save Changes</span>
@@ -740,11 +741,8 @@ function BadgeReport(props) {
         <Modal isOpen={showModal} className={darkMode ? 'text-light dark-mode' : ''}>
           <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
             <p>Woah, easy tiger! Are you sure you want to delete this badge?</p>
-            <br />
-            <p>
-              Note: Even if you click &quot;Yes, Delete&quot;, this won&apos;t be fully deleted
-              until you click the &quot;Save Changes&quot; button below.
-            </p>
+            
+            
           </ModalBody>
           <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
             <Button onClick={() => handleCancel()} style={darkMode ? boxStyleDark : boxStyle}>

--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -35,11 +35,7 @@ import hasPermission from '../../utils/permissions';
 import { changeBadgesByUserID } from '../../actions/badgeManagement';
 import './BadgeReport.css';
 import { getUserProfile } from '../../actions/userProfile';
-
-
-
 import { PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE } from 'utils/constants';
-import { deleteBadge } from '../../actions/badgeManagement';
 
 pdfMake.vfs = pdfFonts.pdfMake.vfs;
 function BadgeReport(props) {
@@ -332,12 +328,12 @@ function BadgeReport(props) {
     }
     setSortBadges(newBadges);
     toast.success('Badges deleted successfully.');
-    saveChanges(newBadges);
+    saveChanges(newBadges, true);
     setShowModal(false);
     setBadgeToDelete([]);
   };
 
-  const saveChanges = async (sortBadges) => {
+  const saveChanges = async (sortBadges, openModal) => {
     setSavingChanges(true);
     try {
       let newBadgeCollection = JSON.parse(JSON.stringify(sortBadges));
@@ -360,7 +356,8 @@ function BadgeReport(props) {
 
       props.handleSubmit();
       // Close the modal
-      props.close();
+      if(!openModal)
+        props.close();
     } catch (error) {
       // Handle errors and display error message
       toast.error('Failed to save badges. Please try again.');
@@ -521,7 +518,7 @@ function BadgeReport(props) {
           style={darkMode ? { ...boxStyleDark, margin: 5 } : { ...boxStyle, margin: 5 }}
           disabled={savingChanges}
           onClick={e => {
-            saveChanges(sortBadges);
+            saveChanges(sortBadges,false);
           }}
         >
           Save Changes
@@ -717,7 +714,7 @@ function BadgeReport(props) {
               if (props.isRecordBelongsToJaeAndUneditable) {
                 alert(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
               }
-              saveChanges(sortBadges);
+              saveChanges(sortBadges,false);
             }}
           >
             <span>Save Changes</span>


### PR DESCRIPTION
# Description
![Bug_Badge_Delete](https://github.com/user-attachments/assets/f8a2ac9d-da33-4c8a-a02a-fbadf9689a8a)

When you delete a user's badge, you must click the 'Save Changes' button to confirm the deletion. Otherwise, it may seem like the badge has been deleted, but reloading the page will show the badge again. Additionally, there is no message indicating that the badge was successfully deleted.
 
## Main changes explained:
-In the deleteBadge function, I am calling the saveChanges function, passing the updated badge list and the openModal parameter set to true to keep the modal open.

## How to test:
1. check into current branch 
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ Select a User from leaderboard and open his profile → Assign a Random Badge → Select featured…
6. Click on Delete and verify that the badge is deleted and a message is shown


## Screenshots or videos of changes:

https://github.com/user-attachments/assets/4c1ddd54-e87a-4a9a-aebb-3489dc660004


