### PR TITLE
Koushica - Hotfixes in the User Profile Page

### DIFF
--- a/src/components/CommunityPortal/EventPersonalization/EventStats.css
+++ b/src/components/CommunityPortal/EventPersonalization/EventStats.css
@@ -146,7 +146,7 @@
   color: #ffffff;
 }
 
-.summary {
+.event-summary {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 10px;

--- a/src/components/CommunityPortal/EventPersonalization/EventStats.jsx
+++ b/src/components/CommunityPortal/EventPersonalization/EventStats.jsx
@@ -131,7 +131,7 @@ export default function PopularEvents() {
           </div>
         ))}
       </div>
-      <div className="summary">
+      <div className="event-summary">
         <div className={`summary-item ${darkMode ? 'summary-item-dark' : ''}`}>
           <div className={`summary-title ${darkMode ? 'summary-title-dark' : ''}`}>
             Total Number of Events

--- a/src/components/UserManagement/SetUpFinalDayButton.jsx
+++ b/src/components/UserManagement/SetUpFinalDayButton.jsx
@@ -26,7 +26,7 @@ function SetUpFinalDayButton(props) {
         )(dispatch);
 
         setIsSet(false);
-        onFinalDaySave({ ...userProfile, endDate: undefined });
+        onFinalDaySave && onFinalDaySave({ ...userProfile, endDate: undefined });
         toast.success("This user's final day has been deleted.");
       } catch (error) {
         console.error('Error deleting final day:', error);
@@ -49,7 +49,7 @@ function SetUpFinalDayButton(props) {
 
       setIsSet(true);
       setFinalDayDateOpen(false);
-      onFinalDaySave({ ...userProfile, endDate: finalDayDate });
+      onFinalDaySave && onFinalDaySave({ ...userProfile, endDate: finalDayDate });
       toast.success("This user's final day has been set.");
     } catch (error) {
       console.error('Error setting final day:', error);

--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -103,7 +103,7 @@
   background-color: #1da1ff;
 }
 
-@media (max-width: 1420px) {
+@media (max-width: 1450px) {
   #wrapper .report { 
      left: 102%;
      top: 0px; 


### PR DESCRIPTION
# Description

This PR addresses two  issues:

1. Fixed a bug in **Profile → Basic Information → Set Final Day**, where a success action was incorrectly showing an error message. The issue was due to a method being called without checking if it was defined.
2. Adjusted the layout for the **Blue Square reason popup**, which was overflowing off-screen and requiring a scroll to view. The fix involved updating relevant classNames affected by recent changes related to `eventStats`.

## Related PRs (if any):

- Use the `development` branch for the backend.
- Use this branch (`Koushica_hotfix_UI_changes`) for the frontend.

## Main Changes Explained:

- Updated `eventStats.css` and `eventStats.jsx` to correct the layout of the Blue Square popup, which was broken by recent UI updates.
- Added a check before calling the `handleFinalDaySave` method in the profile component to prevent an undefined function error when setting the final day.

## How to Test:

1. Checkout this frontend branch locally.
2. Run `npm install` if not already done.
3. Start the app using `npm run start:local`.
4. Clear your browser site data/cache.
5. Log in as an Admin user.
6. Go to **Dashboard → Leaderboard → [Select a user]** to open their User Profile.
7. Try to set the **Final Day** — it should save successfully and display a success banner (no error).
8. Hover over a **Blue Square** on the user profile. The popup should appear fully on screen without needing to scroll.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/87402426-bd1b-40ca-b7db-009c614c5093

