### PR TITLE
reina-create-map-showing-locations-of-orgs

### DIFF
--- a/src/actions/bmdashboard/organizationLocation.js
+++ b/src/actions/bmdashboard/organizationLocation.js
@@ -1,0 +1,75 @@
+// Fix import order
+import axios from "axios";
+import { GET_ERRORS } from "constants/errors";
+import { ENDPOINTS } from "utils/URL";
+import { GET_MAP_ORGS, GET_MAP_ORG_DETAILS } from '../../constants/bmdashboard/orgLocationConstants';
+
+// Action creators (moved to the top to fix "used before defined" errors)
+export const setOrgs = payload => {
+  return {
+    type: GET_MAP_ORGS,
+    payload
+  };
+};
+
+export const setOrgDetails = payload => {
+  return {
+    type: GET_MAP_ORG_DETAILS,
+    payload
+  };
+};
+
+export const setErrors = payload => {
+  return {
+    type: GET_ERRORS,
+    payload
+  };
+};
+
+// fetch all orgs for dispatch calls
+export const fetchOrgsWithLocation = (startDate = null, endDate = null) => {
+  let url = ENDPOINTS.BM_ORGS_WITH_LOCATION;
+  
+  // Add query parameters if dates are provided
+  if (startDate || endDate) {
+    url += '?';
+    if (startDate) {
+      url += `startDate=${startDate}`;
+    }
+    if (startDate && endDate) {
+      url += '&';
+    }
+    if (endDate) {
+      url += `endDate=${endDate}`;
+    }
+  }
+  
+  return async (dispatch) => {
+    try {
+      const response = await axios.get(url);
+      const orgsData = response.data.data;
+      dispatch(setOrgs(orgsData));
+      return orgsData;
+    } catch (error) {
+      dispatch(setErrors(error));
+      throw error;
+    }
+  };
+};
+
+// Fetch orgs details by ID
+export const fetchMapOrgById = (orgId) => {
+  const url = ENDPOINTS.ORG_DETAILS(orgId);
+  
+  return async (dispatch) => {
+    try {
+      const response = await axios.get(url);
+      const orgData = response.data.data;
+      dispatch(setOrgDetails(orgData));
+      return orgData;
+    } catch (error) {
+      dispatch(setErrors(error));
+      throw error;
+    }
+  };
+};

