### PR TITLE
Nikhitha - Fix delete featured badge on Profile below 1000px 

### DIFF
--- a/src/components/Badge/__tests__/BadgeReport.test.js
+++ b/src/components/Badge/__tests__/BadgeReport.test.js
@@ -49,8 +49,11 @@ describe('BadgeReport Component', () => {
 
     //headers only in desktop view
     expect(screen.getByText('Earned Dates')).toBeInTheDocument();
-    expect(screen.getByText('Count')).toBeInTheDocument();
-    expect(screen.getByText('Featured')).toBeInTheDocument();
+    const countHeaders = screen.getAllByText('Count');
+    expect(countHeaders).toHaveLength(2);
+    const featuredHeaders = screen.getAllByText('Featured');
+    expect(featuredHeaders).toHaveLength(2);
+
   });
 
   test('renders all mobile view specific fields properly', () => {
@@ -60,7 +63,8 @@ describe('BadgeReport Component', () => {
     expect(optionsField).toBeInTheDocument();
 
     optionsField.click();
-    expect(screen.getByText('Count:')).toBeInTheDocument();
+    const countText = screen.getAllByText('Count:');
+    expect(countText).toHaveLength(1);
     expect(screen.getByText('Featured:')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
# Description
Resolved merge conflicts related to PR2873

## Related PRS (if any):
This frontend PR is related PR2873

## How to test:
Run npm install and npm start to set up and run the branch locally.
Clear your browser’s site data/cache.
Log in as an admin user.
Navigate to the Dashboard → View profile → Select featured → Delete Badge functionality.
Verify that the delete badge button is visible and works as expected on screen widths below 1000px.
Confirm that the feature also works seamlessly in dark mode.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/128af81b-888f-4198-81f5-d7c8140731ca


