### PR TITLE
Koushica - Hotfix - Auto saving the links in the QST

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
@@ -77,6 +77,7 @@ function AssignSetUpModal({ isOpen, setIsOpen, title, userProfile, setUserProfil
       if (userProfile.teams.includes(title?.teamAssiged)) data.teams.pop();
       if (userProfile.projects.includes(title.projectAssigned)) data.projects.pop();
 
+      const result = await updateUserProfile({...userProfile,...data});
       if (hasPermission("manageAdminLinks")) {
         setUserProfile(prev => ({ ...prev, ...data }));
       }

--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
@@ -145,6 +145,7 @@ function QuickSetupModal(props) {
           setShowMessage={setShowMessage}
           editMode={editMode}
           title={curtitle}
+          QSTTeamCodes={QSTTeamCodes}
         />
       ) : (
         ''
@@ -162,6 +163,7 @@ function QuickSetupModal(props) {
           title={curtitle}
           setTitleOnSet={props.setTitleOnSet}
           refreshModalTitles={refreshModalTitles}
+          updateUserProfile={props.updateUserProfile}
         />
       ) : (
         ''

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -1012,6 +1012,7 @@ function UserProfile(props) {
               projectsData={props?.allProjects?.projects || []}
               titleOnSet={titleOnSet}
               setTitleOnSet={setTitleOnSet}
+              updateUserProfile={props.updateUserProfile}
             />
 
           </div>
@@ -1413,6 +1414,7 @@ function UserProfile(props) {
                       !formValid.lastName ||
                       !formValid.email ||
                       !codeValid ||
+                      (userStartDate > userEndDate && userEndDate !== '') ||
                       titleOnSet ||
                       (isProfileEqual && isTasksEqual && isProjectsEqual)
                     }


### PR DESCRIPTION
# Description
1. Deactivated the "Save Changes" button while adding media links.
2. Ensured Google Doc and Media Folder remain visible after a page refresh (saved properly in the backend).

## Related PRS (if any):
Use the development backend and my current branch for the frontend.

## Main changes explained:
- Admin links are now saved in the backend instead of just updating the frontend.

## How to test:
1. check into current branch
3. do `npm install` and `...` to run this PR locally
4. Clear site data/cache
5. log as admin user
6. go to dashboard→ View Profiles
7. Click on any existing title -> Fill out the form with a valid Google Doc link -> Click "Yes"
8. Verify the following after clicking "Yes":
  - A green success message appears without any extra blank space.
  - The "Save Changes" button at the top-right becomes disabled.
  - The Google Doc and Media Folder fields remain visible and persist after refreshing the page.
