### PR TITLE
Koushica Hotfix - Added toast for adding and updating Quick setup title

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
@@ -11,6 +11,7 @@ import {
   Input,
 } from 'reactstrap';
 import { useSelector } from 'react-redux';
+import { toast } from 'react-toastify';
 import { addTitle, editTitle } from '../../../actions/title';
 import AssignProjectField from './AssignProjectField';
 import AssignTeamField from './AssignTeamField';
@@ -192,6 +193,7 @@ function AddNewTitleModal({
           } else {
             setIsOpen(false);
             refreshModalTitles();
+            toast.success('Title updated successfully');
           }
         })
         .catch(e => {
@@ -206,6 +208,7 @@ function AddNewTitleModal({
           } else {
             setIsOpen(false);
             refreshModalTitles();
+            toast.success('Title added successfully');
           }
         })
         .catch(e => {


### PR DESCRIPTION
# Description
This PR adds a success toast notification when a user adds or updates a Quick Setup Title (QST) in the Quick Setup modal.

## Related PRS (if any):
This frontend PR is not related to any backend PR.
To test this frontend PR you need to checkout the development backend PR.

## Main changes explained:
- Added toast in ```src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx``` file

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Navigate to User Profile → Quick Setup Codes.
6. Add a new Quick Setup Title (QST) and verify that a success toast appears.
7. Update an existing Quick Setup Title (QST) and confirm that the success toast appears.

## Screenshots or videos of changes:
<img width="1440" alt="Screenshot 2025-03-11 at 3 49 24 PM" src="https://github.com/user-attachments/assets/68ff8b0d-38ee-4c92-863d-5798856a4246" />
<img width="1440" alt="Screenshot 2025-03-11 at 3 48 52 PM" src="https://github.com/user-attachments/assets/6e2cf1dc-ebe7-4bfe-8c69-51093504e73b" />


https://github.com/user-attachments/assets/cc880468-3135-4248-8ee8-22638ad0c5f9



