### PR TITLE
Fix Input label missing warning in UpdatePassword component

### DIFF
--- a/src/components/UpdatePassword/UpdatePassword.jsx
+++ b/src/components/UpdatePassword/UpdatePassword.jsx
@@ -113,6 +113,7 @@ class UpdatePassword extends Form {
             {this.renderInput({
               name: 'currentpassword',
               type: this.state.showPassword.currentpassword ? 'text' : 'password',
+              label: 'Current Password', // passing label as it is labelled as required.
             })}
           </div>
 
@@ -128,6 +129,7 @@ class UpdatePassword extends Form {
             {this.renderInput({
               name: 'newpassword',
               type: this.state.showPassword.newpassword ? 'text' : 'password',
+              label: 'New Password', // passing label as it is labelled as required.
             })}
           </div>
 
@@ -143,6 +145,7 @@ class UpdatePassword extends Form {
             {this.renderInput({
               name: 'confirmnewpassword',
               type: this.state.showPassword.confirmnewpassword ? 'text' : 'password',
+              label: 'Confirm Password', // passing label as it is labelled as required.
             })}
           </div>
 


### PR DESCRIPTION
# Description
This PR fixes a PropTypes warning in the UpdatePassword component. The `<Input>` component was receiving an undefined `label` prop because the `renderInput` method in UpdatePassword did not pass a label. This change addresses the issue raised in PR #2732 by adding the required `label` prop for each input field.  


## Related PRS (if any):
This frontend PR is related to #2732  


## Main changes explained:
- Updated `src/components/UpdatePassword/UpdatePassword.jsx` to add required labels for all password inputs.

## How to test:
1. Check into the current branch.
2. Run npm install to install dependencies.
3. Run npm test UpdatePassword.test.js to execute the unit tests.
## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/14124d08-cbf1-424b-a036-ffb57540d2b5)
