### PR TITLE
Jinxiong - Fix a poor layout of the pop up window when clicking the reset time button.

### DIFF
--- a/src/components/common/NewModal/NewModal.css
+++ b/src/components/common/NewModal/NewModal.css
@@ -5,7 +5,7 @@
 }
 
 .popup-content-wrapper {
-  height: calc(100% - 40px - 60px);
+  height: calc(100% - 60px - 60px);
   overflow-y: scroll;
   padding: 14px 14px 0 4px;
 }
@@ -36,13 +36,17 @@
 }
 
 .popup-content-wrapper::-webkit-scrollbar {
-  width: 10px; /* width of the entire scrollbar */
+  width: 10px;
+  /* width of the entire scrollbar */
 }
 
 .popup-content-wrapper::-webkit-scrollbar-thumb {
-  background-color: #c6c6c6; /* color of the scroll thumb */
-  border-radius: 20px; /* roundness of the scroll thumb */
-  border: 3px solid white; /* creates padding around scroll thumb */
+  background-color: #c6c6c6;
+  /* color of the scroll thumb */
+  border-radius: 20px;
+  /* roundness of the scroll thumb */
+  border: 3px solid white;
+  /* creates padding around scroll thumb */
 }
 
 .popup-close-button {


### PR DESCRIPTION
# Description
Fixes #57 

## Related PRS (if any):
This frontend PR is related to the development backend PR.
To test this backend PR you need to checkout the development frontend PR.
…

## Main changes explained:
- Fix the strange layout of reset time button pop up window modal.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→Start timer, and click "reset" button
6. verify if the layout looks good, and it doesn't look like what it is in the picture.
8. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
![Screenshot 2025-1-20 185830](https://github.com/user-attachments/assets/ea8e3f91-ae7a-4292-aca7-40a4d1e2ff1e)
![Screenshot 2025-1-20 190039](https://github.com/user-attachments/assets/c4c76308-294e-4d26-9a62-32174cb3b49b)


## Note:
Include the information the reviewers need to know.
