### PR TITLE
jatin fixed invalid image issues for new created users

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -928,7 +928,7 @@ function UserProfile(props) {
             
             <div className="profile-img">
               <Image
-                src={profilePic !== undefined && profilePic!==null? profilePic : '/pfp-default.png'}
+                src={profilePic && profilePic.trim().length > 0 ? profilePic : '/pfp-default.png'}
                 alt="Profile Picture"
                 roundedCircle
                 className="profilePicture bg-white"


### PR DESCRIPTION
# Description
New users added via setup link had invalid profile image.

## Related PRS (if any):
This frontend PR is related to the [#1267](https://github.com/OneCommunityGlobal/HGNRest/pull/1267) backend PR.


## Main changes explained:
- Updated `src/components/userprofile/userprofile.jsx"


## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally

