### PR TITLE
Aaryaneil - Updated allTimeEntriesReducer Unit Tests

### DIFF
--- a/src/reducers/__tests__/allTimeEntriesReducer.test.js
+++ b/src/reducers/__tests__/allTimeEntriesReducer.test.js
@@ -1,0 +1,36 @@
+import allTimeEntriesReducer from '../allTimeEntriesReducer'; // Adjust the path as necessary
+
+describe('allTimeEntriesReducer', () => {
+  // Test 1: Should return the initial state when no action is passed
+  it('should return the initial state when no action is passed', () => {
+    const initialState = null;
+    const action = {}; // No action provided
+
+    const result = allTimeEntriesReducer(initialState, action);
+    expect(result).toBeNull(); // Expect the state to be null, which is the initial state
+  });
+
+  // Test 2: Should handle GET_ALL_TIME_ENTRIES action and return the payload
+  it('should handle GET_ALL_TIME_ENTRIES action and return payload', () => {
+    const initialState = null; // Initial state is null
+    const action = {
+      type: 'GET_ALL_TIME_ENTRIES',
+      payload: [{ id: 1, entry: 'Sample entry' }] // Action payload
+    };
+
+    const result = allTimeEntriesReducer(initialState, action);
+    expect(result).toEqual(action.payload); // Expect the state to match the action's payload
+  });
+
+  // Test 3: Should return the previous state when an unknown action is passed
+  it('should return the previous state when an unknown action is passed', () => {
+    const initialState = [{ id: 1, entry: 'Sample entry' }]; // Initial state with some data
+    const action = {
+      type: 'UNKNOWN_ACTION', // An unknown action
+      payload: [{ id: 2, entry: 'Another entry' }] // Payload won't matter for unknown actions
+    };
+
+    const result = allTimeEntriesReducer(initialState, action);
+    expect(result).toEqual(initialState); // Expect the state to remain the same as the previous state
+  });
+});


### PR DESCRIPTION
# Description
Unit test for `src/reducers/allTimeEntriesReducer.js`, updated from previous PR (#2972 ) to fix merge conflicts.


## Main changes explained:
Added test cases for the following:
1. should return the initial state when no action is passed
2. should handle GET_ALL_TIME_ENTRIES action and return payload
3. should return the previous state when an unknown action is passed


## How to test:
1. check into current branch
2. do `npm install` and `npm test allTimeEntriesReducer.test.js` to run this PR locally


## Related PRs:
 PR #2972 


## Screenshots or videos of changes:
<img width="1291" alt="Screenshot 2024-12-21 at 6 04 19 AM" src="https://github.com/user-attachments/assets/f8dc6b83-8cdd-4ad3-8c8d-163dd3e08035" />
