### PR TITLE
Reina create interactive map showing locations of projects

### DIFF
--- a/src/actions/bmdashboard/organizationLocation.js
+++ b/src/actions/bmdashboard/organizationLocation.js
@@ -1,0 +1,93 @@
+organizationLocation.js in actions
+
+import axios from "axios";
+import { ENDPOINTS } from "utils/URL";
+import { GET_MAP_ORGS, GET_MAP_ORG_DETAILS } from '../../constants/bmdashboard/orgLocationConstants';
+import { GET_ERRORS } from "constants/errors";
+
+// fetch all orgs for dispatch calls
+export const fetchOrgsWithLocation = (startDate = null, endDate = null) => {
+  let url = ENDPOINTS.BM_ORGS_WITH_LOCATION;
+  
+  // Add query parameters if dates are provided
+  if (startDate || endDate) {
+    url += '?';
+    if (startDate) {
+      url += `startDate=${startDate}`;
+    }
+    if (startDate && endDate) {
+      url += '&';
+    }
+    if (endDate) {
+      url += `endDate=${endDate}`;
+    }
+  }
+  
+  return async (dispatch) => {
+    try {
+      const response = await axios.get(url);
+      const orgsData = response.data.data; 
+      
+      // Console log the location data
+      console.log('Orgs with location data:', orgsData);
+      
+      // Log each org's coordinates
+      orgsData.forEach(org => {
+        console.log(`Org ${org.orgId} (${org.name}): Lat ${org.latitude}, Lng ${org.longitude}, Status: ${org.status}`);
+      });
+      
+      dispatch(setOrgs(orgsData));
+      return orgsData;
+    } catch (error) {
+      console.error('Error fetching organizations with location:', error);
+      dispatch(setErrors(error));
+      throw error;
+    }
+  };
+};
+
+// Fetch orgs details by ID
+export const fetchMapOrgById = (orgId) => {
+  const url = ENDPOINTS.ORG_DETAILS(orgId);
+  
+  return async (dispatch) => {
+    try {
+      const response = await axios.get(url);
+      const orgData = response.data.data; // Assuming your API returns { data: {...} }
+      
+      // Console log the organization details
+      console.log('org details:', orgData);
+      console.log(`org ${orgData.orgId} location: Lat ${orgData.location.coordinates[1]}, Lng ${orgData.location.coordinates[0]}`);
+      
+      dispatch(setOrgDetails(orgData));
+      return orgData;
+    } catch (error) {
+      console.error(`Error fetching org ${orgId} details:`, error);
+      dispatch(setErrors(error));
+      throw error;
+    }
+  };
+};
+
+// Action creators
+export const setOrgs = payload => {
+  return {
+    type: GET_MAP_ORGS,
+    payload
+  };
+};
+
+export const setOrgDetails = payload => {
+  return {
+    type: GET_MAP_ORG_DETAILS,
+    payload
+  };
+};
+
+export const setErrors = payload => {
+  return {
+    type: GET_ERRORS,
+    payload
+  };
+};
+

--- a/src/components/BMDashboard/InteractiveMap/InteractiveMap.jsx
+++ b/src/components/BMDashboard/InteractiveMap/InteractiveMap.jsx
@@ -1,0 +1,130 @@
+import { useState, useEffect } from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import { Icon } from 'leaflet';
+import axios from 'axios';
+import { ENDPOINTS } from 'utils/URL';
+import markerIconPng from 'leaflet/dist/images/marker-icon.png';
+import markerShadowPng from 'leaflet/dist/images/marker-shadow.png';
+
+function InteractiveMap() {
+    const [orgs, setOrgs] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [tags, setTags] = useState([]); // For testing with tags like LessonForm
+
+    // Define custom icons for different org statuses
+    const activeIcon = new Icon({
+        iconUrl: markerIconPng,
+        shadowUrl: markerShadowPng,
+        iconSize: [25, 41],
+        iconAnchor: [12, 41],
+        popupAnchor: [1, -34],
+        shadowSize: [41, 41],
+        className: 'active-marker'
+    });
+
+    // Test fetching tags like LessonForm does
+    const fetchTags = async () => {
+        try {
+            console.log("Attempting to fetch tags from:", ENDPOINTS.BM_TAGS);
+            const response = await axios.get(ENDPOINTS.BM_TAGS);
+            console.log("Tags response:", response);
+            setTags(response.data);
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching tags: ', error.message);
+            return [];
+        }
+    };
+
+    // Test fetching orgs like LessonForm does
+    const fetchOrgs = async () => {
+        try {
+            console.log("Attempting to fetch orgs from:", ENDPOINTS.BM_ORGS_WITH_LOCATION);
+            const response = await axios.get(ENDPOINTS.BM_ORGS_WITH_LOCATION);
+            console.log("orgs response:", response);
+            setOrgs(response.data.data || []);
+            return response.data.data || [];
+        } catch (error) {
+            console.error('Error fetching orgs: ', error.message);
+            return [];
+        }
+    };
+
+    useEffect(() => {
+        // First try to fetch tags and orgs to see if those endpoints work
+        const testEndpoints = async () => {
+            console.log("Testing endpoints that work in LessonForm...");
+            
+            // Test tags endpoint
+            const tagsResult = await fetchTags();
+            console.log("Tags fetch result:", tagsResult);
+            
+            // Test orgs endpoint
+            const orgsResult = await fetchOrgs();
+            console.log("Orgs fetch result:", orgsResult);
+            
+        };
+        
+        testEndpoints();
+    }, []);
+
+    return (
+        <div>
+            <h1>Global Distribution and Org Status Overview</h1>
+            
+            {loading && <p>Loading org data...</p>}
+            {error && <p className="error-message">{error}</p>}
+            
+            <button onClick={fetchTags}>Test Tags Endpoint</button>
+            <button onClick={fetchOrgs}>Test Orgs Endpoint</button>
+            
+            <div style={{ height: '500px', width: '100%' }}>
+                <MapContainer
+                    center={[20, 0]}
+                    zoom={2}
+                    style={{ height: '100%', width: '100%' }}
+                    scrollWheelZoom={true}
+                >
+                    <TileLayer
+                        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                    />
+                    
+                    {!loading && orgs.length > 0 && orgs.map((org, index) => (
+                        <Marker 
+                            key={org.orgId || index}
+                            position={[org.latitude, org.longitude]}
+                            icon={activeIcon}
+                        >
+                            <Popup>
+                                <div>
+                                    <h3>{org.name}</h3>
+                                    <p>Org ID: {org.orgId}</p>
+                                    <p>Status: {org.status}</p>
+                                    <button onClick={() => console.log('Clicked on org:', org)}>
+                                        View Details
+                                    </button>
+                                </div>
+                            </Popup>
+                        </Marker>
+                    ))}
+                </MapContainer>
+            </div>
+            
+            <div className="debug-section" style={{ marginTop: '20px' }}>
+                <h3>Debug: Org Data ({orgs.length} orgs)</h3>
+                <pre>{JSON.stringify(orgs, null, 2)}</pre>
+                
+                <h3>Debug: Tags Data ({tags.length} tags)</h3>
+                <pre>{JSON.stringify(tags, null, 2)}</pre>
+                
+                <h3>Debug: Orgs Data ({orgs.length} orgs)</h3>
+                <pre>{JSON.stringify(orgs, null, 2)}</pre>
+            </div>
+        </div>
+    );
+}
+
+export default InteractiveMap;

--- a/src/components/BMDashboard/InteractiveMap/InteractiveMap.jsx
+++ b/src/components/BMDashboard/InteractiveMap/InteractiveMap.jsx
@@ -2,134 +2,142 @@ import { useState, useEffect } from 'react';
 import { MapContainer, TileLayer, CircleMarker, Popup } from 'react-leaflet';
 import axios from 'axios';
 import { ENDPOINTS } from 'utils/URL';
