### PR TITLE
Strallia - Fix Volunteer Status comparison percentage

### DIFF
--- a/src/utils/totalOrgSummary.js
+++ b/src/utils/totalOrgSummary.js
@@ -17,7 +17,7 @@ export const normalizeVolunteerStats = (volunteerNumberStats, totalHoursWorked) 
     {
       ...VOLUNTEER_STATUS_TAB.totalHoursWorked,
       number: Math.round(totalHoursWorked.current),
-      percentageChange: Math.abs(totalHoursWorked.percentage ?? 0).toFixed(0),
+      percentageChange: Math.abs((totalHoursWorked.percentage ?? 0) * 100).toFixed(0),
       isIncreased: (totalHoursWorked.percentage ?? 0) >= 0,
     },
   ];


### PR DESCRIPTION
# Description
This PR fixes the comparison percentage in the Volunteer Status component on Total Org Summary page to match the data in the backend API. It used to display "1" and now it displays the correct percentage.

## How to test:
1. check into current branch
2. do `npm install` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ Total Org Summary
6. verify the comparison percentage is displaying accurately

<img width="333" alt="Screenshot 2025-05-17 at 12 47 22 PM" src="https://github.com/user-attachments/assets/09346c1c-3183-462f-b960-043d377d2087" />
