### PR TITLE
Rishitha Fix Other Links>Projects>Active column deactivation ability

### DIFF
--- a/src/components/Projects/Project/Project.jsx
+++ b/src/components/Projects/Project/Project.jsx
@@ -49,6 +49,11 @@ const Project = props => {
     } 
   };
 
+  const onProjectStatusChange = () => {
+    // Trigger the modal from Projects component via props
+    props.onClickProjectStatusBtn(projectData); // This will open the modal
+  };
+
   const onUpdateProjectActive = () => {
     updateProject('isActive', !isActive);
   }
@@ -140,7 +145,7 @@ const Project = props => {
       </td>
       {/* <td className="projects__active--input" data-testid="project-active" onClick={canPutProject ? updateActive : null}>
         {props.active ? ( */}
-          <td className="projects__active--input" data-testid="project-active" onClick={canEditCategoryAndStatus || canPutProject ? onUpdateProjectActive : null}>
+          <td className="projects__active--input" data-testid="project-active" onClick={canEditCategoryAndStatus || canPutProject ? onProjectStatusChange : null}>
               {isActive ? (
           <div className="isActive">
             <i className="fa fa-circle" aria-hidden="true"></i>

--- a/src/components/Projects/Project/Project.test.jsx
+++ b/src/components/Projects/Project/Project.test.jsx
@@ -42,6 +42,7 @@ describe('Project Component', () => {
     hasPermission: jest.fn((permission) => true),
     onUpdateProject: jest.fn(),
     onClickArchiveBtn: jest.fn(),
+    onClickProjectStatusBtn: jest.fn(),
   };
 
   it('renders correctly with props', () => {

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -79,7 +79,7 @@ const projectFetchStatus = useSelector(state => state.allProjects.status);
     setProjectTarget(projectData);
     setModalData({
       showModal: true,
-      modalMessage: `<p>Do you want to archive ${projectData.projectName}?</p>`,
+      modalMessage: `<p style="${darkMode ? 'color: white' : 'color: black;'}">Do you want to archive ${projectData.projectName}?</p>`,
       modalTitle: CONFIRM_ARCHIVE,
       hasConfirmBtn: true,
       hasInactiveBtn: false,
@@ -93,7 +93,7 @@ const projectFetchStatus = useSelector(state => state.allProjects.status);
       // If the project is archived, allow unarchiving
       setModalData({
         showModal: true,
-        modalMessage: `<p>${PROJECT_INACTIVE_CONFIRMATION}</p>`,
+        modalMessage: `<p style="${darkMode ? 'color: white' : 'color: black'}">${PROJECT_INACTIVE_CONFIRMATION}</p>`,
         modalTitle: `Inactive Confirmation - ${projectData.projectName} `,
         hasConfirmBtn: false,
         hasInactiveBtn: true, // No need for inactive button
@@ -103,7 +103,7 @@ const projectFetchStatus = useSelector(state => state.allProjects.status);
       // If the project is inactive, allow setting it to active
       setModalData({
         showModal: true,
-        modalMessage: `<p>${PROJECT_ACTIVE_CONFIRMATION}</p>`,
+        modalMessage: `<p style="${darkMode ? 'color: white' : 'color: black;'}">${PROJECT_ACTIVE_CONFIRMATION}</p>`,
         modalTitle: `Active Confirmation - ${projectData.projectName} `,
         hasConfirmBtn: false,
         hasInactiveBtn: false, // No need for inactive button

--- a/src/components/common/Modal/Modal.jsx
+++ b/src/components/common/Modal/Modal.jsx
@@ -23,6 +23,11 @@ const ModalExample = props => {
     closeModal,
     confirmModal,
     setInactiveModal,
+    setActiveModal,
+    setInactiveButton,
+    isSetInactiveDisabled = false,
+    setActiveButton,
+    isSetActiveDisabled = false,
     modalTitle,
     modalMessage,
     type,
@@ -80,9 +85,21 @@ const ModalExample = props => {
         )}
       </ModalBody>
       <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
-        <Button color="primary" onClick={closeModal} style={darkMode ? boxStyleDark : boxStyle}>
-          Close
-        </Button>
+        {setInactiveModal != null ? (
+          <Button color="danger" onClick={closeModal} style={darkMode ? boxStyleDark : boxStyle}>
+            Nope, changed my mind
+          </Button>
+        ) : null}
+        {setActiveModal != null ? (
+          <Button color="danger" onClick={closeModal} style={darkMode ? boxStyleDark : boxStyle}>
+            Nope, leave it buried
+          </Button>
+        ) : null}
+        {confirmModal != null ? (
+          <Button color="primary" onClick={closeModal} style={darkMode ? boxStyleDark : boxStyle}>
+            Close
+          </Button>
+        ) : null}
 
         {confirmModal != null ? (
           <Button
@@ -96,11 +113,24 @@ const ModalExample = props => {
         ) : null}
         {setInactiveModal != null ? (
           <Button
-            color="warning"
+            color="success"
+            disabled={isSetInactiveDisabled}
             onClick={setInactiveModal}
             style={darkMode ? boxStyleDark : boxStyle}
           >
-            Set inactive
+            {/* Yes, hide it all */}
+            {setInactiveButton}
+          </Button>
+        ) : null}
+        {setActiveModal != null ? (
+          <Button
+            color="success"
+            disabled={isSetActiveDisabled}
+            onClick={setActiveModal}
+            style={darkMode ? boxStyleDark : boxStyle}
+          >
+            {/* Yes, revive the monster */}
+            {setActiveButton}
           </Button>
         ) : null}
 

--- a/src/components/common/Modal/__tests__/Modal.test.jsx
+++ b/src/components/common/Modal/__tests__/Modal.test.jsx
@@ -28,7 +28,12 @@ describe('ModalExample Component', () => {
     const closeModalMock = jest.fn();
     render(
       <Provider store={store}>
-        <ModalExample isOpen closeModal={closeModalMock} modalTitle="Test Modal" />
+        <ModalExample
+          isOpen
+          closeModal={closeModalMock}
+          confirmModal={() => {}}
+          modalTitle="Test Modal"
+        />
       </Provider>,
     );
 
@@ -82,12 +87,13 @@ describe('ModalExample Component', () => {
           isOpen
           closeModal={() => {}}
           setInactiveModal={setInactiveModalMock}
+          setInactiveButton="Yes, hide it all"
           modalTitle="Test Modal"
         />
       </Provider>,
     );
 
-    fireEvent.click(screen.getByText(/set inactive/i));
+    fireEvent.click(screen.getByText(/yes, hide it all/i));
     expect(setInactiveModalMock).toHaveBeenCalled();
   });
 

--- a/src/languages/en/messages.js
+++ b/src/languages/en/messages.js
@@ -20,3 +20,9 @@ export const USER_DELETE_DATA_ARCHIVE = 'Wait, Save the Data! Data Archiving is 
 export const USER_DELETE_OPTION_HEADING = 'Choose A Delete Action';
 export const USER_STATUS_CHANGE_CONFIRMATION = (fullName, status) =>
   `Please confirm that you want to make "${fullName}" as ${status}.`;
+export const PROJECT_INACTIVE_CONFIRMATION = `<strong>Wait, what?!</strong>
+    <br />Switching to Inactive pulls the project and its tasks from the whole team’s view. That’s a lot of disappearing. 
+    <br /><b/>Sure about this?`;
+export const PROJECT_ACTIVE_CONFIRMATION = `<strong>It’s alive! IT’S ALIVE!</strong>
+    <br />You’re about to reanimate this project and unleash all its action items back onto your team’s dashboards. 
+    <br/><b/>Proceed like the mad scientist you are?`;


### PR DESCRIPTION
# Description
(PRIORITY URGENT) Jae: Fix Other Links>Projects>Active column deactivation ability (WIP Rishitha) 

Admin or Owner Login>Other Links>Projects>Active column>Click dot in this column Clicking the green or gray dot in this column should switch the Project from Active to Inactive (or vice versa) Make sure these actions match the confirmation modals below. A confirmation modal should appear when doing this. It should say:  
Active to Inactive switch:

"Wait, what?!"

Switching to 'Inactive' pulls the project and its tasks from the whole team’s view. That’s a lot of disappearing. Sure about this?

Buttons: GREEN: <Yes, hide it all>  RED: <Nope, changed my mind>


Inactive to Active switch:

"It’s alive! IT’S ALIVE!"

You’re about to reanimate this project and unleash all its action items back onto your team’s dashboards. Proceed like the mad scientist you are?

Buttons:: < Yes, revive the monster>  RED: <Nope, leave it buried>


## Related PRS (if any):
This frontend PR is related to the development backend PR.
To test this frontend PR you need to checkout the development backend PR.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ projects
6. In the Projects table, locate the "Active" column:
    Click the status circle for any project.
    A modal should appear:
7. Confirm the modal action, The modal should close, The status icon should immediately update, Project status should persist after page reload.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/da44de01-7adf-4c7c-97ef-f32b0439f128


