### PR TITLE
Supriya - Project Navigation Dropdown to all BM Manager Pages

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -20,9 +20,11 @@
 }
 
 .navbar {
-  z-index: 100;
+  z-index: 1050;
+  /* z-index: 100; */
   white-space: nowrap;
   margin-bottom: 20px;
+  overflow: visible;
 }
 
 .timer-message-section {
@@ -58,6 +60,19 @@
   display: flex;
   align-items: center;
 }
+
+.dropdown-menu {
+  max-height: none; 
+  overflow-y: auto; 
+}
+
+
+.nav-item .dropdown-menu {
+  position: absolute; 
+  transform: translate3d(0, 0, 0); 
+}
+
+
 
 .dropdown-item-hover:hover{
   background-color: #2f4157 !important;
@@ -101,4 +116,11 @@
   .responsive-spacing{
     margin-right: 5px;
   }
+
+  .dropdown-menu {
+    max-height: 50vh; 
+    overflow-y: auto; 
+  }
 }
+
+

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import { useState, useEffect, useMemo } from 'react';
 // import { getUserProfile } from '../../actions/userProfile'
 import { ENDPOINTS } from 'utils/URL';
@@ -114,6 +115,20 @@ export function Header(props) {
     props.hasPermission('postTask', !isAuthUser && canInteractWithViewingUser) ||
     props.hasPermission('updateTask', !isAuthUser && canInteractWithViewingUser) ||
     props.hasPermission('deleteTask', !isAuthUser && canInteractWithViewingUser);
+
+  // Projects Dropdown
+  const projectPaths = [
+    '/bmdashboard/materials/add',
+    '/bmdashboard/logMaterial',
+    '/bmdashboard/materials',
+    '/bmdashboard/equipment/add',
+    '/bmdashboard/equipment',
+    '/bmdashboard/equipment/:equipmentId',
+    '/bmdashboard/tools/:equipmentId/update',
+    '/bmdashboard/Issue',
+    '/bmdashboard/lessonform/',
+  ];
+
   // Tasks
   const canUpdateTask = props.hasPermission(
     'updateTask',
@@ -293,8 +308,14 @@ export function Header(props) {
     }
   }, [lastDismissed, userId, userDashboardProfile]);
 
+  // useEffect(() => {
+  //   setShowProjectDropdown(location.pathname.startsWith('/bmdashboard/projects/'));
+  // }, [location.pathname]);
   useEffect(() => {
-    setShowProjectDropdown(location.pathname.startsWith('/bmdashboard/projects/'));
+    const pathMatches = projectPaths.some(
+      path => location.pathname === path || location.pathname.startsWith(path),
+    );
+    setShowProjectDropdown(location.pathname.startsWith('/bmdashboard/projects/') || pathMatches);
   }, [location.pathname]);
 
   const fontColor = darkMode ? 'text-white dropdown-item-hover' : '';


### PR DESCRIPTION
# Description
Implement Projects dropdown after navigating to the pages in the dropdown

## Related PRS (if any):
No related PRs
…

## Main changes explained:
Created the Projects dropdown in the navigation of all BM Manager Pages
…

## How to test:
1.check into current branch
2. do npm install and npm run start:local to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to bmdashboard -> Select a Project -> Go to Project Dashboard -> Projects(in Header) -> check the dropdown Pages
http://localhost:3000/bmdashboard/login
Verify each and every page in dropdown list has the Projects dropdown in the header 



## Screenshots or videos of changes:



## Note:
Pages in the dropdown list are not in the dark mode yet
