### PR TITLE
Geeta - 'Generate Summary Intro' button's visibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test-results # Adjust the path to your test results if necessary

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -1055,7 +1055,7 @@ function UserProfile(props) {
               >
                 {showSelect ? 'Hide Team Weekly Summaries' : 'Show Team Weekly Summaries'}
               </Button>
-              {canGetProjectMembers && teams.length !== 0 ? (
+              {(canGetProjectMembers && teams.length !== 0) || ['Owner','Administrator','Manager'].includes(requestorRole) ? (
                 <Button
                   onClick={() => {
                     navigator.clipboard.writeText(summaryIntro);


### PR DESCRIPTION
# Description
<img width="683" alt="Screenshot 2025-01-30 at 1 06 50 PM" src="https://github.com/user-attachments/assets/56e742f7-5e90-4dbb-82e3-478b8ab2811e" />


## Related PRS (if any):
None

## Main changes explained:
- Updated UserProfile.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner/manager user
5. go to profile page
6. verify if 'Generate Summary Intro' is visible for above user roles. 

## Screenshots or videos of changes:

<img width="718" alt="Screenshot 2025-01-30 at 1 11 28 PM" src="https://github.com/user-attachments/assets/42448475-bf39-4539-bef8-8bfc994ad196" />

