### PR TITLE
Yili -  Make tasks in User Management component clickable hyperlinks

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
@@ -277,9 +277,9 @@ const UserProjectsTable = React.memo(props => {
                             <td>
                               <span className='opacity-70'>{project.projectName} </span>
                               <br />
-                              <Link className="fs-18" to={`/wbs/tasks/${task._id}`}>
+                              <a className="fs-18" href={`/wbs/tasks/${task._id}`}>
                                 {task.taskName && `\u2003 ↳ ${task.taskName}`}
-                              </Link>
+                              </a>
                             </td>
                             {!isCompletedTask && props.edit && props.role && canDeleteTasks && (
                               <td>

--- a/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
@@ -277,7 +277,9 @@ const UserProjectsTable = React.memo(props => {
                             <td>
                               <span className='opacity-70'>{project.projectName} </span>
                               <br />
-                              <span className="fs-18">{task.taskName && `\u2003 ↳ ${task.taskName}`}</span>
+                              <Link className="fs-18" to={`/wbs/tasks/${task._id}`}>
+                                {task.taskName && `\u2003 ↳ ${task.taskName}`}
+                              </Link>
                             </td>
                             {!isCompletedTask && props.edit && props.role && canDeleteTasks && (
                               <td>


### PR DESCRIPTION
# Description
<img width="807" alt="Make tasks in User Management component clickable hyperlinks" src="https://github.com/user-attachments/assets/c118af24-f224-4be8-a260-e6e36fcd99e1" />

## Related PRS (if any):
For backend use development branch


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ Click on the profile of any user who has tasks.
6. navigate to the Projects section → Confirm that the task titles are displayed as clickable links.

## Screenshots or videos of changes:
![1](https://github.com/user-attachments/assets/db6afa75-4d12-4a38-a39f-ad2268f3be00)
![2](https://github.com/user-attachments/assets/2c7e7ace-497a-4c77-93e9-99a720045bdb)
![3](https://github.com/user-attachments/assets/2f056de1-a65b-48b4-8bb9-f431961d34c9)

