### PR TITLE
Barnaboss - Fix Add Task Modal dropdown issue

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -447,6 +447,7 @@ function AddTaskModal(props) {
                     resourceItems={resourceItems}
                     disableInput={false}
                     inputTestId="resource-input"
+                    projectId={props.projectId}
                   />
                 </div>
               </div>


### PR DESCRIPTION
# Description
When users open Add Task → Resources and start typing, the autosuggest list is empty. The same dropdown works correctly in Edit Task.

Observed symptoms:
- No project-member array is returned in the Network tab while typing in the Add Task modal.
- In Redux DevTools, state.projectMembers.foundProjectMembers stays [] when adding a task, but is populated when editing.

## Related PRS (if any):
This PR is related to the changes made in this [PR](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3576). Checkout the backend development PR.

## Main changes explained:

- Edit Task passes projectId, so the search request is dispatched and the list appears.
- Add Task did not forward projectId from AddTaskModal → TagsSearch, so the request is never fired and the dropdown remains empty.

## How to test:

1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to view profile→ projects→Assign Project→ Click to access WBSs → Add new WBS → Add Task…
6. verify that the resources are visible in a dropdown in the resources field and the task is successfully allotted to the user.
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)
