### PR TITLE
Revert User Management table header background color

### DIFF
--- a/src/components/JobCCDashboard/JobCCDashboard.css
+++ b/src/components/JobCCDashboard/JobCCDashboard.css
@@ -52,11 +52,6 @@
   margin-top: 10px;
 }
 
-.table th {
-  background-color: #007bff;
-  color: #ffffff;
-}
-
 .dark-mode .table th {
   background-color: #0056b3;
 }


### PR DESCRIPTION
# Description
PR #2924 introduced a CSS change that altered the User Management table header background color to dark blue with white text. This PR reverts it back to the original light background with black text for better readability and consistency with the design.

## Related PRS (if any):
This PR reverts the unintended style change from PR #2924.

## Main changes explained:
- Reverted .table th styles in JobCCDashboard.css to restore the original background and text color.
- Ensured consistency in the User Management table header appearance.

## How to test:
1. log in as an admin user.
2. Go to User Management.
3. Verify that the table headers are no longer dark blue with white text but have a light background with black text instead.

## Screenshots or videos of changes:
Before:
<img width="901" alt="image" src="https://github.com/user-attachments/assets/11a3e3a4-174c-4fa0-a146-af640b887a87" />
After:
<img width="902" alt="image" src="https://github.com/user-attachments/assets/c1a61058-61ba-464b-aaf9-97ee45d5130c" />

