### PR TITLE
resolved the test cases for tasks dropdown

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/components/__tests__/TagsSearch.test.js
+++ b/src/components/Projects/WBS/WBSDetail/components/__tests__/TagsSearch.test.js
@@ -8,12 +8,12 @@ import thunk from 'redux-thunk';
 import TagsSearch from '../TagsSearch';
 import { findProjectMembers } from 'actions/projectMembers';
 
-// Mock member data
+// Mock member data - Added profilePic property
 const allMembers = [
-  { firstName: 'aaa', isActive: true, lastName: 'volunteer', _id: 'aaa123' },
-  { firstName: 'bbb', isActive: true, lastName: 'test', _id: 'bbb456' },
-  { firstName: 'ccc', isActive: false, lastName: 'manager', _id: 'ccc789' },
-  { firstName: 'aaa', isActive: true, lastName: 'owner', _id: 'aaa067' },
+  { firstName: 'aaa', isActive: true, lastName: 'volunteer', _id: 'aaa123', profilePic: 'pic1.jpg' },
+  { firstName: 'bbb', isActive: true, lastName: 'test', _id: 'bbb456', profilePic: 'pic2.jpg' },
+  { firstName: 'ccc', isActive: false, lastName: 'manager', _id: 'ccc789', profilePic: 'pic3.jpg' },
+  { firstName: 'aaa', isActive: true, lastName: 'owner', _id: 'aaa067', profilePic: 'pic4.jpg' },
 ];
 
 const middlewares = [thunk];
@@ -21,8 +21,8 @@ const mockStore = configureMockStore(middlewares);
 
 // Mock functions for resource management
 const mockFunctions = mockResourceItems => {
-  const addResources = jest.fn((userID, firstName, lastName) => {
-    mockResourceItems.push({ userID, name: `${firstName} ${lastName}` });
+  const addResources = jest.fn((userID, firstName, lastName, profilePic) => {
+    mockResourceItems.push({ userID, name: `${firstName} ${lastName}`, profilePic });
   });
 
   const removeResources = jest.fn(userID => {
@@ -41,7 +41,10 @@ const mockFoundProjectMembers = searchQuery => {
 
 const renderTagsSearchComponent = props => {
   const store = mockStore({
-    projectMembers: { foundProjectMembers: mockFoundProjectMembers('') }, // Initial empty search
+    projectMembers: { 
+      foundProjectMembers: mockFoundProjectMembers(''),
+      members: allMembers // Add members to the store state
+    },
   });
 
   return render(
@@ -70,8 +73,9 @@ describe('TagsSearch Component', () => {
     resourceItems: [],
     addResources,
     removeResource: removeResources,
-    findProjectMembers: mockFoundProjectMembers,
+    findProjectMembers: jest.fn(), // Mock the Redux action
   };
+
   it('renders without crashing', () => {
     renderTagsSearchComponent(sampleProps);
   });
@@ -118,10 +122,9 @@ describe('TagsSearch Component', () => {
       fireEvent.mouseDown(ownerOption);
     });
 
-    // Check if addResources was called with the correct arguments
     await waitFor(() => {
-      expect(addResources).toHaveBeenCalledWith('aaa123', 'aaa', 'volunteer');
-      expect(addResources).toHaveBeenCalledWith('aaa067', 'aaa', 'owner');
+      expect(addResources).toHaveBeenCalledWith('aaa123', 'aaa', 'volunteer', 'pic1.jpg');
+      expect(addResources).toHaveBeenCalledWith('aaa067', 'aaa', 'owner', 'pic4.jpg');
     });
   });
 


### PR DESCRIPTION
# Description
The task here was to resolve the test cases that was failing for Add Task - resources dropdown

## Related PRS (if any):
This PR is related to the frontend PR: [3576](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3576)
…

## Main changes explained:
Updated src/components/Projects/WBS/WBSDetail/components/TagsSearch.test.js to include profile pic parameter in the addResources
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to view profile→ projects→Assign Project→ Click to access WBSs → Add new WBS → Add Task…
6. verify that the resources are visible in a dropdown in the resources field and the task is successfully allotted to the user.
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)


## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
