### PR TITLE
Aaryaneil unit tests wbsReducer

### DIFF
--- a/src/reducers/__tests__/wbsReducer.test.js
+++ b/src/reducers/__tests__/wbsReducer.test.js
@@ -1,0 +1,86 @@
+import { wbsReducer } from "../wbsReducer";
+import * as types from "../../constants/WBS";
+
+describe("wbsReducer", () => {
+  const initialState = {
+    fetching: false,
+    fetched: false,
+    WBSItems: [],
+    error: '',
+  };
+
+  it("should return the initial state when an unknown action is provided", () => {
+    expect(wbsReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it("should handle FETCH_WBS_START", () => {
+    const action = { type: types.FETCH_WBS_START };
+    const expectedState = { ...initialState, fetching: true, error: 'none' };
+    expect(wbsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it("should handle FETCH_WBS_ERROR", () => {
+    const action = { type: types.FETCH_WBS_ERROR, err: "Error fetching WBS" };
+    const expectedState = {
+      ...initialState,
+      fetching: false,
+      fetched: true,
+      error: "Error fetching WBS",
+    };
+    expect(wbsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it("should handle RECEIVE_WBS", () => {
+    const action = {
+      type: types.RECEIVE_WBS,
+      WBSItems: [{ id: 1, name: "WBS Item 1" }],
+    };
+    const expectedState = {
+      ...initialState,
+      WBSItems: [{ id: 1, name: "WBS Item 1" }],
+      fetching: false,
+      fetched: true,
+      error: 'none',
+    };
+    expect(wbsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it("should handle ADD_NEW_WBS", () => {
+    const action = {
+      type: types.ADD_NEW_WBS,
+      wbs: { id: 2, name: "New WBS Item" },
+    };
+    const expectedState = {
+      ...initialState,
+      WBSItems: [{ id: 2, name: "New WBS Item" }, ...initialState.WBSItems],
+    };
+    expect(wbsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it("should handle ADD_NEW_WBS_ERROR", () => {
+    const action = { type: types.ADD_NEW_WBS_ERROR, err: "Error adding WBS" };
+    const expectedState = {
+      ...initialState,
+      fetching: false,
+      fetched: true,
+      error: "Error adding WBS",
+    };
+    expect(wbsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it("should handle DELETE_WBS", () => {
+    const currentState = {
+      ...initialState,
+      WBSItems: [
+        { _id: 1, name: "WBS Item 1" },
+        { _id: 2, name: "WBS Item 2" },
+      ],
+    };
+    const action = { type: types.DELETE_WBS, wbsId: 1 };
+    const expectedState = {
+      ...initialState,
+      WBSItems: [{ _id: 2, name: "WBS Item 2" }],
+    };
+    expect(wbsReducer(currentState, action)).toEqual(expectedState);
+  });
+});


### PR DESCRIPTION
# Description
Unit test for `src/reducers/wbsReducer.js`




## Main changes explained:
Added test cases for the following:
1. should return the initial state when an unknown action is provided
2. should handle FETCH_WBS_START
3. should handle FETCH_WBS_ERROR
4. should handle RECEIVE_WBS
5. should handle ADD_NEW_WBS
6. should handle ADD_NEW_WBS_ERROR
7. should handle DELETE_WBS



## How to test:
1. check into current branch
8. do `npm install` and `npm test wbsReducer.test.js` to run this PR locally


## Screenshots or videos of changes:
<img width="1144" alt="Screenshot 2024-12-31 at 3 08 58 PM" src="https://github.com/user-attachments/assets/9a0eff3e-69f5-4e46-9273-f8f3b2fcbf6f" />

