### PR TITLE
Mohan Fix Dropdown Overlap with Taking Time Off Content on Large Screens

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/components/__tests__/TagsSearch.test.js
+++ b/src/components/Projects/WBS/WBSDetail/components/__tests__/TagsSearch.test.js
@@ -21,8 +21,8 @@ const mockStore = configureMockStore(middlewares);
 
 // Mock functions for resource management
 const mockFunctions = mockResourceItems => {
-  const addResources = jest.fn((userID, firstName, lastName) => {
-    mockResourceItems.push({ userID, name: `${firstName} ${lastName}` });
+  const addResources = jest.fn((userID, firstName, lastName, profilePic) => {
+    mockResourceItems.push({ userID, name: `${firstName} ${lastName}`, profilePic });
   });
 
   const removeResources = jest.fn(userID => {
@@ -120,8 +120,8 @@ describe('TagsSearch Component', () => {
 
     // Check if addResources was called with the correct arguments
     await waitFor(() => {
-      expect(addResources).toHaveBeenCalledWith('aaa123', 'aaa', 'volunteer');
-      expect(addResources).toHaveBeenCalledWith('aaa067', 'aaa', 'owner');
+      expect(addResources).toHaveBeenCalledWith('aaa123', 'aaa', 'volunteer', undefined);
+      expect(addResources).toHaveBeenCalledWith('aaa067', 'aaa', 'owner', undefined);
     });
   });
 

--- a/src/components/TeamMemberTasks/style.css
+++ b/src/components/TeamMemberTasks/style.css
@@ -501,6 +501,15 @@
   color: #fff !important;
 }
 
+.multi-select-filter {
+  position: relative;
+  z-index: 20;
+}
+
+.multi-select-filter:focus-within {
+  z-index: 30;
+}
+
 @media (max-width: 1240px) and (min-width: 992px) {
   .header-box {
     flex-direction: column;


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/dd77186b-ad16-471f-aec9-ceb65ace60ad) 

## Main changes explained:
- Added CSS rules for the .multi-select-filter class to set proper z-index (20) and positioning.
- Enhanced the styling with focus-within state to increase z-index (30) when the dropdown is active.
- This ensures that the dropdown menus in Team Member Tasks appear above any overlapping content.
- Fixed the TagsSearch test failures that were causing Husky pre-commit errors.
- Updated test cases to properly handle the profilePic parameter in the addResources function.
- This ensures both visual correctness of dropdowns and successful code commits.

## How to test:
1. check into current branch
2. do `npm install`, and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. Log as admin user
5. Navigate to Dashboard → Team Member Tasks → Dropdown Menus
6. Verify that dropdown menus appear correctly on top of other content, particularly on large screens
7. Test on both small screens (below 768px) and large screens to ensure proper behavior in both cases

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/85afdbed-b673-401c-a7ee-b981e8566639

