### PR TITLE
Koushica - Hotfixes due to style changes and added Cmd/Ctrl + Click for the Reports Icon

### DIFF
--- a/src/components/Collaboration/JobFormBuilder.css
+++ b/src/components/Collaboration/JobFormBuilder.css
@@ -79,10 +79,10 @@ h2 {
   margin-top: 15px;
 }
 
-input,
+/* input,
 textarea,
 select {
-  /* width: 95%; */
+  width: 95%;
   padding: 10px;
   margin-top: 5px;
   margin-bottom: 15px;
@@ -94,7 +94,7 @@ select {
 textarea {
   height: 80px;
   resize: vertical;
-}
+} */
 
 .new-field-section {
   background-color: #d9d9d9;

--- a/src/components/LBDashboard/BiddingOverview/BiddingOverview.module.css
+++ b/src/components/LBDashboard/BiddingOverview/BiddingOverview.module.css
@@ -330,7 +330,7 @@
 
 /* Style for date inputs */
 input[type="date"] {
-  width: 77%;
+  /* width: 77%; */
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 2px;

--- a/src/components/Projects/WBS/WBSDetail/wbs.css
+++ b/src/components/Projects/WBS/WBSDetail/wbs.css
@@ -143,6 +143,7 @@
 
 .taskName {
   height: auto;
+  text-align: left !important;
 }
 
 .taskDrop {

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -11,7 +11,7 @@ import {
 import CopyToClipboard from 'components/common/Clipboard/CopyToClipboard';
 import { Table, Progress } from 'reactstrap';
 
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import hasPermission from 'utils/permissions';
 import './style.css';
 
@@ -52,6 +52,7 @@ const TeamMemberTask = React.memo(
     const currentDate = moment.tz('America/Los_Angeles').startOf('day');
     const dispatch = useDispatch();
     const canSeeFollowUpCheckButton = userRole !== 'Volunteer';
+    const history = useHistory();
 
     const totalHoursRemaining = user.tasks.reduce((total, task) => {
       task.hoursLogged = task.hoursLogged || 0;
@@ -122,6 +123,15 @@ const TeamMemberTask = React.memo(
         setIsTruncated(!isTruncated);
       }
     };
+
+    const handleReportClick = (event,to) => {
+      if (event.metaKey || event.ctrlKey || event.button === 1) {
+        return;
+      }
+  
+      event.preventDefault(); // prevent full reload
+      history.push(`/peoplereport/${to}`);
+    }
 
     const openDetailModal = request => {
       dispatch(showTimeOffRequestModal(request));
@@ -279,6 +289,7 @@ const TeamMemberTask = React.memo(
                             <Link
                               className='team-member-tasks-user-report-link'
                               to= {`/peoplereport/${user?.personId}`}
+                              onClick={(event)=>handleReportClick(event,user?.personId)}
                             >
                                <img 
                                   src ="/report_icon.png"


### PR DESCRIPTION
# Description
Fixed the below issues:
1. Disoriented tick icon in the Tasks tab
2. Misaligned input field on the Blue Square page
3. Left-aligning tasks on the WBS page
4. Disoriented initial Goal Timer in the Timer modal
5. Reports now open in a new tab on Cmd/Ctrl + Click (preserves browser behavior)

Some of these issues were introduced in the following PRs:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2928
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3343

## Related PRS (if any):
Use the development backend and my current branch for the frontend.

## Main changes explained:
- Updated JobFormBuilder.css and BiddingOverview.module.css to fix layout and style issues impacting multiple areas.
- Added logic to support Cmd/Ctrl + Click to open Reports in a new tab, while keeping in-app navigation for normal clicks.

## How to test:
1. check into current branch
6. do `npm install` and `...` to run this PR locally
7. Clear site data/cache
8. log as admin user
9. go to dashboard→ Tasks→ task→…
10. verify function “A” (feel free to include screenshot here)
11. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

