### PR TITLE
Yili fix “Edit Task” permission for managers

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -89,11 +89,12 @@ const TeamMemberTask = React.memo(
     const isAllowedToResolveTasks =
       rolesAllowedToResolveTasks.includes(userRole) || dispatch(hasPermission('resolveTask'));
     const isAllowedToSeeDeadlineCount = rolesAllowedToSeeDeadlineCount.includes(userRole);
+    const isAllowedToEditTask = rolesAllowedToResolveTasks.includes(userRole);
     // ^^^
 
     const canGetWeeklySummaries = dispatch(hasPermission('getWeeklySummaries'));
     const canSeeReports = rolesAllowedToResolveTasks.includes(userRole)||dispatch(hasPermission('getReports'));
-    const canUpdateTask = dispatch(hasPermission('updateTask'));
+    const canUpdateTask = dispatch(hasPermission('updateTask')) || isAllowedToEditTask;
     const canRemoveUserFromTask = dispatch(hasPermission('removeUserFromTask'));
     const numTasksToShow = isTruncated ? NUM_TASKS_SHOW_TRUNCATE : activeTasks.length;
 


### PR DESCRIPTION
# Description
<img width="731" alt="Fix “Edit Task” permission for managers " src="https://github.com/user-attachments/assets/6db3c8ff-dd3e-4bc5-bc46-b69be84b6c8b" />


## Related PRS (if any):
This frontend PR is related to the backend[ #1211](https://github.com/OneCommunityGlobal/HGNRest/pull/1211)


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ user management→ select a user who is not currently a manager → click on the user's profile → Basic Information → Role → change it to "Manager" → click the "Save Changes" button
6. log in as the promoted manager user
7. go to dashboard→ Tasks → click into any tasks of any member 
8. In the Action section of the task details, verify that the Edit button is present.


## Screenshots or videos of changes:
**log as owner user**

<img width="1412" alt="1" src="https://github.com/user-attachments/assets/8e71267f-7aa7-403a-93f5-89f354ed0317" />

<img width="1410" alt="2" src="https://github.com/user-attachments/assets/068ce27b-b7ac-47b5-9a79-03aad93c40ca" />

<img width="1343" alt="3" src="https://github.com/user-attachments/assets/47e9d6bd-e07c-4dd2-9119-b588eae3ac17" />

**log in as the promoted manager user**

<img width="658" alt="4" src="https://github.com/user-attachments/assets/7d7fde72-7fe1-48b7-8f2a-97dad04842a8" />

<img width="638" alt="5" src="https://github.com/user-attachments/assets/fad802de-84ae-4de5-8473-00900e7cc19d" />
