### PR TITLE
Rohith | Fix dropdown options visibility in Weekly Summaries report

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -859,7 +859,7 @@ export class WeeklySummariesReport extends Component {
                 const [code, count] = item.label.split(' (');
                 return {
                   ...item,
-                  label: `${code.padEnd(10," ")} (${count}`, // count already has closing parenthesis
+                  label: `${code.padEnd(10, ' ')} (${count}`, // count already has closing parenthesis
                 };
               })}
               value={selectedCodes}

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -855,7 +855,14 @@ export class WeeklySummariesReport extends Component {
           <Col lg={{ size: 5, offset: 1 }} md={{ size: 6 }} xs={{ size: 6 }}>
             <MultiSelect
               className={cn(styles.multiSelectFilter, `text-dark ${darkMode ? 'dark-mode' : ''}`)}
-              options={teamCodes}
+              options={teamCodes.map(item => {
+                const [code, count] = item.label.split(' (');
+                return {
+                  ...item,
+                  label: `${code.padEnd(10," ")} (${count}`, // count already has closing parenthesis
+                };
+              })}
+            
               value={selectedCodes}
               onChange={e => {
                 this.handleSelectCodeChange(e);

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -862,7 +862,6 @@ export class WeeklySummariesReport extends Component {
                   label: `${code.padEnd(10," ")} (${count}`, // count already has closing parenthesis
                 };
               })}
-            
               value={selectedCodes}
               onChange={e => {
                 this.handleSelectCodeChange(e);

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.module.scss
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.module.scss
@@ -118,7 +118,7 @@
 }
 
 .multiSelectFilter :global(.options) {
-  max-height: 570px;
+  max-height: 600px;
   overflow-y: auto;
   font-family: 'Courier New', Courier, monospace;
 
@@ -132,4 +132,11 @@
     background: rgb(206, 212, 218);
     border-radius: 8px;
   }
+}
+
+.multiSelectFilter :global(.select-item) {
+  font-family: 'Courier New', Courier, monospace;
+  padding: 2px 8px;
+  line-height: 1.2;
+  font-size: 14px;
 }

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.module.scss
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.module.scss
@@ -139,4 +139,5 @@
   padding: 2px 8px;
   line-height: 1.2;
   font-size: 14px;
+  white-space: pre;
 }

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.module.scss
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.module.scss
@@ -117,21 +117,19 @@
   padding: 8px;
 }
 
-.multiSelectFilter {
-  .options {
-    max-height: 570px;
-    overflow-y: auto;
-    font-family: 'Courier New', Courier, monospace;
+.multiSelectFilter :global(.options) {
+  max-height: 570px;
+  overflow-y: auto;
+  font-family: 'Courier New', Courier, monospace;
 
-    &::-webkit-scrollbar {
-      width: 5px;
-    }
-    &::-webkit-scrollbar-track {
-      background: rgb(0, 0, 0);
-    }
-    &::-webkit-scrollbar-thumb {
-      background: rgb(206, 212, 218);
-      border-radius: 8px;
-    }
+  &::-webkit-scrollbar {
+    width: 5px;
+  }
+  &::-webkit-scrollbar-track {
+    background: rgb(0, 0, 0);
+  }
+  &::-webkit-scrollbar-thumb {
+    background: rgb(206, 212, 218);
+    border-radius: 8px;
   }
 }


### PR DESCRIPTION
# Description
This PR resolves an issue in the Weekly Summaries Report screen where the dropdown component (used to select team codes and colors) was only showing 4 options. The issue was introduced after the styling was migrated to SCSS modules. The original .options class was no longer applying due to CSS scoping in modules, which limited the dropdown height and visibility. A fix was implemented by using the :global selector inside the .multiSelectFilter class to properly target the .options dropdown container.

Fixes # (bug list priority medium 2.4.3)

## Related PRS (if any):
None
…

## Main changes explained:
- Updated WeeklySummariesReport.module.scss to apply global styles to .options container inside .multiSelectFilter
- Restored max-height and scroll behavior to dropdown content
- Resolved issue with dropdown only showing limited number of options
…

## How to test:
1. git checkout Rohith_fix_dropdown_limit
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Dashboard → Reports → Weekly Summaries
6. Click the dropdown to select team codes or colors
7. Confirm that:
All options are visible
Scroll works correctly
The dropdown doesn’t cut off at 4 items
Works in dark mode

## Screenshots or videos of changes:
Before: 
https://www.loom.com/share/129be3455a0c48218d884e9466a9103a?sid=b6e818df-e50a-499d-bc0a-843bf1acbcd4
After: 
https://www.loom.com/share/450bfb08a49c45bfaeddd7d4ae006971?sid=91dcbd6d-cf5d-4f2b-9fc4-fd5e0d6413e8
## Note:
The fix was confirmed to work using the :global selector in SCSS module, allowing the dropdown to display the full list with custom scrollbar styling. No functional code was modified, only scoped styles were corrected.
