### PR TITLE
neha-Timer popout feature implementation.

### DIFF
--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -22,8 +22,10 @@ import config from '../../config.json';
 import TimeEntryForm from '../Timelog/TimeEntryForm';
 import Countdown from './Countdown';
 import TimerStatus from './TimerStatus';
+import TimerPopout from './TimerPopout';
 
 function Timer({ authUser, darkMode }) {
+  const isPopout = !!window.opener;
   /**
    *  Because the websocket can not be closed when internet is cut off (lost server connection),
    *  the readyState will be stuck at OPEN, so here we need to use a custom readyState to
@@ -402,7 +404,7 @@ function Timer({ authUser, darkMode }) {
   const bodyBg = darkMode ? 'bg-yinmn-blue' : '';
 
   return (
-    <div className={css.timerContainer}>
+    <div className={cs(css.timerContainer)}>
       <button
         type="button"
         disabled={isButtonDisabled}
@@ -527,13 +529,18 @@ function Timer({ authUser, darkMode }) {
               fontSize="1.3rem"
             />
           </button>
+          {!isPopout && (
+            <button type="button" aria-label="Open Timer Popout" className="popout">
+              <TimerPopout authUser={authUser} darkMode={darkMode} TimerComponent={Timer} />
+            </button>
+          )}
         </div>
       )}
 
       {showTimer && (
         <div className={css.timer}>
           <div className={css.timerContent}>
-            {customReadyState === ReadyState.OPEN ? (
+            {customReadyState === ReadyState.OPEN && !isPopout && (
               <Countdown
                 message={message}
                 timerRange={{ MAX_HOURS, MIN_MINS }}
@@ -548,7 +555,8 @@ function Timer({ authUser, darkMode }) {
                 handleStopButton={handleStopButton}
                 toggleTimer={toggleTimer}
               />
-            ) : (
+            )}
+            {customReadyState !== ReadyState.OPEN && (
               <TimerStatus
                 readyState={customReadyState}
                 message={message}

--- a/src/components/Timer/Timer.module.css
+++ b/src/components/Timer/Timer.module.css
@@ -8,6 +8,18 @@
   -moz-user-select: none;
 }
 
+/* .popout {
+  position: absolute;
+  width: 280px;
+  height: 400px;
+  left: 0;
+  top: 4rem;
+  background: #343a40;
+  border-radius: 1rem;
+  box-shadow: 15px 20px 25px -5px rgb(0 0 0 / 0.5), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  overflow: hidden;
+} */
+
 .previewContainer {
   display: flex;
   flex-direction: column;

--- a/src/components/Timer/TimerPopout.jsx
+++ b/src/components/Timer/TimerPopout.jsx
@@ -1,0 +1,83 @@
+import { FaExternalLinkAlt } from 'react-icons/fa';
+import ReactDOM from 'react-dom';
+import { useRef, useEffect } from 'react';
+import cs from 'classnames';
+import styles from './Timer.module.css';
+
+function TimerPopout({ authUser, darkMode, TimerComponent }) {
+  const popupRef = useRef(null);
+
+  const openPopoutWindow = () => {
+    if (popupRef.current && !popupRef.current.closed) {
+      popupRef.current.focus();
+      return;
+    }
+
+    const features = {
+      width: 300,
+      height: 200,
+      right: window.screen.width - 350,
+      top: 30,
+      menubar: 'no',
+      toolbar: 'no',
+      location: 'no',
+      status: 'no',
+      resizable: 'yes',
+    };
+
+    const featuresStr = Object.entries(features)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(',');
+
+    const popup = window.open('', 'Timer', featuresStr);
+
+    popupRef.current = popup;
+
+    popup.document.write(`
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Timer</title>
+          <link rel="stylesheet" href="${window.location.origin}/Timer.module.css">
+          ${darkMode ? '<style>body { background-color: #1a1a2e; color: white; }</style>' : ''}
+        </head>
+        <body>
+          <h1 style="text-align: center;">Timer</h1>
+          <div id="timer-root"></div>
+        </body>
+      </html>
+    `);
+
+    const root = popup.document.getElementById('timer-root');
+    ReactDOM.render(<TimerComponent authUser={authUser} darkMode={darkMode} />, root);
+
+    popup.onbeforeunload = () => {
+      ReactDOM.unmountComponentAtNode(root);
+    };
+  };
+
+  useEffect(() => {
+    return () => {
+      if (popupRef.current && !popupRef.current.closed) {
+        popupRef.current.close();
+      }
+    };
+  }, []);
+
+  return (
+    <button
+      type="button"
+      onClick={openPopoutWindow}
+      className={styles.btnDiv}
+      aria-label="Open timer in new window"
+    >
+      <FaExternalLinkAlt
+        className={cs(styles.transitionColor, styles.btn)}
+        fontSize="1.5rem"
+        title="Open timer in new window"
+      />
+    </button>
+  );
+}
+
+export default TimerPopout;


### PR DESCRIPTION
# Description
Tried to implement a feature that pops out the timer into a separate window on top. I managed to open the timer with all its components in a separate window. Couldn't figure out how to make it stay on top all the time (like YouTube's Picture in picture feature).

## Related PRS (if any):
…

## Main changes explained:
- Added a new file (TimerPopout.jsx) to implement the Timer popout feature.
- Integrated the TimerPopout in Timer.jsx
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Dashboard -> click on the popout (external link symbol)
6. Check if the Timer is opening in a separate window or not.
7. Check with different browsers.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/4c6b5d84-d0d1-4534-b0ac-95e3a778b47b

## Note:
Include the information the reviewers need to know.
