### PR TITLE
Akanksha - Fix the ‘X’ button on the dashboard under task name

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -95,7 +95,7 @@ const TeamMemberTask = React.memo(
     const canGetWeeklySummaries = dispatch(hasPermission('getWeeklySummaries'));
     const canSeeReports = rolesAllowedToResolveTasks.includes(userRole)||dispatch(hasPermission('getReports'));
     const canUpdateTask = dispatch(hasPermission('updateTask'));
-    const canRemoveUserFromTask = dispatch(hasPermission('removeUserFromTask'));
+    const canRemoveUserFromTask = dispatch(hasPermission('removeUserFromTask')) || dispatch(hasPermission('putReviewStatus'));
     const numTasksToShow = isTruncated ? NUM_TASKS_SHOW_TRUNCATE : activeTasks.length;
 
     const colors_objs = {


### PR DESCRIPTION
# Description:
Fix the ‘X’ button on the dashboard under task name. The Owner account is able to delete a task, but other accounts that are assigned the ‘Interact with Task’ permission are not able to delete the task. 

## Related PRS:
To test this frontend PR you need to checkout the https://github.com/OneCommunityGlobal/HGNRest/pull/1374 backend PR.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to Other Links → Permissions Management → Manage User Permissions → Choose your volunteer account → click on Add button beside the ‘Interact with Task "Ready for Review"’ permission → Scroll down then submit
6. Log in to your volunteer account, try to click the red ‘X’ button beside tasks. You will see the error message below: 
<img width="659" alt="Screenshot 2025-05-08 at 1 15 14 PM" src="https://github.com/user-attachments/assets/a3fa6b8a-6d51-4812-a2c3-dde0095fa5aa" />

## Screenshots or videos of changes:
After the fix:
<img width="1367" alt="Screenshot 2025-05-08 at 1 52 34 PM" src="https://github.com/user-attachments/assets/e2d30e82-4077-44f9-8859-1a193f4fa37f" />