### PR TITLE
pavan-swaroop-add-title-column-reduce-role-width

### DIFF
--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -55,6 +55,7 @@ class UserManagement extends React.PureComponent {
       firstNameSearchText: '',
       lastNameSearchText: '',
       roleSearchText: '',
+      titleSearchText: '',
       weeklyHrsSearchText: '',
       emailSearchText: '',
       wildCardSearchText: '',
@@ -117,6 +118,7 @@ class UserManagement extends React.PureComponent {
     const searchStateChanged = (prevState.firstNameSearchText !== this.state.firstNameSearchText) || 
                                (prevState.lastNameSearchText !== this.state.lastNameSearchText) || 
                                (prevState.roleSearchText !== this.state.roleSearchText) || 
+                               prevState.titleSearchText !== this.state.titleSearchText ||
                                (prevState.weeklyHrsSearchText !== this.state.weeklyHrsSearchText) || 
                                (prevState.emailSearchText !== this.state.emailSearchText);
   
@@ -247,6 +249,7 @@ class UserManagement extends React.PureComponent {
               onResetClick={that.onResetClick}
               authEmail={this.props.state.userProfile.email}
               user={user}
+              jobTitle={this.props.state.userProfile.jobTitle}
               role={this.props.state.auth.user.role}
               roles={rolesPermissions}
               timeOffRequests={timeOffRequests[user._id] || []}
@@ -312,6 +315,7 @@ class UserManagement extends React.PureComponent {
       return (
         nameMatches &&
         user.role.toLowerCase().includes(this.state.roleSearchText.toLowerCase()) &&
+        user.jobTitle.toLowerCase().includes(this.state.titleSearchText.toLowerCase()) &&
         user.email.toLowerCase().includes(this.state.emailSearchText.toLowerCase()) &&
         (this.state.weeklyHrsSearchText === '' ||
           user.weeklycommittedHours === Number(this.state.weeklyHrsSearchText)) &&
@@ -565,6 +569,16 @@ class UserManagement extends React.PureComponent {
   };
 
   /**
+   * Call back for search filter - Job Title
+   */
+  onTitleSearch = searchText => {
+    this.setState({
+      titleSearchText: searchText.trim(),
+      selectedPage: 1,
+    });
+  };
+
+  /**
    * Call back for search filter - email
    */
   onEmailSearch = searchText => {
@@ -760,6 +774,7 @@ class UserManagement extends React.PureComponent {
                   onFirstNameSearch={this.onFirstNameSearch}
                   onLastNameSearch={this.onLastNameSearch}
                   onRoleSearch={this.onRoleSearch}
+                  onTitleSearch={this.onTitleSearch}
                   onEmailSearch={this.onEmailSearch}
                   onWeeklyHrsSearch={this.onWeeklyHrsSearch}
                   roles={roles}

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -33,6 +33,7 @@ const UserTableData = React.memo(props => {
     lastName: props.user.lastName,
     id: props.user._id,
     role: props.user.role,
+    jobTitle: props.user.jobTitle,
     email: props.user.email,
     weeklycommittedHours: props.user.weeklycommittedHours,
     startDate: formatDate(props.user.startDate),
@@ -77,6 +78,7 @@ const UserTableData = React.memo(props => {
       lastName: props.user.lastName,
       id: props.user._id,
       role: props.user.role,
+      jobTitle:props.user.jobTitle,
       email: props.user.email,
       weeklycommittedHours: props.user.weeklycommittedHours,
       startDate: formatDateYYYYMMDD(props.user.startDate),
@@ -179,7 +181,7 @@ const UserTableData = React.memo(props => {
           />
         )}
       </td>
-      <td>
+      <td id="usermanagement_role">
         {editUser?.role && roles !== undefined ? (
           formData.role
         ) : (
@@ -198,6 +200,33 @@ const UserTableData = React.memo(props => {
               </option>
             ))}
           </select>
+        )}
+      </td>
+
+
+      <td className="email_cell">
+        {editUser?.jobTitle ? (
+          <div>
+            {formData.jobTitle}
+            <FontAwesomeIcon
+              className="copy_icon"
+              icon={faCopy}
+              onClick={() => {
+                navigator.clipboard.writeText(formData.jobTitle);
+                toast.success('Title Copied!');
+              }}
+            />
+          </div>
+        ) : (
+          <input
+            type="text"
+            className="edituser_input"
+            value={formData.jobTitle}
+            onChange={e => {
+              updateFormData({ ...formData, jobTitle: e.target.value });
+              addUserInformation('jobTitle', e.target.value, props.user._id);
+            }}
+          />
         )}
       </td>
 

--- a/src/components/UserManagement/UserTableHeader.jsx
+++ b/src/components/UserManagement/UserTableHeader.jsx
@@ -13,6 +13,7 @@ import {
   FIRST_NAME,
   LAST_NAME,
   ROLE,
+  TITLE,
   EMAIL,
   WKLY_COMMITTED_HRS,
   PAUSE,
@@ -136,6 +137,32 @@ const UserTableHeader = React.memo(
                     icon={faSave}
                     className="editbutton"
                     onClick={() => disableEdit({ ...editFlag, role: 1 })}
+                  />
+                );
+              }
+              return <> </>;
+            })()}
+          </div>
+        </th>
+        <th scope="col" id="usermanagement_title">
+          <div className="text-center">
+            <span className="m-auto">{TITLE}</span>
+            {(() => {
+              if (authRole === 'Owner') {
+                if (editFlag.jobTitle === 1) {
+                  return (
+                    <FontAwesomeIcon
+                      icon={faEdit}
+                      className="editbutton"
+                      onClick={() => enableEdit({ ...editFlag, jobTitle: 0 })}
+                    />
+                  );
+                }
+                return (
+                  <FontAwesomeIcon
+                    icon={faSave}
+                    className="editbutton"
+                    onClick={() => disableEdit({ ...editFlag, jobTitle: 1 })}
                   />
                 );
               }

--- a/src/components/UserManagement/UserTableSearchHeader.jsx
+++ b/src/components/UserManagement/UserTableSearchHeader.jsx
@@ -21,6 +21,10 @@ const UserTableSearchHeader = React.memo(props => {
     props.onRoleSearch(text);
   };
 
+  const onTitleSearch = text => {
+    props.onTitleSearch(text);
+  };
+
   const onEmailSearch = text => {
     props.onEmailSearch(text);
   };
@@ -48,6 +52,14 @@ const UserTableSearchHeader = React.memo(props => {
       </td>
       <td id="user_role">
         <DropDownSearchBox id="role_search" items={props.roles} searchCallback={onRoleSearch} />
+      </td>
+      <td id="user_title">
+        <TextSearchBox
+          id="title_search"
+          searchCallback={onTitleSearch}
+          style={{ width: '100%' }}
+          placeholder=" Search Title"
+        />
       </td>
       <td id="user_email">
         <TextSearchBox

--- a/src/components/UserManagement/__tests__/UserTableSearchHeader.test.js
+++ b/src/components/UserManagement/__tests__/UserTableSearchHeader.test.js
@@ -7,12 +7,14 @@ describe('user table search header row', () => {
   let onFirstNameSearch;
   let onLastNameSearch;
   let onRoleSearch;
+  let onTitleSearch;
   let onEmailSearch;
   let onWeeklyHrsSearch;
   beforeEach(() => {
     onFirstNameSearch = jest.fn();
     onLastNameSearch = jest.fn();
     onRoleSearch = jest.fn();
+    onTitleSearch = jest.fn();
     onEmailSearch = jest.fn();
     onWeeklyHrsSearch = jest.fn();
     render(
@@ -22,6 +24,7 @@ describe('user table search header row', () => {
             onFirstNameSearch={onFirstNameSearch}
             onLastNameSearch={onLastNameSearch}
             onRoleSearch={onRoleSearch}
+            onTitleSearch={onTitleSearch}
             onEmailSearch={onEmailSearch}
             onWeeklyHrsSearch={onWeeklyHrsSearch}
             roles={['1', '2', '3', '4', 'Volunteer', 'Owner', 'Manager']}
@@ -35,7 +38,7 @@ describe('user table search header row', () => {
       expect(screen.getByRole('row')).toBeInTheDocument();
     });
     it('should render 4 text field', () => {
-      expect(screen.getAllByRole('textbox')).toHaveLength(4);
+      expect(screen.getAllByRole('textbox')).toHaveLength(5);
     });
     it('should render one dropdown box', () => {
       expect(screen.getByRole('combobox')).toBeInTheDocument();
@@ -69,6 +72,10 @@ describe('user table search header row', () => {
       userEvent.selectOptions(screen.getByRole('combobox'), 'Manager');
       expect(onRoleSearch).toHaveBeenCalled();
       expect(onRoleSearch).toHaveBeenCalledWith('Manager');
+    });
+    it('should fire Title search once the user type something in the title search box', async () => {
+      await userEvent.type(screen.getAllByRole('textbox')[2], 'test', { allAtOnce: false });
+      expect(onTitleSearch).toHaveBeenCalledTimes(4);
     });
     it('should fire Email search once the user type something in the email search box', async () => {
       await userEvent.type(screen.getAllByRole('textbox')[2], 'test', { allAtOnce: false });

--- a/src/components/UserManagement/__tests__/UserTableSearchHeader.test.js
+++ b/src/components/UserManagement/__tests__/UserTableSearchHeader.test.js
@@ -78,21 +78,21 @@ describe('user table search header row', () => {
       expect(onTitleSearch).toHaveBeenCalledTimes(4);
     });
     it('should fire Email search once the user type something in the email search box', async () => {
-      await userEvent.type(screen.getAllByRole('textbox')[2], 'test', { allAtOnce: false });
+      await userEvent.type(screen.getAllByRole('textbox')[3], 'test', { allAtOnce: false });
       expect(onEmailSearch).toHaveBeenCalledTimes(4);
     });
     it('should fire Email search once the user type something in the email search box', async () => {
-      await userEvent.type(screen.getAllByRole('textbox')[2], 'Jhon.wick@email.com', {
+      await userEvent.type(screen.getAllByRole('textbox')[3], 'Jhon.wick@email.com', {
         allAtOnce: true,
       });
       expect(onEmailSearch).toHaveBeenCalled();
     });
     it('should fire onWeeklyHrsSearch once the user type something in the weeklycommitted hrs search box', async () => {
-      await userEvent.type(screen.getAllByRole('textbox')[3], 'test', { allAtOnce: false });
+      await userEvent.type(screen.getAllByRole('textbox')[4], 'test', { allAtOnce: false });
       expect(onWeeklyHrsSearch).toHaveBeenCalledTimes(4);
     });
     it('should fire onWeeklyHrsSearch once the user type something in the weeklycommitted hrs search box', async () => {
-      await userEvent.type(screen.getAllByRole('textbox')[3], '15', { allAtOnce: true });
+      await userEvent.type(screen.getAllByRole('textbox')[4], '15', { allAtOnce: true });
       expect(onWeeklyHrsSearch).toHaveBeenCalled();
     });
   });

--- a/src/components/UserManagement/usermanagement.css
+++ b/src/components/UserManagement/usermanagement.css
@@ -89,6 +89,16 @@ thead {
 
 }
 
+#usermanagement_role, 
+#user_role, 
+td#usermanagement_role {
+  width: 100px;
+  max-width: 180px; 
+  overflow: hidden;
+  text-overflow: ellipsis; 
+  white-space: nowrap; 
+}
+
 .copy_icon {
   cursor: pointer;
   position: absolute;

--- a/src/languages/en/ui.js
+++ b/src/languages/en/ui.js
@@ -3,6 +3,7 @@
  * Stores all variables that display texts on the UI
  ******************************************************************************* */
 export const ACTIVE = 'Active';
+export const TITLE = 'Title'
 export const INACTIVE = 'InActive';
 export const ACTIVE_PROJECTS = 'Active Projects';
 export const BM_DASHBOARD = 'BM Dashboard';

--- a/src/reducers/allUserProfilesReducer.js
+++ b/src/reducers/allUserProfilesReducer.js
@@ -5,7 +5,7 @@ const userProfilesInitial = {
   fetching: false,
   fetched: false,
   userProfiles: [],
-  editable: { 'first': 1, 'last': 1, 'role': 1, 'email': 1, 'weeklycommittedHours': 1 ,'startDate':1,'endDate':1},
+  editable: { 'first': 1, 'last': 1, 'role': 1, 'jobTitle': 1, 'email': 1, 'weeklycommittedHours': 1 ,'startDate':1,'endDate':1},
   pagestats: { pageSize: 10, selectedPage: 1 },
   status: 100,
   updating:false,


### PR DESCRIPTION
# Description
Add “Title” column and reduce “Role” column on User Management page
a. Admin Login → Other Links → User Management
b. Add “Title” column to the right of Role
c. Should be editable from this page by Admin/Owner, just like the other columns
d. Should be searchable/filterable like the email
e. Also make the “Role” Column as narrow as possible. There are only a few roles, so we could turn those into icons instead of words, if needed to make it even narrower.

## Related PRS (if any):
This frontend PR is related to the [#1191](https://github.com/OneCommunityGlobal/HGNRest/pull/1191) backend PR.
…

## Main changes explained:
- added title column which is searchable and editable with admin permissions, and reduced tole column width
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ other links -> User management
Check for a,b,c, and d from the description above

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/2505febe-428f-4a87-92e0-e15677355c53

<img width="379" alt="Screenshot 2024-12-26 at 11 45 24 PM" src="https://github.com/user-attachments/assets/3ff01e40-a90b-401e-8448-a9b5e693919b" />
<img width="220" alt="Screenshot 2024-12-26 at 11 45 31 PM" src="https://github.com/user-attachments/assets/174dc7c5-8a6e-43b1-896f-4d7f0e898723" />
<img width="412" alt="Screenshot 2024-12-26 at 11 45 38 PM" src="https://github.com/user-attachments/assets/1ead0e92-824e-4083-932b-28152d104972" />
<img width="1408" alt="Screenshot 2024-12-26 at 11 45 48 PM" src="https://github.com/user-attachments/assets/16913693-2c76-4ebd-8ac5-e87c4c40159d" />

