### PR TITLE
Akshay - Fix - Total-Report-Components

### DIFF
--- a/src/components/Reports/Reports.jsx
+++ b/src/components/Reports/Reports.jsx
@@ -281,7 +281,7 @@ class ReportsPage extends Component {
       });
       return;
     }
-  
+
     this.setState({
       loading: true,
       showProjects: false,
@@ -303,7 +303,7 @@ class ReportsPage extends Component {
       }, 2000);  // Adjust the delay as needed
     });
   }
-  
+
   // showTotalProject() {
   //   this.setState(prevState => ({
   //     showProjects: false,
@@ -318,7 +318,7 @@ class ReportsPage extends Component {
   //     showAddTeamHistory: false,
   //   }));
   // }
-  
+
   showAddProjHistory() {
     this.setState(prevState => ({
       showProjects: false,
@@ -404,24 +404,24 @@ class ReportsPage extends Component {
       <Container fluid className={`mb-5 container-component-wrapper ${isOxfordBlue}`}>
         <div
           className={`category-data-container ${isOxfordBlue} ${
-            this.state.showPeople ||
-            this.state.showProjects ||
-            this.state.showTeams ||
-            this.state.showTotalProject ||
-            this.state.showTotalPeople ||
-            this.state.showTotalTeam ||
-            this.state.showAddTimeForm ||
-            this.state.showAddPersonHistory ||
-            this.state.showAddTeamHistory ||
-            this.state.showAddProjHistory
+              this.state.showPeople ||
+              this.state.showProjects ||
+              this.state.showTeams ||
+              this.state.showTotalProject ||
+              this.state.showTotalPeople ||
+              this.state.showTotalTeam ||
+              this.state.showAddTimeForm ||
+              this.state.showAddPersonHistory ||
+              this.state.showAddTeamHistory ||
+              this.state.showAddProjHistory
               ? ''
               : 'no-active-selection'
-          }`}
-        type="button">
+            }`}
+          type="button">
           <div className="container-component-category">
             <h2 className="mt-3 mb-5">
-                {/* Loading spinner at the top */}
-                {this.state.loading && (
+              {/* Loading spinner at the top */}
+              {this.state.loading && (
                 <div className="loading-spinner-top">
                   <Loading align="center" darkMode={darkMode} />
                 </div>
@@ -447,8 +447,8 @@ class ReportsPage extends Component {
                 <button
                   type="button"
                   className={`card-category-item ${
-                    this.state.showProjects ? 'selected' : ''
-                  } ${isYinmnBlue}`}
+                      this.state.showProjects ? 'selected' : ''
+                    } ${isYinmnBlue}`}
                   style={boxStyling}
                   onClick={this.showProjectTable}
                 >
@@ -457,12 +457,12 @@ class ReportsPage extends Component {
                     {this.state.projectSearchData.length}{' '}
                   </h3>
                   <img src={projectsImage} alt="Projects" />
-                </button> 
+                </button>
                 <button
                   type="button"
                   className={`card-category-item ${
-                    this.state.showPeople ? 'selected' : ''
-                  } ${isYinmnBlue}`}
+                      this.state.showPeople ? 'selected' : ''
+                    } ${isYinmnBlue}`}
                   style={boxStyling}
                   onClick={this.showPeopleTable}
                 >
@@ -475,8 +475,8 @@ class ReportsPage extends Component {
                 <button
                   type="button"
                   className={`card-category-item ${
-                    this.state.showTeams ? 'selected' : ''
-                  } ${isYinmnBlue}`}
+                      this.state.showTeams ? 'selected' : ''
+                    } ${isYinmnBlue}`}
                   style={boxStyling}
                   onClick={this.showTeamsTable}
                 >
@@ -488,7 +488,7 @@ class ReportsPage extends Component {
               <div
                 className={`mt-4 p-3 rounded-lg ${
                   darkMode ? 'bg-yinmn-blue text-light' : 'bg-white'
-                }`}
+                  }`}
                 style={darkMode ? boxStyleDark : boxStyle}
               >
                 <ReportFilter
@@ -538,14 +538,24 @@ class ReportsPage extends Component {
                       />
                     </div>
                   </div>
-                <div>
-          <div className="total-report-item">
-  <Button color="info" onClick={this.showTotalProject}>
-    {this.state.showTotalProject ? 'Hide Total Project Report' : 'Show Total Project Report'}
-  </Button>
-</div>
-</div>
-</div>
+                  <div className="total-report-item">
+                    <Button color="info" onClick={this.showTotalTeam}>
+                      {this.state.showTotalTeam
+                        ? 'Hide Total Team Report'
+                        : 'Show Total Team Report'}
+                    </Button>
+                    <div style={{ display: 'inline-block', marginLeft: 10 }}>
+                      <EditableInfoModal
+                        areaName="totalTeamReportInfoPoint"
+                        areaTitle="Total Team Report"
+                        role={userRole}
+                        fontSize={15}
+                        isPermissionPage
+                        darkMode={darkMode}
+                      />
+                    </div>
+                  </div>
+                </div>
 
                 {myRole !== 'Owner' && (
                   <div className="lost-time-container">
@@ -714,12 +724,12 @@ class ReportsPage extends Component {
             )}
             {!this.state.loading && this.state.showTotalProject && (
               <TotalProjectReport
-              startDate={this.state.startDate}
-              endDate={this.state.endDate}
-              userProfiles={userProfilesBasicInfo}
-              projects={projects}
-              darkMode={darkMode}
-            />
+                startDate={this.state.startDate}
+                endDate={this.state.endDate}
+                userProfiles={userProfilesBasicInfo}
+                projects={projects}
+                darkMode={darkMode}
+              />
             )}
             {this.state.showAddTimeForm && myRole === 'Owner' && (
               <AddLostTime

--- a/src/components/Reports/TotalReport/TotalProjectReport.jsx
+++ b/src/components/Reports/TotalReport/TotalProjectReport.jsx
@@ -6,6 +6,7 @@ import './TotalReport.css';
 import { Button } from 'reactstrap';
 import ReactTooltip from 'react-tooltip';
 import TotalReportBarGraph from './TotalReportBarGraph';
+import Loading from '../../common/Loading';
 
 function TotalProjectReport(props) {
   const { startDate, endDate, userProfiles, projects, darkMode } = props;
@@ -152,13 +153,13 @@ function TotalProjectReport(props) {
       setAllProject(filterOneHourProject(groupedProjects));
       checkPeriodForSummary();
     }
-  }, [totalProjectReportDataLoading,totalProjectReportDataReady,sumByProject, filterOneHourProject, allTimeEntries, checkPeriodForSummary]);
+  }, [totalProjectReportDataLoading, totalProjectReportDataReady, sumByProject, filterOneHourProject, allTimeEntries, checkPeriodForSummary]);
 
   const onClickTotalProjectDetail = () => setShowTotalProjectTable(prevState => !prevState);
 
   const totalProjectTable = totalProject => (
     <table className="table table-bordered table-responsive-sm">
-      <thead className={darkMode ? 'bg-space-cadet text-light' : ''} style={{pointerEvents: 'none' }}>
+      <thead className={darkMode ? 'bg-space-cadet text-light' : ''} style={{ pointerEvents: 'none' }}>
         <tr>
           <th scope="col" id="projects__order">#</th>
           <th scope="col">Project Name</th>
@@ -193,7 +194,7 @@ function TotalProjectReport(props) {
       <div className={`total-container ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}>
         <div className={`total-title ${darkMode ? 'text-azure' : ''}`}>Total Project Report</div>
         <div className="total-period">
-        In the period from {startDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })} to {endDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })}:
+          In the period from {startDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })} to {endDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })}:
         </div>
         <div className="total-item">
           <div className="total-number">{allProject.length}</div>
