### PR TITLE
Fixed the bug in dashboard with several issues

### DIFF
--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -23,9 +23,7 @@ export function Dashboard(props) {
   const {match, authUser} = props;
   const checkSessionStorage = () => JSON.parse(sessionStorage.getItem('viewingUser')) ?? false;
   const [viewingUser, setViewingUser] = useState(checkSessionStorage);
-  const [displayUserId, setDisplayUserId] = useState(
-    match.params.userId || authUser.userid,
-  );
+  const [displayUserId, setDisplayUserId] = useState(match.params.userId || viewingUser?.userId || authUser.userid);
   const isNotAllowedToEdit = cantUpdateDevAdminDetails(viewingUser?.email, authUser.email);
   const darkMode = useSelector(state => state.theme.darkMode);
 

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -366,11 +366,11 @@ function LeaderBoard({
     toast.error('Please wait for the users to appear in the Leaderboard table.');
 
   useEffect(() => {
-    setFilteredUsers(teamsUsers);
+    setFilteredUsers(leaderBoardData);
     return () => {
       setSearchInput('');
     };
-  }, [teamsUsers]);
+  }, [leaderBoardData]);
 
   const debouncedFilterUsers = useCallback(
     debounce(query => {

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -403,7 +403,7 @@ const TeamMemberTasks = React.memo(props => {
       await dispatch(fetchTeamMembersTask(displayUser._id));
     };
     initialFetching();
-  }, []);
+  }, [displayUser]);
 
   useEffect(() => {
     if (clickedToShowModal) {


### PR DESCRIPTION
# Description
<img width="712" alt="Screenshot 2025-02-07 at 11 09 44 AM" src="https://github.com/user-attachments/assets/b4b7bb65-fcc8-4c1e-8719-6c81b76eddf0" />


## Related PRS (if any):
This frontend PR is related to the development branch of backend.
…

## Main changes explained:
- Added a condition to set the displayUserId as viewingUserId upon page refresh …
- Added a condition for the displayUserId to be updated when the user closes dashboard view of other users …
- Added a condition to make the leaderboard be updated depending on the user's dashboard …
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ Leaderboard→ Any User→ Status Dot …
6. verify function “A” (feel free to include screenshot here)

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/8b1397f2-97ef-4130-b7c5-a55a9680c8f7

## Note:
All the steps to be followed to verify and test the PR are included in the video above
