### PR TITLE
pavanswaroop-timer-space-formatting-dashboard-fix

### DIFF
--- a/src/components/Timer/Timer.module.css
+++ b/src/components/Timer/Timer.module.css
@@ -38,9 +38,14 @@
 .btns {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0;
   color: white;
   border:none;
+}
+
+.btns > * {
+  margin-right: 2px;
+  padding: 2px;
 }
 
 .timer {


### PR DESCRIPTION
# Description
(PRIORITY MEDIUM) Hakan: Fix timelog formatting  (WIP Pavan) 
A recent change (as of 3/27/2025) seems to have made the buttons of the timelog stretch out over a larger area.
Find the change that caused this and revert it.



## Related PRS (if any):
This frontend PR is not related to any backend PRs.

## Main changes explained:
- As the change that caused this is a total revamp and refactoring of the dashboard styling, I found a way to reduce the space and make the timer panel look like before in a CSS file

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in
5. go to dashboard→ Timer space compare


## Screenshots or videos of changes:



https://github.com/user-attachments/assets/b1e2938e-bda2-49b4-bb1c-db3daf4245cc

<img width="645" alt="Screenshot 2025-04-18 at 10 36 15 PM" src="https://github.com/user-attachments/assets/4d7ce74e-9780-484e-adb0-d110dcbd3f7a" />
<img width="645" alt="Screenshot 2025-04-18 at 10 36 15 PM" src="https://github.com/user-attachments/assets/f62a5585-0543-4f8f-a89a-0c944b97e4c5" />

