### PR TITLE
Haoyue - Modified the hover text for Add QST button

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
@@ -81,7 +81,7 @@ function QuickSetupModal(props) {
             onClick={() => setShowAddTitle(true)}
             style={darkMode ? boxStyleDark : boxStyle}
             disabled={editMode == true}
-            title="Click this to add a new QST"
+            title="Click this to add a new Quick Setup Title"
           >
             Add New QST
           </Button>


### PR DESCRIPTION
# Description
Please include the exact bug/functionality description and a summary of the changes/ related issues. Please also include any other relevant motivation and context:
<img width="749" alt="Screenshot 2025-01-03 at 3 59 21 PM" src="https://github.com/user-attachments/assets/0a322b38-c4df-4d55-bc9a-294413c52de0" />


## Related PRS (if any):
…

## Main changes explained:
- Modified src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx for changing the hover text to "Click this to add a new Quick Setup Title"

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Add New QST 
6. hover on the button. Mouseover text should be "Click this to add a new Quick Setup Title"


## Screenshots or videos of changes:

<img width="516" alt="Screenshot 2025-01-03 at 3 52 15 PM" src="https://github.com/user-attachments/assets/26e0851a-2b10-451a-b3b0-7ebcbc934f38" />
