### PR TITLE
Fix end date display logic for deactivated accounts

### DIFF
--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -74,7 +74,7 @@ export const getTimeEntriesForPeriod = (userId, fromDate, toDate) => {
 export const getTimeEndDateEntriesByPeriod = (userId, fromDate, toDate) => { //Find last week of work in date
   toDate = moment(toDate)
     .endOf('day')
-    .format('YYYY-MM-DD');
+    .format('YYYY-MM-DDTHH:mm:ss');
   const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate,toDate);
   return async dispatch => {
     let loggedOut = false;

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -625,12 +625,12 @@ function UserProfile(props) {
     });
   };
 
-  const setActiveInactive = isActive => {
+  const setActiveInactive = async isActive => {
     let endDate;
 
     if (!isActive) {
-      endDate = dispatch(
-        getTimeEndDateEntriesByPeriod(userProfile._id, userProfile.createdDate, userProfile.toDate),
+      endDate = await dispatch(
+        getTimeEndDateEntriesByPeriod(userProfile._id, userProfile.createdDate, userProfile.toDate)
       );
       if (endDate == 'N/A') {
         endDate = userProfile.createdDate;
@@ -643,7 +643,7 @@ function UserProfile(props) {
     };
 
     try {
-      props.updateUserStatus(
+      await props.updateUserStatus(
         newUserProfile,
         isActive ? UserStatus.Active : UserStatus.InActive,
         undefined,


### PR DESCRIPTION
PR Description:
Description
Fixes the issue where the deactivation date on the profile page is incorrectly displayed as "Invalid date" when the green button 
![image](https://github.com/user-attachments/assets/89b7a56a-21d6-43cd-bbce-5eca19d4d754)
is clicked to deactivate an account. Now, the deactivation date will correctly show the last day the user logged time.

Fixes:

Bug priority: Medium
Related task: "Fix deactivation date not showing when the green button is clicked on the profile page."
Main Changes Explained:

Updated the logic for fetching and displaying the deactivation date.
Integrated a backend call to retrieve the last logged time for the user.
Ensured the End Date field displays the correct last logged time when the account is deactivated.
Adjusted fallback behavior:
If no logged time is available, the End Date will now default to the account creation date.
Verified display functionality in both light mode and dark mode.
How to Test:
Switch to this branch: fix_end_date_display_bug_v2.
Run the project locally.
Clear the browser cache and site data to ensure no stale data interferes with testing.
Steps to Test:
a. Log in as an admin user.
b. Navigate to the profile page of a user.
c. Click the green button to deactivate the account.
d. Verify that the End Date field correctly displays the last day the user logged time.
e. Reactivate the account, then deactivate again to ensure consistency.
f. Test this functionality in dark mode to ensure proper visibility.
Screenshots/Videos of Changes:


https://github.com/user-attachments/assets/fa3e8da4-4106-4afc-bcdc-cab157e05663


