### PR TITLE
Koushica - Add confirmation modal and function for scheduling time off in the following week

### DIFF
--- a/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
+++ b/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
@@ -233,6 +233,10 @@ const ScheduleReasonModal = ({
     setShowStartWeekModal(prev => !prev);
   };
 
+  const handleStartWeekConfirmationModal = () => {
+    setShowStartWeekModal(false);
+  };
+
   const getWeekIntervals = data => {
     const dateOfLeaveStr = getDateWithoutTimeZone(data.dateOfLeave);
     const intervals = [];
@@ -486,7 +490,10 @@ const ScheduleReasonModal = ({
                   </Container>
                 </ModalBody>
                 <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
-                  <Button variant="primary" onClick={handelConfirmReason}>
+                  <Button variant="primary" onClick={()=>{
+                    handelConfirmReason()
+                    handleStartWeekConfirmationModal()
+                  }}>
                     Confirm
                   </Button>
                   <Button variant="secondary" onClick={toggleConfirmationModal}>

--- a/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
+++ b/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
@@ -30,6 +30,11 @@ const ScheduleReasonModal = ({
     .isoWeekday(7)
     .startOf('day');
   const nextSunday = new Date(nextSundayStr.year(), nextSundayStr.month(), nextSundayStr.date());
+  
+  const currSundayStr = moment()
+    .startOf('week');
+  const currSunday = new Date(currSundayStr.year(), currSundayStr.month(), currSundayStr.date());
+  
   const initialRequestData = {
     dateOfLeave: nextSunday,
     numberOfWeeks: 1,
@@ -57,6 +62,7 @@ const ScheduleReasonModal = ({
   const [allowedDurationModal, setAllowedDurationModal] = useState(false);
   const [allowedDurationData, setAllowedDurationData] = useState({});
   const [requestTodelete, setRequestTodelete] = useState('');
+  const [showStartWeekModal, setShowStartWeekModal] = useState(false);
 
   const ContainerMaxHeight = checkIfUserCanScheduleTimeOff() ? '160px' : '600px';
 
@@ -223,6 +229,10 @@ const ScheduleReasonModal = ({
     setAllowedDurationModal(prev => !prev);
   };
 
+  const toggleStartWeekConfirmationModal = () => {
+    setShowStartWeekModal(prev => !prev);
+  };
+
   const getWeekIntervals = data => {
     const dateOfLeaveStr = getDateWithoutTimeZone(data.dateOfLeave);
     const intervals = [];
@@ -241,6 +251,28 @@ const ScheduleReasonModal = ({
     return day === 0;
   };
 
+  const handleSave = ( data = requestData ) => {
+    const { intervals, startDate } = getWeekIntervals(data);
+    setConfirmationModalData({
+      offTimeWeeks: intervals,
+      returnDate: startDate.format('MM-DD-YYYY'),
+      reasonForLeave: data.reasonForLeave,
+    });
+    toggleConfirmationModal();
+  }
+
+  const handleWeekStart = (selectedSunday) => {
+    setRequestData(prev => {
+      const newData = {
+      ...prev,
+      dateOfLeave: selectedSunday,
+      }
+      handleSave(newData);
+      return newData;
+    })
+    
+  }
+
   const handleSaveReason = e => {
     e.preventDefault();
     setRequestDataErrors(initialRequestDataErrors);
@@ -251,13 +283,12 @@ const ScheduleReasonModal = ({
     if (!validateNumberOfWeeks(requestData)) return;
     if (!validateReasonForLeave(requestData)) return;
 
-    const { intervals, startDate } = getWeekIntervals(requestData);
-    setConfirmationModalData({
-      offTimeWeeks: intervals,
-      returnDate: startDate.format('MM-DD-YYYY'),
-      reasonForLeave: requestData.reasonForLeave,
-    });
-    toggleConfirmationModal();
+    if(nextSunday.getTime() === requestData.dateOfLeave.getTime()){
+      toggleStartWeekConfirmationModal();
+    }
+    else{
+      handleSave();
+    }
   };
 
   const handelConfirmReason = () => {
@@ -472,6 +503,34 @@ const ScheduleReasonModal = ({
                 <ModalFooter className={darkMode ? 'text-light' : ''}>
                   <Button variant="secondary" onClick={toggleDurationInfoModal}>
                     Close
+                  </Button>
+                </ModalFooter>
+              </NestedModal>
+              <NestedModal isOpen={showStartWeekModal} toggle={toggleStartWeekConfirmationModal} className={darkMode ? 'text-light dark-mode' : ''}>
+                <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
+                  <Container>
+                    <Row>You are about to schedule time off starting next week. Please confirm this is what you want to do.</Row>
+                  </Container>
+                </ModalBody>
+                <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
+                  <Button
+                      variant="primary"
+                      onClick={()=>handleWeekStart(nextSunday)}
+                      className="w-100"
+                      size="md"
+                      style={darkMode ? boxStyleDark : boxStyle}
+                    >
+                      Yes, NEXT WEEK is when I want my time off to start! 
+                  </Button>
+                  <Button
+                      variant="primary"
+                      onClick={()=>handleWeekStart(currSunday)}
+                      className="w-100"
+                      size="md"
+                      style={darkMode ? boxStyleDark : boxStyle}
+                    >
+                      No, I meant to start my time off THIS WEEK.
+                      Please adjust this request to start this week instead. 
                   </Button>
                 </ModalFooter>
               </NestedModal>


### PR DESCRIPTION
# Description
<img width="798" alt="Screenshot 2025-01-07 at 10 53 36 PM" src="https://github.com/user-attachments/assets/13a7f855-7678-461a-acd3-26332e7da77a" />


## Related PRS (if any):
No related PRs.

## Main changes explained:
- Updated src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx file.
- added a modal to ask for confirmation when scheduling for next week.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to User Profile → Schedule Blue Square Reason
6. input the Start date to be next week
7. Check if you are prompted to confirm the Start of the Week

## Screenshots or videos of changes:
Before:

https://github.com/user-attachments/assets/4b1e4502-54f4-4be2-9c80-8c51acae722b

After:

https://github.com/user-attachments/assets/726f0c24-d0be-4826-b882-afa80a776ac9

## Note:
Try different Sundays:
- Previous Sunday:  It should not allow you to schedule for previous week
- Current week Sunday: It should continue the flow and let you schedule a Blue Square Reason
- Next week Sunday: It will prompt you to confirm the correct Sunday.


Please verify in both Light and dark modes

