### PR TITLE
Ramsundar Fix tasks not adding efficiently to WBS

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -20,6 +20,7 @@ import './wbs.css';
 
 import { useFetchWbsTasks } from './hook';
 import { FilterBar } from './FilterBar';
+import { use } from 'react';
 
 function WBSTasks(props) {
   // const { tasks, fetched, darkMode } = props;
@@ -43,6 +44,12 @@ function WBSTasks(props) {
   const myRef = useRef(null);
 
   const { tasks, isLoading, error, refresh } = useFetchWbsTasks(wbsId);
+
+  useEffect(() => {
+    if(!isLoading){
+      setPageLoadTime(Date.now());
+    }
+  },[tasks, isLoading]);
 
   useEffect(() => {
     setLevelOneTasks(


### PR DESCRIPTION
# Description
<img width="791" alt="Screenshot 2025-06-06 at 4 48 12 PM" src="https://github.com/user-attachments/assets/9c52e47b-d9e6-4ea7-875a-a4bda9266cb2" />

Main issue: On initial page load, adding the very first task succeeds with no alert. After that first addition, every subsequent “Save” action, even when done within a second triggers this alert "Database changed since your page loaded, click OK to get the newest data!” 
The rootcause for the issue is pageLoadTime was only set once at mount, so after the very first add, every subsequent save looked “older” than the database’s last‐modified.

Video Link to navigate and How to add a task: https://www.loom.com/share/8bc672c323b64955aac4bce46c3794aa?sid=b05f5604-87cb-4ca1-80b8-49bd823893ee 

## Related PRS (if any):
This frontend PR is related to the development backend PR.
To test this frontend PR, you need to checkout the development backend PR
…

## Main changes explained:
- The main changes made were to ensure that the pageLoadTime is always up-to-date before adding a new task, preventing the backend from returning an "outdated" error. 
- Updated the WBSTasks.jsx, I added a useEffect to update pageLoadTime using setPageLoadTime(Date.now()) when tasks finish loading. 

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/Owner user
5. go to Other Links -> Projects -> WBS -> Choose the WBS -> Assign the task or add a task
6. Save the task, check adding a 4-5 tasks and verify that the alert "Database changed since your page loaded, click OK to get the newest data!"  is not coming. 


## Screenshots or videos of changes:

Before:
https://www.loom.com/share/8b2274e4f7324931ae0ac967b65ffb49?sid=4809be4e-1ccd-41c8-81ae-016787c4e2b0

After:
https://www.loom.com/share/78e542e9f18f43ec9e10f15145bea2bd?sid=aaed036e-4a13-4206-998e-566e19b55bb2


## Note:
Include the information the reviewers need to know.
