### PR TITLE
Deepthi fix leaderboard header

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.css
+++ b/src/components/LeaderBoard/Leaderboard.css
@@ -34,6 +34,40 @@
   .leaderboard thead th[data-abbr] span {
     display: none; 
   }
+
+  .leaderboard thead th[data-abbr="Name"] {
+    width: auto !important;
+    min-width: 120px; 
+    text-align: left; 
+  }
+
+  .leaderboard thead th[data-abbr="Name"] > div {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start; 
+    gap: 6px; /* Adds space between "Name" and the icon */
+    width: 100%;
+    white-space: nowrap; 
+  }
+
+  .leaderboard thead th[data-abbr="Name"]::before {
+    content: none; 
+  }
+
+  .leaderboard thead th[data-abbr="Name"] span {
+    flex-grow: 0; /* Pushes the icon to the right */
+    display: inline-block;
+    white-space: nowrap;
+  }
+
+  .leaderboard thead th[data-abbr="Name"] .p-2 {
+    margin-left: 0; /* Moves "i" icon to the right */
+    display: flex;
+    align-items: center;
+    white-space: nowrap; 
+  }
+
+  
 }
 
 

--- a/src/components/LeaderBoard/Leaderboard.css
+++ b/src/components/LeaderBoard/Leaderboard.css
@@ -16,6 +16,28 @@
   border-top-color: rgb(222, 226, 230);
 }
 
+@media screen and (max-width: 768px) {
+  .leaderboard thead th {
+    font-size: 0.75rem; 
+    white-space: nowrap; 
+    line-height: 1.2; 
+    text-overflow: ellipsis; /* Add ellipsis for overflow */
+    overflow: hidden; 
+    max-height: 2.4em; 
+  }
+
+  .leaderboard thead th[data-abbr]::before {
+    content: attr(data-abbr); /* Display the abbreviated version */
+    font-weight: bold;
+  }
+
+  .leaderboard thead th[data-abbr] span {
+    display: none; 
+  }
+}
+
+
+
 /* Small devices (landscape phones, 544px and up) */
 @media (max-width: 544px) {
   .leaderboard {

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -542,10 +542,12 @@ function LeaderBoard({
         >
           <thead className="responsive-font-size">
             <tr className={darkMode ? 'bg-space-cadet' : ''}>
-              <th>Status</th>
-              <th>
+              <th data-abbr="Stat.">
+                <span>Status</span>
+              </th>
+              <th data-abbr="Name">
                 <div className="d-flex align-items-center">
-                  <span className="mr-2">Name</span>
+                  <span>Name</span>
                   <EditableInfoModal
                     areaName="Leaderboard"
                     areaTitle="Team Members Navigation"
@@ -553,25 +555,26 @@ function LeaderBoard({
                     fontSize={18}
                     isPermissionPage
                     darkMode={darkMode}
-                    className="p-2" // Add Bootstrap padding class to the EditableInfoModal
+                    className="p-2"
                   />
                 </div>
               </th>
-              <th>Days Left</th>
-              <th>Time Off</th>
-              <th>
-                <span className="d-sm-none">Tan. Time</span>
-                <span className="d-none d-sm-block">Tangible Time</span>
+              <th data-abbr="Days Lft.">
+                <span>Days Left</span>
               </th>
-              <th>Progress</th>
-
-              <th style={{ textAlign: 'right' }}>
+              <th data-abbr="Time Off">
+                <span>Time Off</span>
+              </th>
+              <th data-abbr="Tan. Time">
+                <span>Tangible Time</span>
+              </th>
+              <th data-abbr="Prog.">
+                <span>Progress</span>
+              </th>
+              <th data-abbr="Tot. Time" style={{ textAlign: 'right' }}>
                 <div style={{ display: 'flex', alignItems: 'center' }}>
                   <div style={{ textAlign: 'left' }}>
-                    <span className="d-sm-none">Tot. Time</span>
-                    <span className="d-none d-sm-inline-block" title={mouseoverTextValue}>
-                      Total Time{' '}
-                    </span>
+                    <span>Total Time</span>
                   </div>
                   {isOwner && (
                     <MouseoverTextTotalTimeEditButton onUpdate={handleMouseoverTextUpdate} />
@@ -580,6 +583,7 @@ function LeaderBoard({
               </th>
             </tr>
           </thead>
+
           <tbody className="my-custome-scrollbar responsive-font-size">
             <tr className={darkMode ? 'bg-yinmn-blue' : ''}>
               <td aria-label="Placeholder" />


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/42368957-2e72-4367-8878-11c85920a560)

…

## Main changes explained:
- LeaderBoard.jsx: Added data-abbr attributes for table headers to display abbreviations on smaller screens and ensured numbers stay on a single line with consistent formatting.
- LeaderBoard.css: Introduced media queries for responsive styling, preventing text wrapping for headers and numbers on smaller screens.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user/ owner user
5. go to dashboard→ leaderboard
6. verify the headers are displayed in abbreviations, and numbers under each time column stay on a single line without wrapping at half screen size of 768px and below.

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/1a4a2f36-b004-4d70-bf81-bfddc9ee5786)


## Note:
The vertical alignment and icons discussed in the video were found to be too cramped when tested on half screens and were therefore omitted. Instead, the new approach of using abbreviations for half screen sizes and below was implemented and approved by Jae.
