### PR TITLE
Guirong-Create Weekly Progress Update email template and send functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9746,6 +9746,14 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.8.tgz",
       "integrity": "sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw=="
     },
+    "@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "requires": {
+        "parchment": "^1.1.2"
+      }
+    },
     "@types/raf": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
@@ -20575,8 +20583,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -27650,6 +27657,11 @@
         }
       }
     },
+    "parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -29275,6 +29287,249 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
+    "quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "requires": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+          "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+          "requires": {
+            "call-bind-apply-helpers": "^1.0.0",
+            "es-define-property": "^1.0.0",
+            "get-intrinsic": "^1.2.4",
+            "set-function-length": "^1.2.2"
+          }
+        },
+        "deep-equal": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+          "requires": {
+            "is-arguments": "^1.1.1",
+            "is-date-object": "^1.0.5",
+            "is-regex": "^1.1.4",
+            "object-is": "^1.1.5",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.5.1"
+          }
+        },
+        "define-properties": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+          "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+          "requires": {
+            "define-data-property": "^1.0.1",
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "es-object-atoms": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+          "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+          "requires": {
+            "es-errors": "^1.3.0"
+          }
+        },
+        "eventemitter3": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+          "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+        },
+        "function-bind": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        },
+        "get-intrinsic": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+          "requires": {
+            "call-bind-apply-helpers": "^1.0.2",
+            "es-define-property": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.1.1",
+            "function-bind": "^1.1.2",
+            "get-proto": "^1.0.1",
+            "gopd": "^1.2.0",
+            "has-symbols": "^1.1.0",
+            "hasown": "^2.0.2",
+            "math-intrinsics": "^1.1.0"
+          },
+          "dependencies": {
+            "call-bind-apply-helpers": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+              "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+              "requires": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+              }
+            },
+            "es-define-property": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+              "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+            }
+          }
+        },
+        "gopd": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+        },
+        "has-symbols": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+        },
+        "regexp.prototype.flags": {
+          "version": "1.5.4",
+          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+          "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+          "requires": {
+            "call-bind": "^1.0.8",
+            "define-properties": "^1.2.1",
+            "es-errors": "^1.3.0",
+            "get-proto": "^1.0.1",
+            "gopd": "^1.2.0",
+            "set-function-name": "^2.0.2"
+          }
+        }
+      }
+    },
+    "quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+          "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+          "requires": {
+            "call-bind-apply-helpers": "^1.0.0",
+            "es-define-property": "^1.0.0",
+            "get-intrinsic": "^1.2.4",
+            "set-function-length": "^1.2.2"
+          }
+        },
+        "deep-equal": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+          "requires": {
+            "is-arguments": "^1.1.1",
+            "is-date-object": "^1.0.5",
+            "is-regex": "^1.1.4",
+            "object-is": "^1.1.5",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.5.1"
+          }
+        },
+        "define-properties": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+          "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+          "requires": {
+            "define-data-property": "^1.0.1",
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "es-object-atoms": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+          "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+          "requires": {
+            "es-errors": "^1.3.0"
+          }
+        },
+        "fast-diff": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+          "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+        },
+        "function-bind": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+          "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        },
+        "get-intrinsic": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+          "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+          "requires": {
+            "call-bind-apply-helpers": "^1.0.2",
+            "es-define-property": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.1.1",
+            "function-bind": "^1.1.2",
+            "get-proto": "^1.0.1",
+            "gopd": "^1.2.0",
+            "has-symbols": "^1.1.0",
+            "hasown": "^2.0.2",
+            "math-intrinsics": "^1.1.0"
+          },
+          "dependencies": {
+            "call-bind-apply-helpers": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+              "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+              "requires": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+              }
+            },
+            "es-define-property": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+              "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+            }
+          }
+        },
+        "gopd": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+        },
+        "has-symbols": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+        },
+        "regexp.prototype.flags": {
+          "version": "1.5.4",
+          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+          "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+          "requires": {
+            "call-bind": "^1.0.8",
+            "define-properties": "^1.2.1",
+            "es-errors": "^1.3.0",
+            "get-proto": "^1.0.1",
+            "gopd": "^1.2.0",
+            "set-function-name": "^2.0.2"
+          }
+        }
+      }
+    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -29854,6 +30109,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
       "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
