### PR TITLE
Vijay Anand - Added unit test for leaderboardData action

### DIFF
--- a/src/actions/__tests__/leaderBoardDataAction.test.js
+++ b/src/actions/__tests__/leaderBoardDataAction.test.js
@@ -1,0 +1,60 @@
+import { getLeaderboardData, getOrgData } from '../leaderBoardData';
+import { ENDPOINTS } from '../../utils/URL';
+import httpService from '../../services/httpService';
+import {
+  getOrgData as getOrgDataActionCreator,
+  getLeaderBoardData as getLeaderBoardDataActionCreator,
+} from '../../constants/leaderBoardData';
+
+jest.mock('../../services/httpService');
+
+describe('leaderBoardActions', () => {
+  let dispatch;
+
+  beforeEach(() => {
+    dispatch = jest.fn(); // Mock the dispatch function
+    jest.clearAllMocks(); // Clear mocks before each test
+  });
+
+  describe('getLeaderboardData', () => {
+    it('should fetch leaderboard data and dispatch the corresponding action', async () => {
+      const userId = '123';
+      const mockData = { leaderBoard: [] };
+      httpService.get.mockResolvedValueOnce({ data: mockData }); // Mock HTTP GET response
+
+      await getLeaderboardData(userId)(dispatch);
+
+      expect(httpService.get).toHaveBeenCalledWith(ENDPOINTS.LEADER_BOARD(userId));
+      expect(dispatch).toHaveBeenCalledWith(getLeaderBoardDataActionCreator(mockData));
+    });
+  });
+
+  describe('getOrgData', () => {
+    it('should fetch organization data and dispatch the corresponding action', async () => {
+      const mockData = { organization: {} };
+      httpService.get.mockResolvedValueOnce({ data: mockData }); // Mock HTTP GET response
+
+      await getOrgData()(dispatch);
+
+      expect(httpService.get).toHaveBeenCalledWith(ENDPOINTS.ORG_DATA);
+      expect(dispatch).toHaveBeenCalledWith(getOrgDataActionCreator(mockData));
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle errors gracefully in getLeaderboardData', async () => {
+      const userId = '123';
+      httpService.get.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(getLeaderboardData(userId)(dispatch)).rejects.toThrow('Network error');
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors gracefully in getOrgData', async () => {
+      httpService.get.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(getOrgData()(dispatch)).rejects.toThrow('Network error');
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
# Description
Added unit tests for the leaderboardData action creators.

## Related PRS (if any):
No related PRs.

## Main changes explained:
- Created a new test file leaderBoardActions.test.js under the appropriate directory.
  - The test suite includes:
  - Positive Test Cases:
  - getLeaderboardData: Ensures the correct endpoint is called and verifies that the correct action is dispatched with the fetched data.
  - getOrgData: Similar validation as getLeaderboardData, but for organization data.
  - Error Handling:
  - Validates that errors are handled gracefully, ensuring no dispatch is made when the httpService.get method fails.

## How to test:
1. Check out the current branch.
2. Run npm install if necessary.
3. Execute the following command: npm test leaderBoardDataAction.test.js
4. Verify that all test cases pass successfully without any errors.

## Screenshots or videos of changes:
<img width="779" alt="image" src="https://github.com/user-attachments/assets/8d4630c5-41ae-4877-9b90-17d08b0a8b0e" />


