### PR TITLE
Julia - Add unit test for allUserProfileBasicInfoReducer

### DIFF
--- a/src/reducers/__tests__/allUserProfilesBasicInfoReducer.test.js
+++ b/src/reducers/__tests__/allUserProfilesBasicInfoReducer.test.js
@@ -1,0 +1,89 @@
+import { allUserProfilesBasicInfoReducer } from '../allUserProfilesBasicInfoReducer';
+import * as types from '../../constants/userManagement';
+
+describe('allUserProfilesBasicInfoReducer', () => {
+  // Test 1: Should return the initial state when no action is passed
+  it('should return the initial state when no action is passed', () => {
+    const initialState = null;
+    const action = {}; // No action provided
+
+    const result = allUserProfilesBasicInfoReducer(initialState, action);
+    expect(result).toBeNull(); // Expect the state to be null, which is the initial state
+  });
+
+  it('should handle FETCH_USER_PROFILE_BASIC_INFO and return the state', () => {
+    const action = {
+      type: types.FETCH_USER_PROFILE_BASIC_INFO,
+    };
+    const result = allUserProfilesBasicInfoReducer({}, action);
+    expect(result).toMatchObject({
+      fetching: true,
+      status: '200',
+    });
+  });
+
+  it('should handle FETCH_USER_PROFILE_BASIC_INFO_ERROR and return the error', () => {
+    const action = {
+      type: types.FETCH_USER_PROFILE_BASIC_INFO_ERROR,
+    };
+    const result = allUserProfilesBasicInfoReducer({}, action);
+    expect(result).toMatchObject({
+      fetching: false,
+      status: '404',
+    });
+  });
+
+  it('should handle RECEIVE_USER_PROFILE_BASIC_INFO on empty initialState', () => {
+    const action = {
+      type: types.RECEIVE_USER_PROFILE_BASIC_INFO,
+      payload: 'profiles',
+    };
+    const result = allUserProfilesBasicInfoReducer({}, action);
+    expect(result).toMatchObject({
+      userProfilesBasicInfo: 'profiles',
+      fetching: false,
+      fetched: true,
+      status: '200',
+    });
+  });
+
+  it('should handle RECEIVE_USER_PROFILE_BASIC_INFO and update existed infor', () => {
+    const initialState = {
+      fetching: false,
+      fetched: false,
+      userProfilesBasicInfo: { id: 1, name: 'Test' },
+      status: 404,
+    };
+    const action = {
+      type: types.RECEIVE_USER_PROFILE_BASIC_INFO,
+      payload: { id: 1, name: 'Updated Test' },
+    };
+    const result = allUserProfilesBasicInfoReducer(initialState, action);
+    expect(result).toMatchObject({
+      userProfilesBasicInfo: { id: 1, name: 'Updated Test' },
+      fetching: false,
+      fetched: true,
+      status: '200',
+    });
+  });
+
+  it('should return the previous state when an unknown action is passed', () => {
+    const initialState = {
+      fetching: false,
+      fetched: false,
+      userProfilesBasicInfo: [],
+      status: 404,
+    };
+    const action = {
+      type: 'UNKNOWN_ACTION',
+      payload: {
+        fetching: true,
+        fetched: false,
+        userProfilesBasicInfo: [1, 2, 3],
+        status: 200,
+      },
+    };
+    const result = allUserProfilesBasicInfoReducer(initialState, action);
+    expect(result).toEqual(initialState);
+  });
+});


### PR DESCRIPTION
# Description
Add unit test for src/reducers/allUserProfileBasicInfoReducer.js

## Related PRS (if any):
No related PR

## Main changes explained:
Added test cases for the following:
1. should return the initial state when no action is passed
2. should handle FETCH_USER_PROFILE_BASIC_INFO
3. should handle FETCH_USER_PROFILE_BASIC_INFO_ERROR
4. should handle RECEIVE_USER_PROFILE_BASIC_INFO on empty initialState
5. should handle RECEIVE_USER_PROFILE_BASIC_INFO and update existing state
6. should return the previous state when an unknown action is passed

## How to test:
1. check into current branch
2. do `npm install` 
3. Run npm test allUserProfilesBasicInfoReducer.test.js 

## Screenshots or videos of changes:
![Add unit test for allUserProfileBasicInfoReducer](https://github.com/user-attachments/assets/93aa43e2-4401-4255-8a85-16e035a28fa1)
