### PR TITLE
deepthi hotfix for 3345

### DIFF
--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -150,7 +150,7 @@ function LeaderBoard({
 
   useEffect(() => {
     const checkAbbreviatedView = () => {
-      const isAbbrev = window.innerWidth < 1024;
+      const isAbbrev = window.innerWidth < window.screen.width * 0.75;
       setIsAbbreviatedView(isAbbrev);
     };
 


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/37e8afe3-e927-487c-8a52-2fc769ce0dd9)

## Related PRS (if any):
This frontend PR is related to the #3345 PR.
…

## Main changes explained:
- LeaderBoard.jsx: Dynamic 0.75 screen width check introduced.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user/ owner user
5. go to dashboard→ leaderboard
6. verify function “A” (feel free to include screenshot here)
7. verify the headers are displayed in abbreviations, and numbers under each time column stay on a single line without wrapping at half screen size and below.

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/ebc0fa1c-bd39-4ce4-b560-6fc39db598cb)

