### PR TITLE
jatin fixed blue color tables issues

### DIFF
--- a/src/components/JobCCDashboard/JobCCDashboard.css
+++ b/src/components/JobCCDashboard/JobCCDashboard.css
@@ -3,7 +3,7 @@
   font-family: 'Arial', sans-serif;
 }
 
-.dark-mode {
+.dark-mode-job-cc-dashboard {
   background-color: #2c2f33;
   color: #ffffff;
 }
@@ -22,7 +22,7 @@
   margin-bottom: 30px;
 }
 
-.dark-mode .form-container {
+.dark-mode-job-cc-dashboard .form-container {
   background-color: #3c3f44;
   color: #ffffff;
 }
@@ -44,27 +44,27 @@
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
 }
 
-.dark-mode .cc-list-container {
+.dark-mode-job-cc-dashboard .cc-list-container {
   background-color: #3c3f44;
 }
 
-.table {
+.job-cc-dashboard-table {
   margin-top: 10px;
 }
 
-.table th {
+.job-cc-dashboard-table th {
   background-color: #007bff;
   color: #ffffff;
 }
 
-.dark-mode .table th {
+.dark-mode-job-cc-dashboard .job-cc-dashboard-table th {
   background-color: #0056b3;
 }
 
-.table td {
+.job-cc-dashboard-table td {
   vertical-align: middle;
 }
 
-.table button {
+.job-cc-dashboard-table button {
   font-size: 0.85rem;
 }

--- a/src/components/JobCCDashboard/JobCCDashboard.jsx
+++ b/src/components/JobCCDashboard/JobCCDashboard.jsx
@@ -79,7 +79,7 @@ function JobCCDashboard({ darkMode }) {
   };
 
   return (
-    <div className={`job-cc-dashboard ${darkMode ? 'dark-mode' : ''}`}>
+    <div className={`job-cc-dashboard ${darkMode ? 'dark-mode-job-cc-dashboard' : ''}`}>
       <h1 className="dashboard-title">Job CC Dashboard</h1>
       <div className="filters-container">
         <FormGroup>
@@ -113,7 +113,7 @@ function JobCCDashboard({ darkMode }) {
         </div>
       </div>
 
-      <Table striped bordered hover>
+      <Table striped bordered hover className="job-cc-dashboard-table">
         <thead>
           <tr>
             <th>Job Title</th>


### PR DESCRIPTION
# Description
All over the HGN App the tables had turned blue. This PR is a hotfix for that

## Related PRS (if any):
This frontend PR is related to the development backend PR.

## Main changes explained:
- Updated `JobCCDashboard.jsx, JobCCDashboard.css`

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
