### PR TITLE
Aaryaneil - Unit Tests for rolePresetReducer

### DIFF
--- a/src/reducers/__tests__/rolePresetReducer.test.js
+++ b/src/reducers/__tests__/rolePresetReducer.test.js
@@ -1,0 +1,86 @@
+import { rolePresetReducer } from '../rolePresetReducer';
+import * as types from '../../constants/rolePermissionPresets';
+
+describe('rolePresetReducer', () => {
+  const initialState = {
+    presets: [],
+  };
+
+  // Test case 1: Test RECEIVE_PRESETS action
+  it('should handle RECEIVE_PRESETS', () => {
+    const action = {
+      type: types.RECEIVE_PRESETS,
+      presets: [{ _id: 1, presetName: 'Admin' }, { _id: 2, presetName: 'User' }],
+    };
+
+    const newState = rolePresetReducer(initialState, action);
+
+    expect(newState).toEqual({
+      presets: [{ _id: 1, presetName: 'Admin' }, { _id: 2, presetName: 'User' }],
+    });
+  });
+
+  // Test case 2: Test ADD_NEW_PRESET action
+  it('should handle ADD_NEW_PRESET', () => {
+    const action = {
+      type: types.ADD_NEW_PRESET,
+      payload: { _id: 3, presetName: 'Editor' },
+    };
+
+    const newState = rolePresetReducer(
+      { ...initialState, presets: [{ _id: 1, presetName: 'Admin' }] },
+      action
+    );
+
+    expect(newState).toEqual({
+      presets: [{ _id: 1, presetName: 'Admin' }, { _id: 3, presetName: 'Editor' }],
+    });
+  });
+
+  // Test case 3: Test UPDATE_PRESET action
+  it('should handle UPDATE_PRESET', () => {
+    const action = {
+      type: types.UPDATE_PRESET,
+      payload: { _id: 2, presetName: 'Super User' },
+    };
+
+    const initialStateWithPresets = {
+      presets: [{ _id: 1, presetName: 'Admin' }, { _id: 2, presetName: 'User' }],
+    };
+
+    const newState = rolePresetReducer(initialStateWithPresets, action);
+
+    expect(newState).toEqual({
+      presets: [{ _id: 1, presetName: 'Admin' }, { _id: 2, presetName: 'Super User' }],
+    });
+  });
+
+  // Test case 4: Test DELETE_PRESET action
+  it('should handle DELETE_PRESET', () => {
+    const action = {
+      type: types.DELETE_PRESET,
+      presetId: 1,
+    };
+
+    const initialStateWithPresets = {
+      presets: [{ _id: 1, presetName: 'Admin' }, { _id: 2, presetName: 'User' }],
+    };
+
+    const newState = rolePresetReducer(initialStateWithPresets, action);
+
+    expect(newState).toEqual({
+      presets: [{ _id: 2, presetName: 'User' }],
+    });
+  });
+
+  // Test case 5: Test default case (no action matches)
+  it('should return the current state for unknown action', () => {
+    const action = {
+      type: 'UNKNOWN_ACTION',
+    };
+
+    const newState = rolePresetReducer(initialState, action);
+
+    expect(newState).toEqual(initialState);
+  });
+});


### PR DESCRIPTION
# Description
Unit test for `src/reducers/rolePresetReducer.js`




## Main changes explained:
Added test cases for the following:
1. should handle RECEIVE_PRESETS
2. should handle ADD_NEW_PRESET
3. should handle UPDATE_PRESET
4. should handle DELETE_PRESET
5. should return the current state for unknown action



## How to test:
1. check into current branch
2. do `npm install` and `npm test rolePresetReducer.test.js` to run this PR locally


## Screenshots or videos of changes:
<img width="1134" alt="Screenshot 2024-12-31 at 4 41 18 PM" src="https://github.com/user-attachments/assets/806dca85-3b6a-4607-8244-ca5c7001cdfe" />