--- a/src/components/BMDashboard/InteractiveMap/EmbedInteractiveMap.jsx
+++ b/src/components/BMDashboard/InteractiveMap/EmbedInteractiveMap.jsx
@@ -1,0 +1,163 @@
+/* eslint-disable */
+import { useState, useEffect } from 'react';
+import { MapContainer, TileLayer, CircleMarker, Popup, useMap, Tooltip } from 'react-leaflet';
+import axios from 'axios';
+import L from 'leaflet';
+import { ENDPOINTS } from 'utils/URL';
+
+// legend added
+function Legend() {
+  const map = useMap();
+  useEffect(() => {
+    const legend = L.control({ position: 'bottomleft' });
+    legend.onAdd = () => {
+      const div = L.DomUtil.create('div', 'info legend');
+      const statuses = ['active', 'delayed', 'completed'];
+      const colors = ['#DE6A6A', '#E3D270', '#6ACFDE'];
+      div.innerHTML += '<div style="color: black; font-size: 25px;">Project Distribution</div>';
+
+      statuses.forEach((status, i) => {
+        div.innerHTML +=
+          `${'<div style="display: flex; align-items: center; margin-bottom: 5px;">' +
+            '<div style="width: 12px; height: 12px; border-radius: 50%; background-color: '}${
+            colors[i]
+          }; margin-right: 8px;"></div>` +
+          `<span style="text-transform: capitalize;">${status}</span>` +
+          `</div>`;
+      });
+      return div;
+    };
+    legend.addTo(map);
+    // clean function, rmv legend when component unmounts
+    return () => {
+      legend.remove();
+    };
+  }, [map]);
+  return null;
+}
+
+function EmbedInteractiveMap() {
+  const [orgs, setOrgs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [hoveredOrg, setHoveredOrg] = useState(null);
+
+  // status color: active, delayed, completed
+  const getStatusColor = status => {
+    switch (status.toLowerCase()) {
+      case 'active':
+        return '#DE6A6A';
+      case 'delayed':
+        return '#E3D270';
+      case 'completed':
+        return '#6ACFDE';
+      default:
+        return '#CCCCCC';
+    }
+  };
+
+  // fetch orgs
+  const fetchOrgs = async () => {
+    try {
+      const response = await axios.get(ENDPOINTS.BM_ORGS_WITH_LOCATION);
+      setOrgs(response.data.data || []);
+      return response.data.data || [];
+    } catch (error) {
+      return [];
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchOrgs();
+  }, []);
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <MapContainer
+        center={[20, 0]}
+        maxBounds={[
+          [-90, -180],
+          [90, 180],
+        ]}
+        maxBoundsViscosity={1.0}
+        zoom={1}
+        minZoom={1}
+        scrollWheelZoom
+        style={{
+          width: '100%',
+          height: '100%',
+          borderRadius: '8px',
+        }}
+        worldCopyJump
+      >
+        <TileLayer
+          noWrap={false}
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          minZoom={1}
+          maxZoom={15}
+        />
+        <Legend />
+        {orgs.map((org, index) => (
+          <CircleMarker
+            key={org.orgId || index}
+            center={[org.latitude, org.longitude]}
+            radius={6}
+            pathOptions={{
+              fillColor: getStatusColor(org.status),
+              fillOpacity: 0.8,
+              color: 'white',
+              weight: 1,
+            }}
+            eventHandlers={{
+              mouseover: () => {
+                setHoveredOrg(org);
+              },
+              mouseout: () => {
+                setHoveredOrg(null);
+              },
+            }}
+          >
+            <Tooltip direction="top" offset={[0, -10]} opacity={1} permanent={false}>
+              <div style={{ fontSize: '12px' }}>
+                {org.name} - {org.status}
+              </div>
+            </Tooltip>
+            <Popup>
+              <div style={{ fontSize: '12px' }}>
+                <h4>{org.name}</h4>
+                <p>Status: {org.status}</p>
+                <p>Country: {org.country}</p>
+                <button
+                  type="button"
+                  /** onClick={() => console.log('Clicked on org:', org)} * */
+                  style={{
+                    backgroundColor: '#4CAF50',
+                    color: 'white',
+                    padding: '4px 8px',
+                    border: 'none',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontSize: '12px',
+                  }}
+                >
+                  View Details
+                </button>
+              </div>
+            </Popup>
+          </CircleMarker>
+        ))}
+      </MapContainer>
+    </div>
+  );
+}
+
+export default EmbedInteractiveMap;

