### PR TITLE
Nikhitha - Fix delete featured badge on Profile below 1000px

### DIFF
--- a/src/components/Badge/BadgeReport.jsx
+++ b/src/components/Badge/BadgeReport.jsx
@@ -47,6 +47,7 @@ function BadgeReport(props) {
   const canDeleteBadges = props.hasPermission('deleteBadges');
   const canUpdateBadges = props.hasPermission('updateBadges');
 
+
   const darkMode = props.darkMode;
 
   async function imageToUri(url, callback) {
@@ -362,13 +363,13 @@ function BadgeReport(props) {
               className={darkMode ? 'bg-space-cadet' : ''}
             >
               <tr style={{ zIndex: '10' }}>
-                <th style={{ width: '90px' }}>Badge</th>
+                <th >Badge</th>
                 <th>Name</th>
-                <th style={{ width: '110px' }}>Modified</th>
-                <th style={{ width: '110px' }}>Earned Dates</th>
-                <th style={{ width: '90px' }}>Count</th>
+                <th >Modified</th>
+                <th>Earned Dates</th>
+                <th >Count</th>
                 {canDeleteBadges ? <th>Delete</th> : []}
-                <th style={{ width: '70px', zIndex: '1' }}>Featured</th>
+                <th>Featured</th>
               </tr>
             </thead>
             <tbody>
@@ -406,7 +407,7 @@ function BadgeReport(props) {
                             timeZone: 'America/Los_Angeles',
                           })}
                     </td>
-                    <td style={{ display: 'flex', alignItems: 'center' }}>
+                    <td>
                       <>
                         {' '}
                         <UncontrolledDropdown className="me-2" direction="down">
@@ -548,13 +549,16 @@ function BadgeReport(props) {
       </div>
       <div className="tablet">
         <div style={{ overflow: 'auto', height: '68vh' }}>
-          <Table className={darkMode ? 'text-light' : ''}>
+          <Table>
             <thead style={{ zIndex: '10' }}>
               <tr style={{ zIndex: '10' }}>
-                <th style={{ width: '93px' }}>Badge</th>
+                <th >Badge</th>
                 <th>Name</th>
-                <th style={{ width: '110px' }}>Modified</th>
+                <th>Modified</th>
                 <th style={{ width: '100%', zIndex: '10' }}>Earned</th>
+                <th >Count</th>
+                {canDeleteBadges ? <th>Delete</th> : []}
+                <th>Featured</th>
               </tr>
             </thead>
             <tbody>
@@ -683,6 +687,50 @@ function BadgeReport(props) {
                           </DropdownMenu>
                         </UncontrolledDropdown>
                       </ButtonGroup>
+                    </td>
+                    <td>
+                      {canUpdateBadges ? (
+                        <Input
+                          type="number"
+                          value={Math.round(value.count)}
+                          min={0}
+                          step={1}
+                          onChange={e => {
+                            countChange(value, index, e.target.value);
+                          }}
+                        ></Input>
+                      ) : (
+                        Math.round(value.count)
+                      )}
+                    </td>
+                    {canDeleteBadges ? (
+                      <td>
+                        <button
+                          type="button"
+                          className="btn btn-outline-danger"
+                          onClick={e => handleDeleteBadge(sortBadges[index])}
+                          style={darkMode ? boxStyleDark : boxStyle}
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    ) : (
+                      []
+                    )}
+                    <td style={{ textAlign: 'center' }}>
+                      <FormGroup check inline style={{ zIndex: '0' }}>
+                        <Input
+                          /* alternative to using the formgroup
+                          style={{ position: 'static' }} 
+                          */
+                          type="checkbox"
+                          id={value.badge._id}
+                          checked={value.featured}
+                          onChange={e => {
+                            featuredChange(value, index, e);
+                          }}
+                        />
+                      </FormGroup>
                     </td>
                   </tr>
                 ))

--- a/src/components/Badge/__tests__/BadgeReport.test.js
+++ b/src/components/Badge/__tests__/BadgeReport.test.js
@@ -49,8 +49,11 @@ describe('BadgeReport Component', () => {
 
     //headers only in desktop view
     expect(screen.getByText('Earned Dates')).toBeInTheDocument();
-    expect(screen.getByText('Count')).toBeInTheDocument();
-    expect(screen.getByText('Featured')).toBeInTheDocument();
+    const countHeaders = screen.getAllByText('Count');
+    expect(countHeaders).toHaveLength(2);
+    const featuredHeaders = screen.getAllByText('Featured');
+    expect(featuredHeaders).toHaveLength(2);
+
   });
 
   test('renders all mobile view specific fields properly', () => {
@@ -60,7 +63,8 @@ describe('BadgeReport Component', () => {
     expect(optionsField).toBeInTheDocument();
 
     optionsField.click();
-    expect(screen.getByText('Count:')).toBeInTheDocument();
+    const countText = screen.getAllByText('Count:');
+    expect(countText).toHaveLength(1);
     expect(screen.getByText('Featured:')).toBeInTheDocument();
   });
 

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -122,7 +122,7 @@ export const Badges = (props) => {
                   <Button className="btn--dark-sea-green" onClick={toggle} style={darkMode ? boxStyleDark : boxStyle}>
                     Select Featured
                   </Button>
-                  <Modal size="lg" isOpen={isOpen} toggle={toggle} className={darkMode ? 'text-light dark-mode' : ''}>
+                  <Modal size="xl" isOpen={isOpen} toggle={toggle} className={darkMode ? 'text-light dark-mode' : ''} fullscreen>
                     <ModalHeader toggle={toggle} className={darkMode ? 'bg-space-cadet' : ''}>Full View of Badge History</ModalHeader>
                     <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
                       <BadgeReport


### PR DESCRIPTION
# Description
Resolve merge conflict related to PR2873, the delete and featured options are not appearing below 1000px screen width. 
 
## Related PRS (if any):
This frontend PR is related to the #2873

## Main changes explained:
The test was updated to use getAllByText instead of getByText to handle multiple elements containing the text "Count" and "Featured". The assertion now checks if at least one "Count" element exists, allowing for multiple occurrences.
…

## How to test:
Check out the current branch
Run npm install and npm start to set up and run the branch locally.
Clear your browser’s site data/cache.
Log in as an admin user.
Navigate to the Dashboard → View profile → Select featured → Delete Badge functionality.
Verify that the delete badge button is visible and works as expected on screen widths below 1000px.
Confirm that the feature also works seamlessly in dark mode.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/128af81b-888f-4198-81f5-d7c8140731ca