### PR TITLE
Strallia - Fix spacing and darkmode of role distribution chart

### DIFF
--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -395,6 +395,7 @@ function TotalOrgSummary(props) {
               <RoleDistributionPieChart
                 isLoading={isLoading}
                 roleDistributionStats={volunteerOverview?.roleDistributionStats}
+                darkMode={darkMode}
               />
             </div>
           </Col>

--- a/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
@@ -18,7 +18,7 @@ const COLORS = [
   '#46d130',
 ];
 
-export default function RoleDistributionPieChart({ isLoading, roleDistributionStats }) {
+export default function RoleDistributionPieChart({ isLoading, roleDistributionStats, darkMode }) {
   if (isLoading) {
     return (
       <div className="d-flex justify-content-center align-items-center">
@@ -65,10 +65,10 @@ export default function RoleDistributionPieChart({ isLoading, roleDistributionSt
           )}
         </text>
         <text fill="blue" textAnchor="middle" dominantBaseline="central">
-          <tspan x={cx} y={cy - 15} fontSize="1.2em" fill="grey">
+          <tspan x={cx} y={cy - 15} fontSize="1.2em" fill={darkMode ? 'white ' : 'grey'}>
             TOTAL ROLES
           </tspan>
-          <tspan x={cx} y={cy + 15} fontSize="1.5em" fill="grey">
+          <tspan x={cx} y={cy + 15} fontSize="1.5em" fill={darkMode ? 'white ' : 'grey'}>
             {data.length}
           </tspan>
         </text>
@@ -79,7 +79,7 @@ export default function RoleDistributionPieChart({ isLoading, roleDistributionSt
   const renderCustomLegend = props => {
     const { payload } = props;
     return (
-      <ul>
+      <ul style={{ marginLeft: 20 }}>
         {payload.map(entry => (
           <li
             key={`item-${entry.value}`}
@@ -93,7 +93,9 @@ export default function RoleDistributionPieChart({ isLoading, roleDistributionSt
                 marginRight: '3px',
               }}
             />
-            <span style={{ color: 'grey', fontSize: '12px' }}>{entry.value}</span>
+            <span style={{ color: darkMode ? 'white ' : 'grey', fontSize: '12px' }}>
+              {entry.value}
+            </span>
           </li>
         ))}
       </ul>
@@ -101,7 +103,7 @@ export default function RoleDistributionPieChart({ isLoading, roleDistributionSt
   };
 
   return (
-    <div>
+    <div style={{ margin: '15px 10px 10px 10px' }}>
       <ResponsiveContainer width="100%" height="100%" minWidth={400} minHeight={430}>
         <PieChart className="test2">
           <Pie


### PR DESCRIPTION
# Description
Added more spacing between legend and pie chart in Role Distribution chart on Total Org Summary page. Also made the text white in dark mode.

<img width="566" alt="image" src="https://github.com/user-attachments/assets/3f9b9135-64d1-40ca-a416-fbb07b290a80" />

## How to test:
1. check into current branch
2. do `npm install` and `npm start` to run this PR locally
3. Clear site data/cache
4. login as admin user
5. go to dashboard→ reports → total org summary 
6. verify the changes have been made to the Role Distribution chart
