### PR TITLE
Neha - Progress bar formatting fix

### DIFF
--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -578,7 +578,11 @@ function SummaryBar(props) {
               }`}
               style={{ border: '1px solid black' }}
             >
-              <div className="align-items-center" id="timelogweeklychart">
+              <div
+                className="align-items-center"
+                id="timelogweeklychart"
+                style={{ whiteSpace: 'nowrap', padding: '0px 10px' }}
+              >
                 <div className="align-items-center med_text_summary">
                   Current Week : {totalEffort.toFixed(2)} / {weeklyCommittedHours.toFixed(2)}
                   <Progress


### PR DESCRIPTION
# Description
<img width="737" alt="Screenshot 2025-02-28 at 12 31 25 PM" src="https://github.com/user-attachments/assets/d5affb1c-38cf-4087-916f-2db2d31340cf" />

## Related PRS (if any):
…

## Main changes explained:
- Added styling to the progress bar feature in the SummaryBar.jsx file.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard
6. Change the size of the window and verify that the "Current Week: ... " line is not breaking into the next line.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/530a8369-d4ad-4372-968b-cd69ec6eee55

## Note:
At some points, the line briefly overlaps with the adjacent blocks. Open to suggestions on how to best address this.
