### PR TITLE
Changes the functionality of the button named 'Edit Job Application Email CC'

### DIFF
--- a/src/components/UserProfile/BlueSquareLayout.jsx
+++ b/src/components/UserProfile/BlueSquareLayout.jsx
@@ -10,6 +10,7 @@ import BlueSquaresTable from './BlueSquaresTable/BlueSquaresTable';
 import BluequareEmailAssignmentPopUp from './BluequareEmailBBCPopUp';
 import './UserProfile.scss';
 import './UserProfileEdit/UserProfileEdit.scss';
+import {useHistory } from 'react-router-dom';
 
 
 const BlueSquareLayout = ({
@@ -20,6 +21,7 @@ const BlueSquareLayout = ({
   user,
   darkMode,
 }) => {
+    const history = useHistory();
   const dispatch = useDispatch();
   const allRequests = useSelector(state => state.timeOffRequests.requests);
   const canManageTimeOffRequests = dispatch(hasPermission('manageTimeOffRequests'));
@@ -143,7 +145,7 @@ const BlueSquareLayout = ({
                 <div className="Job-Email-CC-div">
                   <Button
                     variant="primary"
-                    onClick={() => {window.open("/job-notification-dashboard")}}
+                    onClick={() => {history.push("/job-notification-dashboard")}}
                     className="mt-3 w-100 Job-Email-CC-button"
                     size="md"
                     style={darkMode ? boxStyleDark : boxStyle}


### PR DESCRIPTION
# Description
This PR changes the functionality of the button named "Edit Job Application Email CC" so that the user navigates to the page in the same tab instead of opening a new one.


## Related PRS (if any):
None
…

## Main changes explained:
The JobCCDashboard.jsx component has been modified to implement the feature.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an admin or owner user.
5. Go to View Profile, click on the button named "Edit Job Application Email CC", and you should be redirected to the page in the same tab instead of opening a new one.

## Screenshots or videos of changes:
![Gif2](https://github.com/user-attachments/assets/4fca4c37-0ca7-4e96-83f4-60acb2b75d1a)

## Note:
None
