### PR TITLE
Rishitha fix suggestion categories displaying nan

### DIFF
--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -864,7 +864,7 @@ function SummaryBar(props) {
                     -- select an option --
                   </option>
                   {suggestionCategory.map((item, index) => (
-                    <option key={index} value={item}>
+                    <option key={item} value={item}>
                       {`${index + 1}. ${item}`}
                     </option>
                   ))}


### PR DESCRIPTION
# Description
(PRIORITY MEDIUM) Hakan: Fix suggestion categories displaying NaN (Needs new developer) (WIP Rishitha)
Needs new developer: [PR 3191](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3191)
Remove the “NaN.” from categories in the User Suggestions popup (press the lightbulb in the top right of dashboard) 
Previous developer said: This PR has the necessary updates in place, but there are Netlify-related conflicts that seem unrelated to the functionality I worked on. A second pair of eyes would be helpful here as well.
•⁠  ⁠My PR only touches dropdown logic, and doesn’t affect deploy settings or Netlify config.
•⁠  ⁠I checked similar PRs and noticed they’re also failing with the same Netlify errors.
•⁠  ⁠I re-ran the jobs, but the errors persist.
•⁠  ⁠Tests pass locally on my machine.

## Related PRS (if any):
This frontend PR is related to the development backend PR.
To test this frontend PR you need to checkout the development frontend PR.

## Main changes explained:
- Update src/components/SummaryBar/SummaryBar.jsx for remove lint errors

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Suggestions → User Suggestion
6. verify the ordered list
7. verify this new feature works in dark mode

## Screenshots or videos of changes:
Before:
![image](https://github.com/user-attachments/assets/64ff8eb0-533c-4e07-96ef-ea84942294f1)

After:
![image](https://github.com/user-attachments/assets/144c3355-3cf0-4aaa-bbd9-d74ce692308f)

