### PR TITLE
Aaryaneil - Unit tests for popupEditorReducer

### DIFF
--- a/src/reducers/__tests__/popupEditorReducer.test.js
+++ b/src/reducers/__tests__/popupEditorReducer.test.js
@@ -1,0 +1,58 @@
+import { popupEditorReducer } from "../popupEditorReducer";
+import * as types from "../../constants/popupEditorConstants";
+
+describe("popupEditorReducer", () => {
+  const initialState = {
+    fetching: false,
+    fetched: false,
+    popupItems: [],
+    currPopup: {},
+    error: '',
+  };
+
+  it("should return the initial state when no action is provided", () => {
+    expect(popupEditorReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it("should handle RECEIVE_POPUP", () => {
+    const action = {
+      type: types.RECEIVE_POPUP,
+      popupItems: [{ id: 1, title: "Popup 1" }],
+    };
+
+    const expectedState = {
+      ...initialState,
+      popupItems: action.popupItems,
+      fetched: true,
+      fetching: false,
+      error: 'none',
+    };
+
+    expect(popupEditorReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it("should handle CURRENT_POPUP", () => {
+    const action = {
+      type: types.CURRENT_POPUP,
+      currPopup: { id: 1, title: "Popup 1" },
+    };
+
+    const expectedState = {
+      ...initialState,
+      currPopup: action.currPopup,
+      fetched: true,
+      fetching: false,
+      error: 'none',
+    };
+
+    expect(popupEditorReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it("should return the current state for an unknown action type", () => {
+    const unknownAction = {
+      type: "UNKNOWN_ACTION",
+    };
+
+    expect(popupEditorReducer(initialState, unknownAction)).toEqual(initialState);
+  });
+});


### PR DESCRIPTION
# Description
Unit test for `src/reducers/popupEditorReducer.js`




## Main changes explained:
Added test cases for the following:
1. should return the initial state when no action is provided
2. should handle RECEIVE_POPUP
3. should handle CURRENT_POPUP
4. should return the current state for an unknown action type



## How to test:
1. check into current branch
2. do `npm install` and `npm test popupEditorReducer.test.js` to run this PR locally


## Screenshots or videos of changes:
<img width="1134" alt="Screenshot 2024-12-31 at 5 28 46 PM" src="https://github.com/user-attachments/assets/5435328c-2020-48e6-b2ac-d11f00bd5eee" />

