### PR TITLE
Koushica - Hotfix - userProfile QST auto save

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
@@ -80,7 +80,7 @@ function AssignSetUpModal({ isOpen, setIsOpen, title, userProfile, setUserProfil
       if (hasPermission("manageAdminLinks")) {
         setUserProfile(prev => ({ ...prev, ...data }));
       }
-      const result = await handleSubmit();
+      const result = await handleSubmit(Object.assign({},userProfile,data));
 
       setTitleOnSet(true); 
       setValid(() => ({ volunteerAgree: false }));

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -638,14 +638,15 @@ function UserProfile(props) {
     }
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (updatedUserProfile) => {
     for (let i = 0; i < updatedTasks.length; i += 1) {
       const updatedTask = updatedTasks[i];
       const url = ENDPOINTS.TASK_UPDATE(updatedTask.taskId);
       axios.put(url, updatedTask.updatedTask).catch(err => console.log(err));
     }
     try {
-      const result = await props.updateUserProfile(userProfileRef.current);
+      const userProfileToUpdate = updatedUserProfile || userProfileRef.current;
+      const result = await props.updateUserProfile(userProfileToUpdate);
       if (userProfile._id === props.auth.user.userid && props.auth.user.role !== userProfile.role) {
         await props.refreshToken(userProfile._id);
       }


### PR DESCRIPTION
# Description
Fix: Auto-saving for Links: Fixed issue where adding links in the User Profile was not saving properly.

## Related PRS (if any):
Use the development backend and my current branch for the frontend.

## Main changes explained:
- Fixed auto-save issues by updating the userProfile object using deep cloning.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Leaderboard
6. Test Case: Click on a QST, add a link, and save. Check if the links are saved.

## Screenshots or videos of changes:
