### PR TITLE
Anthony/Permissions Management White Screen Fix

### DIFF
--- a/src/components/PermissionsManagement/PermissionChangeLogTable.jsx
+++ b/src/components/PermissionsManagement/PermissionChangeLogTable.jsx
@@ -23,9 +23,9 @@ function PermissionChangeLogTable({ changeLogs, darkMode }) {
   };
 
   const formatName = name => {
-    if (name.startsWith('INDIVIDUAL:')) {
-      return name.replace('INDIVIDUAL:', '').trim();
-    }
+    // if (name.startsWith('INDIVIDUAL:')) {
+    //   return name.replace('INDIVIDUAL:', '').trim();
+    // }
     return name;
   };
 
@@ -122,9 +122,13 @@ function PermissionChangeLogTable({ changeLogs, darkMode }) {
                 )} ${formattedAmPmTime(log.logDateTime)}`}</td>
                 <td
                   className={`permission-change-log-table--cell ${bgYinmnBlue}`}
-                  style={{
-                    fontWeight: log.name.startsWith('INDIVIDUAL:') ? 'bold' : 'normal',
-                  }}
+                  style={
+                    {
+                      // Commented out the below code as log.name is undefined currently so accessing it causes the white
+                      // screen error on the Permissions Management page
+                      // fontWeight: log.name.startsWith('INDIVIDUAL:') ? 'bold' : 'normal',
+                    }
+                  }
                 >
                   {formatName(log.name)}
                 </td>


### PR DESCRIPTION
# Description
Fixes #2 Priority Urgent
![White Screen Issue](https://github.com/user-attachments/assets/bfd85779-3e99-4c9b-9c0f-08b75926d395)

Fix: Should now enable Owner users to view Permissions Management page and edit permissions without the page turning into a white screen

## Related PRS (if any):
No backend related PR

## Main changes explained:
- Commented out some code in PermissionChangeLogTable.jsx accessing a name parameter that's undefined

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally, backend is the normal routine
3. Clear site data/cache
4. log as owner user
5. go to Other Link>Permissions Management>Manage User Permissions
6. verify that the page doesn't go white screen after some time or during actions

