### PR TITLE
Jatin Disallow Negative Time Logged

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -474,7 +474,7 @@ function EditTaskModal(props) {
                         min="0"
                         max="500"
                         value={hoursBest}
-                        onChange={e => setHoursBest(e.target.value)}
+                        onChange={e => setHoursBest(Math.abs(e.target.value))}
                         onBlur={() => calHoursEstimate()}
                         id="bestCase"
                         className="m-auto"
@@ -500,7 +500,7 @@ function EditTaskModal(props) {
                         min={hoursBest}
                         max="500"
                         value={hoursWorst}
-                        onChange={e => setHoursWorst(e.target.value)}
+                        onChange={e => setHoursWorst(Math.abs(e.target.value))}
                         onBlur={() => calHoursEstimate('hoursWorst')}
                         className="m-auto"
                       />,
@@ -525,7 +525,7 @@ function EditTaskModal(props) {
                         min="0"
                         max="500"
                         value={hoursMost}
-                        onChange={e => setHoursMost(e.target.value)}
+                        onChange={e => setHoursMost(Math.abs(e.target.value))}
                         onBlur={() => calHoursEstimate('hoursMost')}
                         className="m-auto"
                       />,
@@ -550,7 +550,7 @@ function EditTaskModal(props) {
                         min="0"
                         max="500"
                         value={hoursEstimate}
-                        onChange={e => setHoursEstimate(e.target.value)}
+                        onChange={e => setHoursEstimate(Math.abs(e.target.value))}
                         className="m-auto"
                       />,
                       editable,


### PR DESCRIPTION
# Description
<img width="756" alt="Screenshot 2025-01-30 at 7 11 09 PM" src="https://github.com/user-attachments/assets/a3ddb86b-7096-426e-8a29-3430d4b6af46" />

## Related PRS (if any):
To test this frontend PR you need to checkout the [#1223 ](https://github.com/OneCommunityGlobal/HGNRest/pull/1223)backend PR.

## Main changes explained:
- Update file `EditTaskModal.jsx`

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to dashboard→ Other Links→ Projects -> Select a Project WBS -> Open a Task.
6. Follow steps in the video.
7. Try adding negative value in the hours for the task. Any of the time field 1) Best 2) Worst 3) Most 4) Estimated.
8. The app shouldn't allow you to do that.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/d0e1ba57-fee8-4c42-9fda-ecfac2e6ffff
