### PR TITLE
Newell - Fix timer service using different endpoint

### DIFF
--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -124,7 +124,7 @@ export const ENDPOINTS = {
   REJECT_TASK_EDIT_SUGGESTION: taskEditSuggestionId =>
     `${APIEndpoint}/taskeditsuggestion/${taskEditSuggestionId}`,
 
-  TIMER_SERVICE: `${APIEndpoint.replace('http', 'ws').replace('api', 'timer-service')}`,
+  TIMER_SERVICE: `${APIEndpoint.replace(/^https?/i, 'ws').replace('api', 'timer-service')}`,
   TIMEZONE_LOCATION: location => `${APIEndpoint}/timezone/${location}`,
 
   ROLES: () => `${APIEndpoint}/roles`,


### PR DESCRIPTION
# Description
Fixed that timer service is using beta endpoint due to incorrect URL replacement.

## Related PRS (if any):
N/A

## Main changes explained:
- Fixed URL replacement logic.

## How to test:
1. Go on the app and test

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
