### PR TITLE
Fix the bug that prevents users from using dark mode

### DIFF
--- a/src/components/JobCCDashboard/JobCCDashboard.css
+++ b/src/components/JobCCDashboard/JobCCDashboard.css
@@ -4,7 +4,8 @@
 }
 
 .dark-mode-job-cc-dashboard {
-  background-color: #2c2f33;
+  /*  #2c2f33 */
+  background-color: #1b2a41;
   color: #ffffff;
 }
 

--- a/src/components/JobCCDashboard/JobCCDashboard.jsx
+++ b/src/components/JobCCDashboard/JobCCDashboard.jsx
@@ -1,5 +1,6 @@
 import { toast } from 'react-toastify';
 import { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import axios from 'axios';
 import { Table, Button, FormGroup, Label, Input } from 'reactstrap';
 import './JobCCDashboard.css';
@@ -7,7 +8,7 @@ import { ENDPOINTS } from 'utils/URL';
 import JobCCModal from './JobCCModal'; // Modal for managing CC list
 import JobCategoryCCModal from './JobCategoryCCModal';
 
-function JobCCDashboard({ darkMode }) {
+function JobCCDashboard() {
   const [jobs, setJobs] = useState([]);
   const [filter, setFilter] = useState('');
   const [search, setSearch] = useState('');
@@ -16,6 +17,7 @@ function JobCCDashboard({ darkMode }) {
   const [selectedJob, setSelectedJob] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [showJobCategoryCCModal, setShowJobCategoryCCModal] = useState(false);
+  const darkMode = useSelector(state => state.theme.darkMode);
 
   const fetchJobs = async () => {
     try {
@@ -79,12 +81,27 @@ function JobCCDashboard({ darkMode }) {
   };
 
   return (
-    <div className={`job-cc-dashboard ${darkMode ? 'dark-mode-job-cc-dashboard' : ''}`}>
+    <div
+      className={`job-cc-dashboard ${darkMode ? 'dark-mode-job-cc-dashboard' : ''}`}
+      style={{ height: '100%' }}
+    >
       <h1 className="dashboard-title">Job CC Dashboard</h1>
       <div className="filters-container">
         <FormGroup>
-          <Label for="filter">Filter by Category</Label>
-          <Input type="select" id="filter" value={filter} onChange={handleFilterChange}>
+          <Label for="filter" className={`${darkMode ? 'text-light' : 'text-dark'}`}>
+            Filter by Category
+          </Label>
+          <Input
+            type="select"
+            id="filter"
+            style={
+              darkMode
+                ? { backgroundColor: 'black', color: 'white', border: 'none' }
+                : { backgroundColor: 'white', color: 'black' }
+            }
+            value={filter}
+            onChange={handleFilterChange}
+          >
             <option value="">All</option>
             {categories.map(category => (
               <option key={category} value={category}>
@@ -94,10 +111,17 @@ function JobCCDashboard({ darkMode }) {
           </Input>
         </FormGroup>
         <FormGroup>
-          <Label for="search">Search by Title or Email</Label>
+          <Label for="search" className={`${darkMode ? 'text-light' : 'text-dark'}`}>
+            Search by Title or Email
+          </Label>
           <Input
             type="text"
             id="search"
+            style={
+              darkMode
+                ? { backgroundColor: 'black', color: 'white', border: 'none' }
+                : { backgroundColor: 'white', color: 'black' }
+            }
             placeholder="Search..."
             value={search}
             onChange={handleSearchChange}
@@ -126,11 +150,15 @@ function JobCCDashboard({ darkMode }) {
         <tbody>
           {filteredJobs.map(job => (
             <tr key={job._id}>
-              <td>{job.title}</td>
-              <td>{job.category}</td>
-              <td>{new Date(job.datePosted).toLocaleDateString()}</td>
-              <td>{job.ccList.map(entry => entry.email).join(', ') || 'No CCs'}</td>
-              <td>
+              <td className={`${darkMode ? 'text-light' : 'text-dark'}`}>{job.title}</td>
+              <td className={`${darkMode ? 'text-light' : 'text-dark'}`}>{job.category}</td>
+              <td className={`${darkMode ? 'text-light' : 'text-dark'}`}>
+                {new Date(job.datePosted).toLocaleDateString()}
+              </td>
+              <td className={`${darkMode ? 'text-light' : 'text-dark'}`}>
+                {job.ccList.map(entry => entry.email).join(', ') || 'No CCs'}
+              </td>
+              <td className={`${darkMode ? 'text-light' : 'text-dark'}`}>
                 <Button color="info" size="sm" onClick={() => handleOpenModal(job)}>
                   Manage CCs
                 </Button>


### PR DESCRIPTION
# Description
This PR was created to fix a bug that prevents the user from using dark mode.

## Related PRS (if any):
None

## Main changes explained:
The JobCCDashboard.jsx component has been modified to fix the bug.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an admin or owner user.
5. go to view profile→ Edit Job Application Email CC
6. Click on 'Welcome' and your username. Click on 'Dark Mode'. The background should change to a darker color, and the text should become white.

## Screenshots or videos of changes:
![Gif](https://github.com/user-attachments/assets/54d80188-d7f6-49f7-9f4a-42a260852b9a)

## Note:
None