### PR TITLE
Anoushka job application search frontend

### DIFF
--- a/src/components/Collaboration/Collaboration.jsx
+++ b/src/components/Collaboration/Collaboration.jsx
@@ -81,6 +81,29 @@ class Collaboration extends Component {
     );
   };
 
+  handleResetFilters = async () => {
+    try {
+      const response = await fetch(`${ApiEndpoint}/jobs/reset-filters`, {
+        method: 'GET',
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to reset filters: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      this.setState({
+        searchTerm: '',
+        selectedCategory: '',
+        currentPage: 1,
+        jobAds: data.jobs,
+        totalPages: data.pagination.totalPages,
+      });
+    } catch (error) {
+      toast.error('Error resetting filters');
+    }
+  };
+
   setPage = pageNumber => {
     this.setState({ currentPage: pageNumber }, this.fetchJobAds);
   };
@@ -138,6 +161,9 @@ class Collaboration extends Component {
                   />
                   <button className="search-button" type="submit" onClick={this.handleSubmit}>
                     Go
+                  </button>
+                  <button type="button" onClick={this.handleResetFilters}>
+                    Reset
                   </button>
                   <button
                     className="show-summaries"
@@ -206,8 +232,11 @@ class Collaboration extends Component {
                   value={searchTerm}
                   onChange={this.handleSearch}
                 />
-                <button className="search" type="submit" onClick={this.handleSubmit}>
+                <button className="search-button" type="submit" onClick={this.handleSubmit}>
                   Go
+                </button>
+                <button type="button" onClick={this.handleResetFilters}>
+                  Reset
                 </button>
                 <button className="show-summaries" type="button" onClick={this.handleShowSummaries}>
                   Show Summaries

--- a/src/components/Collaboration/Collaboration.jsx
+++ b/src/components/Collaboration/Collaboration.jsx
@@ -70,7 +70,7 @@ class Collaboration extends Component {
 
   handleSubmit = event => {
     event.preventDefault();
-    this.setState({ currentPage: 1 }, this.fetchJobAds);
+    this.setState({ summaries: null, currentPage: 1 }, this.fetchJobAds);
   };
 
   handleCategoryChange = event => {
@@ -98,6 +98,7 @@ class Collaboration extends Component {
         currentPage: 1,
         jobAds: data.jobs,
         totalPages: data.pagination.totalPages,
+        summaries: null,
       });
     } catch (error) {
       toast.error('Error resetting filters');
@@ -109,11 +110,14 @@ class Collaboration extends Component {
   };
 
   handleShowSummaries = async () => {
-    const { searchTerm } = this.state;
+    const { searchTerm, selectedCategory } = this.state;
     try {
-      const response = await fetch(`${ApiEndpoint}/jobs/summaries?search=${searchTerm}`, {
-        method: 'GET',
-      });
+      const response = await fetch(
+        `${ApiEndpoint}/jobs/summaries?search=${searchTerm}&category=${selectedCategory}`,
+        {
+          method: 'GET',
+        },
+      );
 
       if (!response.ok) {
         throw new Error(`Failed to fetch summaries: ${response.statusText}`);

--- a/src/components/Collaboration/Collaboration.jsx
+++ b/src/components/Collaboration/Collaboration.jsx
@@ -14,6 +14,7 @@ class Collaboration extends Component {
       jobAds: [],
       totalPages: 0,
       categories: [],
+      summaries: null, // Add this line
     };
   }
 
@@ -51,7 +52,6 @@ class Collaboration extends Component {
   fetchCategories = async () => {
     try {
       const response = await fetch(`${ApiEndpoint}/jobs/categories`, { method: 'GET' });
-
       if (!response.ok) {
         throw new Error(`Failed to fetch categories: ${response.statusText}`);
       }
@@ -85,6 +85,24 @@ class Collaboration extends Component {
     this.setState({ currentPage: pageNumber }, this.fetchJobAds);
   };
 
+  handleShowSummaries = async () => {
+    const { searchTerm } = this.state;
+    try {
+      const response = await fetch(`${ApiEndpoint}/jobs/summaries?search=${searchTerm}`, {
+        method: 'GET',
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch summaries: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      this.setState({ summaries: data }); // Update state with summaries
+    } catch (error) {
+      toast.error('Error fetching summaries');
+    }
+  };
+
   render() {
     const {
       searchTerm,
@@ -93,7 +111,79 @@ class Collaboration extends Component {
       jobAds,
       totalPages,
       categories,
+      summaries, // Add this line
     } = this.state;
+
+    if (summaries) {
+      return (
+        <div className="job-landing">
+          <div className="header">
+            <a
+              href="https://www.onecommunityglobal.org/collaboration/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <img src={OneCommunityImage} alt="One Community Logo" />
+            </a>
+          </div>
+          <div className="container">
+            <nav className="navbar">
+              <div className="navbar-left">
+                <form className="search-form">
+                  <input
+                    type="text"
+                    placeholder="Search by title..."
+                    value={searchTerm}
+                    onChange={this.handleSearch}
+                  />
+                  <button className="search-button" type="submit" onClick={this.handleSubmit}>
+                    Go
+                  </button>
+                  <button
+                    className="show-summaries"
+                    type="button"
+                    onClick={this.handleShowSummaries}
+                  >
+                    Show Summaries
+                  </button>
+                </form>
+              </div>
+
+              <div className="navbar-right">
+                <select
+                  value={selectedCategory}
+                  onChange={event => this.handleCategoryChange(event)}
+                >
+                  <option value="">Select from Categories</option>
+                  {categories.map(category => (
+                    <option key={category} value={category}>
+                      {category}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </nav>
+
+            <div className="summaries-list">
+              <h1>Summaries</h1>
+              {summaries && summaries.jobs && summaries.jobs.length > 0 ? (
+                summaries.jobs.map(summary => (
+                  <div key={summary._id} className="summary-item">
+                    <h3>
+                      <a href={summary.jobDetailsLink}>{summary.title}</a>
+                    </h3>
+                    <p>{summary.description}</p>
+                    <p>Date Posted: {new Date(summary.datePosted).toLocaleDateString()}</p>
+                  </div>
+                ))
+              ) : (
+                <p>No summaries found.</p>
+              )}
+            </div>
+          </div>
+        </div>
+      );
+    }
 
     return (
       <div className="job-landing">
@@ -118,6 +208,9 @@ class Collaboration extends Component {
                 />
                 <button className="search" type="submit" onClick={this.handleSubmit}>
                   Go
+                </button>
+                <button className="show-summaries" type="button" onClick={this.handleShowSummaries}>
+                  Show Summaries
                 </button>
               </form>
             </div>


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/1a55f7ea-96d0-4ecd-a237-7b788e951b18)

## Related PRS (if any):
This frontend PR is related to the [1195](https://github.com/OneCommunityGlobal/HGNRest/pull/1195) backend PR
To test this frontend PR you need to checkout PR 1195 in backend
…

## Main changes explained:
- Added a new show Summary button and handler which takes the search terms in the search box and shows the summaries of the jobs
- The summary page shows the clickable job link, a brief description and also the date posted for the job
- Added a reset filter which resets any search terms and category selections of the title search box
- The backend ensured that pagination was applied

…

## How to test:
1. check into current  frontend branch
2. check into the backend branch and run the backend locally using `npm install` and `npm start`
3. Run the frontend using `npm run start:local'
4. Go to `http://localhost:3000/collaboration`
5. Test using the newly added show summary and reset button in the Navbar
6. The Go button fetches jobs with the mentioned search category
7. Show summaries shows the summaries of the respective jobs
8. Reset button clears the title search box and also category dropdown 

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/16605efb-b670-4348-87ca-6a5f3e9cd15f



## Note:
- Tried adding boundaries and spaces between the boxes but was unsuccessful. Someone else can please take a look
