### PR TITLE
Anjali - Tab title to display user name

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -220,6 +220,12 @@ function UserProfile(props) {
     loadUserTasks();
   }, [props?.match?.params?.userId]);
 
+  useEffect(() => {
+    if (userProfile?.firstName && userProfile?.lastName) {
+      document.title = `${userProfile.firstName} ${userProfile.lastName}`;
+    }
+  }, [userProfile]);  
+
   const checkIsProjectsEqual = () => {
     const originalProjectProperties = [];
     originalProjects?.forEach(project => {

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -221,10 +221,12 @@ function UserProfile(props) {
   }, [props?.match?.params?.userId]);
 
   useEffect(() => {
-    if (userProfile?.firstName && userProfile?.lastName) {
-      document.title = `${userProfile.firstName} ${userProfile.lastName}`;
+    if (userProfile?.firstName || userProfile?.lastName) {
+      document.title = `${userProfile.firstName ?? ''} ${userProfile.lastName ?? ''}`.trim();
+    } else {
+      document.title = 'User';
     }
-  }, [userProfile]);  
+  }, [userProfile]);    
 
   const checkIsProjectsEqual = () => {
     const originalProjectProperties = [];


### PR DESCRIPTION
# Description
This PR addresses a bug where the browser tab title fails to reflect the correct user's name when navigating between profiles from the User Management page. 

## Main changes explained:
- Implemented a useEffect hook to update the document.title whenever the userProfile object changes.
- Ensured the tab title reflects the full name (firstName + lastName) of the user being viewed.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ select a user from the list
6. verify that the persons name appears on the tab once opened on a new tab

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/2cac5415-6302-4190-b38f-28d698173e97


