### PR TITLE
Prit-Fixed: Profile page formatting of Teams row box and Team Name vertical centering

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.css
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.css
@@ -25,3 +25,7 @@
 .div-addteam .btn-addteam[disabled] {
   pointer-events: none;
 }
+tbody tr td,
+thead tr th {
+  text-align: center;
+}

--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
@@ -276,8 +276,8 @@ const UserTeamsTable = props => {
             {props.userTeamsById.length > 0 ? (
               props.userTeamsById.map((team, index) => (
                 <tr key={index} className={`tr ${darkMode ? 'dark-mode' : ''}`}>
-                  <td>{index + 1}</td>
-                  <td>{`${team.teamName}`}</td>
+                  <td style={{ alignContent: 'center' }}>{index + 1}</td>
+                  <td style={{ alignContent: 'center' }}>{`${team.teamName}`}</td>
                   {props.edit && props.role && (
                     <>
                       <td
@@ -285,6 +285,7 @@ const UserTeamsTable = props => {
                       >
                         <button
                           style={darkMode ? {} : boxStyle}
+                          style={{ boxShadow: 'none' }}
                           disabled={!canAssignTeamToUsers}
                           type="button"
                           className="btn btn-outline-info"


### PR DESCRIPTION
Fixed: Profile page formatting of Teams row box and Team Name vertical centering. Removed shadow from members button

# Description
Fixes: # (bug list priority: medium)
Title: Fixed Teams row alignment and removed shadow from Members button on Profile Page

Summary of Changes:
Fixed vertical alignment of Team Names to ensure they are centered within their respective rows.
Adjusted the layout of the Teams row box for consistent spacing and alignment.
Removed the box-shadow styling from the Members button.

Motivation & Context:
The previous layout had misaligned text and inconsistent styling, affecting the visual clarity and polish of the Profile Page. This fix ensures a cleaner, more consistent user experience and adheres to the design guidelines.

## Related PRS (if any):
This frontend PR is not related to the backend PR.
…

## Main changes explained:
- Fixed vertical alignment of Team Names to ensure they are centered within their respective rows.
- Adjusted the layout of the Teams row box for consistent spacing and alignment.
- Removed the box-shadow styling from the Members button.
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to View Profile→ Teams
6. verify the alignment of teams table
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
![Fixed Layout](https://github.com/user-attachments/assets/d80320d2-5e26-48cc-b59a-0fe7de7b78c5)
