### PR TITLE
Honglin fix css conflicts between Projects page and Auth components

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14'
 
@@ -25,7 +25,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test-results # Adjust the path to your test results if necessary

--- a/src/components/LBDashboard/Auth/Auth.css
+++ b/src/components/LBDashboard/Auth/Auth.css
@@ -20,7 +20,7 @@
     min-width: 250px;
   }
   
-  .form-container {
+  .lb-auth-page .form-container {
     background-color: white;
     border: 1px solid #ccc;
     border-radius: 8px;
@@ -68,7 +68,7 @@
     min-width: 140px;
   }
 
-  form {
+  .lb-auth-page form {
     display: flex;
     flex-direction: column;
     width: 100%;

--- a/src/components/LBDashboard/Auth/Login.jsx
+++ b/src/components/LBDashboard/Auth/Login.jsx
@@ -59,7 +59,7 @@ function Login() {
   };
 
   return (
-    <div className="auth-page">
+    <div className="auth-page lb-auth-page">
       <div className="logo-container">
         <img src={logo} alt="One Community Logo" />
       </div>

--- a/src/components/LBDashboard/Auth/Register.jsx
+++ b/src/components/LBDashboard/Auth/Register.jsx
@@ -65,7 +65,7 @@ function Register() {
   };
 
   return (
-    <div className="auth-page">
+    <div className="auth-page lb-auth-page">
       <div className="logo-container">
         <img src={logo} alt="One Community Logo" />
       </div>


### PR DESCRIPTION
# Description
This PR resolves layout issues caused by merge #3080 (Create Login and Registration pages for Listing and Bidding Dashboard) where generic CSS selectors were affecting the Projects page layout. 

## Related PRS:
This specific merge commit previously breaks the projects page UI
[Link](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/commit/11c5ab361c01ba12dcb9743492ad2137ee363d73#diff-481bff25593155cc0695aeb0f112c109e3075ef703d254734ec2a3c5266ee0be)

## Main changes explained:
- Added CSS namespace `.lb-auth-page` to scope Auth component styles
- Updated Login and Register components to include the namespaced class

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links → Projects→
6. Verify the search bar UI layout
7. go to http://localhost:3000/lbdashboard/register
8. Verify the register page UI layout
9. go to http://localhost:3000/lbdashboard/login
10. Verify the login page UI layout

## Screenshots or videos of changes:
search bar UI layout
![image](https://github.com/user-attachments/assets/06f437c1-b133-498c-8c56-d0281bf2f687)
![image](https://github.com/user-attachments/assets/0cf42426-c03a-4e3a-af84-0ae0b7a246ef)
![image](https://github.com/user-attachments/assets/e07b358b-7051-41d4-931f-9a379c0e6b39)
