### PR TITLE
Koushica - HotFix: TeamCode suggestion population and ui fix 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -138,7 +138,11 @@ body {
   background-color: #007BFF !important;
 }
 
-.text-oxford-blue{
+.pdrl-1 {
+  padding: 0 1em !important;
+}
+
+.text-oxford-blue {
   color: #1B2A41 !important;
 }
 

--- a/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
@@ -27,6 +27,7 @@ function AddNewTitleModal({
   setShowMessage,
   editMode,
   title,
+  qstTeamCodes
 }) {
   const darkMode = useSelector(state => state.theme.darkMode);
   const teamCodes = useSelector(state => state.teamCodes?.teamCodes || []);
@@ -88,9 +89,9 @@ function AddNewTitleModal({
 
   useEffect(() => {
     setIsValidTeamCode(
-      titleData.teamCode === '' || teamCodes.some(code => code.value === titleData.teamCode),
+      titleData.teamCode === '' || qstTeamCodes.some(code => code.value === titleData.teamCode),
     );
-  }, [titleData.teamCode, teamCodes]);
+  }, [titleData.teamCode, qstTeamCodes]);
 
   let existTeamCodes = new Set();
   let existTeamName = new Set();
@@ -316,7 +317,7 @@ function AddNewTitleModal({
               Team Code<span className="qsm-modal-required">*</span>:
             </Label>
             <AssignTeamCodeField
-              teamCodeData={teamCodes}
+              teamCodeData={qstTeamCodes}
               onDropDownSelect={selectTeamCode}
               selectedTeamCode={selectedTeamCode}
               cleanTeamCodeAssign={cleanTeamCodeAssign}

--- a/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
@@ -185,7 +185,7 @@ function AssignSetUpModal({ isOpen, setIsOpen, title, userProfile, setUserProfil
           ) : (
             ''
           )}
-          <div className="container ml-1">
+          <div className="container ml-1 pdrl-1">
             <Input
               type="checkbox"
               required

--- a/src/components/UserProfile/QuickSetupModal/QuickSetupCodes.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupCodes.jsx
@@ -1,5 +1,3 @@
-import { useSelector } from 'react-redux';
-
 function QuickSetupCodes({
   titles,
   setShowAssignModal,
@@ -7,8 +5,8 @@ function QuickSetupCodes({
   setShowAddTitle,
   editMode,
   assignMode,
+  teamCodes
 }) {
-  const teamCodes = useSelector(state => state.teamCodes?.teamCodes || []);
 
   return (
     <div className="blueSquares mt-3" id="qsc-outer-wrapper">

--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
@@ -28,6 +28,9 @@ function QuickSetupModal(props) {
   const [adminLinks, setAdminLinks] = useState([]);
   const [editModal, showEditModal] = useState(false);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const [qstTeamCodes, setqstTeamCodes] = useState([])
+
+  const stateTeamCodes = useSelector(state => state.teamCodes?.teamCodes || []);
 
   useEffect(() => {
     getAllTitle()
@@ -49,6 +52,18 @@ function QuickSetupModal(props) {
     }
   };
 
+  useEffect(()=>{
+    let teamCodes = [];
+    if(stateTeamCodes.length) {
+      teamCodes = [...stateTeamCodes];
+    }else if (props.teamsData?.allTeams) {
+      if( props.teamsData?.allTeamCode?.distinctTeamCodes ) {
+        teamCodes = props.teamsData.allTeamCode.distinctTeamCodes.map(value => ({ value }));
+      }
+    }
+    setqstTeamCodes(teamCodes);
+  },[stateTeamCodes])
+
   return (
     <div>
       {canAssignTitle || canEditTitle || canAddTitle ? (
@@ -62,6 +77,7 @@ function QuickSetupModal(props) {
           editMode={editMode}
           assignMode={canAssignTitle}
           setShowAddTitle={setShowAddTitle}
+          teamCodes={qstTeamCodes}
         />
       ) : (
         ''
@@ -147,6 +163,7 @@ function QuickSetupModal(props) {
           setShowMessage={setShowMessage}
           editMode={editMode}
           title={curtitle}
+          qstTeamCodes={qstTeamCodes}
         />
       ) : (
         ''


### PR DESCRIPTION
# Description
1. 'TeamCode' suggestion not populating while trying to add a new Quick Setup Title Code.
2. Ui break in the volunteer agreement confirmed.

## Related PRS (if any):
no related PR's

## Main changes explained:
- There was an workflow issue from: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2751 which caused this issue of teamCode not populating.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. Navigate to User Profile → Quick Setup Codes.
6. Edit or add a new title and verify that it:
- Accepts special characters.
- Allows spaces between characters.
- Requires at least one uppercase or lowercase letter.
- Maintains titleCode consistency between the tile display and the edit modal.
