### PR TITLE
Koba - Change back the background color

### DIFF
--- a/src/components/CommunityPortal/CPDashboard.css
+++ b/src/components/CommunityPortal/CPDashboard.css
@@ -1,6 +1,6 @@
 body {
   font-family: 'Poppins', sans-serif;
-  background: linear-gradient(120deg, #e0f7fa, #e8eaf6);
+  background: #fff;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
# Description
<img width="500" alt="image" src="https://github.com/user-attachments/assets/f98314b9-622a-4842-ae88-86070e8e0c9e" />

## Related PRS (if any):
None

## Main changes explained:
- Investigated what was causing the background to be light blue color
- Changed the background color in `src\components\CommunityPortal\CPDashboard.css -> body` back to white
- Found the PR that caused the change in background color, that is [PR #2984](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2984)

## How to test:
1. check into the current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Log Into the dashboard
4. Verify that the dashboard background color is indeed white and that other pages don't have any bugs related to color.

## Screenshots or videos of changes:
Fix:
<img width="953" alt="Background -Color-Fix" src="https://github.com/user-attachments/assets/29f04917-aa5b-4eea-bea3-50ea6854585c" />

Previous change that cause the bug:
<img width="683" alt="Background -Color-Fix-Prev-Change" src="https://github.com/user-attachments/assets/a179d787-4620-4321-aa2e-fa769d29f452" />

The initial color of the dashboard:
<img width="360" alt="Background -Color-Fix-Prev-Color" src="https://github.com/user-attachments/assets/e353d7c4-9a42-473a-a789-a9618f85daf2" />
