### PR TITLE
Verify that after deleting any task from the wbs task list it should not show blank screen.

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -65,10 +65,14 @@ function AddTaskModal(props) {
   };
 
   // states from hooks
+
   const defaultCategory = useMemo(() => {
     if (props.taskId) {
-      const task = tasks.find(({ _id }) => _id === props.taskId);
-      return task?.category || 'Unspecified';
+        const task = tasks.find(({ _id }) => _id === props.taskId);
+        return task && task.category ? task.category : 'Unspecified';
+    } else if (props.projectId) {
+        const project = allProjects.projects.find(({ _id }) => _id === props.projectId);
+        return project && project.category ? project.category : 'Unspecified';
     }
     
     if (props.projectId) {
@@ -77,8 +81,8 @@ function AddTaskModal(props) {
     }
   
     return 'Unspecified';
-  }, [props.taskId, props.projectId, tasks, allProjects.projects]);
-  
+}, [props.taskId, props.projectId, tasks, allProjects.projects]);
+
 
   const [taskName, setTaskName] = useState('');
   const [priority, setPriority] = useState('Primary');


### PR DESCRIPTION
# Description
This PR addresses the issue that caused the screen to go blank after editing or deleting a task from the WBS tasks list. The issue was due to missing checks for undefined task categories, which caused the UI to break. Now, the task list updates correctly without needing a page refresh


## Related PRS (if any):
None

## Main changes explained:
1. It first checks if task exists before trying to access task.category, to prevent runtime errors when no matching task is found.
2. Ensures project exists before accessing its properties, it will avoid crashes when find returns undefined.
3. If neither task nor project exists or has a category, it will safely defaults to 'Unspecified' instead of causing an error.

## How to test:
1. check into current branch
4. do `npm install` and `...` to run this PR locally
5. Clear site data/cache
6. log as admin user
7. go to dashboard→ Other Links→ projects→select WBS icon for project you want to test-> Select WBS name->Edit it and try to remove/ edit any task under WBS
8. verify if after deleting/ editing task it should be quickly deleted from task list and it should not show blank page.
9. verify this feature works in [dark mode]
**(Verify this for both Admin and Owner user role)**

## Screenshots or videos of changes:
**Before fix:**

https://github.com/user-attachments/assets/0b699662-df1c-41df-9384-620cbee48372

**After fix:**

https://github.com/user-attachments/assets/a31928a9-557e-4dca-abcf-5df8d8a02c08





## Note:
you will need to have a project with wbs and tasks created under it, before testing this flow.
