### PR TITLE
Zhifan hotfix import syntax in weeklySummaryRecipientsReducer.test.js

### DIFF
--- a/src/reducers/__tests__/weeklySummaryRecipientsReducer.test.js
+++ b/src/reducers/__tests__/weeklySummaryRecipientsReducer.test.js
@@ -1,5 +1,5 @@
 import * as actions from '../../constants/weeklySummariesReport';
-import { weeklySummaryRecipientsReducer } from '../weeklySummaryRecipientsReducer';
+import weeklySummaryRecipientsReducer from '../weeklySummaryRecipientsReducer';
 
 describe('weeklySummaryRecipientsReducer', () => {
   const initialState = {


### PR DESCRIPTION
# Description
There’s an import syntax issue that caused all new pushes to the frontend repo to fail the “Pull Request Unit Test / test (pull_request).”


## Related PRS (if any):
This frontend PR is not related to backend PR.

…

## Main changes explained:
- modified import syntax 
…

## How to test:


## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
