### PR TITLE
Jatin fix errors in summary and userprofile due to image size issues 

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -930,7 +930,7 @@ function UserProfile(props) {
           <Col md="4" id="profileContainer">
             <div className="profile-img">
               <Image
-                src={profilePic !== undefined ? profilePic : '/pfp-default.png'}
+                src={profilePic !== undefined && profilePic!==null? profilePic : '/pfp-default.png'}
                 alt="Profile Picture"
                 roundedCircle
                 className="profilePicture bg-white"


### PR DESCRIPTION
# Description
The auto profile assignment from official one community website was causing issues in submitting weekly summaries and making changes to userprofile information. The reason being the image assigned was greater than 50kb in size.

## Related PRS (if any):
This frontend PR is related to the [#1248](https://github.com/OneCommunityGlobal/HGNRest/pull/1248) backend PR.

## Main changes explained:
- Updated function `getProfileImagesFromWebsite` in  `src/helpers/userhelper.js`

## How to test:
1. check into current branch
2. do `npm install` and `npm run build` and `npm start` to run this PR locally
3. Follow steps in the video.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/d4d09b01-b667-4c17-ae78-397698c4049c

