### PR TITLE
Bhavpreet - Fixed the end and start date on activation/deactivation of account

### DIFF
--- a/src/actions/__tests__/timeEntries.js.test.js
+++ b/src/actions/__tests__/timeEntries.js.test.js
@@ -186,22 +186,22 @@ describe('timeEntries action creators', () => {
 
   // Test suite for getTimeEndDateEntriesByPeriod
   describe('getTimeEndDateEntriesByPeriod', () => {
-    it('should return the last entry date formatted as YYYY-MM-DD', async () => {
+    it('should return the last entry date', async () => {
       const dispatchMock = jest.fn(); // Mock dispatch function
       const userId = '123'; // Sample user ID
       const fromDate = moment().subtract(2, 'weeks').toISOString(); // Sample from date
       const toDate = moment().toISOString(); // Sample to date
       const formattedToDate = moment(toDate).endOf('day').format('YYYY-MM-DDTHH:mm:ss'); // Adjusted toDate
       const timeEntries = [
-        { dateOfWork: moment().subtract(1, 'days').toISOString() },
-        { dateOfWork: moment().subtract(2, 'days').toISOString() },
-      ]; // Sample time entries
+      { dateOfWork: moment().subtract(1, 'days').toISOString(), createdDateTime: moment().subtract(1, 'days').toISOString() },
+      { dateOfWork: moment().subtract(2, 'days').toISOString(), createdDateTime: moment().subtract(2, 'days').toISOString() },
+    ];  // Sample time entries
       axios.get.mockResolvedValue({ data: timeEntries }); // Mock axios get response
 
       const result = await getTimeEndDateEntriesByPeriod(userId, fromDate, toDate)(dispatchMock); // Call getTimeEndDateEntriesByPeriod
-
+      
       // Verify the result is the formatted date of the last entry
-      expect(result).toBe(moment(timeEntries[0].dateOfWork).format('YYYY-MM-DD'));
+      expect(result).toBe(timeEntries[0].createdDateTime);
       // Verify axios.get was called with the correct URL
       expect(axios.get).toHaveBeenCalledWith(ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate, formattedToDate));
     });

--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -75,12 +75,13 @@ export const getTimeEndDateEntriesByPeriod = (userId, fromDate, toDate) => { //F
   toDate = moment(toDate)
     .endOf('day')
     .format('YYYY-MM-DDTHH:mm:ss');
-  const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate,toDate);
+  
+  const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate, toDate);
   return async dispatch => {
     let loggedOut = false;
-    try{
+    try {
       const res = await axios.get(url);
-      if (!res || !res.data){
+      if (!res || !res.data) {
         console.log("Request failed or no data");
         return "N/A";
       }
@@ -88,15 +89,52 @@ export const getTimeEndDateEntriesByPeriod = (userId, fromDate, toDate) => { //F
         const entryDate = moment(entry.dateOfWork);
         return entryDate.isBetween(fromDate, toDate, 'day', '[]');
       });
-      filteredEntries.sort((a,b) => {
+      filteredEntries.sort((a, b) => {
         return moment(b.dateOfWork).valueOf() - moment(a.dateOfWork).valueOf();
       });
       const lastEntry = filteredEntries[0];
-      if(!lastEntry){
+      if (!lastEntry) {
         return "N/A";
       }
-      const formattedLastEntryDate = moment(lastEntry.dateOfWork).format('YYYY-MM-DD');
-      return formattedLastEntryDate;
+      const lastEntryDate = lastEntry.createdDateTime;
+      return lastEntryDate;
+    } catch (error) {
+      console.error("Error fetching time entries:", error);
+      if (error.response && error.response.status === 401) {
+        loggedOut = true;
+      }
+      return "N/A"; // Return "N/A" in case of error
+    }
+  };
+};
+
+export const getTimeStartDateEntriesByPeriod = (userId, fromDate, toDate) => { // Find first week of work in date
+  toDate = moment(toDate)
+    .endOf('day')
+    .format('YYYY-MM-DDTHH:mm:ss');
+  
+  const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate, toDate);
+  return async dispatch => {
+    let loggedOut = false;
+    try {
+      const res = await axios.get(url);
+      if (!res || !res.data) {
+        console.log("Request failed or no data");
+        return "N/A";
+      }
+      const filteredEntries = res.data.filter(entry => {
+        const entryDate = moment(entry.dateOfWork);
+        return entryDate.isBetween(fromDate, toDate, 'day', '[]');
+      });
+      filteredEntries.sort((a, b) => {
+        return moment(a.dateOfWork).valueOf() - moment(b.dateOfWork).valueOf();
+      });
+      const firstEntry = filteredEntries[0];
+      if (!firstEntry) {
+        return "N/A";
+      }
+      const firstEntryDate = firstEntry.dateOfWork;
+      return firstEntryDate;
     } catch (error) {
       console.error("Error fetching time entries:", error);
       if (error.response && error.response.status === 401) {
@@ -111,7 +149,7 @@ export const postTimeEntry = timeEntry => {
   return async dispatch => {
     try {
       const res = await axios.post(url, timeEntry);
-      if(timeEntry.entryType == 'default'){
+      if (timeEntry.entryType == 'default') {
         dispatch(updateTimeEntries(timeEntry));
       }
       return res.status;

--- a/src/actions/userManagement.js
+++ b/src/actions/userManagement.js
@@ -18,7 +18,7 @@ import {
 } from '../constants/userManagement';
 import { ENDPOINTS } from '../utils/URL';
 import { UserStatus } from '../utils/enums';
-import { getTimeEndDateEntriesByPeriod } from './timeEntries';
+import { getTimeEndDateEntriesByPeriod, getTimeStartDateEntriesByPeriod } from './timeEntries';
 
 
 /**
@@ -45,7 +45,7 @@ export const getAllUserProfile = () => {
  * @param {*} status  - Active/InActive
  */
 export const updateUserStatus = (user, status, reactivationDate) => {
-  const userProfile = { ...user};
+  const userProfile = { ...user };
   userProfile.isActive = status === UserStatus.Active;
   userProfile.reactivationDate = reactivationDate;
   const patchData = { status, reactivationDate };
@@ -58,9 +58,10 @@ export const updateUserStatus = (user, status, reactivationDate) => {
           patchData.endDate = moment(lastEnddate).format('YYYY-MM-DDTHH:mm:ss');
           userProfile.endDate = moment(lastEnddate).format('YYYY-MM-DDTHH:mm:ss');
         } else { //No work exists, set end date to start date
-          patchData.endDate = moment(user.createdDate).format('YYYY-MM-DDTHH:mm:ss');
-          userProfile.endDate = moment(user.createdDate).format('YYYY-MM-DDTHH:mm:ss');
+          patchData.endDate = moment(user.createdDate);
+          userProfile.endDate = moment(user.createdDate);
         }
+
         const updateProfilePromise = axios.patch(ENDPOINTS.USER_PROFILE(user._id), patchData);
         updateProfilePromise.then(res => {
           dispatch(userProfileUpdateAction(userProfile));
@@ -106,7 +107,7 @@ export const toggleVisibility = (user, isVisible) => {
   const userProfile = { ...user };
   userProfile.isVisible = isVisible
   const requestData = { isVisible };
-  
+
   const toggleVisibilityPromise = axios.patch(ENDPOINTS.TOGGLE_VISIBILITY(user._id), requestData)
   return async dispatch => {
     toggleVisibilityPromise.then(res => {
@@ -198,7 +199,7 @@ export const userProfileDeleteAction = user => {
  * @param {*} finalDate  - the date to be inactive
  */
 export const updateUserFinalDayStatus = (user, status, finalDayDate) => {
-  const userProfile = { ...user};
+  const userProfile = { ...user };
   userProfile.endDate = finalDayDate;
   userProfile.isActive = status === 'Active';
   const patchData = { status, endDate: finalDayDate };
@@ -219,7 +220,7 @@ export const updateUserFinalDayStatus = (user, status, finalDayDate) => {
 };
 
 export const updateUserFinalDayStatusIsSet = (user, status, finalDayDate, isSet) => {
-  const userProfile = { ...user};
+  const userProfile = { ...user };
   userProfile.endDate = finalDayDate;
   userProfile.isActive = status === 'Active';
   userProfile.isSet = isSet === 'FinalDay';
@@ -228,8 +229,8 @@ export const updateUserFinalDayStatusIsSet = (user, status, finalDayDate, isSet)
     patchData.endDate = undefined;
     userProfile.endDate = undefined;
   } else {
-    userProfile.endDate = moment(finalDayDate).add(1,'days').format('YYYY-MM-DD');
-    patchData.endDate = moment(finalDayDate).add(1,'days').format('YYYY-MM-DD');
+    userProfile.endDate = moment(finalDayDate).add(1, 'days').format('YYYY-MM-DD');
+    patchData.endDate = moment(finalDayDate).add(1, 'days').format('YYYY-MM-DD');
   }
 
   const updateProfilePromise = axios.patch(ENDPOINTS.USER_PROFILE(user._id), patchData);
@@ -296,20 +297,20 @@ export const userProfilesBasicInfoFetchErrorAction = payload => {
   };
 };
 
-export const enableEditUserInfo=(value)=>(dispatch,getState)=>{
-  dispatch({type:ENABLE_USER_PROFILE_EDIT,payload:value});
+export const enableEditUserInfo = (value) => (dispatch, getState) => {
+  dispatch({ type: ENABLE_USER_PROFILE_EDIT, payload: value });
 }
 
-export const disableEditUserInfo=(value)=>(dispatch,getState)=>{
-  dispatch({type:DISABLE_USER_PROFILE_EDIT,payload:value});
+export const disableEditUserInfo = (value) => (dispatch, getState) => {
+  dispatch({ type: DISABLE_USER_PROFILE_EDIT, payload: value });
 }
 
-export const changePagination=(value)=>(dispatch,getState)=>{
-  dispatch({type:CHANGE_USER_PROFILE_PAGE,payload:value});
+export const changePagination = (value) => (dispatch, getState) => {
+  dispatch({ type: CHANGE_USER_PROFILE_PAGE, payload: value });
 }
 
-export const updateUserInfomation=(value)=>(dispatch,getState)=>{
-  dispatch({type:START_USER_INFO_UPDATE,payload:value})
+export const updateUserInfomation = (value) => (dispatch, getState) => {
+  dispatch({ type: START_USER_INFO_UPDATE, payload: value })
 }
 
 // export const updateUserInformation=(value)=>async(dispatch,getState)=>{

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -7,7 +7,7 @@ import axios from 'axios';
 import HistoryModal from './HistoryModal';
 import './timeTab.css';
 import { boxStyle, boxStyleDark } from 'styles';
-import { formatDate, formatDateYYYYMMDD, formatDateMMDDYYYY, CREATED_DATE_CRITERIA  } from 'utils/formatDate';
+import { formatDate, formatDateYYYYMMDD, formatDateMMDDYYYY, CREATED_DATE_CRITERIA } from 'utils/formatDate';
 
 const MINIMUM_WEEK_HOURS = 0;
 const MAXIMUM_WEEK_HOURS = 168;
@@ -19,7 +19,7 @@ const startEndDateValidation = props => {
 };
 
 const StartDate = props => {
-  const {darkMode, startDateAlert} = props;
+  const { darkMode, startDateAlert } = props;
 
   if (!props.canEdit) {
     return (
@@ -53,7 +53,7 @@ const StartDate = props => {
 };
 
 const EndDate = props => {
-  const {darkMode, endDateAlert} = props;
+  const { darkMode, endDateAlert } = props;
 
   if (!props.canEdit) {
     return (
@@ -355,17 +355,17 @@ const ViewTab = props => {
   };
 
   useEffect(() => {
-    if (userProfile.startDate === ''){
+    if (userProfile.startDate === '') {
       setStartDateAlert("Invalid date");
-    } else if (userProfile.createdDate >= CREATED_DATE_CRITERIA && userProfile.startDate < userProfile.createdDate){
+    } else if (userProfile.createdDate >= CREATED_DATE_CRITERIA && userProfile.startDate < userProfile.createdDate) {
       setStartDateAlert("The start date is before the account created date");
-    } else{
+    } else {
       setStartDateAlert('')
     }
   }, [userProfile.startDate, userProfile.createdDate]);
 
   useEffect(() => {
-    if (userProfile.endDate !== '' && userProfile.endDate < userProfile.startDate){
+    if (userProfile.endDate !== '' && userProfile.endDate < userProfile.startDate) {
       setEndDateAlert("The end date is before the start date");
     } else {
       setEndDateAlert('');
@@ -379,7 +379,7 @@ const ViewTab = props => {
           <Label className={`hours-label ${darkMode ? 'text-light' : ''}`}>Account Created Date</Label>
         </Col>
         <Col md="6">
-        <p className={darkMode ? 'text-azure' : ''}>{formatDateMMDDYYYY(userProfile.createdDate)}</p>
+          <p className={darkMode ? 'text-azure' : ''}>{formatDateMMDDYYYY(userProfile.createdDate)}</p>
         </Col>
       </Row>
       <Row className="volunteering-time-row">
@@ -526,38 +526,38 @@ const ViewTab = props => {
       </Row>
       {props?.userProfile?.hoursByCategory
         ? Object.keys(userProfile.hoursByCategory).map(key => (
-            <React.Fragment key={'hours-by-category-' + key}>
-              <Row className="volunteering-time-row">
-                <Col md="6">
-                  <Label className={`hours-label ${darkMode ? 'text-light' : ''}`}>
-                    {key !== 'unassigned' ? (
-                      <>Total Tangible {capitalize(key)} Hours</>
-                    ) : (
-                      <>Total Unassigned Category Hours</>
-                    )}
-                  </Label>
-                </Col>
-                <Col md="6">
-                  {canEdit ? (
-                    <Input
-                      type="number"
-                      pattern="^\d*\.?\d{0,2}$"
-                      id={`${key}Hours`}
-                      step=".01"
-                      min="0"
-                      value={roundToTwo(userProfile.hoursByCategory[key])}
-                      onChange={e => handleOnChangeHours(e, key)}
-                      placeholder={`Total Tangible ${capitalize(key)} Hours`}
-                    />
+          <React.Fragment key={'hours-by-category-' + key}>
+            <Row className="volunteering-time-row">
+              <Col md="6">
+                <Label className={`hours-label ${darkMode ? 'text-light' : ''}`}>
+                  {key !== 'unassigned' ? (
+                    <>Total Tangible {capitalize(key)} Hours</>
                   ) : (
-                    <p className={darkMode ? 'text-azure' : ''}>
-                      {userProfile.hoursByCategory[key]?.toFixed(2)}
-                    </p>
+                    <>Total Unassigned Category Hours</>
                   )}
-                </Col>
-              </Row>
-            </React.Fragment>
-          ))
+                </Label>
+              </Col>
+              <Col md="6">
+                {canEdit ? (
+                  <Input
+                    type="number"
+                    pattern="^\d*\.?\d{0,2}$"
+                    id={`${key}Hours`}
+                    step=".01"
+                    min="0"
+                    value={roundToTwo(userProfile.hoursByCategory[key])}
+                    onChange={e => handleOnChangeHours(e, key)}
+                    placeholder={`Total Tangible ${capitalize(key)} Hours`}
+                  />
+                ) : (
+                  <p className={darkMode ? 'text-azure' : ''}>
+                    {userProfile.hoursByCategory[key]?.toFixed(2)}
+                  </p>
+                )}
+              </Col>
+            </Row>
+          </React.Fragment>
+        ))
         : []}
     </div>
   );


### PR DESCRIPTION
# Description
![image_2025-02-19_044632740](https://github.com/user-attachments/assets/9dcc921a-b6f5-4998-af41-4bef489a80c3)
It should have the correct start and end date on the account deactivation and activation plus should reload on the button click

## Related PRS (if any):
This frontend PR is related to the my given frontend branch.
To test this, you need to stay in development backend.
## Main changes explained:
-Clicking the green/gray activation button should reload the page and update the account status.
-The start date should be the first date the user logged time. If no time has been logged, it should default to the account creation date.
-The end date should be the most recent date the user logged time.
-All timestamps should be displayed in Pacific Time.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard → other links → user dashboard → user profile(by clicking the link)
6. verify on three accounts -> I) which has multiple time logs , II) which has only one log and is near the created date and should have the same start and end date, III) which has no time logged which should have the start and end date as created date
7. verify if the page reloads on button click
8. verify if the time matches with the respected logs(start with first and end with last)
9. verify minor details as shown in the videos (i have given before and after changes of the same accounts).
10. follow the videos
## Screenshots or videos of changes:
before the change:- 

https://github.com/user-attachments/assets/51fdf6bd-96b7-4307-8f01-d38788fd85c4

after the change: - 

https://github.com/user-attachments/assets/3e34ae63-d68f-40c6-ae9a-3cf6c4304099


## Note:
comment if you have any question, and checkout into my branch
