### PR TITLE
peterson_fix_bug_in_Team_Member_Tasks_Table

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -59,14 +59,6 @@ import PropTypes from 'prop-types';
 import Badge from '../Badge';
 import { ENDPOINTS } from '../../utils/URL';
 
-const doesUserHaveTaskWithWBS = userHaveTask => {
-  return userHaveTask.reduce((acc, item) => {
-    const hasIncompleteTask = item.resources.some(val => val.completedTask === false);
-    if (hasIncompleteTask) acc.push(item);
-    return acc;
-  }, []);
-};
-
 // startOfWeek returns the date of the start of the week based on offset. Offset is the number of weeks before.
 // For example, if offset is 0, returns the start of this week. If offset is 1, returns the start of last week.
 const startOfWeek = offset => {
@@ -136,6 +128,18 @@ const Timelog = props => {
 
   const { userId: urlId } = useParams();
   const [userprofileId, setUserProfileId] = useState(urlId || authUser.userid);
+
+  const doesUserHaveTaskWithWBS = userHaveTask => {
+    return userHaveTask.reduce((acc, item) => {
+      const hasIncompleteTask = item.resources.some(
+        val =>
+          (viewingUser.userId === val.userID || val.userID === userprofileId) &&
+          val.completedTask === false,
+      );
+      if (hasIncompleteTask) acc.push(item);
+      return acc;
+    }, []);
+  };
 
   const checkSessionStorage = () => JSON.parse(sessionStorage.getItem('viewingUser')) ?? false;
   const [viewingUser, setViewingUser] = useState(checkSessionStorage());


### PR DESCRIPTION
Description
This pull request has been opened to fix the tasks tab reverting to the Current Week Timelog tab for the Volunteer user account, but for any other type of user, the selected tab should be tasks.

Related PRS (if any):
None
…

Main changes explained:
The Timelog.jsx component has been modified to fix the bug.
…

How to test:
check into current branch
do npm install and ... to run this PR locally
Clear site data/cache
Log in as a volunteer user with or without tasks, or any other type of user.
go to dashboard
After the page reloads, if your volunteer user has tasks, the selected tab should be "Tasks". If your volunteer user does not have tasks, the selected tab should be "Current Week Timelog". If you test with any other type of user, the selected tab should be "Tasks".

## Screenshots or videos of changes:
![Peterson_Fix_Tasks_tab_revert_to_Current_Week_Timelog_tab_for_Volunteer_user_accoun](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/73541319/454785c3-f868-48ef-ace1-92e02c0c752e)

## Note:
None.
