### PR TITLE
Koushica - UI hotfixes

### DIFF
--- a/src/components/TeamMemberTasks/FollowUpCheckButton.css
+++ b/src/components/TeamMemberTasks/FollowUpCheckButton.css
@@ -26,7 +26,7 @@
   font-size: 10px;
   color: green;
 }
-@media screen and (max-width: 1240px) {
+@media screen and (max-width: 480px) {
   .team-task-progress-follow-up {
     box-sizing: border-box;
     grid-column: 1 / span 1;

--- a/src/components/UserManagement/ResetPasswordPopup.jsx
+++ b/src/components/UserManagement/ResetPasswordPopup.jsx
@@ -64,14 +64,15 @@ const ResetPasswordPopup = React.memo(props => {
       </ModalHeader>
       <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
         <Form>
-          <div className="flex justify-between items-center">
+          {/* <div className="flex justify-between items-center">
             <Label className={`mr-2 ${darkMode ? 'text-light' : ''}`} for="newpassword">
               New Password
             </Label>
-          </div>
+          </div> */}
           <Input
             darkMode={darkMode}
             label="New Password"
+            textColor={darkMode ? 'text-light' : ''}
             autoFocus
             type={showPassword.newPassword ? 'text' : 'password'}
             name="newpassword"
@@ -93,14 +94,16 @@ const ResetPasswordPopup = React.memo(props => {
             }}
           />
 
-          <div className="flex justify-between items-center mt-4">
+          {/* <div className="flex justify-between items-center mt-4">
             <Label className={`mr-2 ${darkMode ? 'text-light' : ''}`} for="confirmpassword">
               Confirm Password
             </Label>
-          </div>
+          </div> */}
           <Input
             darkMode={darkMode}
+            className={darkMode ? 'text-light' : ''}
             label="Confirm Password"
+            textColor={darkMode ? 'text-light' : ''}
             type={showPassword.confirmPassword ? 'text' : 'password'}
             name="confirmpassword"
             id="confirmpassword"

--- a/src/components/UserProfile/BlueSquares/BlueSquare.css
+++ b/src/components/UserProfile/BlueSquares/BlueSquare.css
@@ -103,6 +103,18 @@
   background-color: #1da1ff;
 }
 
+@media (min-width: 1450px) {
+  #wrapper .report { 
+     left: 102%;
+     top: 0px; 
+     z-index: 1;
+     overflow: visible;
+   }
+   .summary {
+     min-height: 300px;
+   }
+ }
+
 @media (max-width: 1450px) {
   #wrapper .report { 
      left: 102%;

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -1180,7 +1180,7 @@ function UserProfile(props) {
           <h6 className={darkMode ? 'text-light' : 'text-azure'}>{jobTitle}</h6>
           <p className={`proile-rating ${darkMode ? 'text-light' : ''}`}>
             {/* use converted date without tz otherwise the record's will updated with timezoned ts for start date.  */}
-            From :{' '}
+            From:{' '}
             <span className={darkMode ? 'text-light' : ''}>
               {formatDateLocal(userProfile.startDate)}
             </span>

--- a/src/components/common/Input/Input.jsx
+++ b/src/components/common/Input/Input.jsx
@@ -7,11 +7,12 @@ import './input.css';
 import { useSelector } from 'react-redux';
 
 // eslint-disable-next-line react/function-component-definition
-const Input = ({ label, name, error, className, type, invalid, ...rest }) => {
+const Input = ({ label, name, error, className, type, invalid, textColor, ...rest }) => {
   const [eye, setEye] = useState(true);
   const [password, setPassword] = useState('password');
 
   const darkMode = useSelector(state => state.theme.darkMode);
+  const darkModeText = textColor || 'text-azure';
 
   const toggleEye = () => {
     if (password === 'password') {
@@ -25,7 +26,7 @@ const Input = ({ label, name, error, className, type, invalid, ...rest }) => {
 
   return (
     <div className={`form-group ${className || ''}`}>
-      <label htmlFor={name} className={darkMode ? 'text-azure' : ''}>
+      <label htmlFor={name} className={darkMode ? darkModeText : ''}>
         {label}
       </label>
       {type === 'password' ? (


### PR DESCRIPTION
# Description
This PR includes UI fixes across multiple sections to address layout and spacing issues:
1) Removed the extra space after the word “From” on the Profile pages.
2) Adjusted the layout of the BlueSquare summary text to ensure it is fully visible within the UI.
3) Fixed the issue where the green checkmark icon overflowed the container at certain screen widths on the Dashboard → Tasks tab (Admin/Owner login).
4) Resolved the duplicate label issue in the Reset Password section on the Profile page by removing the redundant label.

## Related PRS (if any):
Use the development backend and my current branch for the frontend.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ task→…
6. verify function “A” (feel free to include screenshot here)
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
