### PR TITLE
Calvin-Fix-Auto-Save

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
@@ -4,8 +4,9 @@ import hasPermission from '../../../utils/permissions';
 import { deleteTitleById } from 'actions/title';
 import { useSelector } from 'react-redux';
 import '../../Header/DarkMode.css';
+import { toast } from "react-toastify";
 
-function AssignSetUpModal({ isOpen, setIsOpen, title, userProfile, setUserProfile, setTitleOnSet, refreshModalTitles}) {
+function AssignSetUpModal({ isOpen, setIsOpen, title, userProfile, setUserProfile, setTitleOnSet, refreshModalTitles, updateUserProfile}) {
   const darkMode = useSelector(state => state.theme.darkMode)
   const [validation, setValid] = useState({
     volunteerAgree: false,
@@ -25,7 +26,7 @@ function AssignSetUpModal({ isOpen, setIsOpen, title, userProfile, setUserProfil
       : setValid(prev => ({ ...prev, volunteerAgree: true }));
   };
 
-  const setAssignedOnClick = () => {
+  const setAssignedOnClick = async () => {
     const googleDocRegex = /^https:\/\/docs\.google\.com\/document\/d\/.+$/;
 
     if (!googleDocRegex.test(googleDoc)) {
@@ -83,6 +84,11 @@ function AssignSetUpModal({ isOpen, setIsOpen, title, userProfile, setUserProfil
       setTitleOnSet(false);
       setValid(() => ({ volunteerAgree: false }));
       setIsOpen(false);
+
+      const SUCCESS_MESSAGE =
+        "Success! Google Doc, Team Code, Project Assignment," +
+        "and Media Folder details are now updated for this individual.";
+      toast.success(SUCCESS_MESSAGE, { autoClose: 10000 }); 
     }
   };
 

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -126,6 +126,7 @@ function UserProfile(props) {
   const [pendingRehireableStatus, setPendingRehireableStatus] = useState(null);
   const [isRehireable, setIsRehireable] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [didLinkUpdate, setDidLinkUpdate] = useState(false);
   // Function to toggle the modal
   const toggleModal = () => setIsModalOpen(!isModalOpen);
   const [isRemoveModalOpen, setIsRemoveModalOpen] = useState(false);
@@ -1013,6 +1014,7 @@ function UserProfile(props) {
           </div>
           
           <div className='right-column'>
+            {/*}
             {!isProfileEqual ||
               !isTasksEqual ||
               !isProjectsEqual ? (
@@ -1020,6 +1022,7 @@ function UserProfile(props) {
                 Please click on &quot;Save changes&quot; to save the changes you have made.{' '}
               </Alert>
             ) : null}
+             */}
             {!codeValid ? (
               <Alert color="danger">
                 NOT SAVED! The code must be between 5 and 7 characters long

--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -167,6 +167,24 @@ const EditLinkModal = props => {
     isDifferentMediaUrl();
   }, [mediaFolderLink.Link, userProfile.mediaUrl]);
 
+  useEffect(() => {
+    if (userProfile.adminLinks) {
+      setGoogleLink(
+        userProfile.adminLinks.find(link => link.Name === 'Google Doc')
+        || initialAdminLinkState[0],
+      );
+      setMediaFolderLink(
+        userProfile.adminLinks.find(link => link.Name === 'Media Folder')
+        || initialAdminLinkState[1],
+      );
+      setAdminLinks(
+        userProfile.adminLinks
+          .filter(link => link.Name !== 'Google Doc')
+          .filter(link => link.Name !== 'Media Folder'),
+      );
+    }
+  }, [userProfile.adminLinks]);
+
   return (
     <React.Fragment>
       <Modal isOpen={isOpen} toggle={closeModal} className={darkMode ? 'text-light dark-mode' : ''}>


### PR DESCRIPTION
# Description
This PR allows admin users to update Google Doc links in user profiles seamlessly, ensuring that changes are reflected immediately in the "Google Doc" and "Links Edit" sections without requiring a separate Save Changes step. Additionally, after clicking "Yes", no extra notification prompting to save changes will appear.

## Related PRS (if any):
No related PRs

## Main changes explained:

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ View Profiles
6. Click on any existing title -> Fill out the form with a valid Google Doc link -> Click "Yes" -> A green success pop-up notification will appear in the top right corner.
7. Confirm that the Google Doc link has been successfully updated in both the "Google Doc" section on the left and the "Links Edit" section.

<img width="804" alt="Screenshot" src="https://github.com/user-attachments/assets/e2b613cb-1926-4427-9375-4a365799af06" />

https://github.com/user-attachments/assets/83a350c4-59d1-4754-a96e-a6660d1075e7


## Note:
Include the information the reviewers need to know.
