### PR TITLE
Guirong-Team Stats Bar Chart

### DIFF
--- a/src/components/TotalOrgSummary/TeamStats/TeamStatsBarChart.jsx
+++ b/src/components/TotalOrgSummary/TeamStats/TeamStatsBarChart.jsx
@@ -42,7 +42,7 @@ function TeamStatsBarChart({ data, yAxisLabel }) {
           data={data}
           margin={{ top: 20, right: 150, left: 20, bottom: 20 }}
         >
-          <XAxis type="number">
+          <XAxis type="number" tick={{ fill: darkMode ? 'white' : '#666' }}>
             <Label
               value="Total Volunteers"
               position="insideBottom"

--- a/src/components/TotalOrgSummary/TeamStats/TeamStatsBarChart.jsx
+++ b/src/components/TotalOrgSummary/TeamStats/TeamStatsBarChart.jsx
@@ -7,11 +7,14 @@ import {
   ResponsiveContainer,
   Cell,
   LabelList,
+  Label,
 } from 'recharts';
 import './TeamStatsBarChart.css';
 import TeamStatsBarLabel from './TeamStatsBarLabel';
+import { useSelector } from 'react-redux';
 
 function TeamStatsBarChart({ data, yAxisLabel }) {
+  const darkMode = useSelector(state => state.theme.darkMode);
   const totalValue = data.reduce((acc, item) => acc + item.value, 0);
   const renderCustomLabel = props => {
     const { x, y, width, height, index } = props;
@@ -39,8 +42,24 @@ function TeamStatsBarChart({ data, yAxisLabel }) {
           data={data}
           margin={{ top: 20, right: 150, left: 20, bottom: 20 }}
         >
-          <XAxis type="number" />
-          <YAxis type="category" dataKey={yAxisLabel} className="team-stats-y-axis" />
+          <XAxis type="number">
+            <Label
+              value="Total Volunteers"
+              position="insideBottom"
+              offset={-10}
+              style={{
+                fontWeight: 'bold',
+                fill: darkMode ? 'white' : '#666',
+                color: darkMode ? 'white' : '#666',
+              }}
+            />
+          </XAxis>
+          <YAxis
+            type="category"
+            dataKey={yAxisLabel}
+            className="team-stats-y-axis"
+            tick={{ fill: darkMode ? 'white' : '#666' }}
+          ></YAxis>
           <Tooltip />
           <Bar dataKey="value" fill="#1B6DDF">
             {data.map((_, index) => (

--- a/src/components/TotalOrgSummary/TeamStats/TeamStatsBarChart.jsx
+++ b/src/components/TotalOrgSummary/TeamStats/TeamStatsBarChart.jsx
@@ -10,8 +10,8 @@ import {
   Label,
 } from 'recharts';
 import './TeamStatsBarChart.css';
-import TeamStatsBarLabel from './TeamStatsBarLabel';
 import { useSelector } from 'react-redux';
+import TeamStatsBarLabel from './TeamStatsBarLabel';
 
 function TeamStatsBarChart({ data, yAxisLabel }) {
   const darkMode = useSelector(state => state.theme.darkMode);
@@ -59,7 +59,7 @@ function TeamStatsBarChart({ data, yAxisLabel }) {
             dataKey={yAxisLabel}
             className="team-stats-y-axis"
             tick={{ fill: darkMode ? 'white' : '#666' }}
-          ></YAxis>
+          />
           <Tooltip />
           <Bar dataKey="value" fill="#1B6DDF">
             {data.map((_, index) => (

--- a/src/components/TotalOrgSummary/TeamStats/TeamStatsBarLabel.jsx
+++ b/src/components/TotalOrgSummary/TeamStats/TeamStatsBarLabel.jsx
@@ -2,6 +2,14 @@ import { useSelector } from 'react-redux';
 
 function TeamStatsBarLabel({ x, y, width, height, value, change, percentage }) {
   const darkMode = useSelector(state => state.theme.darkMode);
+  let changeColor;
+  if (darkMode) {
+    changeColor = 'white';
+  } else if (change >= 0) {
+    changeColor = 'green';
+  } else {
+    changeColor = 'red';
+  }
   return (
     <g>
       <text
@@ -29,7 +37,7 @@ function TeamStatsBarLabel({ x, y, width, height, value, change, percentage }) {
       <text
         x={x + width + 10}
         y={y + height / 2 + 20}
-        fill={darkMode ? 'white' : change >= 0 ? 'green' : 'red'}
+        fill={changeColor}
         fontSize="12"
         textAnchor="start"
         dominantBaseline="middle"

--- a/src/components/TotalOrgSummary/TeamStats/TeamStatsBarLabel.jsx
+++ b/src/components/TotalOrgSummary/TeamStats/TeamStatsBarLabel.jsx
@@ -3,10 +3,8 @@ import { useSelector } from 'react-redux';
 function TeamStatsBarLabel({ x, y, width, height, value, change, percentage }) {
   const darkMode = useSelector(state => state.theme.darkMode);
   let changeColor;
-  if (darkMode) {
-    changeColor = 'white';
-  } else if (change >= 0) {
-    changeColor = 'green';
+  if (change >= 0) {
+    changeColor = darkMode ? 'lightgreen' : 'green';
   } else {
     changeColor = 'red';
   }

--- a/src/components/TotalOrgSummary/TeamStats/TeamStatsBarLabel.jsx
+++ b/src/components/TotalOrgSummary/TeamStats/TeamStatsBarLabel.jsx
@@ -1,10 +1,13 @@
+import { useSelector } from 'react-redux';
+
 function TeamStatsBarLabel({ x, y, width, height, value, change, percentage }) {
+  const darkMode = useSelector(state => state.theme.darkMode);
   return (
     <g>
       <text
         x={x + width + 30}
         y={y + height / 2 - 20}
-        fill="#000"
+        fill={darkMode ? 'white' : '#000'}
         fontSize="12"
         textAnchor="start"
         dominantBaseline="middle"
@@ -15,7 +18,7 @@ function TeamStatsBarLabel({ x, y, width, height, value, change, percentage }) {
       <text
         x={x + width + 20}
         y={y + height / 2}
-        fill="#666"
+        fill={darkMode ? 'white' : '#666'}
         fontSize="12"
         textAnchor="start"
         dominantBaseline="middle"
@@ -26,7 +29,7 @@ function TeamStatsBarLabel({ x, y, width, height, value, change, percentage }) {
       <text
         x={x + width + 10}
         y={y + height / 2 + 20}
-        fill={change >= 0 ? 'green' : 'red'}
+        fill={darkMode ? 'white' : change >= 0 ? 'green' : 'red'}
         fontSize="12"
         textAnchor="start"
         dominantBaseline="middle"

--- a/src/components/TotalOrgSummary/TotalOrgSummary.css
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.css
@@ -50,6 +50,6 @@
   margin: 10px;
 }
 
-.chart-title.dark-mode p{
+.chart-title.dark-mode p {
   color: white;
 }

--- a/src/components/TotalOrgSummary/VolunteerTrendsLineChart/styles.css
+++ b/src/components/TotalOrgSummary/VolunteerTrendsLineChart/styles.css
@@ -6,7 +6,7 @@
   position: absolute !important;
   z-index: 1;
   transform: translateX(-50%);
-  box-shadow: 2px 4px 8px rgba(0, 0, 0, 0.2) ;
+  box-shadow: 2px 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 .chart-container {
@@ -23,7 +23,7 @@
 }
 
 .custom-date-range > span {
- font-weight: bold;
+  font-weight: bold;
 }
 
 .date-filter-container {
@@ -35,7 +35,7 @@
 
 .date-filter-container > select {
   margin-top: 0;
-  width: min-content
+  width: min-content;
 }
 
 @media (max-width: 500px) {


### PR DESCRIPTION
# Description
Add the x-ray label and make the pop-up window content could be seen in dark mode.
<img width="911" alt="image" src="https://github.com/user-attachments/assets/06568637-5095-41ad-b379-0c9c26c20c2f" />

## Related PRS (if any):
This frontend PR is related to the development backend PR.


## Main changes explained:
- X-ray label added
- Label could be seen clearly in dark mode
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ Total org summary→ Volunteer Roles and Team Dynamics
6. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
