### PR TITLE
Rishitha add project name in project members page

### DIFF
--- a/src/components/Projects/Members/Members.jsx
+++ b/src/components/Projects/Members/Members.jsx
@@ -6,7 +6,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { NavItem } from 'reactstrap';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import {
   fetchAllMembers,
   findUserProfiles,
@@ -20,7 +20,7 @@ import hasPermission from '../../../utils/permissions';
 import { boxStyle, boxStyleDark } from 'styles';
 import ToggleSwitch from 'components/UserProfile/UserProfileEdit/ToggleSwitch';
 import Loading from 'components/common/Loading';
-
+import { getProjectDetail } from 'actions/project';
 
 const Members = props => {
   const darkMode = props.state.theme.darkMode;
@@ -34,11 +34,14 @@ const Members = props => {
   const canAssignProjectToUsers = props.hasPermission('assignProjectToUsers');
   const canUnassignUserInProject = props.hasPermission('unassignUserInProject');
 
+  const projectName = useSelector(state => state.projectById?.projectName || '');
+
   useEffect(() => {
     const fetchMembers = async () => {
       setIsLoading(true);
       setMembersList([]);
       await props.fetchAllMembers(projectId);
+      props.getProjectDetail(projectId);
       setIsLoading(false);
     };
     fetchMembers();
@@ -100,15 +103,29 @@ const Members = props => {
       <div className={darkMode ? 'bg-oxford-blue text-light' : ''} style={{minHeight: "100%"}}>
         <div className={`container pt-2 ${darkMode ? 'bg-yinmn-blue-light text-light' : ''}`}>
           <nav aria-label="breadcrumb">
-            <ol className={`breadcrumb ${darkMode ? 'bg-space-cadet' : ''}`} style={darkMode ? boxStyleDark : boxStyle}>
-              <NavItem tag={Link} to={`/projects/`}>
-                <button type="button" className="btn btn-secondary" style={darkMode ? {} : boxStyle}>
-                  <i className="fa fa-chevron-circle-left" aria-hidden="true"></i>
-                </button>
-              </NavItem>
-
-              <div id="member_project__name">PROJECTS {props.projectId}</div>
-            </ol>
+            <div className={`d-flex align-items-center breadcrumb ${darkMode ? 'bg-space-cadet' : ''}`} 
+                          style={{ 
+                            ...darkMode ? boxStyleDark : boxStyle,
+                            backgroundColor: darkMode ? '' : '#E9ECEF',
+                            margin: '0 0 16px',
+                            padding: '12px 16px',
+                            position: 'relative'
+                          }}>
+                          <div style={{ position: 'absolute', left: '1rem' }}>
+                            <NavItem tag={Link} to={`/projects/`}>
+                              <button type="button" className="btn btn-secondary" style={darkMode ? boxStyleDark : boxStyle}>
+                                <i className="fa fa-chevron-circle-left" aria-hidden="true"></i>
+                                <span style={{ marginLeft: '8px' }}>Return to Project List</span>
+                              </button>
+                            </NavItem>
+                          </div>
+                          <div style={{ 
+                            width: '100%',
+                            textAlign: 'center',
+                            fontWeight: 'bold',
+                            fontSize: '1.5rem'  
+                          }}>{projectName}</div>
+                        </div>
           </nav>
           {canAssignProjectToUsers ? (
             <div className="input-group" id="new_project">
@@ -240,4 +257,5 @@ export default connect(mapStateToProps, {
   getAllUserProfiles,
   assignProject,
   hasPermission,
+  getProjectDetail,
 })(Members);


### PR DESCRIPTION
# Description
(PRIORITY HIGH) Jae: Add Project Name to Projects>Members [(Needs new developer](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3032)) (WIP Rishitha)
[PR 3032](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3032) works and includes WBS Pages title but previous developer said “The only issue is a failing unit test that doesn’t appear to be related to the code I pushed. It might be best if another developer could take a look and confirm”
Other Links → Projects → Click on Members and/or WBS icons
WBS Pages was done already by another PR and should be removed from this. Then make the Members title look the same
When viewing these pages, I want to know what project I’m on. 

## Related PRS (if any):
This frontend PR is related to the development backend PR.
To test this frontend PR you need to checkout the development backend PR.

## Main changes explained:
- Update src/components/Projects/Members/Members.jsx for including project name

## How to test:
1. check into current branch
2. Run 'npm install" to ensure all dependencies are up to date
3. Clear site data/cache
4. log as admin / owner user
5. Navigate to Dashboard → Projects → WBS Members icon.
6. Verify that the project name is displayed correctly at the top of the page.
7. verify this new feature works in dark mode.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/62560edb-c621-476f-8047-37df65c77af6


