### PR TITLE
Anjali member pagination

### DIFF
--- a/src/components/QuestionnaireDashboard/MemberList.css
+++ b/src/components/QuestionnaireDashboard/MemberList.css
@@ -15,7 +15,7 @@
   .member-card {
     border: 1px solid #ccc;
     padding: 16px;
-    width: 240px;
+    width: 245px;
     border-radius: 8px;
     background: #fdfdfd;
     word-wrap: break-word;

--- a/src/components/QuestionnaireDashboard/MemberList.css
+++ b/src/components/QuestionnaireDashboard/MemberList.css
@@ -1,0 +1,64 @@
+.member-list-container {
+    padding: 20px;
+  }
+  
+  .cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    justify-content: flex-start;
+    justify-content: center; /* center horizontally */
+    align-items: center;     /* center vertically */
+    flex-wrap: wrap;   
+  }
+  
+  .member-card {
+    border: 1px solid #ccc;
+    padding: 16px;
+    width: 240px;
+    border-radius: 8px;
+    background: #fdfdfd;
+    word-wrap: break-word;
+    word-break: break-word;
+    overflow-wrap: break-word;
+  }
+  
+  .pagination-controls {
+    margin-top: 20px;
+    display: flex;
+    gap: 8px;
+    display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px; /* or as needed */
+
+  }
+  
+  .pagination-controls button {
+    padding: 8px 12px;
+    border-radius: 4px;
+    border: 1px solid #aaa;
+    background-color: #fff;
+    cursor: pointer;
+  }
+  
+  .pagination-controls button.active {
+    background-color: #007bff;
+    color: white;
+    font-weight: bold;
+  }
+  
+  .pagination-controls button:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+  .member-avatar {
+    width: 100px;
+    height: 100px;
+    object-fit: cover;
+    border-radius: 50%;
+    margin-top: 8px;
+    margin-bottom: 8px;
+  }
+  
+  

--- a/src/components/QuestionnaireDashboard/MemberList.jsx
+++ b/src/components/QuestionnaireDashboard/MemberList.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import './MemberList.css';
+
+const dummyMembers = Array.from({ length: 45 }, (_, i) => ({
+  id: i + 1,
+  name: `Shreya Laheri`,
+  email: `shreya@onecommunity.com`,
+  slack: `shreya_laheri`,
+  score: `${6 - (i % 3)}/10`,
+  skills: 'HTML, CSS, Java, Reactjs'
+}));
+
+const MemberList = () => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const membersPerPage = 5;
+
+  // Get current page data
+  const indexOfLast = currentPage * membersPerPage;
+  const indexOfFirst = indexOfLast - membersPerPage;
+  const currentMembers = dummyMembers.slice(indexOfFirst, indexOfLast);
+  const totalPages = Math.ceil(dummyMembers.length / membersPerPage);
+
+  const goToPage = (page) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+    }
+  };
+
+  return (
+    <div className="member-list-container">
+      <div className="cards">
+        {currentMembers.map(member => (
+          <div key={member.id} className="member-card">
+            <h3>{member.name}</h3>
+            <img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y"
+               alt={`${member.name}'s avatar`} className="member-avatar"/>
+
+            <p><i className="fa fa-envelope" style={{ marginRight: '6px' }}></i>{member.email}</p>
+            <p><i className="fab fa-slack" style={{ marginRight: '6px', color: '#4A154B' }}></i> {member.slack}</p>
+            <p style={{ color: parseInt(member.score) >= 5 ? 'green' : 'red' }}>
+                Score: {member.score}
+            </p>
+            <p><u>Top Skills:</u> {member.skills}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="pagination-controls">
+        <button onClick={() => goToPage(currentPage - 1)} disabled={currentPage === 1}>Previous</button>
+        {Array.from({ length: totalPages }, (_, i) => (
+          <button key={i} className={currentPage === i + 1 ? 'active' : ''} onClick={() => goToPage(i + 1)}>{i + 1}</button>
+        ))}
+        <button onClick={() => goToPage(currentPage + 1)} disabled={currentPage === totalPages}>Next</button>
+      </div>
+    </div>
+  );
+};
+
+export default MemberList;

--- a/src/components/QuestionnaireDashboard/MemberList.jsx
+++ b/src/components/QuestionnaireDashboard/MemberList.jsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import './MemberList.css';
 
+const names = ['Shreya Laheri', 'Anjali', 'Rahul Verma'];
 const dummyMembers = Array.from({ length: 45 }, (_, i) => ({
   id: i + 1,
-  name: `Shreya Laheri`,
-  email: `shreya@onecommunity.com`,
-  slack: `shreya_laheri`,
+  name: names[i % names.length],
+  email: `user${i + 1}@onecommunity.com`,
   score: `${6 - (i % 3)}/10`,
-  skills: 'HTML, CSS, Java, Reactjs'
+  skills: 'HTML, CSS, Java, Reactjs',
 }));
 
 const MemberList = () => {
@@ -35,8 +35,7 @@ const MemberList = () => {
             <img src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y"
                alt={`${member.name}'s avatar`} className="member-avatar"/>
 
-            <p><i className="fa fa-envelope" style={{ marginRight: '6px' }}></i>{member.email}</p>
-            <p><i className="fab fa-slack" style={{ marginRight: '6px', color: '#4A154B' }}></i> {member.slack}</p>
+            <p><i className="fa fa-envelope" style={{ marginRight: '5px' }}></i>{member.email}</p>
             <p style={{ color: parseInt(member.score) >= 5 ? 'green' : 'red' }}>
                 Score: {member.score}
             </p>

--- a/src/routes.js
+++ b/src/routes.js
@@ -51,6 +51,7 @@ import UnsubscribeForm from './components/EmailSubscribeForm/Unsubscribe';
 import NotFoundPage from './components/NotFound/NotFoundPage';
 import { EmailSender } from './components/common/EmailSender/EmailSender';
 import Collaboration from './components/Collaboration';
+import MemberList from './components/QuestionnaireDashboard/MemberList';
 
 // LB Dashboard
 import LBProtectedRoute from './components/common/LBDashboard/LBProtectedRoute';
@@ -441,6 +442,7 @@ export default(
         <ProtectedRoute path="/userprofile/:userId" fallback component={UserProfile} />
         <ProtectedRoute path="/userprofileedit/:userId" component={UserProfileEdit} />
         <ProtectedRoute path="/updatepassword/:userId" component={UpdatePassword} />
+        <ProtectedRoute path="/memberlist" exact component={MemberList}/>
         <Route path="/Logout" component={Logout} />
         <Route path="/forcePasswordUpdate/:userId" component={ForcePasswordUpdate} />
         <ProtectedRoute path="/hgnform" exact component={Page1}/>


### PR DESCRIPTION
# Description
Implemented frontend pagination for the Questionnaire Dashboard's Member List. This feature displays a limited number of members per page and pagination controls to navigate through the list.


## Main changes explained:
- Created MemberList.jsx for displaying paginated member cards.
- Added MemberList.css for styling layout, alignment, score colors, and responsive grid.
- Updated route in routes.js to load the /memberlist view.
- Styled score display with conditional red/green based on value.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to /memberlist
6. Verify: 
a. cards display a limited number per page (5)
b. Pagination controls (Next, Previous, page numbers) work correctly
c. Score appears green if ≥ 5, red if < 5
d. Layout is centered and visually consistent

## Screenshots or videos of changes:

Uploading Screen Recording 2025-05-01 at 3.18.28 PM.mov…

