### PR TITLE
Honglin fix wbs button align issue

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -195,10 +195,8 @@ function WBSTasks(props) {
           </ol>
         </nav>
         <div
-          className='mb-2 button-group' // Grouping the buttons
+          className='mb-2 wbs-button-group' // Group the buttons
           style={{
-            // display: 'flex',
-            // justifyContent: 'space-between'
           }}>
           {/* <span> */}
           {canPostTask ? (

--- a/src/components/Projects/WBS/WBSDetail/wbs.css
+++ b/src/components/Projects/WBS/WBSDetail/wbs.css
@@ -265,9 +265,18 @@
 .tasks-detail-actions {  /* action column width reduced */
   width: 6%; 
 }
-@media (max-width: 768px) { /* arranging the buttons */
-  .button-group button {
+.wbs-button-group {
+  justify-content: flex-start;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+@media (max-width: 850px) {
+  .wbs-button-group {
+    align-items: flex-start;
+    margin-bottom: 10px;
+  }
+  .wbs-button-group button {
     margin-bottom: 10px;
   }
 }
-

--- a/src/components/Projects/WBS/WBSDetail/wbs.css
+++ b/src/components/Projects/WBS/WBSDetail/wbs.css
@@ -271,7 +271,7 @@
   margin-top: 20px;
 }
 
-@media (max-width: 850px) {
+@media (max-width: 968px) {
   .wbs-button-group {
     align-items: flex-start;
     margin-bottom: 10px;


### PR DESCRIPTION
# Description
This PR fixes the layout issue of the button group in the WBS tasks view. Previously, the buttons were rendered evenly across the top of the page. This fix aligns the buttons in a row on the left, improving the layout.
![image](https://github.com/user-attachments/assets/99cc3956-cd5b-4563-813f-d91206bda11c)


## Related PRS:
This fix addresses an unintended side effect introduced by PR #2714, which added a .button-group CSS class that overrode the media query originally created in PR #2795 for larger screens.

## Main changes explained:
Updated WBSTasks.jsx:
- Changed the className of the button container from button-group to wbs-button-group
Updated wbs.css:
- Added a new wbs-button-group class with appropriate styling for all screen sizes.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links→ Projects→ WBS 
6. If the project doesn't have a WBS, add a new one
7. Click on the WBS
8. Verify that the buttons are aligned in a row on the left as the following screenshot

## Screenshots or videos of changes:
Before:
![image](https://github.com/user-attachments/assets/645e0067-a368-4d46-9b29-30c7f9d605b3)

After:
![image](https://github.com/user-attachments/assets/a83ad4d0-dc3f-49ea-9097-9cf717e0f40b)

