### PR TITLE
Koushica_Ready_to_Review_Actions_HotFix

### DIFF
--- a/src/components/TeamMemberTasks/ReviewButton.jsx
+++ b/src/components/TeamMemberTasks/ReviewButton.jsx
@@ -182,6 +182,41 @@ const ReviewButton = ({
 
   return (
     <>
+      {/* Verification Modal */}
+      <Modal isOpen={verifyModal} toggle={toggleVerify} className={darkMode ? 'text-light dark-mode' : ''}>
+        <ModalHeader toggle={toggleVerify} className={darkMode ? 'bg-space-cadet' : ''}>
+          {selectedAction === 'Complete and Remove' && 'Are you sure you have completed the review?'}
+          {selectedAction === 'More Work Needed' && 'Are you sure?'}
+          </ModalHeader>
+        <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
+        <Button
+              onClick={(e) => {
+                toggleVerify();
+                if (selectedAction === 'More Work Needed') {
+                  updReviewStat("Unsubmitted");
+                  setIsSubmitting(false);
+                } else if (reviewStatus === "Unsubmitted") {
+                  submitReviewRequest(e);
+                } else {
+                  updReviewStat("Reviewed");
+                }
+              }}
+              color="primary"
+              className="float-left"
+              style={darkMode ? boxStyleDark : boxStyle}
+            >
+              {reviewStatus === "Unsubmitted"
+                ? `Submit`
+                : `Complete`}
+            </Button>
+            <Button
+              onClick={toggleVerify}
+              style={darkMode ? boxStyleDark : boxStyle}
+            >
+              Cancel
+            </Button>
+        </ModalFooter>
+      </Modal>
       {/* Second Confirmation Modal */}
       <Modal isOpen={confirmSubmitModal} toggle={toggleConfirmSubmitModal} className={darkMode ? 'text-light dark-mode' : ''}>
         <ModalHeader toggle={toggleConfirmSubmitModal} className={darkMode ? 'bg-space-cadet' : ''}>


### PR DESCRIPTION
# Description
This PR addresses a hotfix with the Ready for Review action items that occurred when using to review the completed task. The modal’s appearance was altered due to recent changes introduced in [PR #2787
](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2787)

## Related PRS (if any):
No related PRs

## Main Issue:
- The issue occurred due to the replacing of the confirmation modal in the ReviewButton.jsx instead of adding a new prompt from [PR #2787](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2787) 

## Main changes explained:
- Updated the file src/components/TeamMemberTasks/ReviewButton.jsx: added the modal to showup on ready for review actions.


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks → Ready for Review
6. Open the action items and select any
7.  Various actions:
- view link : it should open the link
- as complete and remove task : prompt will open for confirmation
- more work needed, reset : prompt will shown up for resetting

## Screenshots or videos of changes:


https://github.com/user-attachments/assets/0ced2922-cc60-41e5-a27f-a0fd7581264a


