### PR TITLE
jaissica-updated content for PopUpBar

### DIFF
--- a/src/components/PopUpBar/PopUpBar.jsx
+++ b/src/components/PopUpBar/PopUpBar.jsx
@@ -6,7 +6,7 @@ function PopUpBar(props) {
   const { firstName, lastName } = viewingUser;
   return (
     <div className="popup_container" data-testid="test-popup">
-      {`You are currently viewing the header for ${firstName} ${lastName}`}
+      {`You are currently viewing the dashboard for ${firstName} ${lastName}`}
       <button type="button" className="close_button" onClick={onClickClose}>
         X
       </button>

--- a/src/components/PopUpBar/__tests__/PopUpBar.test.jsx
+++ b/src/components/PopUpBar/__tests__/PopUpBar.test.jsx
@@ -21,7 +21,7 @@ describe('Test Suite for PopUpBar', () => {
 
   it('Test Case 2: Renders with correct text', () => {
     renderComponent();
-    const expectedText = `You are currently viewing the header for ${viewingUser.firstName} ${viewingUser.lastName}`;
+    const expectedText = `You are currently viewing the dashboard for ${viewingUser.firstName} ${viewingUser.lastName}`;
     const actualText = screen.getByText(expectedText);
     expect(actualText).toBeInTheDocument();
   });


### PR DESCRIPTION
# Description
Fixed "You are currently viewing the header for {name}" to "You are currently viewing the dashboard for {name}"

## Related PRS (if any):
- NA

## Main changes explained:
- Fixed "You are currently viewing the header for {name}" to "You are currently viewing the dashboard for {name}" in PopUpBar.jsx and PopUpBar.test.jsx.

## How to test:
1. check into current branch
2. you can use development branch for backend 
3. do `npm install` and `...` to run this PR locally
4. Clear site data/cache
5. log as admin user
6. Go to Dashboard -> Leaderboard -> Dot besides the name
7. You should be able to see "You are currently viewing the dashboard for {name}"

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
