### PR TITLE
Aaryaneil - Unit Tests for timeEntriesForSpecifiedPeriodReducer

### DIFF
--- a/src/reducers/__tests__/timeEntriesForSpecifiedPeriodReducer.test.js
+++ b/src/reducers/__tests__/timeEntriesForSpecifiedPeriodReducer.test.js
@@ -1,0 +1,32 @@
+import { timeEntriesForSpecifiedPeriodReducer } from '../timeEntriesForSpecifiedPeriodReducer';
+
+describe('timeEntriesForSpecifiedPeriodReducer', () => {
+  it('should return the initial state when state is undefined', () => {
+    const initialState = null;
+    const action = {};
+    expect(timeEntriesForSpecifiedPeriodReducer(undefined, action)).toBe(initialState);
+  });
+
+  it('should return the current state when action type does not match', () => {
+    const currentState = [{ id: 1, duration: '2h' }];
+    const action = { type: 'UNKNOWN_ACTION', payload: [{ id: 2, duration: '3h' }] };
+    expect(timeEntriesForSpecifiedPeriodReducer(currentState, action)).toBe(currentState);
+  });
+
+  it('should return the new state when action type is GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD', () => {
+    const action = {
+      type: 'GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD',
+      payload: [{ id: 2, duration: '3h' }]
+    };
+    expect(timeEntriesForSpecifiedPeriodReducer(null, action)).toEqual(action.payload);
+  });
+
+  it('should update the state with the new time entries when action type is GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD', () => {
+    const currentState = [{ id: 1, duration: '2h' }];
+    const action = {
+      type: 'GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD',
+      payload: [{ id: 2, duration: '3h' }]
+    };
+    expect(timeEntriesForSpecifiedPeriodReducer(currentState, action)).toEqual(action.payload);
+  });
+});


### PR DESCRIPTION
# Description
Unit test for `src/reducers/timeEntriesForSpecifiedPeriodReducer.js`




## Main changes explained:
Added test cases for the following:
1. should return the initial state when state is undefined
2. should return the current state when action type does not match
3. should return the new state when action type is GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD
4. should update the state with the new time entries when action type is GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD



## How to test:
1. check into current branch
5. do `npm install` and `npm test timeEntriesForSpecifiedPeriodReducer.test.js` to run this PR locally


## Screenshots or videos of changes:
<img width="1134" alt="Screenshot 2024-12-31 at 3 57 40 PM" src="https://github.com/user-attachments/assets/edc684b8-77a4-4b14-9b81-1ea810e04fc0" />
