### PR TITLE
added managers to view generate summary button and fixed but which pr…

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -326,9 +326,7 @@ function UserProfile(props) {
       newUserProfile.totalIntangibleHrs = Number(newUserProfile.totalIntangibleHrs.toFixed(2));
 
       const teamId = newUserProfile?.teams[0]?._id;
-      // if (teamId) {
         await loadSummaryIntroDetails(teamId, response.data);
-      // }
 
       const startDate = newUserProfile?.startDate.split('T')[0];
       // Validate team and project data. Remove incorrect data which may lead to page crash. E.g teams: [null]

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -248,6 +248,16 @@ function UserProfile(props) {
 
   const loadSummaryIntroDetails = async (teamId, user) => {
     const currentManager = user;
+    
+    if (!teamId) {
+      setSummaryIntro(
+        `This week’s summary was managed by ${currentManager.firstName} ${currentManager.lastName} and includes . 
+         These people did NOT provide a summary . 
+         <Insert the proofread and single-paragraph summary created by ChatGPT>`,
+      );
+      return;
+    }
+
     try {
       const res = await axios.get(ENDPOINTS.TEAM_USERS(teamId));
       const { data } = res;
@@ -316,9 +326,9 @@ function UserProfile(props) {
       newUserProfile.totalIntangibleHrs = Number(newUserProfile.totalIntangibleHrs.toFixed(2));
 
       const teamId = newUserProfile?.teams[0]?._id;
-      if (teamId) {
+      // if (teamId) {
         await loadSummaryIntroDetails(teamId, response.data);
-      }
+      // }
 
       const startDate = newUserProfile?.startDate.split('T')[0];
       // Validate team and project data. Remove incorrect data which may lead to page crash. E.g teams: [null]

--- a/src/components/Warnings/Warnings.jsx
+++ b/src/components/Warnings/Warnings.jsx
@@ -98,7 +98,7 @@ export default function Warning({ personId, username, userRole, displayUser }) {
       ));
 
   return (
-    (userRole === 'Administrator' || userRole === 'Owner') && (
+    (userRole === 'Administrator' || userRole === 'Owner' || userRole === 'Manager') && (
       <div className="warnings-container">
         <div className="button__container">
           <Button


### PR DESCRIPTION
# Description
-Added managers to the list of allowed users to view the generate summary intro button. 
-Fixed bug that prevented users' i.e. managers/admins/owners from copying the summary to their clipboard if they weren't on a team. 

## Related PRS (if any):

## Main changes explained:
-- Added managers to the list of allowed users to view the button.
--Return a default text if teamCode is null. 

## How to test:
1. check into current branch
2. do `npm run start:local` and  to run this PR locally
3. Clear site data/cache (if needed)
4. log as admin/manager/owner
5. go to dashboard→ User Profile
6. Click the generate Summary Intro which will display a toast message that was successful copied. 

     The format should look like so 
       This week’s summary was managed by luisManager Manager and includes . 
         These people did NOT provide a summary . 
         <Insert the proofread and single-paragraph summary created by ChatGPT>


7. paste on notepad/ or document of your choice and ensure it follows the same format. 


## Screenshots or videos of changes:

<img width="897" alt="Screenshot 2025-02-10 at 8 59 09 PM" src="https://github.com/user-attachments/assets/467d3f1a-3290-4e4b-a69e-f688d7f42007" />
<img width="540" alt="Screenshot 2025-02-10 at 8 59 16 PM" src="https://github.com/user-attachments/assets/72e28888-243f-479c-80ab-778feeabb31c" />

## Note:

