### PR TITLE
Deepthi hotfix leaderboard header screen size optimization

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.css
+++ b/src/components/LeaderBoard/Leaderboard.css
@@ -41,57 +41,6 @@
   background-color: #f0f8ff;
 }
 
-@media screen and (max-width: 768px) {
-  .leaderboard thead th {
-    font-size: 0.75rem;
-    white-space: nowrap;
-    line-height: 1.2;
-    text-overflow: ellipsis; /* Add ellipsis for overflow */
-    overflow: hidden;
-    max-height: 2.4em;
-  }
-
-  .leaderboard thead th[data-abbr]::before {
-    content: attr(data-abbr); /* Display the abbreviated version */
-    font-weight: bold;
-  }
-
-  .leaderboard thead th[data-abbr] span {
-    display: none;
-  }
-
-  .leaderboard thead th[data-abbr='Name'] {
-    width: auto !important;
-    min-width: 120px;
-    text-align: left;
-  }
-
-  .leaderboard thead th[data-abbr='Name'] > div {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 6px; /* Adds space between "Name" and the icon */
-    width: 100%;
-    white-space: nowrap;
-  }
-
-  .leaderboard thead th[data-abbr='Name']::before {
-    content: none;
-  }
-
-  .leaderboard thead th[data-abbr='Name'] span {
-    flex-grow: 0; /* Pushes the icon to the right */
-    display: inline-block;
-    white-space: nowrap;
-  }
-
-  .leaderboard thead th[data-abbr='Name'] .p-2 {
-    margin-left: 0; /* Moves "i" icon to the right */
-    display: flex;
-    align-items: center;
-    white-space: nowrap;
-  }
-}
 
 /* Small devices (landscape phones, 544px and up) */
 @media (max-width: 544px) {
@@ -153,3 +102,17 @@
     font-size: 0.75rem !important;
   }
 }
+
+
+.leaderboard.abbreviated-mode thead th {
+  font-size: 0.75rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+  min-width: 70px;
+  padding: 0.5rem 0.3rem;
+  vertical-align: middle;
+}
+
+

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -103,6 +103,7 @@ function LeaderBoard({
   const [userRole, setUserRole] = useState();
   const [teamsUsers, setTeamsUsers] = useState([]);
   const [innerWidth, setInnerWidth] = useState();
+  const [isAbbreviatedView, setIsAbbreviatedView] = useState(false);
 
   const [isDisplayAlert, setIsDisplayAlert] = useState(false);
   const [stateOrganizationData, setStateOrganizationData] = useState(organizationData);
@@ -146,6 +147,18 @@ function LeaderBoard({
   useEffect(() => {
     setInnerWidth(window.innerWidth);
   }, [window.innerWidth]);
+
+  useEffect(() => {
+    const checkAbbreviatedView = () => {
+      const isAbbrev = window.innerWidth < 1024;
+      setIsAbbreviatedView(isAbbrev);
+    };
+
+    checkAbbreviatedView(); // run on mount
+    window.addEventListener('resize', checkAbbreviatedView);
+
+    return () => window.removeEventListener('resize', checkAbbreviatedView);
+  }, []);
 
   const updateOrganizationData = (usersTaks, contUsers) => {
     // prettier-ignore
@@ -540,16 +553,16 @@ function LeaderBoard({
             <Table
               className={`leaderboard table-fixed ${
                 darkMode ? 'text-light dark-mode bg-yinmn-blue' : ''
-              }`}
+              } ${isAbbreviatedView ? 'abbreviated-mode' : ''}`}
             >
               <thead className="responsive-font-size">
                 <tr className={darkMode ? 'bg-space-cadet' : ''} style={darkModeStyle}>
-                  <th data-abbr="Stat." style={darkModeStyle}>
-                    <span>Status</span>
+                  <th style={darkModeStyle}>
+                    <span>{isAbbreviatedView ? 'Stat.' : 'Status'}</span>
                   </th>
-                  <th data-abbr="Name" style={darkModeStyle}>
+                  <th style={darkModeStyle}>
                     <div className="d-flex align-items-center">
-                      <span>Name</span>
+                      <span>{isAbbreviatedView ? 'Name' : 'Name'}</span>
                       <EditableInfoModal
                         areaName="Leaderboard"
                         areaTitle="Team Members Navigation"
@@ -561,20 +574,19 @@ function LeaderBoard({
                       />
                     </div>
                   </th>
-                  <th data-abbr="Days Lft." style={darkModeStyle}>
-                    <span>Days Left</span>
+                  <th style={darkModeStyle}>
+                    <span>{isAbbreviatedView ? 'Days Lft.' : 'Days Left'}</span>
                   </th>
-                  <th data-abbr="Time Off" style={darkModeStyle}>
-                    <span>Time Off</span>
+                  <th style={darkModeStyle}>
+                    <span>{isAbbreviatedView ? 'Time Off' : 'Time Off'}</span>
                   </th>
-                  <th data-abbr="Tan. Time" style={darkModeStyle}>
-                    <span>Tangible Time</span>
+                  <th style={darkModeStyle}>
+                    <span>{isAbbreviatedView ? 'Tan. Time' : 'Tangible Time'}</span>
                   </th>
-                  <th data-abbr="Prog." style={darkModeStyle}>
-                    <span>Progress</span>
+                  <th style={darkModeStyle}>
+                    <span>{isAbbreviatedView ? 'Prog.' : 'Progress'}</span>
                   </th>
                   <th
-                    data-abbr="Tot. Time"
                     style={
                       darkMode
                         ? { backgroundColor: '#3a506b', color: 'white', textAlign: 'right' }
@@ -583,7 +595,7 @@ function LeaderBoard({
                   >
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                       <div style={{ textAlign: 'left' }}>
-                        <span>Total Time</span>
+                        <span>{isAbbreviatedView ? 'Tot. Time' : 'Total Time'}</span>
                       </div>
                       {isOwner && (
                         <MouseoverTextTotalTimeEditButton onUpdate={handleMouseoverTextUpdate} />


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/7f685123-7e43-4a83-95c1-6b0055b75783)
https://www.loom.com/share/d20ba2b7fc564c769272cc970c598bfe?sid=bb7ab895-b596-451f-a022-0c23ed496f15
…

## Related PRS (if any):
This frontend PR is related to the #3018 PR.
…

## Main changes explained:
- LeaderBoard.jsx: Added responsive abbreviation logic and dynamic class toggle for headers based on screen width.
- LeaderBoard.css: Added .abbreviated-mode styles to prevent header wrapping and maintain alignment on smaller screens.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user/ owner user
5. go to dashboard→ leaderboard
6. verify the headers are displayed in abbreviations, and numbers under each time column stay on a single line without wrapping at half screen size and below.

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/e0092a98-5f77-4953-a5d2-db2b4628b239)

