### PR TITLE
Aureliano improve link requirement for timelog submission

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -230,8 +230,8 @@ function TimeEntryForm(props) {
 
   const handleEditorChange = (content, editor) => {
     const { wordcount } = editor.plugins;
-    const regexFilter = /https:\/\/(?!.*dropbox\.com\/home).*$/i;
-    const hasLink = regexFilter.test(content) && !/https:\/\/.*dropbox\.com\/home/.test(content);
+    const regexFilter = /https:\/\/(?!(www\.)?localhost|(www\.)?dropbox\.com(?!\/scl\/)|(www\.)?[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+).*/gim;
+    const hasLink = regexFilter.test(content);
     const enoughWords = wordcount.body.getWordCount() > 10;
     setFormValues(fv => ({ ...fv, [editor.id]: content }));
     setReminder(r => ({

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -230,7 +230,14 @@ function TimeEntryForm(props) {
 
   const handleEditorChange = (content, editor) => {
     const { wordcount } = editor.plugins;
-    const hasLink = content.indexOf('http://') > -1 || content.indexOf('https://') > -1;
+    // const hasLink = content.indexOf('http://') > -1 || content.indexOf('https://') > -1;
+    // Starts with "https://"
+    // Negative lookahead to exclude "www.dropbox.com/home"
+    // Followed by any subdomain and domain
+    // Optionally followed by any path
+    // Case insensitive
+    const regex = /^https:\/\/(?!www\.dropbox\.com\/home)[\w.-]+\.[\w.-]+\.com(\/\S*)?$/i;
+    const hasLink = regex.test(content);
     const enoughWords = wordcount.body.getWordCount() > 10;
     setFormValues(fv => ({ ...fv, [editor.id]: content }));
     setReminder(r => ({

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -230,14 +230,8 @@ function TimeEntryForm(props) {
 
   const handleEditorChange = (content, editor) => {
     const { wordcount } = editor.plugins;
-    // const hasLink = content.indexOf('http://') > -1 || content.indexOf('https://') > -1;
-    // Starts with "https://"
-    // Negative lookahead to exclude "www.dropbox.com/home"
-    // Followed by any subdomain and domain
-    // Optionally followed by any path
-    // Case insensitive
-    const regex = /^https:\/\/(?!www\.dropbox\.com\/home)[\w.-]+\.[\w.-]+\.com(\/\S*)?$/i;
-    const hasLink = regex.test(content);
+    const regexFilter = /https:\/\/(?!.*dropbox\.com\/home).*$/i;
+    const hasLink = regexFilter.test(content) && !/https:\/\/.*dropbox\.com\/home/.test(content);
     const enoughWords = wordcount.body.getWordCount() > 10;
     setFormValues(fv => ({ ...fv, [editor.id]: content }));
     setReminder(r => ({

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -230,14 +230,17 @@ function TimeEntryForm(props) {
 
   const handleEditorChange = (content, editor) => {
     const { wordcount } = editor.plugins;
-    const regexFilter = /https:\/\/(?!(www\.)?localhost|(www\.)?dropbox\.com(?!\/scl\/)|(www\.)?[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+).*/gim;
+    const regexFilter = /https:\/\/(?!(www\.)?localhost|(www\.)?dropbox\.com(?!\/scl\/)|(www\.)?[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}.*$/gim;
     const hasLink = regexFilter.test(content);
+    const dropboxRegex = /https:\/\/(www\.)?dropbox\.com/gim;
+    const hasDropboxLink = dropboxRegex.test(content);
     const enoughWords = wordcount.body.getWordCount() > 10;
     setFormValues(fv => ({ ...fv, [editor.id]: content }));
     setReminder(r => ({
       ...r,
       enoughWords,
       hasLink,
+      hasDropboxLink,
     }));
   };
 
@@ -259,10 +262,14 @@ function TimeEntryForm(props) {
       remindObj.remind =
         'Please write a more detailed description of your work completed, write at least 1-2 sentences.';
       errorObj.notes = 'Description and reference link are required';
-    } else if (!reminder.hasLink) {
+    } else if (!reminder.hasLink && !reminder.hasDropboxLink) {
       remindObj.remind =
         'Do you have a link to your Google Doc or other place to review this work? You should add it if you do. (Note: Please include http[s]:// in your URL)';
       errorObj.notes = 'Description and reference link are required';
+    } else if (!reminder.hasLink && reminder.hasDropboxLink) {
+      remindObj.remind =
+        'Halt, Link Wrangler! You’ve tried to share a DropBox link by just copying the DropBox URL from your browser, creating a link like a locked door with no key. Use the DropBox “Share” option to create a link that is guest-friendly!';
+      errorObj.notes = 'A valid Dropbox link from the “Share” option is required';
     }
 
     setErrors(errorObj);


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/9149c393-2333-4792-b8f9-9996423905c6)

## Related PRS (if any):
- This frontend PR is related to the [#3206](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3206) frontend PR.
- Feedback can be seen in the related PR as well.


## Main changes explained:
- Updated file src\components\Timelog\TimeEntryForm\TimeEntryForm.jsx to include RegEx pattern
- Pattern should allow any link starting with https:// and disable dropbox links if it is copied from the address bar instead of the share link.
- If the dropbox link is not from the shared link, send a new warning to indicate that it needs to be a shared dropbox link

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log as any user
5. go to dashboard→ Tasks→ task→stop timer and log time
6. Verify that any link starting with https:// are allowed to be submitted with the exception of dropbox links which are copied from the address bar instead of the share link.
7. Verify that logging time still works.

## Screenshots or videos of changes:

## Note:
The related PR will be closed, because an accident occurred where the latest development changes were merged with the PR.
