### PR TITLE
Koushica - Conversion from JobFormBuilder.css file to JobFormBuilder.module.css file

### DIFF
--- a/src/components/Collaboration/JobFormBuilder.module.css
+++ b/src/components/Collaboration/JobFormBuilder.module.css
@@ -1,12 +1,10 @@
-body {
-  background-color: #d9d9d9;
-}
-#onecommunity-image {
+.oneCommunityGlobalImg {
   height: auto;
   max-width: 1000px;
 }
 
-.form-builder-container {
+.formBuilderContainer {
+  background-color: #d9d9d9;
   max-width: 80%;
   margin: 1% 10% 0;
   display: flex;
@@ -16,14 +14,16 @@ body {
   padding: 5px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
-.custom-form {
+
+.customForm {
   background-color: #d9d9d9;
   padding: 10px;
   margin-top: 3%;
   border-radius: 5px;
   border: 1px solid #d9d9d9;
 }
-.jobform-navbar {
+
+.jobformNavbar {
   display: flex;
   padding: 0 10px;
   justify-content: space-between;
@@ -33,21 +33,21 @@ body {
   margin-bottom: 3%;
 }
 
-.jobform-navbar input {
+.jobformNavbar input {
   margin: 8px 0;
 }
 
-.jobform-navbar select {
+.jobformNavbar select {
   margin: 8px 0;
   width: 100%;
 }
 
-.jobform-navbar div {
+.jobformNavbar div {
   display: flex;
   padding: 2px;
 }
 
-.jobform-navbar button {
+.jobformNavbar button {
   padding: 11px 13px;
   margin: 8px 10px;
   border: none;
@@ -59,29 +59,29 @@ body {
   transition: background-color 0.3s;
 }
 
-.jobform-navbar button:hover {
+.jobformNavbar button:hover {
   background-color: grey;
 }
-p {
+
+.jobformDesc {
   line-height: 2;
 }
 
-h1,
-h2 {
+.jobformTitle {
   text-align: center;
   color: black;
   font-weight: bold;
 }
 
-.jbform-label {
+.jbformLabel {
   display: block;
   font-weight: bold;
   margin-top: 15px;
 }
 
-/* input,
-textarea,
-select {
+.jobformInput,
+.jobformTextarea,
+.jobformSelect {
   width: 95%;
   padding: 10px;
   margin-top: 5px;
@@ -91,18 +91,18 @@ select {
   background-color: white;
 }
 
-textarea {
+.jobformTextarea {
   height: 80px;
   resize: vertical;
-} */
+}
 
-.new-field-section {
+.newFieldSection {
   background-color: #d9d9d9;
   padding: 20px;
 }
 
 /* General Container for Each Question */
-.form-field {
+.formField {
   padding: 5px;
   margin-bottom: 2px;
   display: flex;
@@ -110,7 +110,7 @@ textarea {
   gap: 10px;
 }
 
-.form-div {
+.formDiv {
   display: flex;
   padding: 0;
   margin: 0;
@@ -118,7 +118,7 @@ textarea {
   height: 100%;
 }
 
-#form-div-checkbox {
+.formDivCheckbox {
   width: 40px;
   padding: 0;
   bottom: 0;
@@ -126,7 +126,7 @@ textarea {
 }
 
 /* Label for the Question */
-.field-label {
+.fieldLabel {
   font-size: 16px;
   font-weight: bold;
   line-height: 1.2;
@@ -135,20 +135,20 @@ textarea {
 }
 
 /* Container for Options (Checkbox/Radio/Dropdown) */
-.field-options {
+.fieldOptions {
   display: flex;
   flex-direction: column; /* Stack options vertically by default */
   margin: 1px;
   /* gap: 10px;  */
 }
 
-/* .field-options input,
-textarea {
+.fieldOptions input,
+.jobformTextarea {
   width: 95%;
-} */
+}
 
 /* Individual Option Item */
-.option-item {
+.optionItem {
   display: flex; /* Align checkbox and label on the same line */
   align-items: flex-start;
   margin: 0;
@@ -158,27 +158,27 @@ textarea {
   padding: 2px;
 }
 
-.options-section input {
+.optionsSection input {
   margin: 0 12px 0;
 }
 
-.option-item input[type='checkbox'],
-.option-item input[type='radio'] {
+.optionItem input[type='checkbox'],
+.optionItem input[type='radio'] {
   margin: 0; /* Ensure no extra margins around inputs */
   background-color: black;
   width: 1em;
   height: 1em;
 }
 
-.option-item label {
+.optionItem label {
   font-size: 1rem;
   font-weight: normal;
   margin: 0;
   line-height: 1.2;
 }
 
-.add-field-button,
-.add-option-button {
+.addFieldButton,
+.addOptionButton {
   background-color: #4caf50;
   color: white;
   border: none;
@@ -189,13 +189,13 @@ textarea {
   transition: background-color 0.3s;
 }
 
-.add-field-button,
-.add-option-button :hover {
+.addFieldButton,
+.addOptionButton:hover {
   background-color: #45a049;
 }
 
 /* Submit Button */
-.job-submit-button {
+.jobSubmitButton {
   display: block;
   width: 100%;
   /* max-width: 300px; */
@@ -213,6 +213,6 @@ textarea {
   transition: background-color 0.3s;
 }
 
-.job-submit-button:hover {
+.jobSubmitButton:hover {
   background-color: #45a049;
 }

--- a/src/components/Collaboration/JobFormbuilder.jsx
+++ b/src/components/Collaboration/JobFormbuilder.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import './JobFormBuilder.css';
 import axios from 'axios';
 import { useSelector } from 'react-redux';
+import styles from './JobFormBuilder.module.css';
 import { ENDPOINTS } from '../../utils/URL';
 import OneCommunityImage from './One-Community-Horizontal-Homepage-Header-980x140px-2.png';
 
@@ -141,17 +141,26 @@ function JobFormBuilder() {
   };
 
   return (
-    <div className="form-builder-container">
-      <img src={OneCommunityImage} alt="One Community Logo" id="onecommunity-image" />
-      <div className="jobform-navbar">
+    <div className={styles.formBuilderContainer}>
+      <img
+        src={OneCommunityImage}
+        alt="One Community Logo"
+        id="onecommunity-image"
+        className={styles.oneCommunityGlobalImg}
+      />
+      <div className={styles.jobformNavbar}>
         <div>
-          <input placeholder="Enter Job Title" />
-          <button type="button" className="go-button">
+          <input placeholder="Enter Job Title" className={styles.jobformInput} />
+          <button type="button" className={styles.goButton}>
             Go
           </button>
         </div>
         <div>
-          <select value={jobTitle} onChange={q => setJobTitle(q.target.value)}>
+          <select
+            value={jobTitle}
+            onChange={q => setJobTitle(q.target.value)}
+            className={styles.jobformSelect}
+          >
             <option value="Please Choose an option">Please Choose an Option</option>
             {jobPositions.map((e, i) => (
               <option
@@ -165,11 +174,11 @@ function JobFormBuilder() {
           </select>
         </div>
       </div>
-      <h1>FORM CREATION</h1>
+      <h1 className={styles.jobformTitle}>FORM CREATION</h1>
 
       {role === 'Owner' ? (
-        <div className="custom-form">
-          <p>
+        <div className={styles.customForm}>
+          <p className={styles.jobformDesc}>
             Fill the form with questions about a specific position you want to create an ad for. The
             default questions will automatically appear and are alredy selected. You can pick and
             choose them with the checkbox.
@@ -177,43 +186,56 @@ function JobFormBuilder() {
           <form>
             {formFields.map((field, index) => (
               <div
-                className="form-div"
+                className={styles.formDiv}
                 /* eslint-disable-next-line react/no-array-index-key */
                 key={index + 1}
               >
                 <input
                   type="checkbox"
                   id="form-div-checkbox"
+                  className={styles.formDivCheckbox}
                   checked={field.visible}
                   onChange={event => changeVisiblity(event, field)}
                 />
                 <div
                   /* eslint-disable-next-line react/no-array-index-key */
                   key={index + 1}
-                  className="form-field"
+                  className={styles.formField}
                 >
-                  <label className="field-label jbform-label">{field.questionText}</label>
-                  <div className="field-options">
+                  <label className={`${styles.fieldLabel} ${styles.jbformLabel}`}>
+                    {field.questionText}
+                  </label>
+                  <div className={styles.fieldOptions}>
                     {field.questionType === 'textbox' && (
-                      <input type="text" placeholder="Enter Text here" />
+                      <input
+                        type="text"
+                        placeholder="Enter Text here"
+                        className={styles.jobformInput}
+                      />
                     )}
                     {field.questionType === 'date' && (
-                      <input type="date" placeholder="Enter date" />
+                      <input type="date" placeholder="Enter date" className={styles.jobformInput} />
                     )}
-                    {field.questionType === 'textarea' && <textarea />}
+                    {field.questionType === 'textarea' && (
+                      <textarea className={styles.jobformTextarea} />
+                    )}
                     {['checkbox', 'radio'].includes(field.questionType) &&
                       field.options.map((option, idx) => (
                         <div
                           /* eslint-disable-next-line react/no-array-index-key */
                           key={idx + 1}
-                          className="option-item"
+                          className={styles.optionItem}
                         >
-                          <input type={field.questionType} name={`field-${index}`} />
-                          <label className="jbform-label">{option}</label>
+                          <input
+                            type={field.questionType}
+                            name={`field-${index}`}
+                            className={styles.jobformInput}
+                          />
+                          <label className={styles.jbformLabel}>{option}</label>
                         </div>
                       ))}
                     {field.questionType === 'dropdown' && (
-                      <select>
+                      <select className={styles.jobformSelect}>
                         {field.options.map((option, idx) => (
                           <option
                             /* eslint-disable-next-line react/no-array-index-key */
@@ -230,9 +252,9 @@ function JobFormBuilder() {
               </div>
             ))}
           </form>
-          <div className="new-field-section">
+          <div className={styles.newFieldSection}>
             <div>
-              <label className="jbform-label">
+              <label className={styles.jbformLabel}>
                 Field Label:
                 <input
                   type="text"
@@ -242,14 +264,16 @@ function JobFormBuilder() {
                     setNewField(prev => ({ ...prev, questionText: e.target.value }));
                   }}
                   placeholder="Enter Field Label"
+                  className={styles.jobformInput}
                 />
               </label>
             </div>
             <div>
-              <label className="jbform-label">
+              <label className={styles.jbformLabel}>
                 Input Type:
                 <select
                   value={newField.questionType}
+                  className={styles.jobformSelect}
                   onChange={e => {
                     e.persist();
                     setNewField(prev => ({
@@ -271,26 +295,27 @@ function JobFormBuilder() {
 
             {/* Options Section */}
             {['checkbox', 'radio', 'dropdown'].includes(newField.questionType) && (
-              <div className="options-section">
-                <label className="jbform-label">
+              <div className={styles.optionsSection}>
+                <label className={styles.jbformLabel}>
                   Add Option:
                   <input
                     type="text"
                     value={newOption}
                     onChange={e => setNewOption(e.target.value)}
+                    className={styles.jobformInput}
                     placeholder="Enter an option"
                   />
                 </label>
-                <button type="button" onClick={handleAddOption} className="add-option-button">
+                <button type="button" onClick={handleAddOption} className={styles.addOptionButton}>
                   Add Option
                 </button>
-                <div className="options-list">
+                <div className={styles.optionsList}>
                   <h4>Options:</h4>
                   {newField.options.map((option, index) => (
                     <div
                       /* eslint-disable-next-line react/no-array-index-key */
                       key={index + 1}
-                      className="option-item"
+                      className={styles.optionItem}
                     >
                       {option}
                     </div>
@@ -299,11 +324,11 @@ function JobFormBuilder() {
               </div>
             )}
 
-            <button type="button" onClick={handleAddField} className="add-field-button">
+            <button type="button" onClick={handleAddField} className={styles.addFieldButton}>
               Add Field
             </button>
           </div>
-          <button type="submit" className="job-submit-button" onClick={handleSubmit}>
+          <button type="submit" className={styles.jobSubmitButton} onClick={handleSubmit}>
             Proceed to Submit with Details
           </button>
         </div>

--- a/src/routes.js
+++ b/src/routes.js
@@ -14,7 +14,6 @@ import RoleInfoCollections from 'components/UserProfile/EditableModal/RoleInfoMo
 import LessonList from 'components/BMDashboard/LessonList/LessonListForm';
 import AddEquipmentType from 'components/BMDashboard/Equipment/Add/AddEquipmentType';
 import Announcements from 'components/Announcements';
-import JobFormBuilder from 'components/Collaboration/JobFormbuilder';
 import JobCCDashboard from 'components/JobCCDashboard/JobCCDashboard';
 import WeeklyProjectSummary from 'components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary';
 import FaqSearch from 'components/Faq/FaqSearch';
@@ -149,6 +148,7 @@ const PermissionsManagement = lazy(() =>
 );
 const UserRoleTab = lazy(() => import('./components/PermissionsManagement/UserRoleTab'));
 const Teams = lazy(() => import('./components/Teams/Teams'));
+const JobFormBuilder = lazy(() => import('./components/Collaboration/JobFormbuilder'));
 
 
 export default (


### PR DESCRIPTION
# Description
This PR focuses on improving the maintainability and modularity of the JobFormBuilder component by converting the existing global stylesheet JobFormBuilder.css to a CSS Module JobFormBuilder.module.css. The update involves updating all relevant class references within the JSX to use styles.<className> syntax. This change scopes styles locally to avoid potential conflicts with global class names and aligns with best practices for React component styling.

## Related PRS (if any):
Use the development backend and my current branch for the frontend.

## Main changes explained:
- Renamed JobFormBuilder.css to JobFormBuilder.module.css
- Updated JobFormBuilder.jsx to import the new module file and access styles via the styles object
- Verified that the component renders correctly after the update and all styles are preserved

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Navigate to '/jobformbuilder'
6. Verify that:
- Layout and styling of JobFormBuilder remain consistent
- No console errors related to missing styles
- Styles are scoped (you can try to view dashboard elements and verify the styles are not affected by this change)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/56d010e8-027a-4e0c-abf1-7a6d5dab6a0f

