### PR TITLE
Mohan Add ability to reorder jobs on collaboration page.

### DIFF
--- a/src/components/Collaboration/Collaboration.css
+++ b/src/components/Collaboration/Collaboration.css
@@ -280,3 +280,34 @@ select {
     font-size: 14px;
   }
 }
+
+/* Button styles */
+.search-button, 
+.show-summaries, 
+.reorder-button {
+  padding: 6px 12px;
+  margin-right: 6px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+
+.search-button {
+  background-color: #5cb85c;
+  color: white;
+}
+
+.search-button:hover {
+  background-color: #4cae4c;
+}
+
+.reorder-button {
+  background-color: #007bff;
+  color: white;
+}
+
+.reorder-button:hover {
+  background-color: #0069d9;
+}

--- a/src/components/Collaboration/JobReorderModal.css
+++ b/src/components/Collaboration/JobReorderModal.css
@@ -1,0 +1,267 @@
+.jobs-list {
+  min-height: 400px;
+  padding: 10px 0;
+}
+
+.job-item {
+  padding: 15px;
+  margin-bottom: 10px;
+  background-color: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  cursor: grab;
+  transition: all 0.2s ease-in-out;
+  position: relative;
+  display: flex;
+  align-items: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.job-item::before {
+  content: '☰';
+  color: #aaa;
+  position: absolute;
+  left: -20px;
+  font-size: 16px;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.job-item:hover::before {
+  opacity: 1;
+}
+
+.job-item:hover {
+  border-color: #9c0;
+  transform: translateX(5px);
+}
+
+.position-number {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 36px;
+  height: 36px;
+  background-color: #9c0;
+  color: white;
+  border-radius: 50%;
+  font-weight: bold;
+  margin-right: 15px;
+  flex-shrink: 0;
+  font-size: 16px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.job-item-content {
+  position: relative;
+  flex-grow: 1;
+  padding-right: 20px;
+}
+
+.job-item.dragging {
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+  transform: scale(1.02) translateX(10px);
+  z-index: 100;
+  background-color: #f9f9f9;
+  border: 2px solid #9c0;
+}
+
+.job-item.featured {
+  border-left: 4px solid #9c0;
+  background-color: #f9fff0;
+}
+
+.job-item h4 {
+  margin-top: 0;
+  margin-bottom: 12px;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.job-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.job-category {
+  padding: 4px 10px;
+  background-color: #f0f5e6;
+  border: 1px solid #dbebc0;
+  border-radius: 20px;
+  font-weight: 500;
+  color: #547c10;
+}
+
+.featured-badge {
+  position: absolute;
+  top: -10px;
+  right: 0;
+  background-color: #9c0;
+  color: white;
+  padding: 4px 10px;
+  border-radius: 20px 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 5;
+}
+
+.reorder-instructions {
+  margin-bottom: 20px;
+  padding: 15px;
+  background-color: #f0f5e6;
+  border-radius: 6px;
+  border-left: 4px solid #9c0;
+  font-size: 15px;
+  color: #547c10;
+}
+
+/* Modal styling */
+.modal-content {
+  border-radius: 8px;
+  border: none;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+.modal-header {
+  background-color: #f8f9fa;
+  border-bottom: 1px solid #e9ecef;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  padding: 15px 20px;
+}
+
+.modal-header .modal-title {
+  font-weight: 600;
+  color: #333;
+}
+
+.modal-body {
+  padding: 20px;
+}
+
+.modal-dialog {
+  max-width: 800px;
+}
+
+.modal-lg {
+  max-width: 800px;
+}
+
+.modal-footer {
+  border-top: 1px solid #e9ecef;
+  padding: 15px 20px;
+}
+
+.modal-footer .btn-primary {
+  background-color: #9c0;
+  border-color: #9c0;
+}
+
+.modal-footer .btn-primary:hover {
+  background-color: #8ab000;
+  border-color: #8ab000;
+}
+
+/* Dark mode styles */
+.dark-mode .job-item {
+  background-color: #2c3e50;
+  border-color: #445566;
+  color: #f8f9fa;
+}
+
+.dark-mode .job-item h4 {
+  color: #f8f9fa;
+}
+
+.dark-mode .job-details {
+  color: #ddd;
+}
+
+.dark-mode .job-category {
+  background-color: #405224;
+  color: #e0e9d0;
+  border-color: #536b2f;
+}
+
+.dark-mode .job-item.featured {
+  border-left-color: #9c0;
+  background-color: #2a3d1a;
+}
+
+.dark-mode .job-item.dragging {
+  background-color: #34495e;
+  border-color: #9c0;
+}
+
+.dark-mode .position-number {
+  background-color: #9c0;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.dark-mode .featured-badge {
+  background-color: #9c0;
+}
+
+/* Modal dark mode styles */
+.dark-mode .modal-header {
+  background-color: #1e2b38;
+  border-color: #445566;
+  color: #f8f9fa;
+}
+
+.dark-mode .modal-header .modal-title {
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.dark-mode .modal-header h5 {
+  color: #ffffff;
+}
+
+.dark-mode .modal-footer {
+  background-color: #1e2b38;
+  border-color: #445566;
+}
+
+.dark-mode .modal-content {
+  background-color: #1e2b38;
+  border: 1px solid #445566;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}
+
+.dark-mode .modal-header .close {
+  color: #ffffff;
+  opacity: 0.8;
+  text-shadow: none;
+}
+
+.dark-mode .modal-header .close:hover {
+  opacity: 1;
+}
+
+.dark-mode .modal-header i {
+  color: #9c0;
+}
+
+.dark-mode .reorder-instructions {
+  background-color: #263c17;
+  color: #ffffff;
+  border-left: 4px solid #9c0;
+  border-radius: 6px;
+  padding: 15px;
+  margin-bottom: 20px;
+}
+
+.dark-mode .reorder-instructions i {
+  color: #9c0;
+}
+
+.dark-mode .reorder-instructions p {
+  color: #ffffff;
+  margin-bottom: 0;
+}

--- a/src/components/Collaboration/JobReorderModal.jsx
+++ b/src/components/Collaboration/JobReorderModal.jsx
@@ -1,0 +1,222 @@
+import { useState, useEffect } from 'react';
+import { Modal, ModalHeader, ModalBody, ModalFooter, Button, Alert } from 'reactstrap';
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import axios from 'axios';
+import { ApiEndpoint } from 'utils/URL';
+import { toast } from 'react-toastify';
+import { connect } from 'react-redux';
+import hasPermission from 'utils/permissions';
+import './JobReorderModal.css';
+
+function JobReorderModal({ isOpen, toggle, onJobsReordered, darkMode, checkPermission }) {
+  const [jobs, setJobs] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const canReorderJobs = checkPermission('reorderJobs');
+
+  // Define fetchAllJobs first
+  const fetchAllJobs = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await axios.get(`${ApiEndpoint}/jobs?limit=100`);
+      // Sort jobs by displayOrder first, then by datePosted
+      const sortedJobs = response.data.jobs.sort((a, b) => {
+        if (a.displayOrder !== b.displayOrder) {
+          return a.displayOrder - b.displayOrder;
+        }
+        return new Date(b.datePosted) - new Date(a.datePosted);
+      });
+
+      // Assign initial position numbers to each job
+      const jobsWithPositions = sortedJobs.map((job, index) => ({
+        ...job,
+        originalPosition: index + 1,
+      }));
+
+      setJobs(jobsWithPositions);
+    } catch (err) {
+      setError('Failed to fetch jobs. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Fetch all jobs when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      fetchAllJobs();
+    }
+  }, [isOpen]);
+
+  const handleDragEnd = result => {
+    if (!result.destination) return;
+
+    const items = Array.from(jobs);
+    const [reorderedItem] = items.splice(result.source.index, 1);
+    items.splice(result.destination.index, 0, reorderedItem);
+
+    // Update the jobs with new order, but keep original position numbers
+    setJobs(items);
+  };
+
+  const saveNewOrder = async () => {
+    if (!canReorderJobs) {
+      setError('You do not have permission to reorder jobs');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const jobIds = jobs.map(job => job._id);
+      const response = await axios.post(
+        `${ApiEndpoint}/jobs/reorder`,
+        { jobIds },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            userid: localStorage.getItem('userId'),
+          },
+        },
+      );
+
+      if (response.data.success) {
+        toast.success('Jobs reordered successfully');
+        if (onJobsReordered) onJobsReordered();
+        toggle();
+      } else {
+        throw new Error('Failed to reorder jobs');
+      }
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to save new order. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} toggle={toggle} size="xl" className={darkMode ? 'dark-mode' : ''}>
+      <ModalHeader toggle={toggle}>
+        <i className="fa fa-sort mr-2" aria-hidden="true" />
+        Reorder Job Listings
+      </ModalHeader>
+      <ModalBody>
+        {!canReorderJobs && (
+          <Alert color="warning">
+            <i className="fa fa-exclamation-triangle mr-2" aria-hidden="true" />
+            You do not have permission to reorder jobs. You are viewing in read-only mode.
+          </Alert>
+        )}
+
+        {error && (
+          <Alert color="danger">
+            <i className="fa fa-exclamation-circle mr-2" aria-hidden="true" />
+            {error}
+          </Alert>
+        )}
+
+        {loading ? (
+          <div className="text-center p-5">
+            <div className="spinner-border text-primary mb-3" role="status">
+              <span className="sr-only">Loading...</span>
+            </div>
+            <p>Loading jobs...</p>
+          </div>
+        ) : (
+          <div className="reorder-instructions mb-3">
+            <p>
+              <i className="fa fa-info-circle mr-2" aria-hidden="true" />
+              Drag and drop jobs to change their order on the landing page. Jobs will appear in the
+              order shown here.
+            </p>
+          </div>
+        )}
+
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <Droppable droppableId="jobs">
+            {droppableProvided => (
+              <div
+                ref={droppableProvided.innerRef}
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...droppableProvided.droppableProps}
+                className="jobs-list"
+              >
+                {jobs.map((job, index) => (
+                  <Draggable
+                    key={job._id}
+                    draggableId={job._id}
+                    index={index}
+                    isDragDisabled={!canReorderJobs}
+                  >
+                    {(draggableProvided, snapshot) => {
+                      return (
+                        <div
+                          ref={draggableProvided.innerRef}
+                          // eslint-disable-next-line react/jsx-props-no-spreading
+                          {...draggableProvided.draggableProps}
+                          // eslint-disable-next-line react/jsx-props-no-spreading
+                          {...draggableProvided.dragHandleProps}
+                          className={`job-item ${snapshot.isDragging ? 'dragging' : ''} ${
+                            job.featured ? 'featured' : ''
+                          }`}
+                        >
+                          <div className="position-number">{job.originalPosition}</div>
+                          <div className="job-item-content">
+                            {job.featured && <span className="featured-badge">Featured</span>}
+                            <h4>{job.title}</h4>
+                            <div className="job-details">
+                              <span className="job-category">{job.category}</span>
+                              <span className="job-date">
+                                <i className="fa fa-calendar-o mr-1" aria-hidden="true" />
+                                {new Date(job.datePosted).toLocaleDateString()}
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    }}
+                  </Draggable>
+                ))}
+                {droppableProvided.placeholder}
+              </div>
+            )}
+          </Droppable>
+        </DragDropContext>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="secondary" onClick={toggle} disabled={loading}>
+          <i className="fa fa-times mr-1" aria-hidden="true" />
+          Cancel
+        </Button>
+        {canReorderJobs && (
+          <Button color="primary" onClick={saveNewOrder} disabled={loading}>
+            {loading ? (
+              <>
+                <span
+                  className="spinner-border spinner-border-sm mr-1"
+                  role="status"
+                  aria-hidden="true"
+                />
+                Saving...
+              </>
+            ) : (
+              <>
+                <i className="fa fa-save mr-1" aria-hidden="true" />
+                Save Order
+              </>
+            )}
+          </Button>
+        )}
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+const mapStateToProps = () => ({});
+
+const mapDispatchToProps = dispatch => ({
+  checkPermission: permission => dispatch(hasPermission(permission)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(JobReorderModal);


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/06c32b06-a548-4b66-b7a6-66585dbafa8a) 

## Related PRS (if any):
This frontend PR is related to the https://github.com/OneCommunityGlobal/HGNRest/pull/1413 backend PR.
To test this frontend PR you need to checkout the https://github.com/OneCommunityGlobal/HGNRest/pull/1413 backend PR.

## Main changes explained:
- Added displayOrder field to the Job model to control the ordering of jobs on the landing page
- Created new permission 'reorderJobs' to control access to the reordering functionality
- Updated jobsController.js with new reorderJobs endpoint and integrated displayOrder in all job sorting logic
- Created new JobReorderModal component with drag-and-drop functionality using react-beautiful-dnd
- Implemented position indicators to track original job positions during reordering
- Added comprehensive dark mode styling with proper contrast and accessibility
- Ensured new jobs get appropriate displayOrder values when created
- Made the modal responsive with optimal UI/UX for drag operations


## How to test:
1. check into current branch
2. do `npm install`, and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to http://localhost:3000/collaboration
6. Click the "Edit to Reorder" button in the navbar
7. Try reordering jobs by dragging them to new positions
8. The position indicators should show original positions to help track which job moved where
9. Save the changes and verify they persist by refreshing the page
10. Test in both light and dark mode to verify proper styling


## Screenshots or videos of changes:
https://github.com/user-attachments/assets/1ee4abf2-bfc6-4dac-9d0b-1d9e9b90e9e9

