### PR TITLE
Koushica Fix for reset-time-modal UI break

### DIFF
--- a/src/components/NotFound/NotFoundPage.css
+++ b/src/components/NotFound/NotFoundPage.css
@@ -11,8 +11,8 @@
   align-items: center;
   height: 100vh;
   text-align: center;
-  color: #333; 
-  background-color: #fff; 
+  color: #333;
+  background-color: #fff;
 }
 
 .not-found-image {
@@ -47,12 +47,16 @@
 }
 
 .dark-mode {
-  color: #f1f1f1; 
-  background-color: #121212;
-  .not-found-image{
-    height:38%;
+  color: #f1f1f1;
+
+  .not-found-image {
+    height: 38%;
     width: auto;
   }
+}
+
+.bg-black {
+  background-color: #121212;
 }
 
 @media (max-width: 768px) {

--- a/src/components/NotFound/NotFoundPage.jsx
+++ b/src/components/NotFound/NotFoundPage.jsx
@@ -11,7 +11,7 @@ function NotFoundPage() {
   const darkMode = useSelector(state => state.theme.darkMode);
 
   return (
-    <div className={`not-found-container ${darkMode ? 'dark-mode' : ''}`}>
+    <div className={`not-found-container ${darkMode ? 'dark-mode bg-black' : ''}`}>
       <img
         className="not-found-image"
         src={darkMode ? NotFoundDarkImage : NotFoundImage}
@@ -20,7 +20,12 @@ function NotFoundPage() {
       <div className="not-found-text">
         <h1>PAGE NOT FOUND</h1>
         <p>The rabbits have been nibbling the cables again...</p>
-        <p>Maybe this will help <Link to="/" className="back-home-link">Home</Link></p>
+        <p>
+          Maybe this will help{' '}
+          <Link to="/" className="back-home-link">
+            Home
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -587,7 +587,7 @@ function Timer({ authUser, darkMode }) {
         toggle={() => setConfirmationResetModal(!confirmationResetModal)}
         centered
         size="md"
-        className={`${fontColor} dark-mode`}
+        className={cs(fontColor, darkMode ? 'dark-mode' : '')}
       >
         <ModalHeader
           className={darkMode ? 'bg-space-cadet' : ''}
@@ -639,7 +639,7 @@ function Timer({ authUser, darkMode }) {
         </ModalFooter>
       </Modal>
       <Modal
-        className={`${fontColor} dark-mode`}
+        className={cs(fontColor, darkMode ? 'dark-mode' : '')}
         isOpen={timeIsOverModalOpen}
         toggle={toggleTimeIsOver}
         centered


### PR DESCRIPTION
# Description
This PR addresses a UI break issue with the reset-time-modal that occurred when using the timer and clicking the reset-time icon. The modal’s appearance was altered due to recent changes introduced in [PR #2931](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2931)

## Related PRS (if any):
No related PRs

## Main Issue:
The issue occurred due to the background-color addition in the NotFoundPage.css from PR #2931

## Main changes explained:

1. Updated the file NotFoundPage.css and NotFoundPage.jsx: created a new classname for background color in css file and updated in the jsx file.
2. Updated the darkMode condition in the  Timer.jsx file

## How to test:
1. check into current branch
4. do `npm install` and `...` to run this PR locally
5. Clear site data/cache
6. log as admin user / any user
7. Turn on your timer and verify the below:
- refresh the page and check for timer paused modal
- try to reset the timer and check the reset timer modal
verify in both dark and light modes.

## Screenshots or videos of changes:

Before:

https://github.com/user-attachments/assets/9ec6f009-c49c-49bd-a130-fa3628b3c2ce


After:


https://github.com/user-attachments/assets/c77db1fe-f739-4d53-9cfc-1f9212a9e31a