@@ -239,7 +240,7 @@ function TotalProjectReport(props) {
     <div>
       {!totalProjectReportDataReady ? (
         <div style={{ textAlign: 'center' }}>
-          &quot;&quot;
+          <Loading align="center" darkMode={darkMode} />
           <div
             style={{
               width: '50%',

--- a/src/components/Reports/reportsPage.css
+++ b/src/components/Reports/reportsPage.css
@@ -141,7 +141,7 @@
 .total-report-container {
   display: flex;
   flex-direction: row;
-  justify-content: flex-start;
+  justify-content: center;
   padding: 8px 0px 8px 0px;
   flex-wrap: wrap;
   gap: 1rem;

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -48,6 +48,8 @@ export const ENDPOINTS = {
     `${APIEndpoint}/TimeEntry/user/${userId}/${fromDate}/${toDate}`,
   TIME_ENTRIES_USER_LIST: `${APIEndpoint}/TimeEntry/users`,
   TIME_ENTRIES_REPORTS: `${APIEndpoint}/TimeEntry/reports`,
+  TIME_ENTRIES_REPORTS_TOTAL_PROJECT_REPORT: `${APIEndpoint}/TimeEntry/reports/projects`,
+  TIME_ENTRIES_REPORTS_TOTAL_PEOPLE_REPORT: `${APIEndpoint}/TimeEntry/reports/people`,
   TIME_ENTRIES_LOST_USER_LIST: `${APIEndpoint}/TimeEntry/lostUsers`,
   TIME_ENTRIES_LOST_PROJ_LIST: `${APIEndpoint}/TimeEntry/lostProjects`,
   TIME_ENTRIES_LOST_TEAM_LIST: `${APIEndpoint}/TimeEntry/lostTeams`,


### PR DESCRIPTION
# Description
Fix Reports>Reports>“show total project report” and “show total people report” error

## Related PRS (if any):
This frontend PR is not related to any backend PR.
…

## Main changes explained:
- Added the missing API endpoints in utils/url.js for TIME_ENTRIES_REPORTS_TOTAL_PROJECT_REPORT and TIME_ENTRIES_REPORTS_TOTAL_PEOPLE_REPORT.
- Added the missing Loading component in TotalProjectReport.jsx file
- Added the missing in ShowTotalTeamReport component in Reports.jsx file
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ Reoprts→ Reports
6. Verify that the “Show Total Project Report” and “Show Total People Report” display the correct data, including when filters are applied.
7.  Ensure that the “Show Total Project Report” button does not appear multiple times on the reports page.
8. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
Before:
<img width="1539" alt="image" src="https://github.com/user-attachments/assets/07550dc5-5948-4e28-8d96-440ab8a33a8e" />

After:
<img width="1293" alt="image" src="https://github.com/user-attachments/assets/15e0d041-c17a-4dfb-bbdb-e6f8b15c1986" />
<img width="1293" alt="image" src="https://github.com/user-attachments/assets/b055a63a-8268-414f-abd0-53e61a6ad2c8" />

Note:
The functionality of "Show Total Team Report" to be solved in another PR.
