### PR TITLE
Vijay Anand - Add unit test for project action creator

### DIFF
--- a/src/actions/__tests__/projectActions.test.js
+++ b/src/actions/__tests__/projectActions.test.js
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import { getProjectDetail, setProjectDetail } from '../project';
+import { ENDPOINTS } from '../../utils/URL';
+import { GET_PROJECT_BY_ID } from '../../constants/project';
+
+jest.mock('axios');
+
+describe('getProjectDetail action creator', () => {
+  const mockDispatch = jest.fn();
+  const projectId = '12345';
+  const mockProjectData = { id: projectId, name: 'Test Project' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should dispatch setProjectDetail when API call is successful', async () => {
+    axios.get.mockResolvedValueOnce({ data: mockProjectData });
+    const url = ENDPOINTS.PROJECT_BY_ID(projectId);
+
+    await getProjectDetail(projectId)(mockDispatch);
+
+    expect(axios.get).toHaveBeenCalledWith(url);
+    expect(mockDispatch).toHaveBeenCalledWith(setProjectDetail(mockProjectData));
+  });
+
+  it('should not dispatch setProjectDetail when API call returns 401', async () => {
+    axios.get.mockRejectedValueOnce({ status: 401 });
+    const url = ENDPOINTS.PROJECT_BY_ID(projectId);
+
+    await getProjectDetail(projectId)(mockDispatch);
+
+    expect(axios.get).toHaveBeenCalledWith(url);
+    expect(mockDispatch).not.toHaveBeenCalledWith(setProjectDetail(mockProjectData));
+  });
+
+  it('should handle other errors', async () => {
+    axios.get.mockRejectedValueOnce({ status: undefined });
+    const url = ENDPOINTS.PROJECT_BY_ID(projectId);
+    await getProjectDetail(projectId)(mockDispatch);
+    expect(axios.get).toHaveBeenCalledWith(url);
+    expect(mockDispatch).not.toHaveBeenCalledWith(setProjectDetail(mockProjectData));
+  });
+});
+
+describe('setProjectDetail action creator', () => {
+  const mockProjectData = { id: '12345', name: 'Test Project' };
+
+  it('should create the correct action', () => {
+    const action = setProjectDetail(mockProjectData);
+
+    expect(action).toEqual({
+      type: GET_PROJECT_BY_ID,
+      payload: mockProjectData,
+    });
+  });
+});

--- a/src/actions/project.js
+++ b/src/actions/project.js
@@ -12,7 +12,7 @@ export const getProjectDetail = projectId => {
       }
     });
     if (!loggedOut) {
-      await dispatch(setProjectDetail(res.data));
+      await dispatch(setProjectDetail(res?.data));
     }
   };
 };


### PR DESCRIPTION
# Description
Added unit tests for the project action creators.

## Related PRS (if any):
No related PRs

## Main changes explained:
- Verified that `getProjectDetail` action creator dispatches the correct actions with the expected payload when API calls succeed.
- Tested `getProjectDetail` for error scenarios, including handling 401 responses and other errors gracefully.
- Created `projectActions.test.js` under the appropriate directory to ensure comprehensive test coverage.

## How to test:
1. Check into current branch
2. Run `npm install` if required.
3. Execute `npm test projectActions.test.js`.
4. Confirm all tests pass successfully.

## Screenshots or videos of changes:
<img width="739" alt="Screenshot 2025-01-03 at 7 03 37 PM" src="https://github.com/user-attachments/assets/3284d929-47bd-4d58-a000-272113796438" />

## Note:
Include the information the reviewers need to know.
