### PR TITLE
Peterson resolved the bug that prevented the modal from closing when clicking outside

### DIFF
--- a/src/components/Badge/AssignBadge.jsx
+++ b/src/components/Badge/AssignBadge.jsx
@@ -214,12 +214,7 @@ function AssignBadge(props) {
         >
           Assign Badge
         </Button>
-        <Modal
-          isOpen={isOpen}
-          toggle={toggle}
-          backdrop="static"
-          className={darkMode ? 'text-light dark-mode' : ''}
-        >
+        <Modal isOpen={isOpen} toggle={toggle} className={darkMode ? 'text-light dark-mode' : ''}>
           <ModalHeader className={darkMode ? 'bg-space-cadet' : ''} toggle={toggle}>
             Assign Badge
           </ModalHeader>


### PR DESCRIPTION
# Description
This PR has been opened to fix the bug that prevents the user from closing the modal.

## Related PRS (if any):
None

## Main changes explained:
The AssignBadge.jsx component has been modified to fix the bug

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an admin or owner user.
5. Go to Badge Management  → Badge Assignment
6. Click on the search input, type the user's name, and select a radio button in the "Select" column.
7.  Click the 'Assign Badge' button and then click outside the modal; it should close.

## Screenshots or videos of changes:
![Gif2](https://github.com/user-attachments/assets/fa24644b-e169-4d1c-97b6-9614ac43b2ce)


## Note:
None