### PR TITLE
Honglin - Fix icon notification bubbles when numbers are 4-digits 

### DIFF
--- a/src/components/SummaryBar/SummaryBar.css
+++ b/src/components/SummaryBar/SummaryBar.css
@@ -84,7 +84,6 @@
   border-radius: 40px;
   color: #fff;
   padding: 3px 6px;
-  max-width: 39px;
   font-size: 1rem;
   min-width: 29px;
 }

--- a/src/components/UserProfile/AssignBadgePopup.jsx
+++ b/src/components/UserProfile/AssignBadgePopup.jsx
@@ -68,7 +68,9 @@ function AssignBadgePopup(props) {
 
   const addExistBadges = () => {
     if (props.userProfile && props.userProfile.badgeCollection) {
-      const existBadges = props.userProfile.badgeCollection.map(badge => `assign-badge-${badge.badge._id}`);
+      const existBadges = props.userProfile.badgeCollection
+        .filter(b => b.badge !== null)
+        .map(b => `assign-badge-${b.badge._id}`);
       return existBadges;
     }
     return [];


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/173e502d-bf75-4b3e-a39b-98cea9c67e00)

## Related PRS (if any):
To test this backend PR you need to checkout the development frontend

## Main changes explained:
- Fixed icon bubble 4-digit issue

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to MongoDB Compass, connect to the database and change the badgeCollection number (see video below)
6. verify that the four digit number won't exceed the red bubble anymore

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/062bc11b-a00f-463c-8cc6-26b2e3aac633



## Note:
- How to setup MongoDB: https://docs.google.com/document/d/1wI4vCaELQN-qogAqybqdxIMJ3Ah1SZpOyALeS2M2bBM/edit?tab=t.0
- Query example: { firstName: "your_account_first_name" }