### PR TITLE
Yili - Hide Delete Task option  on Dashboard Tasks for people without the permission

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -88,7 +88,7 @@ const TeamMemberTask = React.memo(
 
     const canGetWeeklySummaries = dispatch(hasPermission('getWeeklySummaries'));
     const canUpdateTask = dispatch(hasPermission('updateTask'));
-    const canRemoveUserFromTask = dispatch(hasPermission('removeUserFromTask'));
+    const canRemoveUserFromTask = dispatch(hasPermission('deleteTask', true));
     const numTasksToShow = isTruncated ? NUM_TASKS_SHOW_TRUNCATE : activeTasks.length;
 
     const handleTruncateTasksButtonClick = () => {


### PR DESCRIPTION
# Description

<img width="731" alt="Hide Delete Task option  on Dashboard Tasks for people without the permission" src="https://github.com/user-attachments/assets/e115cde1-8f40-441b-962f-d4d1a74e835d" />

## Related PRS (if any):
This frontend PR is related to the backend [#PR1198](https://github.com/OneCommunityGlobal/HGNRest/pull/1198)

## How to test:

1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an owner user and verify:
- Go to Other Links -> Permissions Management -> Manage User Permissions  -> Select a volunteer user  -> Permissions -> Delete Task 
- Confirm the volunteer user does not have the Delete Task permission.

5. Log in as the volunteer user without Delete Task permission and verify: 
- There is no red "X" button in the Team Member Tasks section on the dashboard.

6. Log back in as the owner user: 
- Go to Other Links -> Permissions Management -> Manage User Permissions  -> Select the volunteer user  -> Permissions -> Delete Task -> Click on "Add" -> Click on "save changes"

7. Log in again as the volunteer user and verify:
- A red "X" button is now visible in the Team Member Tasks section on the dashboard.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/e91dd1e5-545b-435f-b158-a01749969862


<img width="806" alt="0" src="https://github.com/user-attachments/assets/1851e004-6610-4795-83db-31d00fb4549b" />

<img width="806" alt="1" src="https://github.com/user-attachments/assets/63f5e18e-a048-416c-84d1-f2e2612d6a0a" />
<img width="806" alt="2" src="https://github.com/user-attachments/assets/0a2ea8a6-b95d-472e-8d83-a6f0a4fdaeed" />



  