### PR TITLE
Koushica - hotfixes of UI breakages

### DIFF
--- a/src/components/Collaboration/Collaboration.css
+++ b/src/components/Collaboration/Collaboration.css
@@ -1,4 +1,4 @@
-.container,
+.collaboration-container,
 .job-landing .header img {
   width: 60%;
   max-width: 1000px;
@@ -8,7 +8,7 @@
 .job-ad {
   text-align: center;
 }
-.container {
+.collaboration-container {
   width: 90%;
   margin: 0 auto;
   flex-direction: column;
@@ -21,7 +21,7 @@
   margin: 0 auto;
   flex-direction: column;
 }
-.navbar {
+.collaboration-navbar {
   width: 100%;
   display: flex;
   justify-content: space-between;

--- a/src/components/Collaboration/Collaboration.jsx
+++ b/src/components/Collaboration/Collaboration.jsx
@@ -155,8 +155,8 @@ class Collaboration extends Component {
               <img src={OneCommunityImage} alt="One Community Logo" className="responsive-img" />
             </a>
           </div>
-          <div className="container">
-            <nav className="navbar">
+          <div className="collaboration-container">
+            <nav className="collaboration-navbar">
               <div className="navbar-left">
                 <form className="search-form">
                   <input
@@ -228,8 +228,8 @@ class Collaboration extends Component {
             <img src={OneCommunityImage} alt="One Community Logo" />
           </a>
         </div>
-        <div className="container">
-          <nav className="navbar">
+        <div className="collaboration-container">
+          <nav className="collaboration-navbar">
             <div className="navbar-left">
               <form className="search-form">
                 <input

--- a/src/components/ForcePasswordUpdate/__tests__/ForcePasswordUpdate.test.js
+++ b/src/components/ForcePasswordUpdate/__tests__/ForcePasswordUpdate.test.js
@@ -283,6 +283,8 @@ describe('Force Password Update behaviour', () => {
       target: { value: 'newPassword8' },
     });
 
+    console.log('Before Submit:', screen.getByLabelText('New Password:').value);
+
     fireEvent.click(screen.getByText('Submit'));
 
     await waitFor(() => {
@@ -302,7 +304,7 @@ describe('Force Password Update behaviour', () => {
 });
 
 describe('Force Password Update page structure', () => {
-  it('should match the snapshot', () => {
+  it('should match the snapshot', async () => {
     const props = {
       match: { params: { userId: '5edf141c78f1380017b829a6' } },
       auth: { isAuthenticated: true },
@@ -321,6 +323,12 @@ describe('Force Password Update page structure', () => {
         />
       </Provider>,
     );
+
+    await waitFor(() => {
+      expect(screen.getByText('Change Password')).toBeInTheDocument();
+    });
+
+    // Now take the snapshot after the component has stabilized
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/components/LeaderBoard/Leaderboard.css
+++ b/src/components/LeaderBoard/Leaderboard.css
@@ -67,9 +67,9 @@
     border-top-color: rgb(222, 226, 230);
   }
 }
-.row {
+/* .row {
   width: 97%;
-}
+}  Commented since it is breaking the UI in the team member's weekly summary tab*/
 
 .table-fixed tbody td {
   white-space: normal; /* Allow text wrapping within cells */


### PR DESCRIPTION
# Description
Fixed the following UI issues:
1. Other Links → Projects → WBS column → Click Icon – The header displaying the project title was collapsing.
2. Profile Page → Quick Setup Codes under Image → Click to Add – The volunteer agreement confirmation block was collapsing.
3. People’s Time Logs Width Issue – The green box now fits correctly, removing unnecessary white space on the left and right.

## Related PRS (if any):
* Backend: Use the development branch.
* Frontend: Use the Koushica_hotfix_UI_changes branch.

## Main changes explained:
- Updated src/components/Collaboration/Collaboration.css and src/components/Collaboration/Collaboration.jsx.
- Modified the .jobform-navbar class name to prevent styling conflicts.

## How to test:
1. check into current branch
4. do `npm install` and `...` to run this PR locally
5. Clear site data/cache
6. log as admin user
7. Verify the fixes:
a) Projects Page:
* Navigate to Other Links → Projects → WBS column → Click Icon.
* Confirm that the header with the project title is properly aligned.

b) Profile Page:
* Navigate to Quick Setup Codes under the User Profile page
* Click on one of the codes to add.
* Check that the volunteer agreement confirmation block displays correctly.

c) Dashboard:
* Check the People's Time Logs.
* Ensure the green box fits properly, without any extra white space.
