### PR TITLE
Bug10:Quick Setup Tool: Eliminate need for additional saving of changes

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
@@ -110,19 +110,6 @@ function QuickSetupModal(props) {
           ''
         )}
       </div>
-      <div className="col text-center mt-3">
-        {canAssignTitle ? (
-          <SaveButton
-            handleSubmit={props.handleSubmit}
-            userProfile={props.userProfile}
-            disabled={titleOnSet}
-            setSaved={() => props.setSaved(true)}
-            darkMode={darkMode}
-          />
-        ) : (
-          ''
-        )}
-      </div>
       {showAddTitle || editMode ? (
         <AddNewTitleModal
           teamsData={props.teamsData}


### PR DESCRIPTION
# Description
<img width="751" alt="Bug10" src="https://github.com/user-attachments/assets/9275b041-b797-4d5e-8d2a-b1deb08ea6b9" />
Fixes #10 (bug list priority high)

## Related PRS (if any):
No related PRs.

## Main changes explained:
(1) The "Save Changes" button was removed below the "Add New QST" button.

(2) In the "Click Existing" functionality, deleting QSC are now saved automatically.

(3) In the "Add A New Title" functionality, after clicking "Confirm," the changes are saved automatically.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ View Profiles
6. Confirm that the "Save Changes" button has been removed and is no longer visible below the "Add New QST" button.
7. Test Adding a New QST: Click the "Add New QST" button -> Fill out the form with valid information -> Click "Confirm." -> Verify that the new QST is successfully added to the list.
8.  Test Deleting a QST: Click on the newly added QST -> Press the "Delete QSC" button -> Confirm that the selected QST is successfully removed from the list.

## Screenshots or videos of changes:
Before Removal of "Save Change" Button
<img width="371" alt="Before Removal of Save Change Button" src="https://github.com/user-attachments/assets/7d27b8a8-0ac1-4d6b-b905-d3d96784321b" />
After Removal of "Save Change" Button
<img width="296" alt="After Removal of Save Change Button" src="https://github.com/user-attachments/assets/52ebfc6f-31f3-4501-a6a6-3da0e087eec2" />


https://github.com/user-attachments/assets/b0f5d3d1-2212-4de6-a0bb-06f2c8e594b8

## Note:

