### PR TITLE
Dipti - Fix_WBS_content_save_auto_refresh

### DIFF
--- a/src/actions/task.js
+++ b/src/actions/task.js
@@ -112,6 +112,13 @@ export const addNewTask = (newTask, wbsId, pageLoadTime) => async (dispatch, get
     const wbs = await axios.get(ENDPOINTS.TASK_WBS(wbsId));
     if (Date.parse(wbs.data.modifiedDatetime) > pageLoadTime) {
       dispatch(setAddTaskError('outdated'));
+      const res = await axios.post(ENDPOINTS.TASK(wbsId), newTask);
+      dispatch(postNewTask(res.data, status));
+      _id = res.data._id;
+      status = res.status;
+      task = res.data;
+      const userIds = task.resources.map(resource => resource.userID);
+      await createOrUpdateTaskNotificationHTTP(task._id, {}, userIds);
     } else {
       const res = await axios.post(ENDPOINTS.TASK(wbsId), newTask);
       dispatch(postNewTask(res.data, status));

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -330,8 +330,8 @@ function AddTaskModal(props) {
 
   useEffect(() => {
     if (error === 'outdated') {
-      alert('Database changed since your page loaded , click OK to get the newest data!');
-      props.load();
+      
+      clear()
     } else {
       clear();
     }
@@ -377,13 +377,13 @@ function AddTaskModal(props) {
         <ModalBody className={darkMode ? 'bg-yinmn-blue dark-mode no-hover' : ''}>
           <div className="table table-bordered responsive">
             <div>
-              <div className="add_new_task_form-group">
+              {/* <div className="add_new_task_form-group">
                 <span className={`add_new_task_form-label ${fontColor}`} data-tip="WBS ID">
                   WBS #
                 </span>
 
                 <span className={`add_new_task_form-input_area ${fontColor}`}>{newTaskNum}</span>
-              </div>
+              </div> */}
               <div className="add_new_task_form-group" >
                 <span className={`add_new_task_form-label ${fontColor}`}>Task Name</span>
                 <span className="add_new_task_form-input_area">

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -200,7 +200,8 @@ function Task(props) {
               className={`taskNum ${props.hasChildren ? 'has_children' : ''}`}
               onClick={openChild}
             >
-              {props.num.replaceAll('.0', '')}
+              
+              {(props.tasks.findIndex(item => item._id === props.taskId) + 1)}
             </td>
             <td className="taskName">
               {

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -409,6 +409,8 @@ function WBSTasks(props) {
                 pageLoadTime={pageLoadTime}
                 setIsLoading={setIsLoading}
                 darkMode={darkMode}
+                
+                tasks={tasks}
               />
             ))}
           </tbody>


### PR DESCRIPTION
# Description
Please focus on f point
<img width="655" alt="Screenshot 2025-03-06 at 10 45 08 PM" src="https://github.com/user-attachments/assets/2079fd3c-4b1e-4fa8-9611-7676707c856c" />


## Related PRS (if any):
development branch of backend
…

## Main changes explained:
Updated task.js: Added logic to add a task when error == "outdated".
Modified AddTaskModel.jsx: Removed the alert inside the useEffect block when error == "outdated" and instead implemented a clear method.
Enhanced Task.jsx: Now using the tasks length from the backend to ensure the actual sequence of tasks is displayed in the model. To achieve this, tasks is now passed as a prop to the Task component from WBSTasks.jsx.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4.Other Links>Projects>WBS Icon>Choose WBS
5.Keep the above tab open and do this process on a private browser with another account and same WBS: Other Links>Projects>WBS Icon>Choose WBS>Add Task
6. Then go back to the tab from “a” and add task without refreshing 

## Screenshots or videos of changes:
##### Before

https://github.com/user-attachments/assets/b93a34c9-6628-4049-a06d-94329f8d06bb

##### After

https://github.com/user-attachments/assets/e9fe8d32-51c9-41eb-b56a-f3c2804c2947
