### PR TITLE
Michael – Make User Management Title Column a Fixed Width

### DIFF
--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -204,34 +204,34 @@ const UserTableData = React.memo(props => {
       </td>
 
 
-      <td className="email_cell" title={formData.jobTitle}>
-        <div className="fixed-width-container">
-          {editUser?.jobTitle ? (
-            <div style={{ display: "flex", alignItems: "center", justifyContent: "center", maxWidth: "100%" }}>
-              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {formData.jobTitle}
-              </span>
-              <FontAwesomeIcon
-                className="copy_icon"
-                icon={faCopy}
-                onClick={() => {
-                  navigator.clipboard.writeText(formData.jobTitle);
-                  toast.success('Title Copied!');
-                }}
-              />
-            </div>
-          ) : (
-            <input
-              type="text"
-              className="edituser_input"
-              value={formData.jobTitle}
-              onChange={e => {
-                updateFormData({ ...formData, jobTitle: e.target.value });
-                addUserInformation('jobTitle', e.target.value, props.user._id);
+      <td className="title_cell"
+        title={formData.jobTitle}>
+        {editUser?.jobTitle ? (
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "center", maxWidth: "100%" }}>
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {formData.jobTitle}
+            </span>
+            <FontAwesomeIcon
+              className="copy_icon"
+              icon={faCopy}
+              onClick={() => {
+                navigator.clipboard.writeText(formData.jobTitle);
+                toast.success('Title Copied!');
               }}
             />
-          )}
-        </div>
+          </div>
+        ) : (
+          <input
+            type="text"
+            className="edituser_input"
+            value={formData.jobTitle}
+            onChange={e => {
+              updateFormData({ ...formData, jobTitle: e.target.value });
+              addUserInformation('jobTitle', e.target.value, props.user._id);
+            }}
+          />
+        )}
+
       </td>
 
 

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -78,7 +78,7 @@ const UserTableData = React.memo(props => {
       lastName: props.user.lastName,
       id: props.user._id,
       role: props.user.role,
-      jobTitle:props.user.jobTitle,
+      jobTitle: props.user.jobTitle,
       email: props.user.email,
       weeklycommittedHours: props.user.weeklycommittedHours,
       startDate: formatDateYYYYMMDD(props.user.startDate),
@@ -204,31 +204,36 @@ const UserTableData = React.memo(props => {
       </td>
 
 
-      <td className="email_cell">
-        {editUser?.jobTitle ? (
-          <div>
-            {formData.jobTitle}
-            <FontAwesomeIcon
-              className="copy_icon"
-              icon={faCopy}
-              onClick={() => {
-                navigator.clipboard.writeText(formData.jobTitle);
-                toast.success('Title Copied!');
+      <td className="email_cell" title={formData.jobTitle}>
+        <div className="fixed-width-container">
+          {editUser?.jobTitle ? (
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "center", maxWidth: "100%" }}>
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {formData.jobTitle}
+              </span>
+              <FontAwesomeIcon
+                className="copy_icon"
+                icon={faCopy}
+                onClick={() => {
+                  navigator.clipboard.writeText(formData.jobTitle);
+                  toast.success('Title Copied!');
+                }}
+              />
+            </div>
+          ) : (
+            <input
+              type="text"
+              className="edituser_input"
+              value={formData.jobTitle}
+              onChange={e => {
+                updateFormData({ ...formData, jobTitle: e.target.value });
+                addUserInformation('jobTitle', e.target.value, props.user._id);
               }}
             />
-          </div>
-        ) : (
-          <input
-            type="text"
-            className="edituser_input"
-            value={formData.jobTitle}
-            onChange={e => {
-              updateFormData({ ...formData, jobTitle: e.target.value });
-              addUserInformation('jobTitle', e.target.value, props.user._id);
-            }}
-          />
-        )}
+          )}
+        </div>
       </td>
+
 
       <td className="email_cell">
         {editUser?.email ? (
@@ -310,9 +315,8 @@ const UserTableData = React.memo(props => {
       <td className="centered-td">
         <button
           type="button"
-          className={`btn btn-outline-primary btn-sm${
-            props.timeOffRequests?.length > 0 ? ` time-off-request-btn-moved` : ''
-          }`}
+          className={`btn btn-outline-primary btn-sm${props.timeOffRequests?.length > 0 ? ` time-off-request-btn-moved` : ''
+            }`}
           onClick={() => props.onLogTimeOffClick(props.user)}
           id="requested-time-off-btn"
           style={darkMode ? { boxShadow: '0 0 0 0', fontWeight: 'bold' } : boxStyle}

--- a/src/components/UserManagement/UserTableHeader.jsx
+++ b/src/components/UserManagement/UserTableHeader.jsx
@@ -145,31 +145,34 @@ const UserTableHeader = React.memo(
           </div>
         </th>
         <th scope="col" id="usermanagement_title">
-          <div className="text-center">
-            <span className="m-auto">{TITLE}</span>
-            {(() => {
-              if (authRole === 'Owner') {
-                if (editFlag.jobTitle === 1) {
+          <div>
+            <div className="text-center">
+              <span className="m-auto">{TITLE}</span>
+              {(() => {
+                if (authRole === 'Owner') {
+                  if (editFlag.jobTitle === 1) {
+                    return (
+                      <FontAwesomeIcon
+                        icon={faEdit}
+                        className="editbutton"
+                        onClick={() => enableEdit({ ...editFlag, jobTitle: 0 })}
+                      />
+                    );
+                  }
                   return (
                     <FontAwesomeIcon
-                      icon={faEdit}
+                      icon={faSave}
                       className="editbutton"
-                      onClick={() => enableEdit({ ...editFlag, jobTitle: 0 })}
+                      onClick={() => disableEdit({ ...editFlag, jobTitle: 1 })}
                     />
                   );
                 }
-                return (
-                  <FontAwesomeIcon
-                    icon={faSave}
-                    className="editbutton"
-                    onClick={() => disableEdit({ ...editFlag, jobTitle: 1 })}
-                  />
-                );
-              }
-              return <> </>;
-            })()}
+                return <> </>;
+              })()}
+            </div>
           </div>
         </th>
+
         <th scope="col" id="usermanagement_email">
           <div className="text-center">
             <span className="m-auto text-center">{EMAIL}</span>

--- a/src/components/UserManagement/UserTableSearchHeader.jsx
+++ b/src/components/UserManagement/UserTableSearchHeader.jsx
@@ -54,12 +54,14 @@ const UserTableSearchHeader = React.memo(props => {
         <DropDownSearchBox id="role_search" items={props.roles} searchCallback={onRoleSearch} />
       </td>
       <td id="user_title">
-        <TextSearchBox
-          id="title_search"
-          searchCallback={onTitleSearch}
-          style={{ width: '100%' }}
-          placeholder=" Search Title"
-        />
+        <div>
+          <TextSearchBox
+            id="title_search"
+            searchCallback={onTitleSearch}
+            style={{ width: '100%' }}
+            placeholder=" Search Title"
+          />
+        </div>
       </td>
       <td id="user_email">
         <TextSearchBox

--- a/src/components/UserManagement/usermanagement.css
+++ b/src/components/UserManagement/usermanagement.css
@@ -107,7 +107,7 @@ thead {
 
 }
 
-.fixed-width-container {
+.title_cell {
   width: 180px;
   min-width: 180px;
   max-width: 180px;

--- a/src/components/UserManagement/usermanagement.css
+++ b/src/components/UserManagement/usermanagement.css
@@ -37,6 +37,24 @@ thead {
   text-align: center;
 }
 
+#usermanagement_title>div {
+  width: 180px;
+  min-width: 180px;
+  max-width: 180px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#user_title>div {
+  width: 180px;
+  min-width: 180px;
+  max-width: 180px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .usermanagement_overview--top {
   background: gray;
 }
@@ -89,14 +107,25 @@ thead {
 
 }
 
-#usermanagement_role, 
-#user_role, 
+.fixed-width-container {
+  width: 180px;
+  min-width: 180px;
+  max-width: 180px;
+}
+
+.fixed-width-container input {
+  width: 100%;
+  max-width: 180px;
+}
+
+#usermanagement_role,
+#user_role,
 td#usermanagement_role {
   width: 100px;
-  max-width: 180px; 
+  max-width: 180px;
   overflow: hidden;
-  text-overflow: ellipsis; 
-  white-space: nowrap; 
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .copy_icon {
@@ -346,7 +375,7 @@ tr:hover {
   margin: auto;
 }
 
-td{
+td {
   text-align: center;
 }
 


### PR DESCRIPTION
# Description
<img width="670" alt="Screenshot 2025-02-19 at 8 38 46 PM" src="https://github.com/user-attachments/assets/8bba6018-bb8c-4509-aa0e-1207843e72bd" />
<img width="713" alt="Screenshot 2025-02-19 at 8 39 09 PM" src="https://github.com/user-attachments/assets/227a61b8-ff3f-49b0-8e64-513d2341918a" />


## Related PRS (if any):
N/A
…

## Main changes explained:
- Updated the User Management table to set a fixed width for the Title column.
- Modified the <th> and <td> elements to ensure the Title column does not expand with long text.
- Applied CSS changes to enforce a fixed width while maintaining text truncation (ellipsis).
- Ensured that the column remains visually consistent without affecting other columns.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to Other Links → User Management.
6. verify that the Title column maintains a fixed width, sized to fit the text "Administrative Assistant", regardless of screen size.
7. verify that long job titles are truncated with an ellipsis and display the full title on hover

## Screenshots or videos of changes:
Before:
<img width="1417" alt="Screenshot 2025-02-19 at 8 35 42 PM" src="https://github.com/user-attachments/assets/6883d694-4dfb-4b85-bb67-8f7176b19691" />

After:
<img width="1440" alt="Screenshot 2025-02-19 at 8 34 29 PM" src="https://github.com/user-attachments/assets/31233bb6-aa04-409f-9836-e4ba3b551457" />

