### PR TITLE
Reina create way to change order of QST codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12452,6 +12452,14 @@
         "postcss": "^7.0.5"
       }
     },
+    "css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "requires": {
+        "tiny-invariant": "^1.0.6"
+      }
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -22109,6 +22117,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
@@ -22206,6 +22219,27 @@
         "react-themeable": "^1.1.0",
         "section-iterator": "^2.0.0",
         "shallow-equal": "^1.2.1"
+      }
+    },
+    "react-beautiful-dnd": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
+      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "dependencies": {
+        "memoize-one": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+          "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+        }
       }
     },
     "react-bootstrap": {
@@ -26596,6 +26630,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
       "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
+    },
+    "use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ=="
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.14.0",
     "react-autosuggest": "^10.1.0",
+    "react-beautiful-dnd": "^13.1.1",
     "react-bootstrap": "^1.0.1",
     "react-circular-progressbar": "^2.1.0",
     "react-collapsible": "^2.10.0",

--- a/src/components/UserProfile/QuickSetupModal/EditTitlesModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/EditTitlesModal.jsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react';
+import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import { ENDPOINTS } from 'utils/URL';
+import axios from 'axios';
+
+const EditTitlesModal = ({ isOpen, toggle, titles, refreshModalTitles, darkMode }) => {
+  const [orderedTitles, setOrderedTitles] = useState([]);
+
+  useEffect(() => {
+    if (titles && titles.length > 0) {
+      setOrderedTitles(titles);
+    }
+  }, [titles]);
+
+  const handleDragEnd = (result) => {
+    if (!result.destination) return;
+    const items = Array.from(orderedTitles);
+    const [reorderedItem] = items.splice(result.source.index, 1);
+    items.splice(result.destination.index, 0, reorderedItem);
+    setOrderedTitles(items);
+  };
+
+  const handleSave = async () => {
+    try {
+      const orderData = orderedTitles.map((title, index) => ({
+        id: title._id,
+        order: index + 1
+      }));
+      console.log('Sending order data:', orderData);
+  
+      const url = ENDPOINTS.REORDER_TITLES();
+      const response = await axios.put(url, { orderData });
+      console.log('Server response:', response.data);
+      
+      await refreshModalTitles();
+      toggle();
+    } catch (error) {
+      console.error("Error saving title order: ", error);
+    }
+  };
+  
+  return (
+    <Modal
+      isOpen={isOpen}
+      toggle={toggle}
+      className={darkMode ? 'text-light dark-mode' : ''}
+      style={{ maxHeight: '100vh' }}
+    >
+      <ModalHeader 
+        toggle={toggle}
+        className={darkMode ? 'bg-space-cadet' : ''}
+      >
+        Edit Titles Order
+      </ModalHeader>
+      <ModalBody 
+        className={darkMode ? 'bg-yinmn-blue' : ''} 
+        style={{ 
+          overflowY: 'auto',
+          maxHeight: 'calc(100vh - 200px)'
+        }}
+      >
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <Droppable droppableId="titles">
+            {(provided) => (
+              <div 
+                {...provided.droppableProps}
+                ref={provided.innerRef}
+                className="titles-list"
+                style={{ minHeight: '100%' }}
+              >
+                {orderedTitles.map((title, index) => (
+                  <Draggable 
+                    key={title._id} 
+                    draggableId={title._id} 
+                    index={index}
+                  >
+                    {(provided, snapshot) => (
+                    <div
+                      ref={provided.innerRef}
+                      {...provided.draggableProps}
+                      {...provided.dragHandleProps}
+                      className={`role-buttons ${snapshot.isDragging ? 'dragging' : ''}`}
+                      style={{
+                        ...provided.draggableProps.style,
+                        padding: '10px',
+                        margin: '8px 0',
+                        backgroundColor: darkMode ? '#2c3e50' : '#f8f9fa',
+                        border: '1px solid #dee2e6',
+                        borderRadius: '4px',
+                        cursor: 'grab'
+                      }}
+                    >
+                      {title?.titleCode ? title.titleCode : title?.titleName?.substring(0, 5)}
+                    </div>
+                  )}
+                  </Draggable>
+                ))}
+                {provided.placeholder}
+              </div>
+            )}
+          </Droppable>
+        </DragDropContext>
+      </ModalBody>
+      <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
+        <Button color="secondary" onClick={toggle}>
+          Cancel
+        </Button>
+        <Button color="primary" onClick={handleSave}>
+          Save Order
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default EditTitlesModal;

--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.css
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.css
@@ -10,7 +10,25 @@
     background-color: #17a2b8;
     color: white;
   }
+
+  .titles-list {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    max-height: 400px;
+    overflow-y: auto;
+  }
   
+  .role-buttons {
+    display: block;
+    background-color: #17a2b8;
+    border-radius: 5px;
+    padding: 5px 10px;
+    margin: 5px 0;
+    width: 100%;
+  }
+  
+
  #qsc-outer-wrapper #wrapper{
     position: relative;
   }
