### PR TITLE
Rohith | Fix Hours UI responsiveness for mid-sized screens

### DIFF
--- a/src/components/SummaryBar/SummaryBar.css
+++ b/src/components/SummaryBar/SummaryBar.css
@@ -168,6 +168,13 @@
   filter: alpha(opacity=40); /* msie */
 }
 
+/* Custom media query for screen widths between 1200px and 1330px */
+@media (min-width: 1200px) and (max-width: 1330px) {
+  .med_text_summary {
+    font-size: 0.8rem;
+  }
+}
+
 /* XLarge devices (landscape phones, 544px and down) */
 @media (max-width: 1200px) {
   .med_text_summary {


### PR DESCRIPTION
# Description
This PR fixes a layout and readability issue in the Hours UI section for screen widths between 1200px and 1330px.
Previously, a media query reduced the font size to 0.75rem at 1200px, which caused the text to appear too small on mid-sized displays and led to container stretching.
A new media query is added to adjust .med_text_summary font-size to 0.8rem within that range, improving the overall visual balance.


## Related PRS (if any):
None
…

## Main changes explained:
- Update SummaryBar CSS file to introduce a new media query
- Update .med_text_summary font-size to 1rem between 1200px and 1330px
- Preserve default behavior below 1200px and above 1330px…

## How to test:
1. git checkout Rohith_fix_hours_ui_responsive
2. npm install
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ current week hours
6. Verify: 
- The font size looks appropriate
- The container does not stretch
- Layout remains consistent in [dark mode]

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/f3ac22b4-49a5-4fca-a071-224bea7f6fed)


