### PR TITLE
Newell - Fix timer service not working in migrated URL

### DIFF
--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -127,7 +127,7 @@ export const ENDPOINTS = {
   REJECT_TASK_EDIT_SUGGESTION: taskEditSuggestionId =>
     `${APIEndpoint}/taskeditsuggestion/${taskEditSuggestionId}`,
 
-  TIMER_SERVICE: `${APIEndpoint.replace('http', 'ws').replace('api', 'timer-service')}`,
+  TIMER_SERVICE: new URL('/timer-service', APIEndpoint.replace('http', 'ws')).toString(),
   TIMEZONE_LOCATION: location => `${APIEndpoint}/timezone/${location}`,
 
   ROLES: () => `${APIEndpoint}/roles`,


### PR DESCRIPTION
# Description
Timer service not working in migrated endpoint.

## Related PRS (if any):
N/A

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ task→…
6. verify if timer works

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
