### PR TITLE
Koushica - Fix: Character length increased for Quick Setup Codes and issue fixes

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
@@ -56,7 +56,7 @@ function AddNewTitleModal({
       setTitleData({
         id: title._id,
         titleName: title.titleName,
-        titleCode: title.titleCode || title.titleName.slice(0, 5),
+        titleCode: title.titleCode || title.titleName.slice(0, 7),
         mediaFolder: title.mediaFolder,
         teamCode: title.teamCode,
         projectAssigned: title.projectAssigned,
@@ -74,7 +74,7 @@ function AddNewTitleModal({
   }, [title]);
 
   useEffect(() => {
-    const titleCode = titleData.titleName.slice(0, 5);
+    const titleCode = titleData?.titleCode ? titleData.titleCode : titleData.titleName.slice(0, 7);
     setTitleData(prev => ({
       ...prev,
       titleCode,
@@ -280,7 +280,7 @@ function AddNewTitleModal({
                 e.persist();
                 setTitleData({ ...titleData, titleCode: e.target.value });
               }}
-              maxLength={5}
+              maxLength={7}
             />
 
             <Label className={fontColor}>
@@ -297,7 +297,7 @@ function AddNewTitleModal({
               }}
               placeholder="Enter a valid URL"
             />
-            {!/^(https?:\/\/[^\s]+)$/.test(titleData.mediaFolder) && titleData.mediaFolder !== '' && (
+            {!/^(https?:\/\/[^\s]+)$/.test(titleData.mediaFolder.trim()) && titleData.mediaFolder !== '' && (
               <small style={{ color: 'red', marginTop: '5px', display: 'block' }}>
                 Please enter a valid URL that starts with http:// or https://
               </small>
@@ -358,7 +358,7 @@ function AddNewTitleModal({
         <Button 
           color="primary" 
           onClick={() => confirmOnClick()}
-          disabled={!/^(https?:\/\/[^\s]+)$/.test(titleData.mediaFolder) || titleData.mediaFolder === ''}
+          disabled={!/^(https?:\/\/[^\s]+)$/.test(titleData.mediaFolder.trim()) || titleData.mediaFolder === ''}
         >
           Confirm
         </Button>

--- a/src/components/UserProfile/QuickSetupModal/EditTitlesModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/EditTitlesModal.jsx
@@ -91,7 +91,7 @@ const EditTitlesModal = ({ isOpen, toggle, titles, refreshModalTitles, darkMode 
                         cursor: 'grab'
                       }}
                     >
-                      {title?.titleCode ? title.titleCode : title?.titleName?.substring(0, 5)}
+                      {title?.titleCode ? title.titleCode : title?.titleName?.substring(0, 7)}
                     </div>
                   )}
                   </Draggable>

--- a/src/components/UserProfile/QuickSetupModal/QuickSetupCodes.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupCodes.jsx
@@ -24,7 +24,7 @@ function QuickSetupCodes({
           }}
           value={title.titleName}
         >
-          {title?.titleCode ? title.titleCode : title?.titleName?.substring(0, 5)}
+          {title?.titleCode ? title.titleCode : title?.titleName?.substring(0, 7)}
           <div className="title">
             <span className="setup-title-name">{title?.titleName}</span>
           </div>


### PR DESCRIPTION
# Description
<img width="800" alt="Screenshot 2025-02-20 at 9 20 30 PM" src="https://github.com/user-attachments/assets/8a8f3ab3-d35c-4e53-a324-80766dae3a66" />
<img width="802" alt="Screenshot 2025-02-20 at 9 20 59 PM" src="https://github.com/user-attachments/assets/a8524cc0-39a0-41fa-9969-9d6fcd92697c" />

## Related PRS (if any):
This frontend PR is related to the #XXX backend PR.
To test this frontend PR you need to checkout the #XXX backend PR.

## Main changes explained:
- Increased the titleCode character limit from 5 to 7.
- Trimmed the media link to prevent errors.
- Fixed inconsistency between the displayed tiles of titleCodes and the titleCode shown in the edit modal by adding:
const titleCode = titleData?.titleCode ? titleData.titleCode : titleData.titleName.slice(0, 7);

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to User Profile→ Quick Setup Codes
6. Navigate to User Profile → Quick Setup Codes.
7. Edit or add a new title and verify that it:
- Accepts special characters.
- Allows spaces between characters.
- Requires at least one uppercase or lowercase letter.
- Maintains titleCode consistency between the tile display and the edit modal.