### PR TITLE
jaissica-view-resources-while-assigning-task

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/components/TagsSearch.jsx
+++ b/src/components/Projects/WBS/WBSDetail/components/TagsSearch.jsx
@@ -141,9 +141,10 @@ function TagsSearch(props) {
   );
 }
 
-const mapStateToProps = state => {
-  return { state };
-};
+const mapStateToProps = state => ({
+  members: state.projectMembers.members,
+  state,
+});
 
 export default connect(mapStateToProps, {
   findProjectMembers,


### PR DESCRIPTION
# Description
The task here was to ensure Resources show up when assigning task to members of a particular team.

## Related PRS (if any):
- https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3576


## Main changes explained:
- Updated src/components/Projects/WBS/WBSDetail/components/TagsSearch.jsx to show all the team members in a team

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
6. Try adding a task for specific members and check if the resources are available correctly (Refer video below)

## Screenshots or videos of changes:
- https://www.loom.com/share/100da713c2fe42cc96d51031ced91be9?sid=acf703c2-da36-406a-93ba-c4afa784d512

## Note:
Include the information the reviewers need to know.
