### PR TITLE
Siva: Take over from Muzammil_finish_color_discrepancy_fix

### DIFF
--- a/src/components/common/PieChart/PieChart.jsx
+++ b/src/components/common/PieChart/PieChart.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import * as d3 from 'd3/dist/d3.min';
+import * as d3 from 'd3';
 import { CHART_RADIUS, CHART_SIZE } from './constants';
 import './PieChart.css';
 // import './UserProjectPieChart.css';
@@ -13,12 +13,24 @@ export const PieChart = ({
   projectsData = [],
 }) {
   const [totalHours, setTotalHours] = useState(0);
-  
+
   // Custom vibrant color palette
   const customColors = [
-    '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFBE0B',
-    '#FF006E', '#8338EC', '#3A86FF', '#FB5607', '#38B000',
-    '#7209B7', '#F72585', '#4CC9F0', '#80ED99', '#F15BB5',
+    '#FF6B6B',
+    '#4ECDC4',
+    '#45B7D1',
+    '#96CEB4',
+    '#FFBE0B',
+    '#FF006E',
+    '#8338EC',
+    '#3A86FF',
+    '#FB5607',
+    '#38B000',
+    '#7209B7',
+    '#F72585',
+    '#4CC9F0',
+    '#80ED99',
+    '#F15BB5',
   ];
 
   let color = d3.scaleOrdinal().range(customColors);
@@ -77,10 +89,8 @@ export const PieChart = ({
     color = d3.scaleOrdinal().range(customColors);
     const data_ready = pie(Object.entries(data));
 
-    const totalValue = data_ready
-      .map(obj => obj.value)
-      .reduce((a, c) => a + c, 0);
-    
+    const totalValue = data_ready.map(obj => obj.value).reduce((a, c) => a + c, 0);
+
     setTotalHours(totalValue);
 
     let div = d3.select('.tooltip-donut');
@@ -113,7 +123,7 @@ export const PieChart = ({
           .duration('50')
           .attr('opacity', '.7')
           .style('filter', 'brightness(1.2)');
-          
+
         div
           .transition()
           .duration(50)
@@ -125,7 +135,7 @@ export const PieChart = ({
           .map(e => e)
           .indexOf(d.data[0]);
         const legendInfo = taskName[index].toString();
-        
+
         div
           .html(legendInfo)
           .style('max-width', '150px')
@@ -141,7 +151,7 @@ export const PieChart = ({
           .duration('50')
           .attr('opacity', '1')
           .style('filter', 'brightness(1.1)');
-          
+
         div
           .transition()
           .duration(50)
@@ -168,12 +178,12 @@ export const PieChart = ({
         </div>
         {Object.keys(dataLegend).map(key => (
           <div key={key} className="pie-chart-legend-item">
-            <div 
-              className="data-legend-color" 
-              style={{ 
+            <div
+              className="data-legend-color"
+              style={{
                 backgroundColor: color(key),
-                filter: 'brightness(1.1)'
-              }} 
+                filter: 'brightness(1.1)',
+              }}
             />
             <div className="data-legend-info">
               {dataLegend[key].map((legendPart, index) => (


### PR DESCRIPTION
# Description
The wheel chart in Reports -> People displays all segments in the same color when accessed from the Dashboard for the first time. Returning to the previous page and viewing the report again resolves the issue, showing the correct multi-colored segments. This inconsistency occurs every time the report is accessed afresh from the Dashboard.

![image](https://github.com/user-attachments/assets/1bf8e157-f199-43ea-bf0b-55a7574df90e)

## Related PRS (if any):
None
…

## Main changes explained:
Adjust the Pie Chart Colors to Match Personal Test Lists
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
Add the desired user account to the project where you want to test.(https://www.loom.com/share/8bc672c323b64955aac4bce46c3794aa?sid=b05f5604-87cb-4ca1-80b8-49bd823893ee)
Assign at least 10 tasks to the user within the project.
Remember that tasks with zero logged hours will not appear on the Pie Chart.
Open Mongo Compass and connect to the database using the hgnproddb credentials.
Navigate to the "tasks" collection in the database.
Search for the tasks you assigned by using the taskName field.
Update the "hoursLogged" field for each task by entering a non-zero value (e.g., 5).
Save the changes and ensure the updates are applied in the database.
Refresh the application to confirm that tasks with logged hours now appear on the Pie Chart .
Go to the Home Page and navigate to the Reports dropdown.
Select Reports -> People from the dropdown menu.
Use the Search bar to find the user account you assigned tasks to.
Click on the user account to view their details.
Test the functionality by clicking the "View all" button.
Ensure that the colors in the pie chart's legend accurately match the corresponding segments in the pie chart.
Verify that hovering over the segments of the pie chart displays the associated tasks correctly.

## Screenshots or videos of changes:
Before
![image](https://github.com/user-attachments/assets/446b4262-f71c-4a28-a7a1-6612d50d7479)
After

https://github.com/user-attachments/assets/fe552505-ea67-46d6-b03b-3c7b0be43523