--- a/src/components/BMDashboard/InteractiveMap/InteractiveMap.jsx
+++ b/src/components/BMDashboard/InteractiveMap/InteractiveMap.jsx
@@ -1,0 +1,334 @@
+/* eslint-disable */
+import { useState, useEffect } from 'react';
+import { MapContainer, TileLayer, CircleMarker, Popup, Tooltip, useMap } from 'react-leaflet';
+import axios from 'axios';
+import { ENDPOINTS } from 'utils/URL';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+function Legend() {
+  const map = useMap();
+  useEffect(() => {
+    const legend = L.control({ position: 'bottomleft' });
+    legend.onAdd = () => {
+      const div = L.DomUtil.create('div', 'info legend');
+      div.style.backgroundColor = 'white';
+      div.style.padding = '10px';
+      div.style.borderRadius = '5px';
+      div.style.boxShadow = '0 0 15px rgba(0,0,0,0.2)';
+      const statuses = ['active', 'delayed', 'completed'];
+      const colors = ['#DE6A6A', '#E3D270', '#6ACFDE'];
+      div.innerHTML = '<h4 style="margin-top: 0; margin-bottom: 5px;">Project Status</h4>';
+      for (let i = 0; i < statuses.length; i++) {
+        div.innerHTML +=
+          `${'<div style="display: flex; align-items: center; margin-bottom: 5px;">' +
+            '<div style="width: 12px; height: 12px; border-radius: 50%; background-color: '}${
+            colors[i]
+          }; margin-right: 8px;"></div>` +
+          `<span style="text-transform: capitalize;">${statuses[i]}</span>` +
+          `</div>`;
+      }
+
+      return div;
+    };
+
+    // Add the legend to the map
+    legend.addTo(map);
+
+    return () => {
+      legend.remove();
+    };
+  }, [map]);
+
+  return null;
+}
+
+function InteractiveMap() {
+  const [orgs, setOrgs] = useState([]);
+  const [filteredOrgs, setFilteredOrgs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [hoveredOrg, setHoveredOrg] = useState(null);
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  // status color: active, delayed, completed
+  const getStatusColor = status => {
+    switch (status.toLowerCase()) {
+      case 'active':
+        return '#DE6A6A';
+      case 'delayed':
+        return '#E3D270';
+      case 'completed':
+        return '#6ACFDE';
+      default:
+        return '#AAAAAA';
+    }
+  };
+
+  // fetch orgs
+  const fetchOrgs = async () => {
+    try {
+      const response = await axios.get(ENDPOINTS.BM_ORGS_WITH_LOCATION);
+      const data = response.data.data || [];
+      setOrgs(data);
+      setFilteredOrgs(data);
+      return data;
+    } catch (error) {
+      console.error('Error fetching orgs: ', error.message);
+      return [];
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Apply date filters
+  const applyDateFilters = () => {
+    let filtered = [...orgs];
+
+    if (startDate) {
+      const startDateFilter = new Date(startDate);
+      filtered = filtered.filter(org => {
+        const orgStartDate = new Date(org.startDate);
+        return orgStartDate >= startDateFilter;
+      });
+    }
+
+    if (endDate) {
+      const endDateFilter = new Date(endDate);
+      filtered = filtered.filter(org => {
+        const orgStartDate = new Date(org.startDate);
+        return orgStartDate <= endDateFilter;
+      });
+    }
+
+    setFilteredOrgs(filtered);
+  };
+
+  // Reset filters
+  const resetFilters = () => {
+    setStartDate('');
+    setEndDate('');
+    setFilteredOrgs(orgs);
+  };
+
+  useEffect(() => {
+    fetchOrgs();
+  }, []);
+
+  return (
+    <div>
+      <h1 style={{ paddingBottom: '20px' }}>Global Distribution and Org Status Overview</h1>
+      <div
+        style={{
+          position: 'relative',
+          width: '90%',
+          maxWidth: '1200px',
+          margin: '0 auto 10px auto',
+          display: 'flex',
+          justifyContent: 'flex-end',
+        }}
+      >
+        <div
+          style={{
+            backgroundColor: 'white',
+            padding: '15px',
+            borderRadius: '5px',
+            boxShadow: '0 0 15px rgba(0,0,0,0.1)',
+            width: '400px',
+          }}
+        >
+          <h3 style={{ fontSize: '15px' }}>Filter Projects between Dates</h3>
+          <div
+            style={{
+              display: 'flex',
+              gap: '10px',
+              marginBottom: '10px',
+            }}
+          >
+            <div style={{ flex: 1 }}>
+              <label style={{ display: 'block', marginBottom: '5px', fontSize: '14px' }}>
+                Start Date:
+              </label>
+              <input
+                type="date"
+                value={startDate}
+                onChange={e => setStartDate(e.target.value)}
+                style={{
+                  width: '100%',
+                  padding: '8px',
+                  borderRadius: '4px',
+                  border: '1px solid #ddd',
+                }}
+              />
+            </div>
+
+            <div style={{ flex: 1 }}>
+              <label style={{ display: 'block', marginBottom: '5px', fontSize: '14px' }}>
+                End Date:
+              </label>
+              <input
+                type="date"
+                value={endDate}
+                onChange={e => setEndDate(e.target.value)}
+                style={{
+                  width: '100%',
+                  padding: '8px',
+                  borderRadius: '4px',
+                  border: '1px solid #ddd',
+                }}
+              />
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', gap: '10px' }}>
+            <button
+              type="button"
+              onClick={applyDateFilters}
+              style={{
+                backgroundColor: '#4CAF50',
+                color: 'white',
+                padding: '8px 15px',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                flex: 1,
+              }}
+            >
+              Apply Filters
+            </button>
+            <button
+              type="button"
+              onClick={resetFilters}
+              style={{
+                backgroundColor: '#f44336',
+                color: 'white',
+                padding: '8px 15px',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                flex: 1,
+              }}
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          width: '100%',
+        }}
+      >
+        <div
+          style={{
+            height: '700px',
+            width: '90%',
+            maxWidth: '1200px',
+          }}
+        >
+          {loading ? (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                height: '100%',
+                border: '1px solid grey',
+              }}
+            >
+              Loading map data...
+            </div>
+          ) : (
+            <MapContainer
+              center={[51.505, -0.09]}
+              maxBounds={[
+                [-90, -225],
+                [90, 225],
+              ]}
+              maxBoundsViscosity={1.0}
+              zoom={3}
+              scrollWheelZoom
+              style={{
+                border: '1px solid grey',
+                height: '100%',
+                width: '100%',
+              }}
+            >
+              <TileLayer
+                noWrap
+                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                minZoom={2}
+                maxZoom={15}
+              />
+              <Legend />
+
+              {filteredOrgs.map((org, index) => (
+                <CircleMarker
+                  key={org.orgId || index}
+                  center={[org.latitude, org.longitude]}
+                  radius={8}
+                  pathOptions={{
+                    fillColor: getStatusColor(org.status),
+                    fillOpacity: 0.8,
+                    color: 'white',
+                    weight: 1,
+                  }}
+                  eventHandlers={{
+                    mouseover: () => {
+                      setHoveredOrg(org);
+                    },
+                    mouseout: () => {
+                      setHoveredOrg(null);
+                    },
+                  }}
+                >
+                  <Tooltip direction="top" offset={[0, -10]} opacity={1} permanent={false}>
+                    <div>Click here to view Organization {org.orgId} details</div>
+                  </Tooltip>
+                  <Popup>
+                    <div>
+                      <h3>{org.name}</h3>
+                      <p>Org ID: {org.orgId}</p>
+                      <p>Status: {org.status}</p>
+                      <p>Country: {org.country}</p>
+                      <p>Start Date: {new Date(org.startDate).toLocaleDateString()}</p>
+                      <button
+                        type="button"
+                        // onClick={() => console.log('Clicked on org:', org)}
+                        style={{
+                          backgroundColor: '#4CAF50',
+                          color: 'white',
+                          padding: '5px 10px',
+                          border: 'none',
+                          borderRadius: '4px',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        View Details
+                      </button>
+                    </div>
+                  </Popup>
+                </CircleMarker>
+              ))}
+            </MapContainer>
+          )}
+        </div>
+      </div>
+      <div
+        style={{
+          width: '90%',
+          maxWidth: '1200px',
+          margin: '10px auto',
+          textAlign: 'right',
+        }}
+      >
+        Showing {filteredOrgs.length} of {orgs.length} projects
+      </div>
+    </div>
+  );
+}
+
+export default InteractiveMap;

--- a/src/constants/bmdashboard/orgLocationConstants.js
+++ b/src/constants/bmdashboard/orgLocationConstants.js
@@ -1,0 +1,2 @@
+export const GET_MAP_ORGS = 'GET_MAP_ORGS';
+export const GET_MAP_ORG_DETAILS = 'GET_MAP_ORG_DETAILS';

--- a/src/reducers/bmdashboard/orgLocationReducer.js
+++ b/src/reducers/bmdashboard/orgLocationReducer.js
@@ -1,0 +1,29 @@
+import {
+  GET_MAP_ORGS,
+  GET_MAP_ORG_DETAILS,
+} from '../../constants/bmdashboard/orgLocationConstants';
+
+const initialState = {
+  projects: [],
+  projectDetails: null,
+  loading: true,
+};
+// eslint-disable-next-line default-param-last
+export default function orgLocationReducer(state = initialState, action) {
+  switch (action.type) {
+    case GET_MAP_ORGS:
+      return {
+        ...state,
+        projects: action.payload,
+        loading: false,
+      };
+    case GET_MAP_ORG_DETAILS:
+      return {
+        ...state,
+        projectDetails: action.payload,
+        loading: false,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -72,6 +72,7 @@ import CheckTypes from './components/BMDashboard/shared/CheckTypes';
 import Toolslist from './components/BMDashboard/Tools/ToolsList';
 import AddTool from './components/BMDashboard/Tools/AddTool';
 import AddTeamMember from './components/BMDashboard/AddTeamMember/AddTeamMember';
+import InteractiveMap from './components/BMDashboard/InteractiveMap/InteractiveMap';
 
 // Community Portal
 import CPProtectedRoute from './components/common/CPDashboard/CPProtectedRoute';
@@ -390,6 +391,7 @@ export default(
         />
         <BMProtectedRoute path="/bmdashboard/tools" exact component={Toolslist} />
         <BMProtectedRoute path="/bmdashboard/AddTeamMember" component={AddTeamMember} />
+        <BMProtectedRoute path="/bmdashboard/InteractiveMap" component={InteractiveMap} />
         <BMProtectedRoute path="/bmdashboard/tools/add" exact component={AddTool} />
         <BMProtectedRoute path="/bmdashboard/tools/log" exact component={LogTools} />
         <BMProtectedRoute path="/bmdashboard/tools/:toolId" component={ToolDetailPage} />

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -226,6 +226,9 @@ export const ENDPOINTS = {
   BM_TAG_ADD: `${APIEndpoint}/bm/tags`,
   BM_TAGS_DELETE: `${APIEndpoint}/bm/tags`,
 
+  BM_ORGS_WITH_LOCATION: `${APIEndpoint}/bm/orgLocation`,
+  ORG_DETAILS: (projectId) => `${APIEndpoint}/bm/orgLocation/${projectId}`,
+
   GET_TIME_OFF_REQUESTS: () => `${APIEndpoint}/getTimeOffRequests`,
   ADD_TIME_OFF_REQUEST: () => `${APIEndpoint}/setTimeOffRequest`,
   UPDATE_TIME_OFF_REQUEST: id => `${APIEndpoint}/updateTimeOffRequest/${id}`,


### PR DESCRIPTION
# Description
This PR is for the HGN Phase 2 Implementation.
Create an interactive map that shows the location of projects under the title, Global Distribution and Project Status Overview. The map was created using LeafLet.js and dots are shown as markers for various locations of TEST organizations. A date filter is implemented on the top right of the map to allow results to be filtered so the data between those days are displayed.

The interactive map is also implemented in the construction weekly project summary dashboard page.

## Related PRS (if any):
This frontend PR is related to the [#1342]( https://github.com/OneCommunityGlobal/HGNRest/pull/1342 ) backend PR.
…

## Main changes explained:
- Added a new route to bmdashboard/interactivemap
- Implemented a Leaflet.js map with color coded markers / dots to represent test organizations around the world.
- A date filter on the top right that filters results so only data with between those days are displayed.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to http://localhost:3000/bmdashboard/interactivemap
6. Verify that the map is interactive and the dots are clickable
7. Verify that the date filters work.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/1d730c61-8856-418d-b611-01e194291ef9

## Note:
The 'view details' button is just a placeholder for now!
