### PR TITLE
Angad - Hotfix broken teams page formatting and team members not visible.

### DIFF
--- a/src/components/Teams/Team.css
+++ b/src/components/Teams/Team.css
@@ -38,7 +38,7 @@ thead {
 
 /* Targets 2nd column in team rows for better alignment and readability */
 .teams__tr td:nth-child(2) {
-  text-align: center;
+  /* text-align: center; */
   vertical-align: middle;
   font-size: 16px;
   font-weight: 400;

--- a/src/components/Teams/Team.css
+++ b/src/components/Teams/Team.css
@@ -11,7 +11,8 @@ thead {
 }
 
 #teams__active {
-  width: 10px;
+  width: 50px;  /* Increase to provide space */
+  text-align: center;
 }
 
 .centered-cell {
@@ -126,8 +127,10 @@ tr.dark-mode:hover {
 }
 
 .usermanagement-actions-cell {
-  display: table-cell;
-  padding-left: 10px;
+  height: 35px; /* Set a proper height */
+  padding: 5px 10px;
+  font-size: 14px;
+  line-height: normal;
 }
 
 @media (max-width: 768px) {
@@ -139,5 +142,5 @@ tr.dark-mode:hover {
 }
 
 .overflow-container table {
-  min-width: 600px; 
+  min-width: 600px;
 }

--- a/src/components/Teams/Team.css
+++ b/src/components/Teams/Team.css
@@ -36,6 +36,23 @@ thead {
   text-align: start;
 }
 
+/* Targets 2nd column in team rows for better alignment and readability */
+.teams__tr td:nth-child(2) {
+  text-align: center;
+  vertical-align: middle;
+  font-size: 16px;
+  font-weight: 400;
+}
+
+.teams__order--input div {
+  margin-top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+
 
 .teams__overview--top {
   background: transparent;

--- a/src/components/Teams/Team.jsx
+++ b/src/components/Teams/Team.jsx
@@ -1,8 +1,9 @@
 import './Team.css';
 import hasPermission from 'utils/permissions';
-import { boxStyle } from 'styles';
+import { boxStyle, boxStyleDark } from 'styles';
 import { connect, useSelector } from 'react-redux';
 import { DELETE } from '../../languages/en/ui';
+import { Button } from 'reactstrap';
 
 export function Team(props) {
   const darkMode = useSelector(state => state.theme.darkMode);
@@ -49,28 +50,28 @@ export function Team(props) {
       {(canDeleteTeam || canPutTeam) && (
         <td>
           <span className="usermanagement-actions-cell">
-            <button
-              type="button"
-              className="btn btn-outline-success"
+            <Button
+              color="success"
+              // className="btn btn-outline-success"
               onClick={() => {
                 props.onEditTeam(props.name, props.teamId, props.active, props.teamCode);
               }}
               style={darkMode ? {} : boxStyle}
             >
               Edit
-            </button>
+            </Button>
           </span>
           <span className="usermanagement-actions-cell">
-            <button
-              type="button"
-              className="btn btn-outline-danger"
+            <Button
+              color='danger'
+              // className="btn btn-outline-danger"
               onClick={() => {
                 props.onDeleteClick(props.name, props.teamId, props.active, props.teamCode);
               }}
-              style={darkMode ? {} : boxStyle}
+              style={darkMode ? boxStyleDark : boxStyle}
             >
               {DELETE}
-            </button>
+            </Button>
           </span>
         </td>
       )}

--- a/src/components/Teams/Team.jsx
+++ b/src/components/Teams/Team.jsx
@@ -10,7 +10,7 @@ export function Team(props) {
   const canPutTeam = props.hasPermission('putTeam');
 
   return (
-    <tr className={`teams__tr`} id={`tr_${props.teamId}`}>
+    <tr className="teams__tr" id={`tr_${props.teamId}`}>
       <th className="teams__order--input" scope="row">
         <div>{props.index + 1}</div>
       </th>
@@ -25,7 +25,7 @@ export function Team(props) {
             }
           }}
           style={{
-            boxStyle
+            boxStyle,
           }}
           aria-label={`Change status for team ${props.name}`}
         >

--- a/src/components/Teams/Team.jsx
+++ b/src/components/Teams/Team.jsx
@@ -10,7 +10,7 @@ export function Team(props) {
   const canPutTeam = props.hasPermission('putTeam');
 
   return (
-    <tr className="teams__tr" id={`tr_${props.teamId}`}>
+    <tr className={`teams__tr`} id={`tr_${props.teamId}`}>
       <th className="teams__order--input" scope="row">
         <div>{props.index + 1}</div>
       </th>
@@ -25,10 +25,7 @@ export function Team(props) {
             }
           }}
           style={{
-            all: 'unset', // Reset default button styles
-            cursor: 'pointer',
-            width: '100%',
-            height: '100%',
+            boxStyle
           }}
           aria-label={`Change status for team ${props.name}`}
         >

--- a/src/components/Teams/Team.jsx
+++ b/src/components/Teams/Team.jsx
@@ -13,7 +13,7 @@ export function Team(props) {
   return (
     <tr className="teams__tr" id={`tr_${props.teamId}`}>
       <th className="teams__order--input" scope="row">
-        <div>{props.index + 1}</div>
+      <div>{(props.index ?? 0) + 1}</div>
       </th>
       <td>{props.name}</td>
       <td className="teams__active--input">

--- a/src/components/Teams/Team.jsx
+++ b/src/components/Teams/Team.jsx
@@ -2,8 +2,8 @@ import './Team.css';
 import hasPermission from 'utils/permissions';
 import { boxStyle, boxStyleDark } from 'styles';
 import { connect, useSelector } from 'react-redux';
-import { DELETE } from '../../languages/en/ui';
 import { Button } from 'reactstrap';
+import { DELETE } from '../../languages/en/ui';
 
 export function Team(props) {
   const darkMode = useSelector(state => state.theme.darkMode);
@@ -63,7 +63,7 @@ export function Team(props) {
           </span>
           <span className="usermanagement-actions-cell">
             <Button
-              color='danger'
+              color="danger"
               // className="btn btn-outline-danger"
               onClick={() => {
                 props.onDeleteClick(props.name, props.teamId, props.active, props.teamCode);

--- a/src/components/Teams/Team.jsx
+++ b/src/components/Teams/Team.jsx
@@ -13,7 +13,7 @@ export function Team(props) {
   return (
     <tr className="teams__tr" id={`tr_${props.teamId}`}>
       <th className="teams__order--input" scope="row">
-      <div>{(props.index ?? 0) + 1}</div>
+        <div>{(props.index ?? 0) + 1}</div>
       </th>
       <td>{props.name}</td>
       <td className="teams__active--input">

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -24,6 +24,7 @@ import styles from './ToggleSwitch/ToggleSwitch.module.scss';
 
 export const TeamMembersPopup = React.memo(props => {
   const darkMode = useSelector(state => state.theme.darkMode);
+  const hasVisibilityIconPermission = hasPermission('seeVisibilityIcon');
   const [isChecked, setIsChecked] = useState(1); // 0 = false, 1 = true, 2 = all
   const [checkedStatus, setCheckedStatus] = useState('Active'); // 0 = false, 1 = true, 2 = all
   const [selectedUser, setSelectedUser] = useState(undefined);
@@ -333,69 +334,64 @@ export const TeamMembersPopup = React.memo(props => {
               </tr>
             </thead>
             <tbody>
-              {props.fetching && (
-                <tr>
-                  <td align="center" colSpan={6}>
-                    <Spinner
-                      color={`${darkMode ? 'light' : 'dark'}`}
-                      animation="border"
-                      size="sm"
-                    />
-                  </td>
-                </tr>
-              )}
-
-              {!props.fetching && memberList.length === 0 && emptyState}
-
-              {!props.fetching &&
-                memberList.length > 0 &&
-                Array.isArray(props.members.teamMembers) &&
-                props.members.teamMembers.length > 0 &&
-                memberList.toSorted().map(user => (
-                  <tr key={`${props.selectedTeamName}-${user.id}`}>
-                    <td>
-                      <div className={user.isActive ? 'isActive' : 'isNotActive'}>
-                        <i className="fa fa-circle" aria-hidden="true" />
-                      </div>
-                    </td>
-                    <td>{memberList.indexOf(user) + 1}</td>
-                    <td>
-                      {returnUserRole(user) ? (
-                        <b>
-                          {user.firstName} {user.lastName} ({user.role})
-                        </b>
-                      ) : (
-                        <span>
-                          {user.firstName} {user.lastName} ({user.role})
-                        </span>
-                      )}
-                      {hasVisibilityIconPermission && !user.isVisible && (
-                        <i className="fa fa-eye-slash" title="User is invisible" />
-                      )}
-                    </td>
-                    <td>{moment(user.addDateTime).format('MMM-DD-YY')}</td>
-                    <td>
-                      <ToggleSwitch
-                        key={`${props.selectedTeamName}-${user._id}`}
-                        switchType="limit-visibility"
-                        userId={user._id}
-                        choice={memberVisibility[user._id]}
-                        UpdateTeamMembersVisibility={UpdateTeamMembersVisibility}
-                      />
-                    </td>
-                    {canAssignTeamToUsers && (
-                      <td>
-                        <Button
-                          color="danger"
-                          onClick={() => handleDelete(user._id)}
-                          style={darkMode ? boxStyleDark : boxStyle}
-                        >
-                          Delete
-                        </Button>
-                      </td>
-                    )}
-                  </tr>
-                ))}
+            {props.fetching ?
+                 <tr><td align='center' colSpan={6}><Spinner  color={`${darkMode ? 'light' : 'dark'}`} animation="border" size="sm" /></td></tr> :
+                 !memberList.length ?
+                   emptyState :
+                   ((Array.isArray(props.members.teamMembers) &&
+                     props.members.teamMembers.length > 0) ||
+                     (typeof props.members.fetching === 'boolean' &&
+                       !props.members.fetching &&
+                       props.members.teamMembers) ||
+                     (Array.isArray(props.members) && props.members.length > 0)) &&
+                   memberList.toSorted().map((user, index) => {
+                     return (
+                       <tr key={`${props.selectedTeamName}-${user.id}-${index}`}>
+                         <td>
+                           <div className={user.isActive ? 'isActive' : 'isNotActive'}>
+                             <i className="fa fa-circle" aria-hidden="true" />
+                           </div>
+                         </td>
+                         <td className="def-width">{index + 1}</td>
+                         <td className="def-width">
+                           {returnUserRole(user) ? (
+                             <b>
+                               {user.firstName} {user.lastName} ({user.role})
+                             </b>
+                           ) : (
+                             <span>
+                               {user.firstName} {user.lastName} ({user.role})
+                             </span>
+                           )}{' '}
+                           {hasVisibilityIconPermission && !user.isVisible && (  // Invisibility icon from 'Cillian'
+                             <i className="fa fa-eye-slash" title="User is invisible" />
+                           )}
+                         </td>
+                         {/* <td>{user}</td> */}
+                         <td>{moment(user.addDateTime).format('MMM-DD-YY')}</td>
+                         <td>
+                           <ToggleSwitch
+                             key={`${props.selectedTeamName}-${user._id}`}
+                             switchType="limit-visibility"
+                             userId={user._id}
+                             choice={memberVisibility[user._id]}
+                             UpdateTeamMembersVisibility={UpdateTeamMembersVisibility}
+                           />
+                         </td>
+                         {canAssignTeamToUsers && (
+                           <td>
+                             <Button
+                               color="danger"
+                               onClick={() => handleDelete(user._id)}
+                               style={darkMode ? boxStyleDark : boxStyle}
+                             >
+                               Delete
+                             </Button>
+                           </td>
+                         )}
+                       </tr>
+                     );
+                   })}
             </tbody>
           </table>
         </ModalBody>

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -39,6 +39,8 @@ export const TeamMembersPopup = React.memo(props => {
     setDeletedPopup(!deletedPopup);
   };
 
+  console.log(memberList);
+
   const handleDelete = id => {
     props.onDeleteClick(`${id}`);
     setDeletedPopup(true);
@@ -60,6 +62,7 @@ export const TeamMembersPopup = React.memo(props => {
   const canAssignTeamToUsers = props.hasPermission('assignTeamToUsers');
 
   const validation = props.members.teamMembers || props.members;
+  console.log("Validation data:", validation);
 
   const closePopup = () => {
     setMemberList([]);
@@ -152,6 +155,7 @@ export const TeamMembersPopup = React.memo(props => {
         sortedList.push(...item.toSorted(sortByAlpha));
       });
     }
+    console.log("Sorted List:", sortedList);
     setMemberList(sortedList);
   };
 
@@ -187,6 +191,16 @@ export const TeamMembersPopup = React.memo(props => {
     }
     return newMemberVisibility;
   };
+
+  // useEffect(() => {
+  //   // Log team members whenever `props.members.teamMembers` changes
+  //   console.log('Team members:', props.members);
+
+  //   sortList(sortOrder);
+  //   const newMemberVisibility = getMemberVisibility();
+  //   setMemberVisibility(newMemberVisibility);
+  // }, [validation, sortOrder, props.members.teamMembers]); // Dependencies to trigger when teamMembers or sortOrder changes
+
 
   useEffect(() => {
     sortList(sortOrder);

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -305,8 +305,8 @@ export const TeamMembersPopup = React.memo(props => {
                     </div>
                   </div>
                 </th>
-                <th>#</th>
-                <th>User Name</th>
+                <th class="def-width">#</th>
+                <th class="def-width">User Name</th>
                 <th style={{ cursor: 'pointer' }} onClick={toggleOrder}>
                   Date Added{' '}
                   <FontAwesomeIcon
@@ -379,7 +379,7 @@ export const TeamMembersPopup = React.memo(props => {
                            />
                          </td>
                          {canAssignTeamToUsers && (
-                           <td>
+                           <td style={{ whiteSpace: 'nowrap', minWidth: '100px', textAlign: 'center' }}>
                              <Button
                                color="danger"
                                onClick={() => handleDelete(user._id)}

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -273,25 +273,33 @@ export const TeamMembersPopup = React.memo(props => {
           >
             <thead>
               <tr className={darkMode ? 'bg-space-cadet' : ''}>
-                <th>
-                  <div className={styles.divContainer}>
-                    <div className={styles.sliderContainer}>
-                      <input
-                        type="range"
-                        min="0"
-                        max="2"
-                        step="1"
-                        value={isChecked}
-                        onChange={handleToggle}
-                        className={styles.slider}
-                        title="Move Slider for Status change. Left: Inactive, Middle: Active, Right: See All"
-                        // Dynamic inline style for background color based on status
-                        style={{ '--track-color': trackColor, '--thumb-color': trackColor }}
-                      />
-                      <span>{checkedStatus}</span>
-                    </div>
-                  </div>
-                </th>
+              <th style={{ textAlign: 'center', verticalAlign: 'middle' }}>
+                <button
+                  onClick={() => {
+                    const newStatus = (isChecked + 1) % 3;
+                    setIsChecked(newStatus);
+                    setCheckedStatus(
+                      newStatus === 0 ? 'Inactive' : newStatus === 1 ? 'Active' : 'See All'
+                    );
+                  }}
+                  style={{
+                    backgroundColor:
+                      isChecked === 0 ? '#ccc' : isChecked === 1 ? 'limegreen' : 'dodgerblue',
+                    color: isChecked === 0 ? 'black' : 'white', // 🔁 Dynamic text color
+                    border: 'none',
+                    padding: '6px 12px',
+                    borderRadius: '5px',
+                    fontWeight: 'bold',
+                    cursor: 'pointer',
+                    width: '100px',
+                    minWidth: '100px',
+                    textAlign: 'center',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {checkedStatus}
+                </button>
+              </th>
                 <th class="def-width">#</th>
                 <th class="def-width">User Name</th>
                 <th style={{ cursor: 'pointer' }} onClick={toggleOrder}>

--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -40,14 +40,13 @@ export const TeamMembersPopup = React.memo(props => {
     setDeletedPopup(!deletedPopup);
   };
 
-  console.log(memberList);
 
   const handleDelete = id => {
     props.onDeleteClick(`${id}`);
     setDeletedPopup(true);
   };
 
-  const handleToggle = () => {
+  const handleToggle = (event) => {
     setIsChecked(parseInt(event.target.value));
     setCheckedStatus(
       parseInt(event.target.value) == 0
@@ -63,13 +62,12 @@ export const TeamMembersPopup = React.memo(props => {
   const canAssignTeamToUsers = props.hasPermission('assignTeamToUsers');
 
   const validation = props.members.teamMembers || props.members;
-  console.log("Validation data:", validation);
 
   const closePopup = () => {
     setMemberList([]);
     props.onClose();
     setSortOrder(0);
-    setIsChecked(true);
+    setIsChecked(1);
     setCheckedStatus('Active');
   };
   const onAddUser = () => {
@@ -156,7 +154,6 @@ export const TeamMembersPopup = React.memo(props => {
         sortedList.push(...item.toSorted(sortByAlpha));
       });
     }
-    console.log("Sorted List:", sortedList);
     setMemberList(sortedList);
   };
 
@@ -192,16 +189,6 @@ export const TeamMembersPopup = React.memo(props => {
     }
     return newMemberVisibility;
   };
-
-  // useEffect(() => {
-  //   // Log team members whenever `props.members.teamMembers` changes
-  //   console.log('Team members:', props.members);
-
-  //   sortList(sortOrder);
-  //   const newMemberVisibility = getMemberVisibility();
-  //   setMemberVisibility(newMemberVisibility);
-  // }, [validation, sortOrder, props.members.teamMembers]); // Dependencies to trigger when teamMembers or sortOrder changes
-
 
   useEffect(() => {
     sortList(sortOrder);
@@ -347,13 +334,13 @@ export const TeamMembersPopup = React.memo(props => {
                    memberList.toSorted().map((user, index) => {
                      return (
                        <tr key={`${props.selectedTeamName}-${user.id}-${index}`}>
-                         <td>
+                         <td style={{ verticalAlign: 'middle', textAlign: 'center' }}>
                            <div className={user.isActive ? 'isActive' : 'isNotActive'}>
                              <i className="fa fa-circle" aria-hidden="true" />
                            </div>
                          </td>
-                         <td className="def-width">{index + 1}</td>
-                         <td className="def-width">
+                         <td className="def-width" style={{ verticalAlign: 'middle', textAlign: 'center' }}>{index + 1}</td>
+                         <td className="def-width" style={{ verticalAlign: 'middle', textAlign: 'center' }}>
                            {returnUserRole(user) ? (
                              <b>
                                {user.firstName} {user.lastName} ({user.role})
@@ -368,8 +355,10 @@ export const TeamMembersPopup = React.memo(props => {
                            )}
                          </td>
                          {/* <td>{user}</td> */}
-                         <td>{moment(user.addDateTime).format('MMM-DD-YY')}</td>
-                         <td>
+                         <td style={{ verticalAlign: 'middle', textAlign: 'center' }}>
+                          {moment(user.addDateTime).format('MMM-DD-YY')}
+                          </td>
+                         <td style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
                            <ToggleSwitch
                              key={`${props.selectedTeamName}-${user._id}`}
                              switchType="limit-visibility"

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -234,7 +234,6 @@ class Teams extends React.PureComponent {
 
   teampopupElements = allTeams => {
     const { teamMembers: members, fetching } = this.props.state.teamsTeamMembers;
-    console.log("state in teampopupElements:", this.props.state);
     const selectedTeamData = allTeams
       ? allTeams.filter(team => team.teamName === this.state.selectedTeam)
       : [];

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -234,6 +234,7 @@ class Teams extends React.PureComponent {
 
   teampopupElements = allTeams => {
     const { teamMembers: members, fetching } = this.props.state.teamsTeamMembers;
+    console.log("state in teampopupElements:", this.props.state);
     const selectedTeamData = allTeams
       ? allTeams.filter(team => team.teamName === this.state.selectedTeam)
       : [];

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -232,9 +232,12 @@ class Teams extends React.PureComponent {
    * 3. Popup to display delete confirmation of the team upon clicking delete button.
    */
 
-  teampopupElements = (allTeams) => {
+  teampopupElements = allTeams => {
     const { teamMembers: members, fetching } = this.props.state.teamsTeamMembers;
-    const selectedTeamData = allTeams ? allTeams.filter(team => team.teamName === this.state.selectedTeam) : [];
+    const selectedTeamData = allTeams
+      ? allTeams.filter(team => team.teamName === this.state.selectedTeam)
+      : [];
+
     return (
       <>
         <TeamMembersPopup

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -232,11 +232,9 @@ class Teams extends React.PureComponent {
    * 3. Popup to display delete confirmation of the team upon clicking delete button.
    */
 
-  teampopupElements = allTeams => {
+  teampopupElements = (allTeams) => {
     const { teamMembers: members, fetching } = this.props.state.teamsTeamMembers;
-    const selectedTeamData = allTeams
-      ? allTeams.filter(team => team.teamName === this.state.selectedTeam)
-      : [];
+    const selectedTeamData = allTeams ? allTeams.filter(team => team.teamName === this.state.selectedTeam) : [];
     return (
       <>
         <TeamMembersPopup

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -199,7 +199,7 @@ class Teams extends React.PureComponent {
             onMembersClick={this.onTeamMembersPopupShow}
             onDeleteClick={this.onDeleteTeamPopupShow}
             onStatusClick={this.onTeamStatusShow}
-            onEditTeam={this.onEidtTeam}
+            onEditTeam={this.onEditTeam}
             onClickActive={this.onClickActive}
             team={team}
           />
@@ -374,7 +374,7 @@ class Teams extends React.PureComponent {
     });
   };
 
-  onEidtTeam = (teamName, teamId, status, teamCode) => {
+  onEditTeam = (teamName, teamId, status, teamCode) => {
     this.setState({
       isEdit: true,
       createNewTeamPopupOpen: true,

--- a/src/components/Teams/TeamsOverview.css
+++ b/src/components/Teams/TeamsOverview.css
@@ -6,10 +6,18 @@
 }
 
 .teams__overview--top .card {
-  flex: 1;
-  background-color: white;
-  box-shadow: none;
-  border: none;
+  min-width: 220px; /* Enough for 4-digit numbers */
+  max-width: 250px;
+  height: 40px; /* Slimmer card height */
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  color: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  font-weight: bold;
+  font-size: 14px;
 }
 
 /* General table layout */
@@ -91,7 +99,8 @@
   background: linear-gradient(to bottom, #87CEEB, #1E90FF, #4169E1);
 }
 
-.card#card_active {
+.card#card_active,
+.card#card_non_active {
   background: linear-gradient(to bottom, #FFD700, #FFA500, #FF8C00);
 }
 
@@ -106,6 +115,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  white-space: nowrap;
 }
 
 .card-text i {
@@ -192,15 +202,17 @@
   }
 }
 
-/* 479px and below */
-@media (max-width: 479px) {
-  .teams__overview--top .card {
-    flex: 1 1 45%;
-    margin: 5px 0;
+
+/* 480px and below */
+@media (max-width: 480x) {
+  .teams__overview--top {
+    flex-direction: column;
+    align-items: center;
   }
 
-  .teams__overview--top {
-    justify-content: space-between;
+  .teams__overview--top .card {
+    width: 90%;
+    margin-bottom: 10px;
   }
 
   .table th, .table td {
@@ -292,7 +304,8 @@
 }
 
 @media (max-width: 768px) {
-  .card#card_team, .card#card_active {
+  .card#card_team, .card#card_active,
+  .card#card_non_active{
     width: auto;
     height: 30px;
     font-size: 8px;

--- a/src/components/Teams/TeamsOverview.css
+++ b/src/components/Teams/TeamsOverview.css
@@ -41,7 +41,7 @@
 .table th:nth-child(1), .table td:nth-child(1) {
   width: 5%; /* Adjust first column width */
   white-space: nowrap; /* Prevent stacking/wrapping of numbers */
-  text-align: center; 
+  text-align: center;
 }
 
 
@@ -271,7 +271,7 @@
 
 @media (max-width: 575px) {
   .teams__overview--top {
-    font-size: 9px; 
+    font-size: 9px;
   }
 }
 

--- a/src/components/Teams/TeamsOverview.css
+++ b/src/components/Teams/TeamsOverview.css
@@ -28,6 +28,12 @@
   table-layout: auto; /* Allows more flexibility in layout */
 }
 
+.table th {
+  text-align: center;
+  vertical-align: middle;
+}
+
+
 .table th, .table td {
   padding: 10px;
   font-size: 14px;
@@ -64,6 +70,8 @@
 /* Buttons should stay aligned horizontally */
 .usermanagement-actions-cell {
   white-space: nowrap; /* Prevent line breaks in the buttons' container */
+  min-width: 100px;
+  text-align: center;
 }
 
 .usermanagement-actions-cell .btn-group {
@@ -72,7 +80,10 @@
 }
 
 .usermanagement-actions-cell .btn {
-  padding: 5px 8px; /* Adjust padding for better fit */
+  white-space: nowrap;
+  padding: 5px 10px;
+  font-size: 13px;
+  min-width: 80px;  /* Ensures button doesn't shrink */
 }
 
 /* Cards styling */
@@ -80,8 +91,7 @@
   background: linear-gradient(to bottom, #87CEEB, #1E90FF, #4169E1);
 }
 
-.card#card_active,
-.card#card_non_active {
+.card#card_active {
   background: linear-gradient(to bottom, #FFD700, #FFA500, #FF8C00);
 }
 
@@ -282,11 +292,9 @@
 }
 
 @media (max-width: 768px) {
-  .card#card_team, .card#card_active,
-  .card#card_non_active {
+  .card#card_team, .card#card_active {
     width: auto;
     height: 30px;
     font-size: 8px;
   }
 }
-

--- a/src/components/Teams/TeamsOverview.jsx
+++ b/src/components/Teams/TeamsOverview.jsx
@@ -9,7 +9,7 @@ function TeamsOverview({ numberOfTeams, numberOfActiveTeams }) {
       {/* Total Teams Card */}
       <div className="card" id="card_team" data-testid="card_team">
         <div className="card-body">
-          <h6 className="card-text">
+          <h6 className="card-text" id="total_teams" data-testid="total_teams">
             <i className="fa fa-users" aria-hidden="true" /> {TOTAL_TEAMS}: {numberOfTeams}
           </h6>
         </div>
@@ -18,7 +18,7 @@ function TeamsOverview({ numberOfTeams, numberOfActiveTeams }) {
       {/* Active Teams Card */}
       <div className="card" id="card_active" data-testid="card_active">
         <div className="card-body">
-          <h6 className="card-text">
+          <h6 className="card-text" id="active_teams" data-testid="active_teams">
             <i className="fa fa-circle fa-circle-isActive" aria-hidden="true" /> {ACTIVE_TEAMS}:{' '}
             {numberOfActiveTeams}
           </h6>

--- a/src/components/Teams/TeamsOverview.jsx
+++ b/src/components/Teams/TeamsOverview.jsx
@@ -9,7 +9,7 @@ function TeamsOverview({ numberOfTeams, numberOfActiveTeams }) {
       {/* Total Teams Card */}
       <div className="card" id="card_team" data-testid="card_team">
         <div className="card-body">
-          <h6 className="card-text" id="total_teams" data-testid="total_teams">
+          <h6 className="card-text">
             <i className="fa fa-users" aria-hidden="true" /> {TOTAL_TEAMS}: {numberOfTeams}
           </h6>
         </div>
@@ -18,7 +18,7 @@ function TeamsOverview({ numberOfTeams, numberOfActiveTeams }) {
       {/* Active Teams Card */}
       <div className="card" id="card_active" data-testid="card_active">
         <div className="card-body">
-          <h6 className="card-text" id="active_teams" data-testid="active_teams">
+          <h6 className="card-text">
             <i className="fa fa-circle fa-circle-isActive" aria-hidden="true" /> {ACTIVE_TEAMS}:{' '}
             {numberOfActiveTeams}
           </h6>


### PR DESCRIPTION
# Description
There was a bug introduced last week where the Team Members of a particular team were not visible when a user clicks on the team members button. Detailed information about the bug:

![image](https://github.com/user-attachments/assets/b1653532-ee71-487b-bc78-b5aed358fa90)

## Related PRS (if any):
This bug was introduced because of the frontend [PR #3168](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3168)

This PR is related to development branch in backend.
…

## Main changes explained:
- Changed and reverted the logic of team members visibility in popup.
- Changed the CSS to align everything as per requirements.
- Fixed Delete button style to accommodate long team members' names.
- Fixed the Active team members slider (default is Active and slider is green).
- Fixed the Teams overview cards and resized them and made them accommodate more than three digit team numbers.
- Fixed the style of team members in the popup.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin or owner user
5. go to dashboard→ Other Links→ Teams
6. Verify if the alignment of the elements is proper.
7. Click on the members button of a team and verify if the team members are visible.
8. Check if you are able to add team members in the team.
9. Check if delete button text doesn't wrap if team member name is too long.
10. Check the team overview cards have been resized and are looking clean.
11. Check if edit-delete buttons in teams table look like below in screenshot.
12. Verify if team members, team member numbers, active status, toggle switch and date added are aligned and in same line.
13. Verify the active status slider is green by default and are able to change the status by clicking and moving mouse left and right (Right : Inactive (Grey), Middle : Active (Green), Left : See All (Blue)).

## Screenshots or videos of changes:

![Teams Overview 1](https://github.com/user-attachments/assets/6f29e465-90d0-4e89-9364-cda8a0892391)

![PR #3366](https://github.com/user-attachments/assets/74aa6446-67a3-4c2e-9f6a-925931d3aec5)

![PR #3366 - 2](https://github.com/user-attachments/assets/b9d3f355-f4a7-4d89-b9ac-3c2ddeaa5a9a)
