### PR TITLE
Swaroop - Fix: Reports Project/People/Teams List Placement

### DIFF
--- a/src/components/Reports/reportsPage.css
+++ b/src/components/Reports/reportsPage.css
@@ -5,13 +5,14 @@
 
 .container-component-wrapper {
   min-height: 100%;
-  width: 100vw;
+  width: 100%;
   display: grid;
   justify-content: center;
   align-content: start;
   background-color: #faf7fc;
   margin: 0px;
   justify-items: center;
+  overflow-x: hidden;
 }
 
 .category-data-container {
@@ -24,6 +25,7 @@
   background-color: #faf7fc;
   margin: 0 auto;
   gap: 2rem;
+  padding: 0 16px;
 }
 
 .no-active-selection {
@@ -39,26 +41,12 @@
   padding: 32px;
 }
 
-.category-container > .card-category-item.selected {
-  background-color: #d7cdda;
-  box-shadow: 0px 8px 16px rgba(78, 32, 125, 0.2);
-  transform: scale(1.05);
-}
-
-.table-data-container {
-  width: 100%;
-  max-width: 600px;
-  height: fit-content;
-  position: sticky;
-  top: 0;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
 .category-container {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  flex-wrap: wrap;
+  margin: 0 -8px;
 }
 
 .card-category-item {
@@ -72,12 +60,23 @@
   background-color: #f1ebf7;
   border-radius: 8px;
   cursor: pointer;
+  margin: 8px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  transform-origin: center center;
+}
+
+.category-container > .card-category-item.selected {
+  background-color: #d7cdda;
+  box-shadow: 0px 8px 16px rgba(78, 32, 125, 0.2);
+  transform: scale(1.03);
+  position: relative;
+  z-index: 1;
 }
 
 .card-category-item:hover {
   background-color: #f1ebf7;
   box-shadow: 0px 8px 16px rgba(78, 32, 125, 0.2);
-  transform: scale(1.05);
+  transform: scale(1.03);
 }
 
 .card-category-item:focus-visible {
@@ -87,6 +86,7 @@
 .card-category-item img {
   width: 100px;
   height: 100px;
+  object-fit: contain;
 }
 
 .card-category-item-title {
@@ -96,12 +96,23 @@
   align-items: center;
   font-size: 24px;
   font-weight: 400;
+  text-align: center;
 }
 
 .card-category-item-number {
   font-size: 32px;
   font-weight: 700;
   margin: 12px 0;
+}
+
+.table-data-container {
+  width: 100%;
+  max-width: 600px;
+  height: fit-content;
+  position: sticky;
+  top: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .search-field-container {
@@ -112,6 +123,8 @@
   display: flex;
   justify-content: flex-start;
   padding: 16px 0;
+  flex-wrap: wrap;
+  gap: 16px;
 }
 
 .date-picker-item {
@@ -130,6 +143,8 @@
   flex-direction: row;
   justify-content: flex-start;
   padding: 8px 0px 8px 0px;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
 .total-report-item {
@@ -143,6 +158,8 @@
   flex-direction: row;
   justify-content: center;
   padding: 8px 0px 8px 0px;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
 .lost-time-item {
@@ -154,13 +171,14 @@
 .type-container {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
 .type-item {
   padding-left: 30px;
 }
 
-/* Loading spinner styles */
 .loading-spinner-top {
   display: flex;
   justify-content: center;
@@ -176,6 +194,7 @@
     grid-template-columns: repeat(2, 1fr);
     gap: 1rem;
     width: 100%;
+    padding: 0;
   }
 
   .container-component-category {
@@ -184,12 +203,15 @@
 
   .category-container {
     margin-top: 20px;
+    justify-content: center;
   }
 
   .card-category-item {
-    width: calc(100% / 3 - 16px);
+    width: calc(33.333% - 16px);
+    min-width: 120px;
+    max-width: 200px;
     padding: 16px;
-    margin: 4px;
+    margin: 8px;
   }
 
   .card-category-item img {
@@ -205,6 +227,7 @@
 
   .table-data-container {
     padding: 16px;
+    width: 100%;
   }
 }
 
@@ -222,6 +245,7 @@
     max-height: calc(100vh - 200px);
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+    width: 100%;
   }
 
   .table-data-container::-webkit-scrollbar {
@@ -230,13 +254,15 @@
 
   .category-container {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     gap: 1rem;
+    margin: 0;
   }
 
   .card-category-item {
     width: 100%;
-    min-width: 150px;
+    min-width: 120px;
+    margin: 0;
   }
 
   .total-report-container {
@@ -276,6 +302,11 @@
     max-width: 100%;
   }
 
+  .card-category-item {
+    width: 100%;
+    max-width: none;
+  }
+  
   .card-category-item img {
     width: 72px;
     height: 72px;

--- a/src/components/Reports/reportsPage.css
+++ b/src/components/Reports/reportsPage.css
@@ -23,6 +23,7 @@
   align-content: start;
   background-color: #faf7fc;
   margin: 0 auto;
+  gap: 2rem;
 }
 
 .no-active-selection {
@@ -30,7 +31,8 @@
 }
 
 .container-component-category {
-  width: 720px;
+  width: 100%;
+  max-width: 720px;
   display: flex;
   flex-direction: column;
   border-radius: 0 0 16px 16px;
@@ -44,8 +46,13 @@
 }
 
 .table-data-container {
-  width: 600px;
-  margin-top: 150px !important;
+  width: 100%;
+  max-width: 600px;
+  height: fit-content;
+  position: sticky;
+  top: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .category-container {
@@ -153,24 +160,25 @@
   padding-left: 30px;
 }
 
+/* Loading spinner styles */
+.loading-spinner-top {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
 @media screen and (max-width: 1350px) {
   .container-component-wrapper {
     padding: 16px;
   }
 
   .category-data-container {
-    grid-template-columns: 1fr;
-    justify-items: center;
-    margin: 0 auto;
-    width: auto;
-  }
-
-  .table-data-container {
-    margin-top: 0px !important;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+    width: 100%;
   }
 
   .container-component-category {
-    width: 500px;
     padding: 16px;
   }
 
@@ -183,49 +191,61 @@
     padding: 16px;
     margin: 4px;
   }
+
   .card-category-item img {
     width: 72px;
     height: 72px;
   }
+
   .card-category-item-number {
     font-size: 24px;
     font-weight: 700;
     margin: 8px 0;
   }
+
+  .table-data-container {
+    padding: 16px;
+  }
 }
 
 @media screen and (max-width: 1100px) {
+  .category-data-container {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+  }
+
   .container-component-wrapper {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
+    padding: 16px;
   }
+
   .table-data-container {
-    width: 100%;
-    max-width: 600px;
+    max-height: calc(100vh - 200px);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
-  .table-data-container {
-    overflow-x: scroll;
-  }
+
   .table-data-container::-webkit-scrollbar {
     display: none;
-  }  
+  }
+
   .category-container {
-    display: flex;
-    flex-direction: column;    
-  }  
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+  }
+
   .card-category-item {
     width: 100%;
-    padding: 16px;
-    margin: 4px;
+    min-width: 150px;
   }
+
   .total-report-container {
     display: flex;
     flex-direction: column;
     justify-content: space-around;
     gap: 1rem;
   }
+
   .lost-time-container {
     display: flex;
     flex-direction: column;
@@ -238,17 +258,29 @@
   .container-component-wrapper {
     padding: 16px;
   }
+
+  .category-data-container {
+    grid-template-columns: 1fr;
+  }
+
   .container-component-category {
     width: 100%;
+    max-width: 100%;
     display: flex;
     flex-direction: column;
     border-radius: 0 0 16px 16px;
     padding: 16px;
   }
+
+  .table-data-container {
+    max-width: 100%;
+  }
+
   .card-category-item img {
     width: 72px;
     height: 72px;
   }
+
   .card-category-item-number {
     font-size: 24px;
     font-weight: 700;


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/75cb56e3-b7c7-452d-9651-679b232a3326)

## Related PRS (if any):
This frontend PR is related to the development backend branch.

## Main changes explained:
- Fixed layout of Reports page on smaller screens 
- Kept Teams/Projects/People lists visible on the right side consistently
- Added better responsive behavior with proper scrolling


## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ reports→ select a category (projects/people/team)
6. try the responsive mode in dimensions and verify that the reports are placed on the right side
7. verify this new feature works in dark mode

## Screenshots or videos of changes:
## Before the changes: 
[video.webm](https://github.com/user-attachments/assets/059f3e4f-e1d0-448c-9106-861bc3b4a4b9)

![image](https://github.com/user-attachments/assets/c2919aa1-b6ab-4578-92ac-223ce5b80d1d)
![image](https://github.com/user-attachments/assets/6fdaf764-e178-400e-bc2b-b8168cdd6e76)

## After the changes: 
[video (1).webm](https://github.com/user-attachments/assets/072115ea-21bc-4632-9928-388d7c66e282)
![image](https://github.com/user-attachments/assets/e9529f36-568e-4789-969b-943a82beb740)