+    "react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "requires": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      }
     },
     "react-redux": {
       "version": "7.2.9",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-leaflet-cluster": "^1.0.4",
     "react-multi-select-component": "^4.0.2",
     "react-phone-input-2": "^2.14.0",
+    "react-quill": "^2.0.0",
     "react-redux": "^7.2.0",
     "react-router": "^5.3.4",
     "react-router-dom": "^5.2.0",

--- a/src/components/Announcements/index.jsx
+++ b/src/components/Announcements/index.jsx
@@ -101,17 +101,19 @@ function Announcements({ title, email: initialEmail }) {
   };
 
   const addImageToEmailContent = e => {
-    const imageFile = document.querySelector('input[type="file"]').files[0];
+    const file = e.target.files[0];
+    if (!file) return;
     setIsFileUploaded(true);
-    convertImageToBase64(imageFile, base64Image => {
-      const imageTag = `<img src="${base64Image}" alt="Header Image" style="width: 100%; max-width: 100%; height: auto;">`;
-      setHeaderContent(prevContent => `${imageTag}${prevContent}`);
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const imageTag = `<img src="${reader.result}" alt="Header Image" style="width: 100%; max-width: 100%; height: auto;">`;
       const editor = window.tinymce.get('email-editor');
       if (editor) {
         editor.insertContent(imageTag);
-        setEmailContent(editor.getContent());
       }
-    });
+      setEmailContent(editor ? editor.getContent() : '');
+    };
+    reader.readAsDataURL(file);
     e.target.value = '';
   };
 
@@ -121,20 +123,16 @@ function Announcements({ title, email: initialEmail }) {
   };
 
   const handleSendEmails = () => {
-    const htmlContent = emailContent;
+    const editor = window.tinymce.get('email-editor');
+    const htmlContent = editor ? editor.getContent() : emailContent;
 
     if (emailList.length === 0 || emailList.every(e => !e.trim())) {
       toast.error('Error: Empty Email List. Please enter AT LEAST One email.');
       return;
     }
 
-    if (!isFileUploaded) {
-      toast.error('Error: Please upload a file.');
-      return;
-    }
-
-    if (!isFileUploaded) {
-      toast.error('Error: Please upload a file.');
+    if (!htmlContent || htmlContent.trim() === '') {
+      toast.error('Error: Email content cannot be empty.');
       return;
     }
 


### PR DESCRIPTION
# Description
- We currently use MailChimp to send out our weekly progress updates. It is not user friendly and the price keeps going up. I’d like a replacement that an Admin can use via the app.
- Take over the work of previous people: [FE PR 1315](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1315) [BE PR 540](https://github.com/OneCommunityGlobal/HGNRest/pull/540) led to [1784](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1784)
- [Video of what’s needed](https://www.loom.com/share/ce0ff3e66f3e40e19703ad9f4206cad1?sid=775e17db-d792-4a1c-a6d6-26379ccfe48c)

ORIGINAL REQUEST

1. We currently use MailChimp to send out our weekly progress updates. It is not user friendly and the price keeps going up. I’d like a replacement that an Admin can use via the app:
2. “Create Announcement” option for Owners
3. Addition of this to Permissions Page
4. Ability for those with access to input emails to add them to list
5. Ability for those with access to import spreadsheet too add them to the list
6. Unsubscribe function so people can automatically remove themselves from the list
7. Integration with self-setup page so people can choose to subscribe as part of setting themselves up
8. Template for easily inputting the image, YouTube link, and other details we share every week so anyone can easily produce what you see below
9. Test send option to “test send” the blog to a designated email before sending
10. Section/field input for anything else we’d like to say at the end
11. Google also only allows limited sending, so we need this to send in batches of less than 100 (so 90) at a time and timed so that we don't get blocked as spam. Please build this into the email system too.
12. If any auto-posting integration with social media is possible, I’d love to include that too… and anything else that would make this weekly process easier/fasterAdd feature that allows users to schedule their own blue square vacations/emergencies


## Related PRS (if any):
This frontend PR is related to the [#1442 backend PR](https://github.com/OneCommunityGlobal/HGNRest/pull/1442).

## Main changes explained:
- Update `src/components/Announcements/index.jsx` for image upload plugins and remove useless functions.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as **Owner** user
5. See backend how to setup the email sending account
6. go to Dashboard→ Other Links→ Send Emails
7. verify two functions: `Broadcast Weekly Update` and `Send Email to specific user` and remember to test sending the email with image.

## Screenshots or videos of changes:
https://www.loom.com/share/1f66a2dd69fa4be4921370bae2a4c69b?sid=bf0393aa-cd39-44ba-ab9b-c37f6ddaf033

## Note:
If your account want to receive email, you need to set the email subscription in the profile page.
<img width="860" alt="Screenshot 2024-08-20 at 9 01 21 PM" src="https://github.com/user-attachments/assets/d95aa195-8496-43c3-a599-bc46bbad0206">
**Google also only allows limited sending, so we need this to send in batches of less than 100 (so 90) at a time and timed so that we don’t get blocked as spam.** 