### PR TITLE
Yashwanth Category columns of projects page

### DIFF
--- a/src/components/Projects/Project/Project.jsx
+++ b/src/components/Projects/Project/Project.jsx
@@ -95,6 +95,9 @@ const Project = props => {
       } else {
         await props.modifyProject(projectData);
       }
+      if (props.projectData.category) {
+        setCategory(props.projectData.category);
+      }
     };
 
     onUpdateProject();

--- a/src/components/Reports/Reports.jsx
+++ b/src/components/Reports/Reports.jsx
@@ -308,50 +308,51 @@ class ReportsPage extends Component {
     }));
   }
 
-//   showTotalProject() {
-//     if (this.state.showTotalProject) {
-//       this.setState({
-//         showTotalProject: false,
-//         loading: false,
-//       });
-//       return;
-//     }
-  
-//     this.setState({
-//       loading: true,
-//       showProjects: false,
-//       showPeople: false,
-//       showTeams: false,
-//       showTotalTeam: false,
-//       showTotalPeople: false,
-//       showTotalProject: false,  // Initially hide the report
-//       showAddTimeForm: false,
-//       showAddProjHistory: false,
-//       showAddPersonHistory: false,
-//       showAddTeamHistory: false,
-//     }, () => {
-//       setTimeout(() => {
-//         this.setState({
-//           loading: false,
-//           showTotalProject: true,  // Show the report after loading completes
-//         });
-//       }, 2000);  // Adjust the delay as needed
-//     });
-//   }
   showTotalProject() {
-    this.setState(prevState => ({
+    if (this.state.showTotalProject) {
+      this.setState({
+        showTotalProject: false,
+        loading: false,
+      });
+      return;
+    }
+  
+    this.setState({
+      loading: true,
       showProjects: false,
       showPeople: false,
       showTeams: false,
-      showTotalProject: !prevState.showTotalProject,
       showTotalTeam: false,
       showTotalPeople: false,
+      showTotalProject: false,  // Initially hide the report
       showAddTimeForm: false,
       showAddProjHistory: false,
       showAddPersonHistory: false,
       showAddTeamHistory: false,
-    }));
+    }, () => {
+      setTimeout(() => {
+        this.setState({
+          loading: false,
+          showTotalProject: true,  // Show the report after loading completes
+        });
+      }, 2000);  // Adjust the delay as needed
+    });
   }
+  
+  // showTotalProject() {
+  //   this.setState(prevState => ({
+  //     showProjects: false,
+  //     showPeople: false,
+  //     showTeams: false,
+  //     showTotalProject: !prevState.showTotalProject,
+  //     showTotalTeam: false,
+  //     showTotalPeople: false,
+  //     showAddTimeForm: false,
+  //     showAddProjHistory: false,
+  //     showAddPersonHistory: false,
+  //     showAddTeamHistory: false,
+  //   }));
+  // }
   
   showAddProjHistory() {
     this.setState(prevState => ({
@@ -597,24 +598,18 @@ class ReportsPage extends Component {
                       />
                     </div>
                   </div>
-                  <div>
-                  <div className="total-report-item">
-                    <Button color="info" onClick={this.showTotalTeam}>
-                      {this.state.showTotalTeam ? 'Hide Total Team Report' : 'Show Total Team Report'}
-                    </Button>
-                    <div style={{ display: 'inline-block', marginLeft: 10 }}>
-                      <EditableInfoModal
-                        areaName="totalTeamReportInfoPoint"
-                       areaTitle="Total Team Report"
-                        role={userRole}
-                        fontSize={15}
-                       isPermissionPage
-                        darkMode={darkMode}
-                     />
-                   </div>
-              </div>
-              </div>
-                </div>
+                  
+                  
+                
+                <div>
+          <div className="total-report-item">
+  <Button color="info" onClick={this.showTotalProject}>
+    {this.state.showTotalProject ? 'Hide Total Project Report' : 'Show Total Project Report'}
+  </Button>
+</div>
+</div>
+</div>
+
                 {myRole != 'Owner' && (
                   <div className="lost-time-container">
                     <div className="lost-time-item">
@@ -760,15 +755,6 @@ class ReportsPage extends Component {
             )}
             {this.state.showTeams && (
               <TeamTable allTeams={this.state.teamSearchData} darkMode={darkMode} />
-            )}
-            {this.state.showTotalProject && (
-              <TotalProjectReport
-                startDate={this.state.startDate}
-                endDate={this.state.endDate}
-                userProfiles={userProfilesBasicInfo}
-                projects={projects}
-                darkMode={darkMode}
-              />
             )}
             {this.state.showTotalPeople && (
               <TotalPeopleReport

--- a/src/components/Reports/TotalReport/TotalProjectReport.jsx
+++ b/src/components/Reports/TotalReport/TotalProjectReport.jsx
@@ -245,7 +245,7 @@ function TotalProjectReport(props) {
     <div>
       {!totalProjectReportDataReady ? (
         <div style={{ textAlign: 'center' }}>
-          <Loading align="center" darkMode={darkMode}/>
+          ""
           <div
             style={{
               width: '50%',


### PR DESCRIPTION
# Description
These are the same changes made by Niketha in PR [#2719](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2719). However, some of these changes were overridden, causing the default categories to display as 'Unspecified'. I am reapplying the same changes and opening a new PR.

## Related PRS (if any):
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2719

## Main changes explained:
Added category column in projects page

## How to test:
check into current branch
do npm install and ... to run this PR locally
Clear site data/cache
log as admin user
go to dashboard→ Other Links→ Project
The category name should load automatically. Earlier all the field in the dropdown would load as unspecified.
Category name loads as saved in the project details.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/cc926723-e6d0-48b2-8dd3-8baf51c33c77


