### PR TITLE
Srikanth Resolve PropTypes Warnings for Permissions Management

### DIFF
--- a/src/components/PermissionsManagement/PermissionsManagement.test.js
+++ b/src/components/PermissionsManagement/PermissionsManagement.test.js
@@ -8,6 +8,12 @@ import { renderWithRouterMatch } from '../../__tests__/utils';
 import configureMockStore from 'redux-mock-store';
 import userEvent from '@testing-library/user-event';
 import { ModalProvider } from 'context/ModalContext';
+import axios from 'axios';
+jest.mock('axios');
+// Mock API call to prevent real network requests during tests, avoiding ECONNREFUSED errors 
+// and ensuring consistent, fast, and reliable test execution.
+axios.get.mockResolvedValue({ data: [] }); 
+
 
 jest.mock('actions/role.js');
 

--- a/src/components/UserProfile/EditableModal/EditableInfoModal.jsx
+++ b/src/components/UserProfile/EditableModal/EditableInfoModal.jsx
@@ -280,7 +280,7 @@ EditableInfoModal.propTypes = {
   addInfoCollection: PropTypes.func.isRequired,
   updateInfoCollection: PropTypes.func.isRequired,
   deleteInfoCollectionById: PropTypes.func.isRequired,
-  loading: PropTypes.bool.isRequired,
+  loading: PropTypes.bool,//made loading prop optional to avoid warnings if not provided
 };
 
 


### PR DESCRIPTION
# Description
This pull request resolves errors and warnings identified in PR #2729  It improves test reliability and resolves PropTypes warnings in the `PermissionsManagement` component.
Fixes: 
- PropTypes warning for the `loading` prop in `EditableInfoModal.jsx`.
- JSDOM connection errors due to real API calls during tests.

## Related PRs (if any):
This frontend PR addresses issues raised in **PR #2729**. 

## Main changes explained:
1. The `loading` prop was marked as isRequired, but during tests, it was not always provided, causing PropTypes warnings (Failed prop type: The prop 'loading' is marked as required but its value is 'undefined'). By making the loading prop optional, these warnings are avoided, allowing for more flexibility in cases where the loading state is not relevant or explicitly passed.
2. Real network requests caused ECONNREFUSED errors due to no server response. Mocking `axios` isolates tests, ensuring reliability and speed.



## How to test:
1. Check out the current branch.
2. Run npm install to ensure all necessary dependencies are installed.
3. Run the following command to execute the test suite: `npm test PermissionsManagement.test.js` to check for no errors 

## Screenshots or videos of changes:
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/57387647-cd38-48a7-b079-df9018c26c15" />