@@ -43,4 +61,9 @@
 
 .qsm-modal-required{
   color: red;
+}
+
+.titles-list::-webkit-scrollbar {
+  width: 8px;
+  color: black;
 }

--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
@@ -7,9 +7,11 @@ import AssignSetUpModal from './AssignSetupModal';
 import QuickSetupCodes from './QuickSetupCodes';
 import SaveButton from '../UserProfileEdit/SaveButton';
 import AddNewTitleModal from './AddNewTitleModal';
+import EditTitlesModal from './EditTitlesModal';
 import { getAllTitle } from '../../../actions/title';
 import './QuickSetupModal.css';
 import '../../Header/DarkMode.css';
+
 
 function QuickSetupModal(props) {
   const darkMode = useSelector(state => state.theme.darkMode);
@@ -25,6 +27,8 @@ function QuickSetupModal(props) {
   const [showMessage, setShowMessage] = useState(false);
   const [warningMessage, setWarningMessage] = useState({});
   const [adminLinks, setAdminLinks] = useState([]);
+  const [editModal, showEditModal] = useState(false);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
 
   useEffect(() => {
     getAllTitle()
@@ -32,30 +36,20 @@ function QuickSetupModal(props) {
         setTitles(res.data);
       })
       .catch(err => console.log(err));
-  }, []);
+  }, [editModal, refreshTrigger]);
 
   // refresh the QSCs after CREATE/DELETE operations on titles
-  const refreshModalTitles = () => {
-    getAllTitle()
-      .then(res => {
-        setTitles(res.data);
-        props.setUserProfile(props.userProfile);
-        props.setUserProfile(prev => ({ ...prev, adminLinks }));
-      })
-      .catch(err => console.log(err));
+  const refreshModalTitles = async () => {
+    try {
+      setRefreshTrigger(prev => prev + 1);
+      const response = await getAllTitle();
+      const sortedData = response.data.sort((a, b) => a.order - b.order);
+      setTitles(sortedData);
+    } catch (err) {
+      console.error(err);
+    }
   };
-
-  // handle save changes
-  const handleSaveChanges = () => {
-    handleSubmit()
-      .then(() => {
-        setTitleOnSet(true);
-      })
-      .catch(e => {
-        console.log(e);
-      });
-  };
-
+  
   return (
     <div>
       {canAssignTitle || canEditTitle || canAddTitle ? (
@@ -88,6 +82,19 @@ function QuickSetupModal(props) {
         ) : (
           ''
         )}
+        {canAddTitle ? (
+          <Button
+            color="primary mx-2"
+            onClick={() => showEditModal(true)}
+            style={darkMode ? boxStyleDark : boxStyle}
+            disabled={editMode == true}
+            title="Click this to change the order of QST codes"
+          >
+            Change Order
+          </Button>
+        ) : (
+          ''
+        )}
         {canEditTitle ? (
           !editMode ? (
             <Button
@@ -109,6 +116,13 @@ function QuickSetupModal(props) {
         ) : (
           ''
         )}
+        <EditTitlesModal 
+          isOpen={editModal}
+          toggle={() => showEditModal(false)}
+          titles={titles}
+          refreshModalTitles={refreshModalTitles}
+          darkMode={darkMode}
+        />
       </div>
       <div className="col text-center mt-3">
         {canAssignTitle ? (

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -111,6 +111,7 @@ export const ENDPOINTS = {
   CREATE_NEW_TITLE: () => `${APIEndpoint}/title`,
   EDIT_OLD_TITLE: () => `${APIEndpoint}/title/update`,
   DELETE_TITLE_BY_ID: titleId => `${APIEndpoint}/title/${titleId}`,
+  REORDER_TITLES: () => `${APIEndpoint}/title/order`,
 
   DELETE_TASK_NOTIFICATION_BY_USER_ID: (taskId, userId) =>
     `${APIEndpoint}/tasknotification/${userId}/${taskId}`,


### PR DESCRIPTION
# Description
Gives users the ability to change the order of the QST codes.

## Related PRS (if any):
This frontend PR is related to the [#1189 backend PR](https://github.com/OneCommunityGlobal/HGNRest/pull/1189).
…

## Main changes explained:
- Created a new file for the popup modal after clicking "Change Order"
- Adjusted the backend to account for order of QSTs 
- Used 'react-beautiful-dnd' to enable drop and drag functionality
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as any user
5. go to dashboard→ Profile → View Profile
6. the QSTs should be the blue buttons under the "Change Photo" button under the profile picture. Ensure the "Change Order" button shows a popup with the QST codes.
7. Ensure the drag and drop feature works. Hit save.
8. Ensure the new order is reflected after the modal popup disappears.

## Screenshots or videos of changes:


https://github.com/user-attachments/assets/4419c163-0a36-4b3d-bfe2-336dfab3b881


