### PR TITLE
Neha - hours bar in dashboard formatting fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test-results # Adjust the path to your test results if necessary

--- a/src/components/SummaryBar/SummaryBar.css
+++ b/src/components/SummaryBar/SummaryBar.css
@@ -242,7 +242,7 @@
   word-break: break-word;
   white-space: normal;
 }
-  
+
 .sortable-draggable-dragging {
   opacity: .5;
   cursor: grabbing;

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -578,7 +578,11 @@ function SummaryBar(props) {
               }`}
               style={{ border: '1px solid black' }}
             >
-              <div className="align-items-center" id="timelogweeklychart">
+              <div
+                className="align-items-center"
+                id="timelogweeklychart"
+                style={{ whiteSpace: 'nowrap', padding: '0px 10px' }}
+              >
                 <div className="align-items-center med_text_summary">
                   Current Week : {totalEffort.toFixed(2)} / {weeklyCommittedHours.toFixed(2)}
                   <Progress

--- a/src/components/Timelog/TimelogNavbar.jsx
+++ b/src/components/Timelog/TimelogNavbar.jsx
@@ -12,8 +12,9 @@ import {
 } from 'reactstrap';
 import { useSelector } from 'react-redux';
 import { getProgressColor, getProgressValue } from '../../utils/effortColors';
+import { useState } from 'react';
 
-const TimelogNavbar = ({ userId }) => {
+function TimelogNavbar({ userId }) {
   const { firstName, lastName } = useSelector(state => state.userProfile);
   const [collapsed, setCollapsed] = useState(true);
 
@@ -34,7 +35,16 @@ const TimelogNavbar = ({ userId }) => {
         <NavbarToggler onClick={toggleNavbar} />
         <Collapse isOpen={!collapsed} className="ml-auto flex-column" id="timelogsnapshot" navbar>
           <Nav navbar className="navbar-nav w-100">
-            <NavItem className="nav-item navbar-text w-80" id="timelogweeklychart">
+            <NavItem
+              className="nav-item navbar-text w-80"
+              id="timelogweeklychart"
+              style={{
+                whiteSpace: 'nowrap',
+                minWidth: 'max-content',
+                display: 'flex',
+                alignItems: 'center',
+              }}
+            >
               <div>
                 Current Week : {totalEffort.toFixed(2)} / {weeklycommittedHours.toFixed(2)}
               </div>
@@ -79,6 +89,6 @@ const TimelogNavbar = ({ userId }) => {
       </Navbar>
     </div>
   );
-};
+}
 
 export default TimelogNavbar;


### PR DESCRIPTION
# Description
<img width="739" alt="Screenshot 2025-02-27 at 11 31 46 PM" src="https://github.com/user-attachments/assets/a65935a9-fa7a-4911-90c5-15df436cdb4c" />


## Related PRS (if any):

## Main changes explained:
- Added styling to the hours bar in dashboard. Made changes in SummaryBar.jsx file
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as any user
5. go to dashboard
6. Change the size of the window and check if the "Current Week: 0:00 / 0:00" is always in a single line or not.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/07a6245a-eb4e-4c5a-9018-3beebf825b98

## Note:
There is a slight overlap between the line and the neighboring blocks in some cases. Let me know if you have any recommendations for improvement.
