### PR TITLE
Srikanth fix bug wbs auto refresh

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -239,7 +239,7 @@ function AddTaskModal(props) {
   };
 
   const clear = () => {
-    console.log("CLEARING localStorage!");
+    //console.log("CLEARING localStorage!");
     setTaskName('');
     setPriority('Primary');
     setResourceItems([]);
@@ -259,7 +259,6 @@ function AddTaskModal(props) {
     setStartDateError(false);
     setEndDateError(false);
     localStorage.removeItem(STORAGE_KEY);
-    
   };
 
   const paste = () => {
@@ -323,8 +322,6 @@ function AddTaskModal(props) {
         toggle();
         props.load();
       }
-      // If 'outdated', do nothing here (keep data so user can fix concurrency).
-      // If 'error', handle the error if you like.
     } finally {
       setIsLoading(false);
     }
@@ -359,7 +356,7 @@ function AddTaskModal(props) {
 
   /**
    * 1) LOAD from localStorage when the modal component mounts
-   *    (or when user opens the modal).
+   *
    */
   useEffect(() => {
     const savedData = localStorage.getItem(STORAGE_KEY);
@@ -403,9 +400,6 @@ function AddTaskModal(props) {
       setDueDate(storedDueDate || '');
     }
   }, [modal]);
-  // ↑ If you only want to load when the modal opens,
-  //   you can check `modal` state changes or do this once on mount.
-
   /**
    * 2) SAVE to localStorage whenever any relevant piece of state changes.
    */
@@ -429,7 +423,7 @@ function AddTaskModal(props) {
       startedDate,
       dueDate,
     };
-    console.log('[LocalStorage] Setting AddTaskModalFormData:', formData);
+    //console.log('[LocalStorage] Setting AddTaskModalFormData:', formData);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(formData));
   }, [
     taskName,
@@ -448,7 +442,7 @@ function AddTaskModal(props) {
     intentInfo,
     endstateInfo,
     startedDate,
-    dueDate
+    dueDate,
   ]);
 
   const fontColor = darkMode ? 'text-light' : '';


### PR DESCRIPTION
# Description:
This PR addresses the bug/feature request where the “Add Task” form in the WBS Detail page loses user-entered data whenever a forced refresh (due to concurrency updates) occurs. Specifically:

- **Bug**: When another user adds a task in a different browser/tab, the first user’s session sees an “outdated” popup. If they haven’t saved their task yet, all typed data is lost upon re-opening the modal.

<img width="714" alt="image" src="https://github.com/user-attachments/assets/f343f06b-af83-4a89-a487-f6a6ec6313f7" />

## Fixes:
1. **Local Storage Persistence**  
   Implemented local storage logic in `AddTaskModal.jsx`:
   - **Save form data on each field change.**
   - **Load form data on modal open.**
   - **Clear local storage only on successful task creation or manual reset.**


## Related PRs:
- No backend related PRs.

## Main Changes Explained:
- **Local Storage Integration**:  
  Added logic to save form data on every field change and to load this data when the modal is opened. This ensures that even if the modal is forced to close due to concurrency updates, the data remains available.

- **Enhanced `addNewTask` Function**:  
  The function now returns a status string which is checked before clearing the local storage. This prevents accidental data loss when a concurrency error occurs.


## How to Test:
1. **Open WBS in Tab A**:  
   Navigate via **Other Links > Projects > WBS Icon > Choose WBS**.

2. **Add Task in Tab B**:  
   Using a Private/Incognito window with a different account, add a new task on the same WBS.

3. **Return to Tab A**:  
   Without manually refreshing, try adding a task. You should see the “Database changed…/outdated” popup.

4. **Verify Data Persistence**:  
   After dismissing the popup, re-check the modal and observe that your previously typed input remains on the modal.

5. **Finalize the Task**:  
   Click “Add Task” to complete the process. Confirm that:
   - The task is created successfully.

## Screenshots or Videos of Changes:
- Before

https://github.com/user-attachments/assets/c5aebdb3-f9ce-43e7-9f93-3795b178997f

- After

https://github.com/user-attachments/assets/be9cfd51-1c20-47c0-b41e-cd834f788dc9



