### PR TITLE
Dharmik/frontend/fix/add blue squares bottom left first column user mgmt n

### DIFF
--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -151,16 +151,7 @@ const UserTableData = React.memo(props => {
           onClick={() => props.onActiveInactiveClick(props.user)}
         />
         {props.user?.infringements?.length > 0 && (
-          <span
-            style={{
-              position: 'absolute',
-              bottom: 2,
-              left: 4,
-              fontSize: 12,
-              color: '#dc3545',
-              fontWeight: 'bold',
-            }}
-          >
+          <span className="infringement-count">
             {props.user.infringements.length}
           </span>
         )}

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -150,6 +150,20 @@ const UserTableData = React.memo(props => {
           index={props.index}
           onClick={() => props.onActiveInactiveClick(props.user)}
         />
+        {props.user?.infringements?.length > 0 && (
+          <span
+            style={{
+              position: 'absolute',
+              bottom: 2,
+              left: 4,
+              fontSize: 12,
+              color: '#dc3545',
+              fontWeight: 'bold',
+            }}
+          >
+            {props.user.infringements.length}
+          </span>
+        )}
         {!canSeeReports ? (
           <Tooltip
             placement="bottom"

--- a/src/components/UserManagement/usermanagement.css
+++ b/src/components/UserManagement/usermanagement.css
@@ -477,3 +477,11 @@ td {
   opacity: 0;
   transition: opacity 0.2s ease-in-out;
 }
+
+.infringement-count {
+  position: absolute;
+  top: 2px;
+  left: 4px;
+  font-size: 12px;
+  font-weight: bold;
+}


### PR DESCRIPTION
# Description
<img width="742" alt="image" src="https://github.com/user-attachments/assets/e44bc880-3c2a-415f-92bd-9b07368196f7" />

## Related PRS (if any):
This backend PR is related to the #XXX frontend PR.
To test this backend PR you need to checkout the #XXX frontend PR.
…

## Main changes explained:
- While getting the userProfile data for all the users, we get infringements, the length of which is the number of blue squares.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Go to user profile page of the user and assign blue squares
6. Go to the user management page and verify.

## Screenshots or videos of changes:
