### PR TITLE
Bhavpreet - Fixes the issue of code replacement of inactive user

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -672,7 +672,7 @@ export class WeeklySummariesReport extends Component {
     try {
       const { replaceCode, selectedCodes, summaries, teamCodes } = this.state;
       this.setState({ replaceCodeLoading: true });
-  
+
       const isValidCode = fullCodeRegex.test(replaceCode);
       if (!isValidCode) {
         this.setState({
@@ -680,15 +680,15 @@ export class WeeklySummariesReport extends Component {
         });
         return;
       }
-  
+
       const oldTeamCodes = selectedCodes.map(code => code.value);
-  
+
       // Call the new backend API with a POST request
       const response = await axios.post(ENDPOINTS.REPLACE_TEAM_CODE, {
         oldTeamCodes,
         newTeamCode: replaceCode,
       });
-  
+
       if (response.data?.updatedCount > 0) {
         // Update the summaries in the local state
         const updatedSummaries = summaries.map(summary => {
@@ -697,25 +697,29 @@ export class WeeklySummariesReport extends Component {
           }
           return summary;
         });
-  
+
         // Remove old team codes and add the new team code in teamCodes
         const updatedTeamCodes = teamCodes
           .filter(teamCode => !oldTeamCodes.includes(teamCode.value)) // Remove old team codes
           .concat({
             value: replaceCode,
-            label: `${replaceCode} (${updatedSummaries.filter(s => s.teamCode === replaceCode).length})`,
+            label: `${replaceCode} (${
+              updatedSummaries.filter(s => s.teamCode === replaceCode).length
+            })`,
             _ids: updatedSummaries.filter(s => s.teamCode === replaceCode).map(s => s._id),
           });
-  
+
         // Remove old team codes and add the new team code in selectedCodes
         const updatedSelectedCodes = selectedCodes
           .filter(code => !oldTeamCodes.includes(code.value)) // Remove old team codes
           .concat({
             value: replaceCode,
-            label: `${replaceCode} (${updatedSummaries.filter(s => s.teamCode === replaceCode).length})`,
+            label: `${replaceCode} (${
+              updatedSummaries.filter(s => s.teamCode === replaceCode).length
+            })`,
             _ids: updatedSummaries.filter(s => s.teamCode === replaceCode).map(s => s._id),
           });
-  
+
         this.setState({
           summaries: updatedSummaries,
           teamCodes: updatedTeamCodes,
@@ -723,7 +727,7 @@ export class WeeklySummariesReport extends Component {
           replaceCode: '',
           replaceCodeError: null,
         });
-  
+
         // Re-filter the summaries to update the table
         this.filterWeeklySummaries();
       } else {
@@ -732,7 +736,6 @@ export class WeeklySummariesReport extends Component {
         });
       }
     } catch (error) {
-      console.error('Error in handleAllTeamCodeReplace:', error); // Log the error for debugging
       this.setState({
         replaceCodeError: 'Something went wrong. Please try again!',
       });

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -14,6 +14,7 @@ export const ENDPOINTS = {
   MODIFY_BLUE_SQUARE: (userId, blueSquareId) =>
     `${APIEndpoint}/userprofile/${userId}/infringements/${blueSquareId}`,
   USERS_ALLTEAMCODE_CHANGE: `${APIEndpoint}/AllTeamCodeChanges`,
+  REPLACE_TEAM_CODE: `${APIEndpoint}/userProfile/replaceTeamCode`,
 
   USERS_REMOVE_PROFILE_IMAGE: `${APIEndpoint}/userProfile/profileImage/remove`,
   USERS_UPDATE_PROFILE_FROM_WEBSITE: `${APIEndpoint}/userProfile/profileImage/imagefromwebsite`,


### PR DESCRIPTION
# Description
The PR Fixes the issue of Team code not being replaced for inactive users when changes in the weekly summary 
![image_2025-04-11_115943969](https://github.com/user-attachments/assets/62fd3877-9308-4d43-9a09-e1bf09098664)


## Related PRS (if any):
This frontend PR [3398](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3398) is related to the backend PR [1324](https://github.com/OneCommunityGlobal/HGNRest/pull/1324) .
checkout to this branch for frontend which is bhavpreet_teamCode_replace_frontend
checkout to this branch for backend which is bhavpreet_teamCode_replace_backend

## Main changes explained:
- now the team codes for the inactive users also changes when changed for the active users in weekly summary 

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ reports→ weekly summary
7. follow the same steps as the after video
8. make sure the when the code is changed, it changes for the inactive users as well
9. do a review on the backend as well, if on backend do for frontend.

## Screenshots or videos of changes:
### After changes 

https://github.com/user-attachments/assets/1ad061b2-96b7-43b1-95f2-ce11d465c93a

### Before changes 

https://github.com/user-attachments/assets/c3606405-e43f-4f13-a626-1e8597407353

## Note:
This is connected to a backend branch so review both of them and do the same for frontend.
