### PR TITLE
Jatin Add condition to update profiles only for people having bio published #1210

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -951,6 +951,7 @@ function UserProfile(props) {
               {(userProfile?.profilePic!==undefined)?
                 <Button color="danger" onClick={toggleRemoveModal} className="remove-button">
                   Remove Image</Button>:<></>}
+{/*                   
               {((userProfile?.profilePic==undefined || 
                 userProfile?.profilePic==null || 
                 userProfile?.profilePic=="")&& 
@@ -959,10 +960,10 @@ function UserProfile(props) {
                   userProfile?.suggestedProfilePics.length!==0
                 ))?
                 <Button color="primary" onClick={toggleModal}>Suggested Profile Image</Button>
-                :null}
+                :null} */}
                 </div>
 
-                {userProfile!==undefined && userProfile.suggestedProfilePics!==undefined?<ProfileImageModal isOpen={isModalOpen} toggleModal={toggleModal} userProfile={userProfile}/>:<></>}
+                {/* {userProfile!==undefined && userProfile.suggestedProfilePics!==undefined?<ProfileImageModal isOpen={isModalOpen} toggleModal={toggleModal} userProfile={userProfile}/>:<></>} */}
                 <ConfirmRemoveModal
                   isOpen={isRemoveModalOpen}
                   toggleModal={toggleRemoveModal}

--- a/src/components/UserProfile/UserProfileModal/suggestedProfileModal.js
+++ b/src/components/UserProfile/UserProfileModal/suggestedProfileModal.js
@@ -13,9 +13,20 @@ const ProfileImageModal = ({ isOpen, toggleModal, userProfile }) => {
     setSelectedImage(image);  // Store the selected image info
   };
 
+  function getImageSource(image) {
+    if (image.nitro_src !== null && image.nitro_src !== undefined) {
+      return image.nitro_src;
+    } else if (image.src && image.src.startsWith("http")) {
+      return image.src;
+    } else if (image.data_src !== undefined) {
+      return image.data_src;
+    }
+    return null; // Return null if no valid source is found
+  }
+
   const updateProfileImage= async ()=>{
     try {
-      let image=selectedImage.nitro_src!==undefined && selectedImage.nitro_src!==null?selectedImage.nitro_src:selectedImage.src;
+      let image=getImageSource(selectedImage);
       await axios.put(ENDPOINTS.USERS_UPDATE_PROFILE_FROM_WEBSITE,{'selectedImage':image,'user_id':userProfile._id})
       toast.success("Profile Image Updated")
     }    
@@ -36,7 +47,7 @@ const ProfileImageModal = ({ isOpen, toggleModal, userProfile }) => {
               className={`suggestedProfileTile ${selectedImage === image ? 'selected' : ''}`}
               onClick={() => handleImageSelect(image)}
             >
-              <img src={image.nitro_src!==undefined && image.nitro_src!==null?image.nitro_src:image.src} alt={image.alt} />
+              <img src={getImageSource(image)} alt={image.alt} />
             </div>
           ))}
         </div>


### PR DESCRIPTION
# Description
Fetch Profile Images from onecommunityglobal.org for team members who have their bio published on the team's page. PR#1116 was having issues with dealing with accounts who didn't have their bio published on the team's page.

## Related PRS (if any):
This frontend PR is related to the [#1210](https://github.com/OneCommunityGlobal/HGNRest/pull/1210) backend PR.

## Main changes explained:
- Update file `src/components/UserProfile/userprofile.jsx` for removal of suggested Profile Images feature.

## How to test:
1. check into current branch
2. do `npm install` and `npm run install:run` to run this PR locally
3. Clear site data/cache
4. log as any user
5. go to dashboard→ UserProfile.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/d4d09b01-b667-4c17-ae78-397698c4049c

