### PR TITLE
Added unit tests for timeEntriesForSpecifiedPeriod

### DIFF
--- a/src/reducers/__tests__/timeEntriesForSpecifiedPeriodReducer.test.js
+++ b/src/reducers/__tests__/timeEntriesForSpecifiedPeriodReducer.test.js
@@ -1,29 +1,54 @@
-import { timeEntriesForSpecifiedPeriodReducer } from '../timeEntriesForSpecifiedPeriodReducer';
+import reducer from '../timeEntriesForSpecifiedPeriodReducer';
 
 describe('timeEntriesForSpecifiedPeriodReducer', () => {
+  const samplePayload = [{ id: 1, time: '2023-01-01' }, { id: 2, time: '2023-01-02' }];
+  const initialState = null;
+
+  it('should return the initial state when state is undefined', () => {
+    const newState = reducer(undefined, {});
+    expect(newState).toEqual(initialState);
+  });
+
+  it('should return the current state when action type does not match', () => {
+    const currentState = [{ id: 99, time: '2023-04-30' }];
+    const newState = reducer(currentState, { type: 'UNKNOWN_ACTION' });
+    expect(newState).toEqual(currentState);
+  });
+
+  it('should return the new state when action type is GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD', () => {
+    const newState = reducer(initialState, {
+      type: 'GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD',
+      payload: samplePayload,
+    });
+    expect(newState).toEqual(samplePayload);
+  });
+
+  it('should update the state with the new time entries when action type is GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD', () => {
+    const currentState = [{ id: 0, time: '2023-01-01' }];
+    const newState = reducer(currentState, {
+      type: 'GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD',
+      payload: samplePayload,
+    });
+    expect(newState).toEqual(samplePayload);
+  });
+
   it('should return the initial state when no state is provided', () => {
-    const initialState = null;
-    const action = { type: 'UNKNOWN_ACTION' };
-    const result = timeEntriesForSpecifiedPeriodReducer(undefined, action);
-    expect(result).toBe(initialState);
+    const newState = reducer(undefined, {});
+    expect(newState).toEqual(initialState);
   });
 
   it('should return the current state for an unknown action type', () => {
-    const currentState = [{ id: 1, hours: 5 }];
-    const action = { type: 'UNKNOWN_ACTION' };
-    const result = timeEntriesForSpecifiedPeriodReducer(currentState, action);
-    expect(result).toEqual(currentState);
+    const currentState = [{ id: 3, time: '2023-04-29' }];
+    const newState = reducer(currentState, { type: 'SOME_UNKNOWN_TYPE' });
+    expect(newState).toEqual(currentState);
   });
 
   it('should handle GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD and update the state', () => {
     const action = {
       type: 'GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD',
-      payload: [
-        { id: 2, hours: 8 },
-        { id: 3, hours: 6 },
-      ],
+      payload: samplePayload,
     };
-    const result = timeEntriesForSpecifiedPeriodReducer(null, action);
-    expect(result).toEqual(action.payload);
+    const newState = reducer(null, action);
+    expect(newState).toEqual(samplePayload);
   });
 });


### PR DESCRIPTION
# Description
Unit test for `src/reducers/timeEntriesForSpecifiedPeriodReducer.js`




## Main changes explained:
Added test cases for the following:
1. Should return the initial state when state is undefined 
2. Should return the current state when action type does not match
3. Should return the new state when action type is GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD
4. Should update the state with the new time entries when action type is GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD
5. Should return the initial state when no state is provided
6. Should return the current state for an unknown action type
7. Should handle GET_TIME_ENTRY_FOR_SPECIFIED_PERIOD and update the state





## How to test:
1. check into current branch
5. do `npm install` and `npm test timeEntriesForSpecifiedPeriodReducer.test.js` to run this PR locally


## Screenshots or videos of changes:
<img width="949" alt="Screenshot 2025-04-30 at 10 57 30 PM" src="https://github.com/user-attachments/assets/a31ce154-1ed7-4725-b8de-b075a25b19bc" />