+
 function InteractiveMap() {
-    const [orgs, setOrgs] = useState([]);
-    const [loading, setLoading] = useState(true);
+  const [orgs, setOrgs] = useState([]);
+  const [setLoading] = useState(true);
 
-    // status color: active, delayed, completed
-    const getStatusColor = (status) => {
-        switch(status.toLowerCase()) {
-            case 'active':
-                return '#FF0000';
-            case 'delayed':
-                return '#0000FF';
-            case 'completed':
-                return '#FFFF00';
-        }
-    };
+  // status color: active, delayed, completed
+  const getStatusColor = status => {
+    switch (status.toLowerCase()) {
+      case 'active':
+        return '#DE6A6A';
+      case 'delayed':
+        return '#E3D270';
+      case 'completed':
+        return '#6ACFDE';
+      default:
+        return '#CCCCCC';
+    }
+  };
 
-    // fetch orgs 
-    const fetchOrgs = async () => {
-        try {
-            const response = await axios.get(ENDPOINTS.BM_ORGS_WITH_LOCATION);
-            setOrgs(response.data.data || []);
-            return response.data.data || [];
-        } catch (error) {
-            console.error('Error fetching orgs: ', error.message);
-            return [];
-        } finally {
-            setLoading(false);
-        }
-    };
+  // fetch orgs
+  const fetchOrgs = async () => {
+    try {
+      const response = await axios.get(ENDPOINTS.BM_ORGS_WITH_LOCATION);
+      setOrgs(response.data.data || []);
+      return response.data.data || [];
+    } catch (error) {
+      return [];
+    } finally {
+      setLoading(false);
+    }
+  };
 
-    useEffect(() => {
-        fetchOrgs();
-    }, []);
+  useEffect(() => {
+    fetchOrgs();
+  }, []);
 
-    return (
-        <div>
-            <h1>Global Distribution and Org Status Overview</h1>
-            
-            {/* Status Legend */}
-            <div style={{ display: 'flex', gap: '15px', margin: '10px 0' }}>
-                <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <div style={{ 
-                        width: '12px', 
-                        height: '12px', 
-                        borderRadius: '50%', 
-                        backgroundColor: '#FF0000', 
-                        marginRight: '5px' 
-                    }}></div>
-                    <span>Active</span>
-                </div>
-                <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <div style={{ 
-                        width: '12px', 
-                        height: '12px', 
-                        borderRadius: '50%', 
-                        backgroundColor: '#0000FF', 
-                        marginRight: '5px' 
-                    }}></div>
-                    <span>Delayed</span>
-                </div>
-                <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <div style={{ 
-                        width: '12px', 
-                        height: '12px', 
-                        borderRadius: '50%', 
-                        backgroundColor: '#FFFF00', 
-                        marginRight: '5px' 
-                    }}></div>
-                    <span>Completed</span>
-                </div>
-            </div>
-            
-            <div style={{ height: '500px', width: '100%' }}>
-                <MapContainer
-                    center={[20, 0]}
-                    zoom={2}
-                    style={{ height: '100%', width: '100%' }}
-                    scrollWheelZoom={true}
-                >
-                    <TileLayer
-                        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-                        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                    />
-                    
-                    {orgs.map((org, index) => (
-                        <CircleMarker
-                            key={org.orgId || index}
-                            center={[org.latitude, org.longitude]}
-                            radius={8}
-                            pathOptions={{
-                                fillColor: getStatusColor(org.status),
-                                fillOpacity: 0.8,
-                                color: 'white',
-                                weight: 1
-                            }}
-                        >
-                            <Popup>
-                                <div>
-                                    <h3>{org.name}</h3>
-                                    <p>Org ID: {org.orgId}</p>
-                                    <p>Status: {org.status}</p>
-                                    <p>Country: {org.country}</p>
-                                    <button 
-                                        onClick={() => console.log('Clicked on org:', org)}
-                                        style={{
-                                            backgroundColor: '#4CAF50',
-                                            color: 'white',
-                                            padding: '5px 10px',
-                                            border: 'none',
-                                            borderRadius: '4px',
-                                            cursor: 'pointer'
-                                        }}
-                                    >
-                                        View Details
-                                    </button>
-                                </div>
-                            </Popup>
-                        </CircleMarker>
-                    ))}
-                </MapContainer>
-            </div>
-            
-            <div className="debug-section" style={{ marginTop: '20px' }}>
-                <h3>Debug: Orgs Data ({orgs.length} orgs)</h3>
-                <pre>{JSON.stringify(orgs, null, 2)}</pre>
-            </div>
+  return (
+    <div>
+      <h1>Global Distribution and Org Status Overview</h1>
+
+      {/* Status Legend */}
+      <div style={{ display: 'flex', gap: '15px', margin: '10px 0' }}>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <div
+            style={{
+              width: '12px',
+              height: '12px',
+              borderRadius: '50%',
+              backgroundColor: '#FF0000',
+              marginRight: '5px',
+            }}
+          />
+          <span>Active</span>
         </div>
-    );
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <div
+            style={{
+              width: '12px',
+              height: '12px',
+              borderRadius: '50%',
+              backgroundColor: '#0000FF',
+              marginRight: '5px',
+            }}
+          />
+          <span>Delayed</span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <div
+            style={{
+              width: '12px',
+              height: '12px',
+              borderRadius: '50%',
+              backgroundColor: '#FFFF00',
+              marginRight: '5px',
+            }}
+          />
+          <span>Completed</span>
+        </div>
+      </div>
+
+      <div style={{ height: '500px', width: '100%' }}>
+        <MapContainer
+          center={[20, 0]}
+          zoom={2}
+          style={{ height: '100%', width: '100%' }}
+          scrollWheelZoom
+        >
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+
+          {orgs.map((org, index) => (
+            <CircleMarker
+              key={org.orgId || index}
+              center={[org.latitude, org.longitude]}
+              radius={8}
+              pathOptions={{
+                fillColor: getStatusColor(org.status),
+                fillOpacity: 0.8,
+                color: 'white',
+                weight: 1,
+              }}
+            >
+              <Popup>
+                <div>
+                  <h3>{org.name}</h3>
+                  <p>Org ID: {org.orgId}</p>
+                  <p>Status: {org.status}</p>
+                  <p>Country: {org.country}</p>
+                  <button
+                    type="button"
+                    style={{
+                      backgroundColor: '#4CAF50',
+                      color: 'white',
+                      padding: '5px 10px',
+                      border: 'none',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    View Details
+                  </button>
+                </div>
+              </Popup>
+            </CircleMarker>
+          ))}
+        </MapContainer>
+      </div>
+
+      <div className="debug-section" style={{ marginTop: '20px' }}>
+        <h3>Debug: Orgs Data ({orgs.length} orgs)</h3>
+        <pre>{JSON.stringify(orgs, null, 2)}</pre>
+      </div>
+    </div>
+  );
 }
 
 export default InteractiveMap;

--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
@@ -3,6 +3,7 @@ import './WeeklyProjectSummary.css';
 import { useSelector } from 'react-redux';
 import { v4 as uuidv4 } from 'uuid';
 import WeeklyProjectSummaryHeader from './WeeklyProjectSummaryHeader';
+import EmbedInteractiveMap from '../InteractiveMap/EmbedInteractiveMap';
 
 export default function WeeklyProjectSummary() {
   const [openSections, setOpenSections] = useState({});
@@ -110,7 +111,9 @@ export default function WeeklyProjectSummary() {
       className: 'half',
       content: (
         <>
-          <div className="weekly-project-summary-card wide-card">📊 Wide Card</div>
+          <div className="weekly-project-summary-card wide-card">
+            <EmbedInteractiveMap />
+          </div>
           <div className="weekly-project-summary-card normal-card">📊 Normal Card</div>
         </>
       ),

--- a/src/reducers/bmdashboard/orgLocationReducer.js
+++ b/src/reducers/bmdashboard/orgLocationReducer.js
@@ -1,0 +1,26 @@
+import { GET_MAP_ORGS, GET_MAP_ORG_DETAILS } from "../../constants/bmdashboard/orgLocationConstants";
+
+const initialState = {
+  projects: [],
+  projectDetails: null,
+  loading: true
+};
+
+export default function orgLocationReducer(state = initialState, action) {
+  switch (action.type) {
+    case GET_MAP_ORGS:
+      return {
+        ...state,
+        projects: action.payload,
+        loading: false
+      };
+    case GET_MAP_ORG_DETAILS:
+      return {
+        ...state,
+        projectDetails: action.payload,
+        loading: false
+      };
+    default:
+      return state;
+  }
+}

--- a/src/reducers/bmdashboard/orgLocationReducer.js
+++ b/src/reducers/bmdashboard/orgLocationReducer.js
@@ -1,9 +1,12 @@
-import { GET_MAP_ORGS, GET_MAP_ORG_DETAILS } from "../../constants/bmdashboard/orgLocationConstants";
+import {
+  GET_MAP_ORGS,
+  GET_MAP_ORG_DETAILS,
+} from '../../constants/bmdashboard/orgLocationConstants';
 
 const initialState = {
   projects: [],
   projectDetails: null,
-  loading: true
+  loading: true,
 };
 
 export default function orgLocationReducer(state = initialState, action) {
@@ -12,13 +15,13 @@ export default function orgLocationReducer(state = initialState, action) {
       return {
         ...state,
         projects: action.payload,
-        loading: false
+        loading: false,
       };
     case GET_MAP_ORG_DETAILS:
       return {
         ...state,
         projectDetails: action.payload,
-        loading: false
+        loading: false,
       };
     default:
       return state;

--- a/src/routes.js
+++ b/src/routes.js
@@ -63,6 +63,7 @@ import CheckTypes from './components/BMDashboard/shared/CheckTypes';
 import Toolslist from './components/BMDashboard/Tools/ToolsList';
 import AddTool from './components/BMDashboard/Tools/AddTool';
 import AddTeamMember from './components/BMDashboard/AddTeamMember/AddTeamMember';
+import InteractiveMap from './components/BMDashboard/InteractiveMap/InteractiveMap';
 
 // Community Portal
 import CPProtectedRoute from './components/common/CPDashboard/CPProtectedRoute';
@@ -377,6 +378,7 @@ export default (
         />
         <BMProtectedRoute path="/bmdashboard/tools" exact component={Toolslist} />
         <BMProtectedRoute path="/bmdashboard/AddTeamMember" component={AddTeamMember} />
+        <BMProtectedRoute path="/bmdashboard/InteractiveMap" component={InteractiveMap} />
         <BMProtectedRoute path="/bmdashboard/tools/add" exact component={AddTool} />
         <BMProtectedRoute path="/bmdashboard/tools/log" exact component={LogTools} />
         <BMProtectedRoute path="/bmdashboard/tools/:toolId" component={ToolDetailPage} />

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -225,6 +225,9 @@ export const ENDPOINTS = {
   BM_TAG_ADD: `${APIEndpoint}/bm/tags`,
   BM_TAGS_DELETE: `${APIEndpoint}/bm/tags`,
 
+  BM_ORGS_WITH_LOCATION: `${APIEndpoint}/bm/orgLocation`,
+  ORG_DETAILS: (projectId) => `${APIEndpoint}/bm/orgLocation/${projectId}`,
+
   GET_TIME_OFF_REQUESTS: () => `${APIEndpoint}/getTimeOffRequests`,
   ADD_TIME_OFF_REQUEST: () => `${APIEndpoint}/setTimeOffRequest`,
   UPDATE_TIME_OFF_REQUEST: id => `${APIEndpoint}/updateTimeOffRequest/${id}`,


### PR DESCRIPTION
# Description
This PR is for the HGN Phase 2 Implementation.
Create an interactive map that shows the location of projects under the title, Global Distribution and Project Status Overview. The map was created using LeafLet.js and dots are shown as markers for various locations of TEST organizations. A date filter is implemented on the top right of the map to allow results to be filtered so the data between those days are displayed.

The interactive map is also implemented in the construction weekly project summary dashboard page.

## Related PRS (if any):
This frontend PR is related to the [#1342](https://github.com/OneCommunityGlobal/HGNRest/pull/1342) backend PR.
…

## Main changes explained:
- Added a new route to bmdashboard/interactivemap
- Implemented a Leaflet.js map with color coded markers / dots to represent test organizations around the world.
- A date filter on the top right that filters results so only data with between those days are displayed.
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to http://localhost:3000/bmdashboard/interactivemap
6. Verify that the map is interactive and the dots are clickable
7. Verify that the date filters work.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/e4b4d534-af27-44cf-b5f2-6daae458a7be


## Note:
The 'view details' button is just a placeholder for now! 
