### PR TITLE
Vinay fix copying resolved bug

### DIFF
--- a/src/reducers/allTasksReducer.js
+++ b/src/reducers/allTasksReducer.js
@@ -124,6 +124,11 @@ export const taskReducer = (allTasks = allTasksInital, action) => {
       };
     case types.COPY_TASK:
       const copiedTask = allTasks.taskItems.find(item => item._id === action.taskId);
+      copiedTask.resources = copiedTask?.resources?.map(resource=>{
+        const {completedTask, ...otherDetails} = resource
+        // Exclude the "completedTask" status to ensure tasks created by pasting are displayed.
+        return otherDetails
+      }) 
       return { ...allTasks, copiedTask };
     case types.ADD_NEW_TASK_ERROR:
       const error = action.err;


### PR DESCRIPTION
# Description
Fix copying a RESOLVED task doesn't cause that task to show in dashboard/individual’s tasks dropdown
[bug](https://www.loom.com/share/71e7de33d76d497795d9a8b37a1a0861?sid=e31a036b-124c-41f9-9bb4-55d71824a746) 

## Related PRS (if any):
N/A

## Main changes explained:
Updated allTasksReducer.js to modify the existing types.COPY_TASK action, ensuring it excludes the completedTask from the copiedTask.

## How to test:
1. check into vinay_fix_copy_resolved_bug branch
2. do `npm install` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ resolve a task of a particular user
6. click "other Links" -> projects -> selected project which the resolved task belongs -> WBS -> select the WBS where the task belongs to 
7. Click on the edit task -> copy -> Add task -> paste -> save
8. go back to the dashboard, the newly created task should appear in the user's task list. 

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/ae9faf90-d14b-4d3a-b77a-d6b4a59a0a98