### PR TITLE
Guirong-Fix blue square chart

### DIFF
--- a/src/components/TotalOrgSummary/BlueSquareStats/BlueSquareStats.jsx
+++ b/src/components/TotalOrgSummary/BlueSquareStats/BlueSquareStats.jsx
@@ -21,7 +21,7 @@ function BlueSquareStats({ isLoading }) {
     missingSummary: { count: 10, percentageOutOfTotal: 4 },
     missingHoursAndSummary: { count: 96, percentageOutOfTotal: 37 },
     vacationTime: { count: 100, percentageOutOfTotal: 38 },
-    other: { count: 42, percentageOutOfTotal: 16 }
+    other: { count: 42, percentageOutOfTotal: 16 },
   };
 
   // To test no-data state, comment out the above and uncomment below

--- a/src/components/TotalOrgSummary/BlueSquareStats/BlueSquareStats.jsx
+++ b/src/components/TotalOrgSummary/BlueSquareStats/BlueSquareStats.jsx
@@ -3,7 +3,7 @@ import './BlueSquareStats.css';
 import Loading from 'components/common/Loading';
 import DonutChart from '../DonutChart/DonutChart';
 
-function BlueSquareStats({ isLoading, blueSquareStats }) {
+function BlueSquareStats({ isLoading }) {
   if (isLoading) {
     return (
       <div className="d-flex justify-content-center align-items-center">
@@ -13,6 +13,26 @@ function BlueSquareStats({ isLoading, blueSquareStats }) {
       </div>
     );
   }
+
+  // Test data with values
+  const blueSquareStats = {
+    totalBlueSquares: { count: 260, comparisonPercentage: 0 },
+    missingHours: { count: 12, percentageOutOfTotal: 5 },
+    missingSummary: { count: 10, percentageOutOfTotal: 4 },
+    missingHoursAndSummary: { count: 96, percentageOutOfTotal: 37 },
+    vacationTime: { count: 100, percentageOutOfTotal: 38 },
+    other: { count: 42, percentageOutOfTotal: 16 }
+  };
+
+  // To test no-data state, comment out the above and uncomment below
+  // const blueSquareStats = {
+  //   totalBlueSquares: { count: 0, comparisonPercentage: -1 },
+  //   missingHours: { count: 0, percentageOutOfTotal: 0 },
+  //   missingSummary: { count: 0, percentageOutOfTotal: 0 },
+  //   missingHoursAndSummary: { count: 0, percentageOutOfTotal: 0 },
+  //   vacationTime: { count: 0, percentageOutOfTotal: 0 },
+  //   other: { count: 0, percentageOutOfTotal: 0 }
+  // };
 
   const {
     totalBlueSquares,
@@ -31,6 +51,8 @@ function BlueSquareStats({ isLoading, blueSquareStats }) {
     { label: 'Other', value: other.count },
   ];
 
+  const hasData = data.some(item => item.value > 0);
+
   return (
     <section className="blue-square-stats">
       <div className="blue-square-stats-pie-chart">
@@ -40,6 +62,7 @@ function BlueSquareStats({ isLoading, blueSquareStats }) {
           percentageChange={totalBlueSquares.comparisonPercentage}
           data={data}
           colors={BLUE_SQUARE_STATS_COLORS}
+          hasData={hasData}
         />
       </div>
     </section>

--- a/src/components/TotalOrgSummary/BlueSquareStats/BlueSquareStats.jsx
+++ b/src/components/TotalOrgSummary/BlueSquareStats/BlueSquareStats.jsx
@@ -3,7 +3,7 @@ import './BlueSquareStats.css';
 import Loading from 'components/common/Loading';
 import DonutChart from '../DonutChart/DonutChart';
 
-function BlueSquareStats({ isLoading }) {
+function BlueSquareStats({ isLoading, blueSquareStats }) {
   if (isLoading) {
     return (
       <div className="d-flex justify-content-center align-items-center">
@@ -14,24 +14,14 @@ function BlueSquareStats({ isLoading }) {
     );
   }
 
-  // Test data with values
-  const blueSquareStats = {
-    totalBlueSquares: { count: 260, comparisonPercentage: 0 },
-    missingHours: { count: 12, percentageOutOfTotal: 5 },
-    missingSummary: { count: 10, percentageOutOfTotal: 4 },
-    missingHoursAndSummary: { count: 96, percentageOutOfTotal: 37 },
-    vacationTime: { count: 100, percentageOutOfTotal: 38 },
-    other: { count: 42, percentageOutOfTotal: 16 },
-  };
-
-  // To test no-data state, comment out the above and uncomment below
+  // Uncomment and remove blueSquareStats prop to test data with values
   // const blueSquareStats = {
-  //   totalBlueSquares: { count: 0, comparisonPercentage: -1 },
-  //   missingHours: { count: 0, percentageOutOfTotal: 0 },
-  //   missingSummary: { count: 0, percentageOutOfTotal: 0 },
-  //   missingHoursAndSummary: { count: 0, percentageOutOfTotal: 0 },
-  //   vacationTime: { count: 0, percentageOutOfTotal: 0 },
-  //   other: { count: 0, percentageOutOfTotal: 0 }
+  //   totalBlueSquares: { count: 260, comparisonPercentage: 0 },
+  //   missingHours: { count: 12, percentageOutOfTotal: 5 },
+  //   missingSummary: { count: 10, percentageOutOfTotal: 4 },
+  //   missingHoursAndSummary: { count: 96, percentageOutOfTotal: 37 },
+  //   vacationTime: { count: 100, percentageOutOfTotal: 38 },
+  //   other: { count: 42, percentageOutOfTotal: 16 },
   // };
 
   const {
@@ -51,7 +41,7 @@ function BlueSquareStats({ isLoading }) {
     { label: 'Other', value: other.count },
   ];
 
-  const hasData = data.some(item => item.value > 0);
+  const hasData = data.every(item => item.value !== 0);
 
   return (
     <section className="blue-square-stats">

--- a/src/components/TotalOrgSummary/DonutChart/DonutChart.css
+++ b/src/components/TotalOrgSummary/DonutChart/DonutChart.css
@@ -30,12 +30,12 @@
 }
 
 .donut-center .donut-heading {
-  color: #828282;
+  color: var(--text-secondary);
   font-size: 0.88rem;
 }
 
 .donut-center .donut-count {
-  color: #6c6c6c;
+  color: var(--text-primary);
   font-size: 2rem;
 }
 
@@ -49,6 +49,7 @@
   justify-content: center;
   margin-top: 1.8rem;
   width: 100%;
+  color: var(--text-primary);
 }
 
 .donut-label {
@@ -62,6 +63,24 @@
   min-width: 1rem;
   min-height: 1rem;
   margin-right: 1rem;
+}
+
+.donut-no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 21.25rem;
+  width: 100%;
+  text-align: center;
+}
+
+.no-data-text {
+  color: var(--text-primary);
+  font-size: 24px !important;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  line-height: 1.2;
 }
 
 @media (max-width: 615px) {

--- a/src/components/TotalOrgSummary/DonutChart/DonutChart.css
+++ b/src/components/TotalOrgSummary/DonutChart/DonutChart.css
@@ -29,6 +29,10 @@
   font-size: 0.6em;
 }
 
+.donut-center > * {
+  margin: 0.2rem;
+}
+
 .donut-center .donut-heading {
   color: var(--text-secondary);
   font-size: 0.88rem;
@@ -37,6 +41,10 @@
 .donut-center .donut-count {
   color: var(--text-primary);
   font-size: 2rem;
+}
+
+.donut-comparison-percent {
+  font-size: 0.7rem;
 }
 
 .donut-center div {

--- a/src/components/TotalOrgSummary/DonutChart/DonutChart.jsx
+++ b/src/components/TotalOrgSummary/DonutChart/DonutChart.jsx
@@ -63,7 +63,7 @@ function DonutChart(props) {
           <div className="donut-center">
             <h5 className="donut-heading">{title}</h5>
             <h4 className="donut-count">{totalCount}</h4>
-            <h6 style={{ color: percentageChangeColor }}>
+            <h6 className="donut-comparison-percent" style={{ color: percentageChangeColor }}>
               {percentageChange >= 0
                 ? `+${percentageChange}% WEEK OVER WEEK`
                 : `${percentageChange}% WEEK OVER WEEK`}

--- a/src/components/TotalOrgSummary/DonutChart/DonutChart.jsx
+++ b/src/components/TotalOrgSummary/DonutChart/DonutChart.jsx
@@ -7,7 +7,18 @@ import './DonutChart.css';
 Chart.register(ArcElement);
 
 function DonutChart(props) {
-  const { title, totalCount, percentageChange, data, colors } = props;
+  const { title, totalCount, percentageChange, data, colors, hasData } = props;
+
+  if (!hasData) {
+    return (
+      <div className="donut-container">
+        <div className="donut-no-data">
+          <p className="no-data-text">No data available</p>
+        </div>
+      </div>
+    );
+  }
+
   const chartData = {
     labels: data.map(item => item.label),
     datasets: [
@@ -42,7 +53,7 @@ function DonutChart(props) {
     cutout: '55%',
   };
 
-  const percentageChangeColor = percentageChange >= 0 ? 'green' : 'red';
+  const percentageChangeColor = percentageChange >= 0 ? 'var(--success)' : 'var(--danger)';
 
   return (
     <div className="donut-container">
@@ -86,6 +97,11 @@ DonutChart.propTypes = {
     }),
   ).isRequired,
   colors: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  hasData: PropTypes.bool,
+};
+
+DonutChart.defaultProps = {
+  hasData: true,
 };
 
 export default DonutChart;


### PR DESCRIPTION
# Description
The chart currently looks like image 1. It should look like image 2. 
The chart should say "No data available" in place of the circle chart if the data of all the "count" fields in the API response are all 0.
Fix the text colors in dark mode (the "total blue squares" and number in the middle should be white). 
![image](https://github.com/user-attachments/assets/0380691b-4dda-49b0-8e2d-b7739b25cc08)

![image](https://github.com/user-attachments/assets/abb16fe7-4b0e-4118-bf74-cdc0ddb4e491)

Fixes # (bug list priority high/medium/low x.y.z)
Or Implements # (WBS) 
<img width="640" alt="image" src="https://github.com/user-attachments/assets/f28828b7-5070-4067-947f-534a2126694c" />

## Related PRS (if any):
This frontend PR is related to the development backend PR.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ Total Summary Report→Volunteer Roles and Team Dynamics
6. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
![Screenshot 2025-04-22 at 17 00 32](https://github.com/user-attachments/assets/fc497148-3f2d-4d4f-a500-126d23b3d552)
![Screenshot 2025-04-22 at 17 00 48](https://github.com/user-attachments/assets/c03513d2-6cca-4409-adbd-3be2e12cd615)
![Screenshot 2025-04-22 at 17 01 22](https://github.com/user-attachments/assets/76fc6d31-92f0-49c2-ae35-bda94763a63f)

## Note:
Include the information the reviewers need to know.
