### PR TITLE
Aaryaneil - Unit Test for ownerMessageReducer

### DIFF
--- a/src/reducers/__tests__/ownerMessageReducer.test.js
+++ b/src/reducers/__tests__/ownerMessageReducer.test.js
@@ -1,0 +1,38 @@
+import { ownerMessageReducer } from "../ownerMessageReducer";
+import * as types from "../../constants/ownerMessageConstants";
+
+describe("ownerMessageReducer", () => {
+  const initialState = {
+    message: '',
+    standardMessage: '',
+  };
+
+  it("should return the initial state when no action is provided", () => {
+    expect(ownerMessageReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it("should handle UPDATE_OWNER_MESSAGE", () => {
+    const action = {
+      type: types.UPDATE_OWNER_MESSAGE,
+      payload: {
+        message: "Updated owner message",
+        standardMessage: "This is the standard message",
+      },
+    };
+
+    const expectedState = {
+      message: "Updated owner message",
+      standardMessage: "This is the standard message",
+    };
+
+    expect(ownerMessageReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it("should return the current state for an unknown action type", () => {
+    const unknownAction = {
+      type: "UNKNOWN_ACTION",
+    };
+
+    expect(ownerMessageReducer(initialState, unknownAction)).toEqual(initialState);
+  });
+});


### PR DESCRIPTION
# Description
Unit test for `src/reducers/ownerMessageReducer.js`




## Main changes explained:
Added test cases for the following:
1. should return the initial state when no action is provided
2. should handle UPDATE_OWNER_MESSAGE
3. should return the current state for an unknown action type



## How to test:
1. check into current branch
4. do `npm install` and `npm test ownerMessageReducer.test.js` to run this PR locally


## Screenshots or videos of changes:
<img width="1134" alt="Screenshot 2024-12-31 at 5 42 20 PM" src="https://github.com/user-attachments/assets/817cd2cb-1770-4cc4-9a0a-ccc7ac3e3126" />

