### PR TITLE
Fix for nullnull bug in "Other Links" dropdown

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -456,19 +456,15 @@ export function Header(props) {
                       <span className="dashboard-text-link">{OTHER_LINKS}</span>
                     </DropdownToggle>
                     <DropdownMenu className={darkMode ? 'bg-yinmn-blue' : ''}>
-                      {canAccessUserManagement ? (
+                      {canAccessUserManagement && (
                         <DropdownItem tag={Link} to="/usermanagement" className={fontColor}>
                           {USER_MANAGEMENT}
                         </DropdownItem>
-                      ) : (
-                        `null`
                       )}
-                      {canAccessBadgeManagement ? (
+                      {canAccessBadgeManagement && (
                         <DropdownItem tag={Link} to="/badgemanagement" className={fontColor}>
                           {BADGE_MANAGEMENT}
                         </DropdownItem>
-                      ) : (
-                        `null`
                       )}
                       {canAccessProjects && (
                         <DropdownItem tag={Link} to="/projects" className={fontColor}>


### PR DESCRIPTION
# Description
When a user did not have User Management or  Badge Management permissions, the "Other Links" dropdown showed "null" as a menu item. This fix ensures that only authorized dropdown items are rendered, and no placeholder text appears when permissions are missing.

## Related PRS (if any):
This frontend PR is related to the development backend PR.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as a user with the Manager role
5. Navigate to Dashboard → Other Links
6. Verify that no null values appear in the dropdown
7. Repeat the test with different user roles (e.g., Manager, Admin) to validate behavior under various permission sets

## Screenshots or videos of changes:
Before change:
<img width="556" alt="Screenshot 2025-04-24 at 5 54 36 PM" src="https://github.com/user-attachments/assets/b2ea1c22-74f6-4873-a534-e165060bc7f5" />

After change:
<img width="548" alt="Screenshot 2025-04-24 at 6 24 21 PM" src="https://github.com/user-attachments/assets/469f23e8-78e5-4db3-820b-90fa1e8ea949" />


## Note:
Include the information the reviewers need to know.
