### PR TITLE
Vinay Add "Created_By - email" Component to Materials List Page

### DIFF
--- a/src/components/BMDashboard/ItemList/RecordsModal.jsx
+++ b/src/components/BMDashboard/ItemList/RecordsModal.jsx
@@ -95,6 +95,7 @@ export function Record({ record, recordType, setRecord }) {
             <th>Quantity Used</th>
             <th>Quantity Wasted</th>
             <th>Creator</th>
+            <th>Email</th>
           </tr>
         </thead>
         <tbody>
@@ -110,6 +111,7 @@ export function Record({ record, recordType, setRecord }) {
                       {`${data.createdBy.firstName} ${data.createdBy.lastName}`}
                     </a>
                   </td>
+                  <td>{data?.createdBy?.email}</td>
                 </tr>
               );
             })
@@ -133,6 +135,7 @@ export function Record({ record, recordType, setRecord }) {
             <th>Brand</th>
             <th>Quantity</th>
             <th>Requested By</th>
+            <th>Email</th>
             <th>Date</th>
             <th>Status</th>
           </tr>
@@ -151,6 +154,7 @@ export function Record({ record, recordType, setRecord }) {
                         {`${requestedBy.firstName} ${requestedBy.lastName}`}
                       </a>
                     </td>
+                    <td>{requestedBy.email}</td>
                     <td>{moment(date).format('MM/DD/YY')}</td>
                     <td>{status}</td>
                     <td>


### PR DESCRIPTION
# Description
Enhance the Materials List page;s update and puchase models by adding a column to display the email of the user who added each material. This will improve traceability and accountability, making it easier to identify the source of entries.

## Related PRS (if any):
This frontend PR is related to the [1230](https://github.com/OneCommunityGlobal/HGNRest/pull/1230) backend PR.
To test this backend PR you need to checkout the #XXX frontend PR.
…

## Main changes explained:
- Update RecordsModel,jsx to add email for both Purchase and Update recordTypes

## How to test:
1. check into current branch 
2. do `npm install` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to “/bmdashboard/materials” 
6. view update and purchase models to check if they have email column

## Screenshots of changes:
![image](https://github.com/user-attachments/assets/68ad9bef-f517-4301-b64d-a22623fc1c97)
![image](https://github.com/user-attachments/assets/dd20003b-574c-42ec-935b-303af9a8c5d9)

## Note:
Include the information the reviewers need to know.
