### PR TITLE
Anirudh SK - Make deleting users auto refresh without losing filter

### DIFF
--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -109,7 +109,6 @@ class UserManagement extends React.PureComponent {
       let { roles: rolesPermissions } = this.props.state.role;
       let { requests: timeOffRequests } = this.props.state.timeOffRequests;
       
-      
       this.getFilteredData(userProfiles, rolesPermissions, timeOffRequests, darkMode, this.state.editable);
     }
   
@@ -121,10 +120,11 @@ class UserManagement extends React.PureComponent {
                                (prevState.emailSearchText !== this.state.emailSearchText);
   
     const pageSizeChanged = prevState.pageSize !== this.state.pageSize;
+    const userProfilesChanged = prevProps.state.allUserProfiles.userProfiles !== this.props.state.allUserProfiles.userProfiles;
     
     if ((prevState.selectedPage !== this.state.selectedPage) || 
         (prevState.wildCardSearchText !== this.state.wildCardSearchText) || 
-        searchStateChanged || pageSizeChanged) {
+        searchStateChanged || pageSizeChanged || userProfilesChanged ) {
   
       let darkMode = this.props.state.theme.darkMode;
       let { userProfiles, fetching } = this.props.state.allUserProfiles;
@@ -515,15 +515,28 @@ class UserManagement extends React.PureComponent {
    * Call back to trigger the delete based on the type chosen from the popup.
    */
   onDeleteUser = deleteType => {
-    if (deleteType === UserDeleteType.Inactive) {
-      this.props.updateUserStatus(this.state.selectedUser, UserStatus.InActive, undefined);
-    } else {
-      this.props.deleteUser(this.state.selectedUser, deleteType);
-    }
     this.setState({
       deletePopupOpen: false,
       selectedUser: undefined,
+      isUpdating: true
     });
+
+    if (deleteType === UserDeleteType.Inactive) {
+      this.props.updateUserStatus(
+        this.state.selectedUser, 
+        UserStatus.InActive, 
+        undefined
+      ).finally(() => {      
+        this.setState({ isUpdating: false });    
+      });
+    } else {
+      this.props.deleteUser(
+        this.state.selectedUser, 
+        deleteType
+      ).finally(() => {      
+        this.setState({ isUpdating: false });    
+      });
+    }
   };
 
   /**


### PR DESCRIPTION
# Description
Jae (PRIORITY HIGH):  Make deleting users auto refresh without losing filter
1)  Admin Login → Other Links → User Management → filter → Delete user
2)  Should auto refresh without losing the filter results, so I can see that the delete worked
3)  [Video clarification](https://www.loom.com/share/77136a8acc864054ab7ceb5f8678f37e?sid=7b4c513b-77f9-4205-b584-c5ac9df22e51)

## Related PRS (if any):
This frontend PR is related to the development branch in the backend.

## Main changes explained:
Changes in onDeleteUser function in UserManagement.jsx:
- Introduced isUpdating state to indicate the ongoing update process.
- Moved updateUserStatus call inside setState and added a .finally block to reset isUpdating once the process completes.

Changes in componentDidUpdate:
- Added userProfilesChanged condition to detect updates in allUserProfiles and trigger necessary updates.
- Ensures UI reflects the latest user profile changes without requiring additional actions.

## How to test:
1. check into the current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log in as an admin user
5. go to dashboard→ Other Links→ User Management
6. Search for some test/dummy account (or you can create one. Demo in video)
7. Delete the account. The search filter should not reset. 
8. Verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/0ac49fa8-2e2e-4b42-8755-81604e72ce04

