### PR TITLE
Shashank Add Tooltip and Stats in legend

### DIFF
--- a/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
@@ -18,6 +18,29 @@ const COLORS = [
   '#46d130',
 ];
 
+function CustomTooltip({ active, payload }) {
+  if (active && payload && payload.length) {
+    return (
+      <div
+        style={{
+          backgroundColor: 'white',
+          border: '1px solid #ccc',
+          padding: '10px',
+          borderRadius: '4px',
+        }}
+      >
+        {payload.map(entry => (
+          <p key={entry} style={{ color: 'black' }}>
+            {`${entry.name} : ${entry.value}`}
+          </p>
+        ))}
+      </div>
+    );
+  }
+
+  return null;
+}
+
 export default function RoleDistributionPieChart({ isLoading, roleDistributionStats, darkMode }) {
   if (isLoading) {
     return (
@@ -157,7 +180,7 @@ export default function RoleDistributionPieChart({ isLoading, roleDistributionSt
             align="right"
             content={renderCustomLegend}
           />
-          <Tooltip />
+          <Tooltip content={<CustomTooltip />} />
         </PieChart>
       </ResponsiveContainer>
     </div>

--- a/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
@@ -1,5 +1,5 @@
 import Loading from 'components/common/Loading';
-import { ResponsiveContainer, PieChart, Pie, Cell, Legend , Tooltip } from 'recharts';
+import { ResponsiveContainer, PieChart, Pie, Cell, Legend, Tooltip } from 'recharts';
 
 const COLORS = [
   '#F285BB',
@@ -77,7 +77,7 @@ export default function RoleDistributionPieChart({ isLoading, roleDistributionSt
     );
   };
 
-   const renderCustomLegend = props => {
+  const renderCustomLegend = props => {
     const { payload } = props; // payload is an array of legend items provided by Recharts
 
     return (
@@ -157,7 +157,7 @@ export default function RoleDistributionPieChart({ isLoading, roleDistributionSt
             align="right"
             content={renderCustomLegend}
           />
-        <Tooltip />
+          <Tooltip />
         </PieChart>
       </ResponsiveContainer>
     </div>

--- a/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
@@ -1,5 +1,5 @@
 import Loading from 'components/common/Loading';
-import { ResponsiveContainer, PieChart, Pie, Cell, Legend } from 'recharts';
+import { ResponsiveContainer, PieChart, Pie, Cell, Legend , Tooltip } from 'recharts';
 
 const COLORS = [
   '#F285BB',
@@ -35,6 +35,7 @@ export default function RoleDistributionPieChart({ isLoading, roleDistributionSt
     value: item.count,
     color: COLORS[index],
   }));
+  const totalValue = data.reduce((sum, entry) => sum + entry.value, 0);
 
   const RADIAN = Math.PI / 180;
   const renderCustomizedLabel = ({
@@ -76,28 +77,54 @@ export default function RoleDistributionPieChart({ isLoading, roleDistributionSt
     );
   };
 
-  const renderCustomLegend = props => {
-    const { payload } = props;
+   const renderCustomLegend = props => {
+    const { payload } = props; // payload is an array of legend items provided by Recharts
+
     return (
-      <ul style={{ marginLeft: 20 }}>
-        {payload.map(entry => (
-          <li
-            key={`item-${entry.value}`}
-            style={{ display: 'flex', alignItems: 'center', marginBottom: '5px' }}
-          >
-            <div
-              style={{
-                width: '10px',
-                height: '10px',
-                backgroundColor: entry.color,
-                marginRight: '3px',
-              }}
-            />
-            <span style={{ color: darkMode ? 'white ' : 'grey', fontSize: '12px' }}>
-              {entry.value}
-            </span>
-          </li>
-        ))}
+      <ul
+        style={{
+          listStyle: 'none', // Remove default bullet points
+          margin: 0,
+          paddingLeft: '20px', // Indent legend from the pie
+          textAlign: 'left', // Align text to the left
+          maxHeight: '400px', // Max height for the legend area
+          overflowY: 'auto', // Make legend scrollable if it exceeds maxHeight
+        }}
+      >
+        {payload.map(entry => {
+          // 'entry.value' here corresponds to the 'nameKey' of the Pie (which we set to 'name')
+          const itemName = entry.value;
+          // Find the original data object to get the count and original color
+          const itemData = data.find(d => d.name === itemName);
+
+          // If for some reason data is not found, skip rendering this legend item
+          if (!itemData) {
+            return null;
+          }
+
+          const { value, color } = itemData; // 'value' is the count
+          const percentage = totalValue > 0 ? (value / totalValue) * 100 : 0;
+
+          return (
+            <li
+              key={`item-${itemName}`} // Use itemName for a stable key
+              style={{ display: 'flex', alignItems: 'center', marginBottom: '5px' }}
+            >
+              <div
+                style={{
+                  width: '10px',
+                  height: '10px',
+                  backgroundColor: color, // Use the color from our mapped data
+                  marginRight: '5px',
+                  flexShrink: 0, // Prevent the color swatch from shrinking
+                }}
+              />
+              <span style={{ color: darkMode ? 'white' : 'grey', fontSize: '12px' }}>
+                {`${itemName}: ${value} (${percentage.toFixed(1)}%)`}
+              </span>
+            </li>
+          );
+        })}
       </ul>
     );
   };
@@ -130,6 +157,7 @@ export default function RoleDistributionPieChart({ isLoading, roleDistributionSt
             align="right"
             content={renderCustomLegend}
           />
+        <Tooltip />
         </PieChart>
       </ResponsiveContainer>
     </div>


### PR DESCRIPTION
##
Description

This PR improves the UX of the Role Distribution Pie Chart component by adding a tooltip and displaying numerical values in the legend. These changes ensure that even small slices, which were previously hard to read or completely missed, are now easily interpretable.
##
Fixes  (priority: medium - UX visibility issue in role distribution chart)
##
Related PRs (if any):
N/A
##
Main changes explained:
	•	 Enhanced chart interactivity: Added a tooltip to the Role Distribution Pie Chart to show role name and count on hover.
	•	 Improved data visibility: Updated the chart legend to include actual role counts next to labels, ensuring small slices are not missed.
## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Report → Total Org Summary → Role Distribution  
6. verify the changes
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/e4a7ad19-7e3c-4119-816e-d1bdc00df679


