### PR TITLE
Casstiel add href tag to google doc icon

### DIFF
--- a/SetUpFinalDayPopUp.test.js
+++ b/SetUpFinalDayPopUp.test.js
@@ -1,7 +1,7 @@
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import moment from 'moment';
-import SetUpFinalDayPopUp from '../../components/UserManagement/SetUpFinalDayPopUp.jsx';
+import SetUpFinalDayPopUp from '../../components/UserManagement/__tests__/SetUpFinalDayPopUp.jsx';
 
 describe('SetUpFinalDayPopUp', () => {
   it('renders without crashing', () => {

--- a/SetUpFinalDayPopUp.test.js
+++ b/SetUpFinalDayPopUp.test.js
@@ -1,27 +1,27 @@
-
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import moment from 'moment';
-import SetUpFinalDayPopUp from '../../components/UserManagement/SetUpFinalDayPopUp';
+import SetUpFinalDayPopUp from '../../components/UserManagement/SetUpFinalDayPopUp.jsx';
 
 describe('SetUpFinalDayPopUp', () => {
   it('renders without crashing', () => {
-    render(<SetUpFinalDayPopUp open onClose={() => { }} onSave={() => { }} />);
+    render(<SetUpFinalDayPopUp open onClose={() => {}} onSave={() => {}} />);
   });
 
   it('calls onClose when close button is clicked', () => {
     const onCloseMock = jest.fn();
-    const { getByText } = render(<SetUpFinalDayPopUp open onClose={onCloseMock} onSave={() => { }} />);
+    const { getByText } = render(
+      <SetUpFinalDayPopUp open onClose={onCloseMock} onSave={() => {}} />
+    );
 
     fireEvent.click(getByText('Close'));
-
     expect(onCloseMock).toHaveBeenCalled();
   });
 
   it('calls onSave with correct date when Save button is clicked with a future date', () => {
     const onSaveMock = jest.fn();
     const { getByText, getByTestId } = render(
-      <SetUpFinalDayPopUp open onClose={() => { }} onSave={onSaveMock} />
+      <SetUpFinalDayPopUp open onClose={() => {}} onSave={onSaveMock} />
     );
 
     const futureDate = moment().add(1, 'days').format('YYYY-MM-DD');
@@ -34,7 +34,7 @@ describe('SetUpFinalDayPopUp', () => {
   it('shows date error when Save button is clicked with a past date', () => {
     const onSaveMock = jest.fn();
     const { getByText, getByTestId, getByRole } = render(
-      <SetUpFinalDayPopUp open onClose={() => { }} onSave={onSaveMock} />
+      <SetUpFinalDayPopUp open onClose={() => {}} onSave={onSaveMock} />
     );
 
     const pastDate = moment().subtract(1, 'days').format('YYYY-MM-DD');

--- a/SetUpFinalDayPopUp.test.js
+++ b/SetUpFinalDayPopUp.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import moment from 'moment';
+import SetUpFinalDayPopUp from '../../components/UserManagement/SetUpFinalDayPopUp';
+
+describe('SetUpFinalDayPopUp', () => {
+  it('renders without crashing', () => {
+    render(<SetUpFinalDayPopUp open onClose={() => { }} onSave={() => { }} />);
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const onCloseMock = jest.fn();
+    const { getByText } = render(<SetUpFinalDayPopUp open onClose={onCloseMock} onSave={() => { }} />);
+
+    fireEvent.click(getByText('Close'));
+
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it('calls onSave with correct date when Save button is clicked with a future date', () => {
+    const onSaveMock = jest.fn();
+    const { getByText, getByTestId } = render(
+      <SetUpFinalDayPopUp open onClose={() => { }} onSave={onSaveMock} />
+    );
+
+    const futureDate = moment().add(1, 'days').format('YYYY-MM-DD');
+    fireEvent.change(getByTestId('date-input'), { target: { value: futureDate } });
+    fireEvent.click(getByText('Save'));
+
+    expect(onSaveMock).toHaveBeenCalledWith(futureDate);
+  });
+
+  it('shows date error when Save button is clicked with a past date', () => {
+    const onSaveMock = jest.fn();
+    const { getByText, getByTestId, getByRole } = render(
+      <SetUpFinalDayPopUp open onClose={() => { }} onSave={onSaveMock} />
+    );
+
+    const pastDate = moment().subtract(1, 'days').format('YYYY-MM-DD');
+    fireEvent.change(getByTestId('date-input'), { target: { value: pastDate } });
+    fireEvent.click(getByText('Save'));
+
+    expect(onSaveMock).not.toHaveBeenCalled();
+    expect(getByRole('alert')).toHaveTextContent('Please choose a future date.');
+  });
+});

--- a/SetUpFinalDayPopUp.test.js
+++ b/SetUpFinalDayPopUp.test.js
@@ -1,7 +1,7 @@
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import moment from 'moment';
-import SetUpFinalDayPopUp from '../../components/UserManagement/__tests__/SetUpFinalDayPopUp.jsx';
+import SetUpFinalDayPopUp from '../SetUpFinalDayPopUp';
 
 describe('SetUpFinalDayPopUp', () => {
   it('renders without crashing', () => {
@@ -15,6 +15,7 @@ describe('SetUpFinalDayPopUp', () => {
     );
 
     fireEvent.click(getByText('Close'));
+
     expect(onCloseMock).toHaveBeenCalled();
   });
 
@@ -24,8 +25,12 @@ describe('SetUpFinalDayPopUp', () => {
       <SetUpFinalDayPopUp open onClose={() => {}} onSave={onSaveMock} />
     );
 
-    const futureDate = moment().add(1, 'days').format('YYYY-MM-DD');
-    fireEvent.change(getByTestId('date-input'), { target: { value: futureDate } });
+    const futureDate = moment()
+      .add(1, 'days')
+      .format('YYYY-MM-DD');
+    fireEvent.change(getByTestId('date-input'), {
+      target: { value: futureDate },
+    });
     fireEvent.click(getByText('Save'));
 
     expect(onSaveMock).toHaveBeenCalledWith(futureDate);
@@ -37,8 +42,12 @@ describe('SetUpFinalDayPopUp', () => {
       <SetUpFinalDayPopUp open onClose={() => {}} onSave={onSaveMock} />
     );
 
-    const pastDate = moment().subtract(1, 'days').format('YYYY-MM-DD');
-    fireEvent.change(getByTestId('date-input'), { target: { value: pastDate } });
+    const pastDate = moment()
+      .subtract(1, 'days')
+      .format('YYYY-MM-DD');
+    fireEvent.change(getByTestId('date-input'), {
+      target: { value: pastDate },
+    });
     fireEvent.click(getByText('Save'));
 
     expect(onSaveMock).not.toHaveBeenCalled();

--- a/SetUpFinalDayPopUp.test.js
+++ b/SetUpFinalDayPopUp.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import moment from 'moment';

--- a/src/components/common/GoogleDocIcon/GoogleDocIcon.jsx
+++ b/src/components/common/GoogleDocIcon/GoogleDocIcon.jsx
@@ -3,11 +3,10 @@ import googleDocIconPng from '../../../assets/images/google_doc_icon.png';
 import './style.css';
 
 export default function GoogleDocIcon({ link }) {
-  const handleGoogleDocClick = () => {
+  const handleGoogleDocClick = e => {
     const toastGoogleLinkDoesNotExist = 'toast-on-click';
-    if (link) {
-      window.open(link);
-    } else {
+    if (!link) {
+      e.preventDefault();
       toast.error(
         'Uh oh, no Google Doc is present for this user! Please contact an Admin to find out why.',
         {
@@ -20,22 +19,18 @@ export default function GoogleDocIcon({ link }) {
   };
 
   return (
-    <span
+    <a
+      href={link || '#'}
       onClick={handleGoogleDocClick}
-      onKeyDown={event => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          handleGoogleDocClick();
-        }
-      }}
-      tabIndex={0}
-      role="button"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="team-member-tasks-user-report-link"
     >
-      {/* inactive: image will be grey if no Google Doc link present */}
       <img
         className={`google-doc-icon ${link ? '' : 'inactive'}`}
         src={googleDocIconPng}
         alt="google_doc"
       />
-    </span>
+    </a>
   );
 }


### PR DESCRIPTION
# Description
This icon is currently clickable, but it does not expose the link in the html code, which makes it so that middle clicking it does not open the page as it should.
Updated the GoogleDocIcon component to always render an <a> tag with href, and added onClick and onAuxClick handlers to prevent navigation and show a toast error when the link is missing. This ensures both left-click and middle-click trigger the error message without opening a new tab.


## Related PRS (if any):
This frontend PR is related to the development backend PR. 
To test this frontend PR, you need to checkout the development backend PR

## Main changes explained:
Replaced the original `<span>` with an `<a>` tag to support native link behaviors like middle-click.

Kept `href={link || '#'}` to ensure the element remains clickable even without a link.

Added `onClick `and `onAuxClick `handlers to catch both left and middle clicks.

Used `e.preventDefault()` to stop navigation when link is missing.

Ensured displaying of `toast.error()` message to inform the user if no Google Doc link is available when use middle click.

…

## How to test:
Check into current branch
Do `npm install` and `...` to run this PR locally
Clear site data/cache
Log as admin user
Go to the Dashboard, under Tasks and Timelogs
Verify that all google doc icons (colored and greyed) are click and middle click functionalities work properly
The middle click should open a new tab with a colored icon, and display the error message with greyed icon

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/18112d86-aa5d-4027-a647-6fb25b66704f


 
