### PR TITLE
Manoj Add edit ability and limit link type #2

### DIFF
--- a/src/components/TeamMemberTasks/ReviewButton.jsx
+++ b/src/components/TeamMemberTasks/ReviewButton.jsx
@@ -425,19 +425,34 @@ const ReviewButton = ({ user, task, updateTask }) => {
         );
       } else if (user.personId === myUserId) {
         return (
-          <div className="d-flex">
-            <Button className="reviewBtn mr-2" color="info" disabled>
-              Work Submitted and Awaiting Review
-            </Button>
-            <Button
-              className="edit-link-btn"
-              color="secondary"
-              onClick={toggleEditLinkModal}
-              title="Edit submitted link"
+          <UncontrolledDropdown>
+            <DropdownToggle
+              className="btn--dark-sea-green reviewBtn"
+              caret
+              style={darkMode ? boxStyleDark : boxStyle}
             >
-              <FontAwesomeIcon icon={faPencilAlt} />
-            </Button>
-          </div>
+              Work Submitted and Awaiting Review
+            </DropdownToggle>
+            <DropdownMenu className={darkMode ? 'bg-space-cadet' : ''}>
+              {task.relatedWorkLinks &&
+                task.relatedWorkLinks.map((link, index) => (
+                  <DropdownItem
+                    key={index}
+                    href={link}
+                    target="_blank"
+                    className={darkMode ? 'text-light dark-mode-btn' : ''}
+                  >
+                    View Link
+                  </DropdownItem>
+                ))}
+              <DropdownItem
+                onClick={toggleEditLinkModal}
+                className={darkMode ? 'text-light dark-mode-btn' : ''}
+              >
+                <FontAwesomeIcon icon={faPencilAlt} /> Edit Link
+              </DropdownItem>
+            </DropdownMenu>
+          </UncontrolledDropdown>
         );
       } else {
         return (

--- a/src/components/TeamMemberTasks/ReviewButton.jsx
+++ b/src/components/TeamMemberTasks/ReviewButton.jsx
@@ -396,6 +396,12 @@ const ReviewButton = ({ user, task, updateTask }) => {
                   </DropdownItem>
                 ))}
               <DropdownItem
+                onClick={toggleEditLinkModal}
+                className={darkMode ? 'text-light dark-mode-btn' : ''}
+              >
+                <FontAwesomeIcon icon={faPencilAlt} /> Edit Link
+              </DropdownItem>
+              <DropdownItem
                 onClick={() => {
                   setSelectedAction('Complete and Remove');
                   toggleVerify();

--- a/src/components/TeamMemberTasks/ReviewButton.jsx
+++ b/src/components/TeamMemberTasks/ReviewButton.jsx
@@ -18,7 +18,7 @@ import './reviewButton.css';
 import { boxStyle, boxStyleDark } from 'styles';
 import '../Header/DarkMode.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCheck, faPencilAlt } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faPencilAlt, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import httpService from '../../services/httpService';
 import { ApiEndpoint } from 'utils/URL';
 import hasPermission from 'utils/permissions';
@@ -392,7 +392,7 @@ const ReviewButton = ({ user, task, updateTask }) => {
                     target="_blank"
                     className={darkMode ? 'text-light dark-mode-btn' : ''}
                   >
-                    View Link
+                    <FontAwesomeIcon icon={faExternalLinkAlt} /> View Link
                   </DropdownItem>
                 ))}
               <DropdownItem
@@ -442,7 +442,7 @@ const ReviewButton = ({ user, task, updateTask }) => {
                     target="_blank"
                     className={darkMode ? 'text-light dark-mode-btn' : ''}
                   >
-                    View Link
+                    <FontAwesomeIcon icon={faExternalLinkAlt} /> View Link
                   </DropdownItem>
                 ))}
               <DropdownItem

--- a/src/components/TeamMemberTasks/reviewButton.css
+++ b/src/components/TeamMemberTasks/reviewButton.css
@@ -16,6 +16,14 @@
   background-color: #2f4157 !important;
 }
 
+.edit-link-btn {
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.25rem;
+  margin-left: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 
 @media screen and (max-width: 1307px) and (min-width: 1152px) {
   .reviewBtn {
@@ -24,6 +32,10 @@
   }
   .dropdown-menu{
     max-height: 200px;
+  }
+  .edit-link-btn {
+    padding: 5px !important;
+    font-size: 0.75rem !important;
   }
 }
 
@@ -36,6 +48,10 @@
     max-height: 150px;
     width: 100%
   }
+  .edit-link-btn {
+    padding: 2px !important;
+    font-size: 0.75rem !important;
+  }
 }
 @media screen and (max-width: 991px) {
   .reviewBtn {
@@ -47,6 +63,10 @@
     max-height: 150px;
     width: 100%
   }
+  .edit-link-btn {
+    padding: 2px !important;
+    font-size: 0.75rem !important;
+  }
 }
 
 @media screen and (max-width: 480px) {
@@ -57,5 +77,9 @@
   .dropdown-menu{
     max-height: 120px;
     width: 100%
+  }
+  .edit-link-btn {
+    padding: 2px !important;
+    font-size: 0.65rem !important;
   }
 }


### PR DESCRIPTION
# Description
Added View Link and Edit buttons on both the task Assignee and Reviewer Dashboard
![image](https://github.com/user-attachments/assets/6e53d8a9-0824-4a76-8053-8d0d5878e3d7)

## Related PRS (if any):
This is continuation of the Link Limit PR https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3251
The same limit link check is applied when editing links.

## Main changes explained:
- Changed the disabled "Work Submitted and Awaiting Review"  button which appears when the user submits their task with a link. I changed to a dropdown menu with the edit and view link buttons
- On the reviewer side added two options in the existing "Ready for Review" Dropdown. - View and Edit Link

 ## How to test:
1. check into current branch
2. do npm install and npm run start:local to run this PR locally
3. Clear site data/cache
4. Follow this video for adding task to a user https://www.loom.com/share/8bc672c323b64955aac4bce46c3794aa?sid=8eb46081-a3a0-46c5-91e1-cc38c034c0c2
5. After the task has be assigned to user, login to two accounts: both the reviewer ( a manager account) and the task assignee account. (Use two browser instances)
6. Submit the task with a link
7. Test the buttons to view and edit on both instances. (Might have to reload the other browser to get the reflected changes)
8. Veirfy the buttons function as intended

## Screenshots or videos of changes:
![Screenshot from 2025-03-18 21-55-32](https://github.com/user-attachments/assets/c9e9d19b-aa22-4643-8252-fafd6a1d67ee)
![Screenshot from 2025-03-18 21-56-12](https://github.com/user-attachments/assets/6df9e357-e7a4-470a-ad16-665963d457ce)


