### PR TITLE
Nikhil Routh Migrate src/common and scr/Collaboration css to module css

### DIFF
--- a/refactor-css-classes.js
+++ b/refactor-css-classes.js
@@ -1,0 +1,132 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+const postcss = require('postcss');
+const safeParser = require('postcss-safe-parser');
+
+// Helper to convert kebab-case, snake_case, pascalcase to camelCase
+const toCamelCase = str => {
+  const formatted = str.replace(/[-_](\w)/g, (_, char) => char.toUpperCase());
+  return formatted.charAt(0).toLowerCase() + formatted.slice(1);
+};
+
+const classMap = {}; // e.g. { "my-class": "myClass" }
+
+// Step 1: Convert class names in .css files
+const convertCSSFile = filePath => {
+  const css = fs.readFileSync(filePath, 'utf8');
+  const root = postcss.parse(css, { parser: safeParser });
+
+  root.walkRules(rule => {
+    const updated = rule.selectors.map(selector => {
+      return selector.replace(/\.(\w[\w-]*)/g, (_, className) => {
+        const camel = toCamelCase(className);
+        classMap[className] = camel;
+        return `.${camel}`;
+      });
+    });
+    // eslint-disable-next-line no-param-reassign
+    rule.selectors = updated;
+  });
+
+  fs.writeFileSync(filePath, root.toString());
+  // eslint-disable-next-line no-console
+  console.log(`✅ Updated CSS: ${filePath}`);
+  // eslint-disable-next-line no-console
+  // console.log('classMap after CSS processing:', classMap);
+};
+
+// Step 2: Replace import statement for CSS module in JSX
+const replaceImportStatement = code => {
+  const importRegex = /import\s+['"]\.\/([a-zA-Z0-9_-]+)\.css['"];/;
+  return code.replace(importRegex, (_, cssFileName) => {
+    return `import styles from './${cssFileName}.module.css';`;
+  });
+};
+
+// Step 3: Replace kebab-case classes in JSX code with styles.camelCase
+const replaceInCodeFile = filePath => {
+  let code = fs.readFileSync(filePath, 'utf8');
+  const originalCode = code;
+
+  console.log(`Processing code file: ${filePath}`);
+
+  // Step 1: Update import statement
+  code = replaceImportStatement(code);
+  console.log(`✅ Updated import`);
+
+  if (Object.keys(classMap).length === 0) {
+    console.log('classMap is empty, please check the refactor script!');
+    return;
+  }
+
+  // Step 2: Replace className="text-light input-file-upload" → className={styles.textLight + " " + styles.inputFileUpload}
+  code = code.replace(/className\s*=\s*["']([^"']+)["']/g, (_, classStr) => {
+    const classList = classStr.trim().split(/\s+/);
+
+    // Skip transforming if no class in classList exists in classMap
+    if (classList.every(cls => !classMap[cls])) {
+      return `className="${classStr}"`;
+    }
+    const mapped = classList.map(cls => {
+      const camel = classMap[cls];
+      return camel ? `\${styles.${camel}}` : cls;
+    });
+    return `className={\`${mapped.join(' ')}\`}`;
+  });
+
+  if (code !== originalCode) {
+    fs.writeFileSync(filePath, code, 'utf8');
+    console.log(`✅ Updated code in: ${filePath}`);
+  } else {
+    console.log('⚠️  No className replacements made.');
+  }
+};
+
+// Step 3: Walk through project and process files
+const walkDir = dir => {
+  const cssFiles = []; // To collect all CSS files
+  const codeFiles = []; // To collect all JS/JSX files
+
+  // First pass: Collect files into two separate arrays
+  fs.readdirSync(dir).forEach(file => {
+    const fullPath = path.join(dir, file);
+    const stats = fs.statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      walkDir(fullPath);
+    } else if (file.endsWith('.css')) {
+      cssFiles.push(fullPath); // Add CSS file path to the array
+    } else if (
+      file.endsWith('.js') ||
+      file.endsWith('.jsx') ||
+      file.endsWith('.ts') ||
+      file.endsWith('.tsx') ||
+      file.endsWith('.html')
+    ) {
+      codeFiles.push(fullPath); // Add JS/JSX file path to the array
+    }
+  });
+
+  // Now process CSS files first
+  cssFiles.forEach(cssFile => {
+    console.log('Processing CSS file:', cssFile);
+    convertCSSFile(cssFile); // Process CSS files
+  });
+
+  // Then process code files (JS/JSX, etc.)
+  codeFiles.forEach(codeFile => {
+    console.log('Processing code file:', codeFile);
+    replaceInCodeFile(codeFile); // Process JS/JSX files
+  });
+};
+
+// 🚀 Start here: Replace with your actual project folder path
+const rootDir = 'src/components/common/PieChart';
+walkDir(rootDir);
+
+// const mapPath = path.join(__dirname, 'class-map.json');
+// fs.writeFileSync(mapPath, JSON.stringify(classMap, null, 2));
+// // eslint-disable-next-line no-console
+// console.log(`🗺️  Class map written to ${mapPath}`);

--- a/src/components/Collaboration/Collaboration.jsx
+++ b/src/components/Collaboration/Collaboration.jsx
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import './Collaboration.module.css';
 import { toast } from 'react-toastify';
 import { ApiEndpoint } from 'utils/URL';
 import OneCommunityImage from './One-Community-Horizontal-Homepage-Header-980x140px-2.png';
+import styles from './Collaboration.module.css';
 
 class Collaboration extends Component {
   constructor(props) {
@@ -96,8 +96,8 @@ class Collaboration extends Component {
     } = this.state;
 
     return (
-      <div className="job-landing">
-        <div className="header">
+      <div className={`${styles.jobLanding}`}>
+        <div className={`${styles.header}`}>
           <a
             href="https://www.onecommunityglobal.org/collaboration/"
             target="_blank"
@@ -106,23 +106,23 @@ class Collaboration extends Component {
             <img src={OneCommunityImage} alt="One Community Logo" />
           </a>
         </div>
-        <div className="container">
-          <nav className="navbar">
-            <div className="navbar-left">
-              <form className="search-form">
+        <div className={`${styles.container}`}>
+          <nav className={`${styles.navbar}`}>
+            <div className={`${styles.navbarLeft}`}>
+              <form className={`${styles.searchForm}`}>
                 <input
                   type="text"
                   placeholder="Search by title..."
                   value={searchTerm}
                   onChange={this.handleSearch}
                 />
-                <button className="search" type="submit" onClick={this.handleSubmit}>
+                <button className={`${styles.search}`} type="submit" onClick={this.handleSubmit}>
                   Go
                 </button>
               </form>
             </div>
 
-            <div className="navbar-right">
+            <div className={`${styles.navbarRight}`}>
               <select value={selectedCategory} onChange={event => this.handleCategoryChange(event)}>
                 <option value="">Select from Categories</option>
                 {categories.map(category => (
@@ -134,14 +134,14 @@ class Collaboration extends Component {
             </div>
           </nav>
 
-          <div className="headings">
+          <div className={`${styles.headings}`}>
             <h1>Like to Work With Us? Apply Now!</h1>
             <p>Learn about who we are and who we want to work with!</p>
           </div>
 
-          <div className="job-list">
+          <div className={`${styles.jobList}`}>
             {jobAds.map(ad => (
-              <div key={ad._id} className="job-ad">
+              <div key={ad._id} className={`${styles.jobAd}`}>
                 <img
                   src={`/api/placeholder/640/480?text=${encodeURIComponent(
                     ad.category || 'Job Opening',
@@ -161,7 +161,7 @@ class Collaboration extends Component {
             ))}
           </div>
 
-          <div className="pagination">
+          <div className={`${styles.pagination}`}>
             {Array.from({ length: totalPages }, (_, i) => (
               <button
                 type="button"

--- a/src/components/Collaboration/Collaboration.module.css
+++ b/src/components/Collaboration/Collaboration.module.css
@@ -1,11 +1,11 @@
 .container,
-.job-landing .header img {
+.jobLanding .header img {
   width: 60%;
   max-width: 1000px;
   display: flex;
 }
 .headings,
-.job-ad {
+.jobAd {
   text-align: center;
 }
 .container {
@@ -16,7 +16,7 @@
   border: 1px solid #ddd;
   border-radius: 10px;
 }
-.job-landing .header img {
+.jobLanding .header img {
   height: auto;
   margin: 0 auto;
   flex-direction: column;
@@ -31,20 +31,20 @@
   padding: 10px;
   flex-flow: row nowrap;
 }
-.navbar-left input,
-.navbar-left select {
+.navbarLeft input,
+.navbarLeft select {
   display: flex;
   padding: 8px;
   margin-right: 10px;
   align-items: center;
 }
-.navbar-left,
-.navbar-right,
-.search-form {
+.navbarLeft,
+.navbarRight,
+.searchForm {
   display: flex;
   align-items: center;
 }
-.search-form input {
+.searchForm input {
   margin-right: 10px;
   padding: 5px;
   border: 1px solid #ccc;
@@ -60,13 +60,13 @@ select {
   border: 1px solid #ccc;
   border-radius: 4px;
 }
-.job-list {
+.jobList {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
   gap: 20px;
   width: 100%;
 }
-.job-ad {
+.jobAd {
   border: 1px solid #ddd;
   border-radius: 10px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
@@ -74,26 +74,26 @@ select {
   background: linear-gradient(135deg, #fff, #f9f9f9);
   transition: transform 0.3s, box-shadow 0.3s;
 }
-.job-ad img {
+.jobAd img {
   max-width: 100%;
   height: auto;
   border-bottom: 1px solid #ddd;
 }
-.job-ad h3 {
+.jobAd h3 {
   font-size: 1.1rem;
   font-weight: 700;
   color: #333;
   margin: 10px 0;
   transition: color 0.3s;
 }
-.job-ad a {
+.jobAd a {
   text-decoration: none;
   color: inherit;
 }
-.job-ad a:hover h3 {
+.jobAd a:hover h3 {
   color: #007acc;
 }
-.job-ad:hover {
+.jobAd:hover {
   transform: translateY(-5px);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
 }

--- a/src/components/Collaboration/JobFormBuilder.module.css
+++ b/src/components/Collaboration/JobFormBuilder.module.css
@@ -6,7 +6,7 @@ body {
   max-width: 1000px;
 }
 
-.form-builder-container {
+.formBuilderContainer {
   max-width: 80%;
   margin: 1% 10% 0;
   display: flex;
@@ -16,14 +16,14 @@ body {
   padding: 5px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
-.custom-form {
+.customForm {
   background-color: #d9d9d9;
   padding: 10px;
   margin-top: 3%;
   border-radius: 5px;
   border: 1px solid #d9d9d9;
 }
-.jobform-navbar {
+.jobformNavbar {
   display: flex;
   padding: 0 10px;
   justify-content: space-between;
@@ -33,21 +33,21 @@ body {
   margin-bottom: 3%;
 }
 
-.jobform-navbar input {
+.jobformNavbar input {
   margin: 8px 0;
 }
 
-.jobform-navbar select {
+.jobformNavbar select {
   margin: 8px 0;
   width: 100%;
 }
 
-.jobform-navbar div {
+.jobformNavbar div {
   display: flex;
   padding: 2px;
 }
 
-.jobform-navbar button {
+.jobformNavbar button {
   padding: 11px 13px;
   margin: 8px 10px;
   border: none;
@@ -59,7 +59,7 @@ body {
   transition: background-color 0.3s;
 }
 
-.jobform-navbar button:hover {
+.jobformNavbar button:hover {
   background-color: grey;
 }
 p {
@@ -73,7 +73,7 @@ h2 {
   font-weight: bold;
 }
 
-.jbform-label {
+.jbformLabel {
   display: block;
   font-weight: bold;
   margin-top: 15px;
@@ -96,13 +96,13 @@ textarea {
   resize: vertical;
 } */
 
-.new-field-section {
+.newFieldSection {
   background-color: #d9d9d9;
   padding: 20px;
 }
 
 /* General Container for Each Question */
-.form-field {
+.formField {
   padding: 5px;
   margin-bottom: 2px;
   display: flex;
@@ -110,7 +110,7 @@ textarea {
   gap: 10px;
 }
 
-.form-div {
+.formDiv {
   display: flex;
   padding: 0;
   margin: 0;
@@ -126,7 +126,7 @@ textarea {
 }
 
 /* Label for the Question */
-.field-label {
+.fieldLabel {
   font-size: 16px;
   font-weight: bold;
   line-height: 1.2;
@@ -135,7 +135,7 @@ textarea {
 }
 
 /* Container for Options (Checkbox/Radio/Dropdown) */
-.field-options {
+.fieldOptions {
   display: flex;
   flex-direction: column; /* Stack options vertically by default */
   margin: 1px;
@@ -148,7 +148,7 @@ textarea {
 } */
 
 /* Individual Option Item */
-.option-item {
+.optionItem {
   display: flex; /* Align checkbox and label on the same line */
   align-items: flex-start;
   margin: 0;
@@ -158,27 +158,27 @@ textarea {
   padding: 2px;
 }
 
-.options-section input {
+.optionsSection input {
   margin: 0 12px 0;
 }
 
-.option-item input[type='checkbox'],
-.option-item input[type='radio'] {
+.optionItem input[type='checkbox'],
+.optionItem input[type='radio'] {
   margin: 0; /* Ensure no extra margins around inputs */
   background-color: black;
   width: 1em;
   height: 1em;
 }
 
-.option-item label {
+.optionItem label {
   font-size: 1rem;
   font-weight: normal;
   margin: 0;
   line-height: 1.2;
 }
 
-.add-field-button,
-.add-option-button {
+.addFieldButton,
+.addOptionButton {
   background-color: #4caf50;
   color: white;
   border: none;
@@ -189,13 +189,13 @@ textarea {
   transition: background-color 0.3s;
 }
 
-.add-field-button,
-.add-option-button :hover {
+.addFieldButton,
+.addOptionButton :hover {
   background-color: #45a049;
 }
 
 /* Submit Button */
-.job-submit-button {
+.jobSubmitButton {
   display: block;
   width: 100%;
   /* max-width: 300px; */
@@ -213,6 +213,6 @@ textarea {
   transition: background-color 0.3s;
 }
 
-.job-submit-button:hover {
+.jobSubmitButton:hover {
   background-color: #45a049;
 }

--- a/src/components/Collaboration/JobFormbuilder.jsx
+++ b/src/components/Collaboration/JobFormbuilder.jsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import './JobFormBuilder.css';
 import axios from 'axios';
 import { useSelector } from 'react-redux';
 import { ENDPOINTS } from '../../utils/URL';
 import OneCommunityImage from './One-Community-Horizontal-Homepage-Header-980x140px-2.png';
+import styles from './JobFormBuilder.module.css';
 
 function JobFormBuilder() {
   const { role } = useSelector(state => state.auth.user);
@@ -141,9 +141,9 @@ function JobFormBuilder() {
   };
 
   return (
-    <div className="form-builder-container">
+    <div className={`${styles.formBuilderContainer}`}>
       <img src={OneCommunityImage} alt="One Community Logo" id="onecommunity-image" />
-      <div className="jobform-navbar">
+      <div className={`${styles.jobformNavbar}`}>
         <div>
           <input placeholder="Enter Job Title" />
           <button type="button" className="go-button">
@@ -168,7 +168,7 @@ function JobFormBuilder() {
       <h1>FORM CREATION</h1>
 
       {role === 'Owner' ? (
-        <div className="custom-form">
+        <div className={`${styles.customForm}`}>
           <p>
             Fill the form with questions about a specific position you want to create an ad for. The
             default questions will automatically appear and are alredy selected. You can pick and
@@ -177,7 +177,7 @@ function JobFormBuilder() {
           <form>
             {formFields.map((field, index) => (
               <div
-                className="form-div"
+                className={`${styles.formDiv}`}
                 /* eslint-disable-next-line react/no-array-index-key */
                 key={index + 1}
               >
@@ -190,10 +190,12 @@ function JobFormBuilder() {
                 <div
                   /* eslint-disable-next-line react/no-array-index-key */
                   key={index + 1}
-                  className="form-field"
+                  className={`${styles.formField}`}
                 >
-                  <label className="field-label jbform-label">{field.questionText}</label>
-                  <div className="field-options">
+                  <label className={`${styles.fieldLabel} ${styles.jbformLabel}`}>
+                    {field.questionText}
+                  </label>
+                  <div className={`${styles.fieldOptions}`}>
                     {field.questionType === 'textbox' && (
                       <input type="text" placeholder="Enter Text here" />
                     )}
@@ -206,10 +208,10 @@ function JobFormBuilder() {
                         <div
                           /* eslint-disable-next-line react/no-array-index-key */
                           key={idx + 1}
-                          className="option-item"
+                          className={`${styles.optionItem}`}
                         >
                           <input type={field.questionType} name={`field-${index}`} />
-                          <label className="jbform-label">{option}</label>
+                          <label className={`${styles.jbformLabel}`}>{option}</label>
                         </div>
                       ))}
                     {field.questionType === 'dropdown' && (
@@ -230,9 +232,9 @@ function JobFormBuilder() {
               </div>
             ))}
           </form>
-          <div className="new-field-section">
+          <div className={`${styles.newFieldSection}`}>
             <div>
-              <label className="jbform-label">
+              <label className={`${styles.jbformLabel}`}>
                 Field Label:
                 <input
                   type="text"
@@ -246,7 +248,7 @@ function JobFormBuilder() {
               </label>
             </div>
             <div>
-              <label className="jbform-label">
+              <label className={`${styles.jbformLabel}`}>
                 Input Type:
                 <select
                   value={newField.questionType}
@@ -271,8 +273,8 @@ function JobFormBuilder() {
 
             {/* Options Section */}
             {['checkbox', 'radio', 'dropdown'].includes(newField.questionType) && (
-              <div className="options-section">
-                <label className="jbform-label">
+              <div className={`${styles.optionsSection}`}>
+                <label className={`${styles.jbformLabel}`}>
                   Add Option:
                   <input
                     type="text"
@@ -281,7 +283,11 @@ function JobFormBuilder() {
                     placeholder="Enter an option"
                   />
                 </label>
-                <button type="button" onClick={handleAddOption} className="add-option-button">
+                <button
+                  type="button"
+                  onClick={handleAddOption}
+                  className={`${styles.addOptionButton}`}
+                >
                   Add Option
                 </button>
                 <div className="options-list">
@@ -290,7 +296,7 @@ function JobFormBuilder() {
                     <div
                       /* eslint-disable-next-line react/no-array-index-key */
                       key={index + 1}
-                      className="option-item"
+                      className={`${styles.optionItem}`}
                     >
                       {option}
                     </div>
@@ -299,11 +305,11 @@ function JobFormBuilder() {
               </div>
             )}
 
-            <button type="button" onClick={handleAddField} className="add-field-button">
+            <button type="button" onClick={handleAddField} className={`${styles.addFieldButton}`}>
               Add Field
             </button>
           </div>
-          <button type="submit" className="job-submit-button" onClick={handleSubmit}>
+          <button type="submit" className={`${styles.jobSubmitButton}`} onClick={handleSubmit}>
             Proceed to Submit with Details
           </button>
         </div>

--- a/src/components/Reports/TeamReport/components/ReportCharts.jsx
+++ b/src/components/Reports/TeamReport/components/ReportCharts.jsx
@@ -4,7 +4,7 @@ import './ReportCharts.css';
 import * as d3 from 'd3/dist/d3.min';
 import { CHART_RADIUS, CHART_SIZE } from '../../../common/PieChart/constants';
 import { generateArrayOfUniqColors } from '../../../common/PieChart/colorsGenerator';
-import '../../../common/PieChart/PieChart.css';
+import '../../../common/PieChart/PieChart.module.css';
 import PieChartInfoDetail from './PieChartInfoDetail';
 
 function ReportCharts({ title, pieChartId }) {

--- a/src/components/Reports/TeamReport/components/TeamReportCharts.jsx
+++ b/src/components/Reports/TeamReport/components/TeamReportCharts.jsx
@@ -3,7 +3,7 @@ import { React, useEffect } from 'react';
 import './ReportCharts.css';
 import * as d3 from 'd3/dist/d3.min';
 import { CHART_RADIUS, CHART_SIZE } from '../../../common/PieChart/constants';
-import '../../../common/PieChart/PieChart.css';
+import '../../../common/PieChart/PieChart.module.css';
 import PieChartInfoDetail from './PieChartInfoDetail';
 
 function TeamReportCharts({

--- a/src/components/Reports/TeamReport/components/TeamsReportCharts.jsx
+++ b/src/components/Reports/TeamReport/components/TeamsReportCharts.jsx
@@ -3,7 +3,7 @@ import { React, useEffect, useState } from 'react';
 import './ReportCharts.css';
 import * as d3 from 'd3/dist/d3.min';
 import { CHART_RADIUS, CHART_SIZE } from '../../../common/PieChart/constants';
-import '../../../common/PieChart/PieChart.css';
+import '../../../common/PieChart/PieChart.module.css';
 import PieChartInfoDetail from './PieChartInfoDetail';
 
 function TeamsReportCharts({ title, pieChartId, selectedTeamsData, selectedTeamsWeeklyEffort, darkMode }) {

--- a/src/components/common/Checkbox/Checkbox.jsx
+++ b/src/components/common/Checkbox/Checkbox.jsx
@@ -1,4 +1,4 @@
-import './Checkbox.css';
+import styles from './Checkbox.module.css';
 
 // eslint-disable-next-line import/prefer-default-export, react/function-component-definition
 export const Checkbox = ({
@@ -11,16 +11,16 @@ export const Checkbox = ({
   textColorCN,
 }) => {
   return (
-    <div className={`checkbox-wrapper ${wrapperClassname} ${backgroundColorCN}`}>
+    <div className={`${styles.checkboxWrapper} ${wrapperClassname} ${backgroundColorCN}`}>
       <input
-        className="checkbox-input"
+        className={`${styles.checkboxInput}`}
         type="checkbox"
         id={id}
         name={id}
         checked={value}
         onChange={onChange}
       />
-      <label className={`checkbox-label ${textColorCN}`} htmlFor={id}>
+      <label className={`${styles.checkboxLabel} ${textColorCN}`} htmlFor={id}>
         {label}
       </label>
     </div>

--- a/src/components/common/Checkbox/Checkbox.module.css
+++ b/src/components/common/Checkbox/Checkbox.module.css
@@ -1,14 +1,14 @@
-.checkbox-wrapper {
+.checkboxWrapper {
   background-color: #f8f7f8;
 }
 
-.checkbox-input {
+.checkboxInput {
   width: 16px;
   height: 16px;
   cursor: pointer;
 }
 
-.checkbox-label {
+.checkboxLabel {
   margin: 0 4px;
   cursor: pointer;
 }

--- a/src/components/common/Clipboard/CopyToClipboard.jsx
+++ b/src/components/common/Clipboard/CopyToClipboard.jsx
@@ -1,8 +1,8 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { toast } from 'react-toastify';
-import './style.css';
 import { useSelector } from 'react-redux';
+import styles from './style.module.css';
 
 // eslint-disable-next-line react/function-component-definition
 const CopyToClipboard = ({ writeText, message }) => {
@@ -14,7 +14,7 @@ const CopyToClipboard = ({ writeText, message }) => {
 
   return (
     <FontAwesomeIcon
-      className="copy-to-clipboard"
+      className={`${styles.copyToClipboard}`}
       icon={faCopy}
       onClick={handleCopyToClipboard}
       color={darkMode ? 'lightgrey' : ''}

--- a/src/components/common/Clipboard/CopyToClipboard_2.jsx
+++ b/src/components/common/Clipboard/CopyToClipboard_2.jsx
@@ -1,7 +1,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { toast } from 'react-toastify';
-import './style.css';
+import styles from './style.module.css';
 
 // eslint-disable-next-line react/function-component-definition
 const CopyToClipboard = ({ writeText, message }) => {
@@ -11,7 +11,11 @@ const CopyToClipboard = ({ writeText, message }) => {
   };
 
   return (
-    <FontAwesomeIcon className="copy-to-clipboard" icon={faCopy} onClick={handleCopyToClipboard} />
+    <FontAwesomeIcon
+      className={`${styles.copyToClipboard}`}
+      icon={faCopy}
+      onClick={handleCopyToClipboard}
+    />
   );
 };
 

--- a/src/components/common/Clipboard/style.module.css
+++ b/src/components/common/Clipboard/style.module.css
@@ -1,4 +1,4 @@
-.copy-to-clipboard {
+.copyToClipboard {
   cursor: pointer;
   margin-right: 10px;
 }

--- a/src/components/common/Clipboard/style_2.module.css
+++ b/src/components/common/Clipboard/style_2.module.css
@@ -1,4 +1,4 @@
-.copy-to-clipboard {
+.copyToClipboard {
   cursor: pointer;
   margin-right: 10px;
 }

--- a/src/components/common/DragAndDrop/DragAndDrop.jsx
+++ b/src/components/common/DragAndDrop/DragAndDrop.jsx
@@ -1,8 +1,8 @@
 /* eslint-disable react/function-component-definition */
 import { useState } from 'react';
-import './DragAndDrop.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faImage } from '@fortawesome/free-solid-svg-icons';
+import styles from './DragAndDrop.module.css';
 
 const DragAndDrop = ({ updateUploadedFiles }) => {
   const [dragActive, setDragActive] = useState(false);

--- a/src/components/common/DragAndDrop/DragAndDrop.module.css
+++ b/src/components/common/DragAndDrop/DragAndDrop.module.css
@@ -22,7 +22,7 @@
   background-color: #ffffff;
 }
 
-#file-upload-label.drag-active{
+#file-upload-label.dragActive{
   background-color: #f8fafc;
 }
 
@@ -38,7 +38,7 @@
 }
 
 
-.upload-button {
+.uploadButton {
   cursor: pointer;
   padding: 0.25rem;
   font-size: 1rem;
@@ -47,7 +47,7 @@
   background-color: transparent;
 }
 
-.upload-button:hover {
+.uploadButton:hover {
   text-decoration-line: underline;
 }
 

--- a/src/components/common/Input/Input.jsx
+++ b/src/components/common/Input/Input.jsx
@@ -3,8 +3,8 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import './input.css';
 import { useSelector } from 'react-redux';
+import styles from './input.module.css';
 
 // eslint-disable-next-line react/function-component-definition
 const Input = ({ label, name, error, className, type, invalid, ...rest }) => {
@@ -29,7 +29,7 @@ const Input = ({ label, name, error, className, type, invalid, ...rest }) => {
         {label}
       </label>
       {type === 'password' ? (
-        <div className="input-text w-100">
+        <div className={`${styles.inputText} w-100`}>
           <input
             {...rest}
             type={password}

--- a/src/components/common/Input/input.module.css
+++ b/src/components/common/Input/input.module.css
@@ -1,14 +1,14 @@
-.input-text {
+.inputText {
   position: relative;
 }
-.input-text .fa-eye-slash {
+.inputText .faEyeSlash {
   position: absolute;
   right: 10px;
   top: 12px;
   font-size: 15px;
   cursor: pointer;
 }
-.fa-eye {
+.faEye {
   position: absolute;
   right: 10px;
   top: 12px;

--- a/src/components/common/NewModal/NewModal.jsx
+++ b/src/components/common/NewModal/NewModal.jsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import Popup from 'reactjs-popup';
-import './NewModal.css';
+import styles from './NewModal.module.css';
 
 // eslint-disable-next-line react/function-component-definition
 const NewModal = ({ header, children, trigger }) => {
@@ -19,8 +19,8 @@ const NewModal = ({ header, children, trigger }) => {
       ref={popupRef}
       contentStyle={{ height: '85vh', borderRadius: '8px', width: 'auto' }}
     >
-      <div className="popup-modal-wrapper">
-        <div className="popup-header">
+      <div className={`${styles.popupModalWrapper}`}>
+        <div className={`${styles.popupHeader}`}>
           <h5 style={{ margin: 0 }}>{header}</h5>
           <div
             onClick={closePopup}
@@ -30,15 +30,15 @@ const NewModal = ({ header, children, trigger }) => {
               }
             }}
             tabIndex={0}
-            className="close-icon"
+            className={`${styles.closeIcon}`}
             role="button"
           >
             &#x2715;
           </div>
         </div>
-        <div className="popup-content-wrapper">{children}</div>
-        <div className="popup-modal-footer">
-          <button type="button" className="popup-close-button" onClick={closePopup}>
+        <div className={`${styles.popupContentWrapper}`}>{children}</div>
+        <div className={`${styles.popupModalFooter}`}>
+          <button type="button" className={`${styles.popupCloseButton}`} onClick={closePopup}>
             Close
           </button>
         </div>

--- a/src/components/common/NewModal/NewModal.module.css
+++ b/src/components/common/NewModal/NewModal.module.css
@@ -1,16 +1,16 @@
-.popup-modal-wrapper {
+.popupModalWrapper {
   position: relative;
   height: 100%;
   padding: 0 0 0 22px;
 }
 
-.popup-content-wrapper {
+.popupContentWrapper {
   height: calc(100% - 40px - 60px);
   overflow-y: scroll;
   padding: 14px 14px 0 4px;
 }
 
-.popup-header {
+.popupHeader {
   position: sticky;
   top: 0;
   display: flex;
@@ -23,7 +23,7 @@
   padding: 0 5px 0 27px;
 }
 
-.popup-modal-footer {
+.popupModalFooter {
   position: sticky;
   bottom: 0;
   display: flex;
@@ -35,17 +35,17 @@
   padding: 0 5px 0 27px;
 }
 
-.popup-content-wrapper::-webkit-scrollbar {
+.popupContentWrapper::-webkit-scrollbar {
   width: 10px; /* width of the entire scrollbar */
 }
 
-.popup-content-wrapper::-webkit-scrollbar-thumb {
+.popupContentWrapper::-webkit-scrollbar-thumb {
   background-color: #c6c6c6; /* color of the scroll thumb */
   border-radius: 20px; /* roundness of the scroll thumb */
   border: 3px solid white; /* creates padding around scroll thumb */
 }
 
-.popup-close-button {
+.popupCloseButton {
   display: block;
   background-color: white;
   border: 2px solid #c6c6c6;
@@ -54,28 +54,28 @@
   cursor: pointer;
 }
 
-.popup-close-button:hover,
-.popup-close-button:focus {
+.popupCloseButton:hover,
+.popupCloseButton:focus {
   border-color: #e7b1ef;
   outline-color: #e7b1ef;
 }
 
-.popup-close-button:active {
+.popupCloseButton:active {
   border-color: #ca50db;
   box-shadow: 0px 0px 3px 0 #ca50db;
 }
 
-.close-icon {
+.closeIcon {
   margin-right: 8px;
   color: #9b9b9b;
   cursor: pointer;
 }
 
-.close-icon:hover,
-.close-icon:focus {
+.closeIcon:hover,
+.closeIcon:focus {
   color: #e7b1ef;
 }
 
-.close-icon:active {
+.closeIcon:active {
   color: #ca50db;
 }

--- a/src/components/common/Paging/Paging.jsx
+++ b/src/components/common/Paging/Paging.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { FiChevronLeft, FiChevronRight } from 'react-icons/fi';
 import classnames from 'classnames';
-import './Paging.css';
+import styles from './Paging.module.css';
 
 // eslint-disable-next-line react/function-component-definition
 const Paging = ({ maxElemPerPage = 6, totalElementsCount, children, darkMode }) => {
@@ -94,14 +94,14 @@ const Paging = ({ maxElemPerPage = 6, totalElementsCount, children, darkMode }) 
   };
 
   return (
-    <div className="paging-wrapper">
+    <div className={`${styles.pagingWrapper}`}>
       {React.cloneElement(children, {
         skip: maxElemPerPage * (currentPage - 1),
         take: maxElemPerPage,
       })}
 
       {totalElementsCount > maxElemPerPage && (
-        <div className="pagination-buttons-wrapper">
+        <div className={`${styles.paginationButtonsWrapper}`}>
           <FiChevronLeft
             className={classnames(`${pageIndexButton}`, {
               disabled: currentPage === 1,

--- a/src/components/common/Paging/Paging.module.css
+++ b/src/components/common/Paging/Paging.module.css
@@ -1,4 +1,4 @@
-.paging-wrapper {
+.pagingWrapper {
   height: 100%;
   position: relative;
   display: flex;
@@ -6,18 +6,18 @@
   justify-content: flex-end;
 }
 
-.pagination-buttons-wrapper {
+.paginationButtonsWrapper {
   display: flex;
   align-items: center;
   margin: auto;
 }
 
-.pagination-buttons {
+.paginationButtons {
   display: flex;
   align-items: baseline;
 }
 
-.page-index-button {
+.pageIndexButton {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -29,26 +29,26 @@
   color: #a1a1a1;
 }
 
-.page-index-button:not(.disabled):hover {
+.pageIndexButton:not(.disabled):hover {
   background-color: #eee7f8;
 }
 
-.page-index-button.disabled {
+.pageIndexButton.disabled {
   cursor: unset;
   color: #c6c6c6;
 }
 
-.active-button {
+.activeButton {
   background-color: #a780d9;
   color: white;
 }
 
-.page-index-button.active-button:hover {
+.pageIndexButton.activeButton:hover {
   background-color: rgb(179, 104, 210);
 }
 
 /* DARK MODE */
-.page-index-button-dark {
+.pageIndexButtonDark {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -60,25 +60,25 @@
   color: #ffffff;
 }
 
-.page-index-button-dark:not(.disabled):hover {
+.pageIndexButtonDark:not(.disabled):hover {
   background-color: #007BFF;
 }
 
-.page-index-button-dark.disabled {
+.pageIndexButtonDark.disabled {
   cursor: unset;
   color: #c6c6c6;
 }
 
-.active-button-dark {
+.activeButtonDark {
   background-color: #1C2541;
   color: white;
 }
 
-.page-index-button-dark.active-button:hover {
+.pageIndexButtonDark.activeButton:hover {
   background-color: #007BFF;
 }
 
-.pagination-buttons-dark {
+.paginationButtonsDark {
   display: flex;
   align-items: baseline;
   color: white;

--- a/src/components/common/PhoneInput/PhoneInput.css
+++ b/src/components/common/PhoneInput/PhoneInput.css
@@ -1,7 +1,0 @@
-.phone-input-container{
- 
-}
-
-.phone-input-content{
-
-}

--- a/src/components/common/PhoneInput/PhoneInput.jsx
+++ b/src/components/common/PhoneInput/PhoneInput.jsx
@@ -1,12 +1,12 @@
 import { InputGroup, FormGroup, Input, Label, Col, Row } from 'reactstrap';
-import './PhoneInput.css';
+import styles from './PhoneInput.module.css';
 
 // eslint-disable-next-line import/prefer-default-export
 export function PhoneInput({ areaCode, setAreaCode, phoneNumber, setPhoneNumber }) {
   return (
-    <FormGroup className="phone-input-container">
+    <FormGroup className={`${styles.phoneInputContainer}`}>
       <Label>Supplier Phone Number</Label>
-      <InputGroup className="phone-input-content">
+      <InputGroup className={`${styles.phoneInputContent}`}>
         <Row>
           {/* Area code */}
           <Col xs="auto" className="pr-1">

--- a/src/components/common/PhoneInput/PhoneInput.module.css
+++ b/src/components/common/PhoneInput/PhoneInput.module.css
@@ -1,0 +1,7 @@
+.phoneInputContainer{
+ 
+}
+
+.phoneInputContent{
+
+}

--- a/src/components/common/PieChart/PieChart.jsx
+++ b/src/components/common/PieChart/PieChart.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useMemo } from 'react';
 import * as d3 from 'd3/dist/d3.min';
 import { CHART_RADIUS, CHART_SIZE } from './constants';
 import { generateArrayOfUniqColors } from './colorsGenerator';
-import './UserProjectPieChart.css';
+import styles from './UserProjectPieChart.module.css';
 
 export function PieChart({
   tasksData = [], // New array format: [{ projectId: "123", projectName: "Project A", totalTime: 10.5 }, ...]
@@ -191,9 +191,9 @@ export function PieChart({
     <div>Loading</div>
   ) : (
     <div className={`pie-chart-wrapper ${darkMode ? 'text-light' : ''}`}>
-      <div id={`pie-chart-container-${pieChartId}`} className="pie-chart" />
-      <div className="pie-chart-legend-container">
-        <div className="pie-chart-legend-table-wrapper">
+      <div id={`pie-chart-container-${pieChartId}`} className={`${styles.pieChart}`} />
+      <div className={`${styles.pieChartLegendContainer}`}>
+        <div className={`${styles.pieChartLegendTableWrapper}`}>
           <table className={darkMode ? 'pie-chart-legend-table-dark' : 'pie-chart-legend-table'}>
             <thead>
               <tr>
@@ -219,7 +219,7 @@ export function PieChart({
           </table>
         </div>
 
-        <div className="data-total-value">
+        <div className={`${styles.dataTotalValue}`}>
           <strong>Total Hours:</strong> {totalHours.toFixed(2)}
         </div>
       </div>

--- a/src/components/common/PieChart/PieChart.module.css
+++ b/src/components/common/PieChart/PieChart.module.css
@@ -1,20 +1,20 @@
-.pie-chart-wrapper {
+.pieChartWrapper {
   display: flex;
   align-items: center;
 }
 
-.pie-chart {
+.pieChart {
   margin-right: 32px;
 }
 
-.pie-chart-legend-header {
+.pieChartLegendHeader {
   display: flex;
   justify-content: space-between;
   margin-bottom: 24px;
   font-weight: 500;
 }
 
-.pie-chart-legend-item {
+.pieChartLegendItem {
   position: relative;
   margin: 12px 0;
   display: flex;
@@ -23,7 +23,7 @@
   font-size: 14px;
 }
 
-.data-legend-color {
+.dataLegendColor {
   position: absolute;
   top: 2px;
   left: -28px;
@@ -36,7 +36,7 @@
   border-radius: 50%;
 }
 
-.data-legend-info {
+.dataLegendInfo {
   width: 240px;
   display: flex;
   justify-content: space-between;
@@ -44,17 +44,17 @@
   color: rgba(0, 0, 0, 0.5);
 }
 
-.data-legend-info-part:not(:last-child) {
+.dataLegendInfoPart:not(:last-child) {
   margin-right: 24px;
 }
 
 @media (max-width: 670px) {
-  .pie-chart-wrapper {
+  .pieChartWrapper {
     flex-direction: column;
   }
 }
 
-div.tooltip-donut {
+div.tooltipDonut {
   position: absolute;
   text-align: center;
   padding: 0.5rem;
@@ -67,7 +67,7 @@ div.tooltip-donut {
   white-space: normal;
 }
 
-div.pie-chart-legend-container {
+div.pieChartLegendContainer {
   min-width: 150px;
 }
 
@@ -118,10 +118,10 @@ input:checked + .slider:before {
 }
 
 /* Optional: Dark mode adjustments */
-.text-light .slider {
+.textLight .slider {
   background-color: #ffffff;
 }
 
-.text-light input:checked + .slider {
+.textLight input:checked + .slider {
   background-color: #4CAF50;
 }

--- a/src/components/common/PieChart/ProjectPieChart.jsx
+++ b/src/components/common/PieChart/ProjectPieChart.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useMemo } from 'react';
 import * as d3 from 'd3/dist/d3.min';
 import { CHART_RADIUS, CHART_SIZE } from './constants';
 import { generateArrayOfUniqColors } from './colorsGenerator';
-import './UserProjectPieChart.css';
+import styles from './UserProjectPieChart.module.css';
 
 function UserProjectPieChart({
   projectsData, // New array format: [{ projectId: "123", projectName: "Project A", totalTime: 10.5 }, ...]
@@ -173,9 +173,9 @@ function UserProjectPieChart({
     <div>Loading</div>
   ) : (
     <div className={`pie-chart-wrapper ${darkMode ? 'text-light' : ''}`}>
-      <div id={`pie-chart-container-${pieChartId}`} className="pie-chart" />
-      <div className="pie-chart-legend-container">
-        <div className="pie-chart-legend-table-wrapper">
+      <div id={`pie-chart-container-${pieChartId}`} className={`${styles.pieChart}`} />
+      <div className={`${styles.pieChartLegendContainer}`}>
+        <div className={`${styles.pieChartLegendTableWrapper}`}>
           <table className={darkMode ? 'pie-chart-legend-table-dark' : 'pie-chart-legend-table'}>
             <thead>
               <tr>
@@ -201,7 +201,7 @@ function UserProjectPieChart({
           </table>
         </div>
 
-        <div className="data-total-value">
+        <div className={`${styles.dataTotalValue}`}>
           <strong>Total Hours:</strong> {totalHours.toFixed(2)}
         </div>
       </div>

--- a/src/components/common/PieChart/UserProjectPieChart.module.css
+++ b/src/components/common/PieChart/UserProjectPieChart.module.css
@@ -1,21 +1,21 @@
-.pie-chart-wrapper {
+.pieChartWrapper {
     display: flex;
     align-items: center;
   }
   
-  .pie-chart {
+  .pieChart {
     margin-right: 32px;
     height: 100%;
   }
   
-  .pie-chart-legend-header {
+  .pieChartLegendHeader {
     display: flex;
     justify-content: space-between;
     margin-bottom: 24px;
     font-weight: 500;
   }
   
-  .pie-chart-legend-item {
+  .pieChartLegendItem {
     position: relative;
     margin: 12px 0;
     display: flex;
@@ -24,7 +24,7 @@
     font-size: 14px;
   }
   
-  .data-legend-color {
+  .dataLegendColor {
     position: absolute;
     top: 2px;
     left: -28px;
@@ -36,24 +36,24 @@
     border-radius: 50%;
   }
   
-  .data-legend-info {
+  .dataLegendInfo {
     width: 240px;
     display: flex;
     justify-content: space-between;
     color: rgba(0, 0, 0, 0.5);
   }
   
-  .data-legend-info-part:not(:last-child) {
+  .dataLegendInfoPart:not(:last-child) {
     margin-right: 24px;
   }
   
   @media (max-width: 670px) {
-    .pie-chart-wrapper {
+    .pieChartWrapper {
       flex-direction: column;
     }
   }
   
-  div.tooltip-donut {
+  div.tooltipDonut {
     position: absolute;
     text-align: center;
     padding: 0.5rem;
@@ -66,7 +66,7 @@
     white-space: normal;
   }
   
-  div.pie-chart-legend-container {
+  div.pieChartLegendContainer {
     min-width: 150px;
   }
   
@@ -117,67 +117,67 @@
   }
   
   /* Optional: Dark mode adjustments */
-  .text-light .slider {
+  .textLight .slider {
     background-color: #ffffff;
   }
   
-  .text-light input:checked + .slider {
+  .textLight input:checked + .slider {
     background-color: #4CAF50;
   }
   
-  .pie-chart-legend-container {
+  .pieChartLegendContainer {
     margin-top: 20px;
     height: 100%;
     width: 100%;
   
   }
   
-  .pie-chart-legend-header {
+  .pieChartLegendHeader {
     font-weight: bold;
     display: flex;
     justify-content: space-between;
     padding-bottom: 8px;
   }
   
-  .pie-chart-legend-table-wrapper {
+  .pieChartLegendTableWrapper {
     max-height: 350px;
     width: 100%;
     /* border: 1px solid rgba(0, 0, 0, 0.1); */
     overflow-y: auto;
   }
   
-  .pie-chart-legend-table {
+  .pieChartLegendTable {
     width: 100%;
     table-layout: auto;
     border-collapse: collapse;
   }
 
-  .pie-chart-legend-table th,
-  .pie-chart-legend-table td {
+  .pieChartLegendTable th,
+  .pieChartLegendTable td {
     padding: 8px;
     text-align: left;
     /* border-bottom: 1px solid rgba(0, 0, 0, 0.1); */
   }
   
  
-  .pie-chart-legend-table th {
+  .pieChartLegendTable th {
     font-weight: bold;
     background: none;
     color: inherit;
   }
-  .pie-chart-legend-table tr{
+  .pieChartLegendTable tr{
     background-color: white;
   }
 
-  .pie-chart-legend-table-dark {
+  .pieChartLegendTableDark {
     width: 100%;
     table-layout: auto;
     border-collapse: collapse;
     height: 80%;
   }
 
-  .pie-chart-legend-table-dark th,
-  .pie-chart-legend-table-dark td {
+  .pieChartLegendTableDark th,
+  .pieChartLegendTableDark td {
     padding: 8px;
     text-align: left;
     /* border-bottom: 1px solid rgba(0, 0, 0, 0.1); */
@@ -185,12 +185,12 @@
   }
   
  
-  .pie-chart-legend-table-dark th {
+  .pieChartLegendTableDark th {
     font-weight: bold;
     background: none;
     /* color: inherit; */
   }
-  .pie-chart-legend-table-dark tr{
+  .pieChartLegendTableDark tr{
     background-color: white;
   }
 
@@ -199,19 +199,19 @@
     height: 16px;
     border-radius: 50%;
   }
-  .total-row {
+  .totalRow {
     font-weight: bold;
     margin-top: 10px;
   }
   
-  .data-total-value {
+  .dataTotalValue {
     font-weight: bold;
     margin-top: 10px;
   }
   
 
   @media (max-width: 671px) {
-    .pie-chart-legend-table-wrapper {
+    .pieChartLegendTableWrapper {
       max-height: 200px; 
     }
   }

--- a/src/components/common/SkeletonLoading/SkeletonLoading.jsx
+++ b/src/components/common/SkeletonLoading/SkeletonLoading.jsx
@@ -1,8 +1,8 @@
 /* eslint-disable no-plusplus */
 
 import { useSelector } from 'react-redux';
-import './SkeletonLoading.css';
 import { Container } from 'reactstrap';
+import styles from './SkeletonLoading.module.css';
 
 const SkeletonLoading = ({ template, className }) => {
   const darkMode = useSelector(state => state.theme.darkMode);
@@ -15,10 +15,10 @@ const SkeletonLoading = ({ template, className }) => {
         return (
           <Container fluid="sm">
             <div className={`skeleton-loading-timelog ${darkMode ? 'bg-space-cadet' : ''}`}>
-              <div className="skeleton-loading-item-timelog" />
-              <div className="skeleton-loading-item-timelog" />
+              <div className={`${styles.skeletonLoadingItemTimelog}`} />
+              <div className={`${styles.skeletonLoadingItemTimelog}`} />
               <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                <div className="skeleton-loading-item-add-intangible" />
+                <div className={`${styles.skeletonLoadingItemAddIntangible}`} />
               </div>
             </div>
           </Container>
@@ -26,17 +26,17 @@ const SkeletonLoading = ({ template, className }) => {
       case 'TimelogFilter':
         return (
           <div className={`skeleton-loading-timelog-filter ${darkMode ? 'bg-space-cadet' : ''}`}>
-            <div className="skeleton-loading-timelog-filter-item" />
-            <div className="skeleton-loading-timelog-filter-item" />
-            <div className="skeleton-loading-timelog-filter-item" />
-            <div className="skeleton-loading-timelog-filter-item" />
+            <div className={`${styles.skeletonLoadingTimelogFilterItem}`} />
+            <div className={`${styles.skeletonLoadingTimelogFilterItem}`} />
+            <div className={`${styles.skeletonLoadingTimelogFilterItem}`} />
+            <div className={`${styles.skeletonLoadingTimelogFilterItem}`} />
           </div>
         );
       case 'TeamMemberTasks':
         for (let i = 0; i < 15; i++) {
           rows.push(
             <tr key={i}>
-              <td colSpan={6} className="skeleton-loading-team-member-tasks-row" />
+              <td colSpan={6} className={`${styles.skeletonLoadingTeamMemberTasksRow}`} />
             </tr>,
           );
         }
@@ -44,21 +44,21 @@ const SkeletonLoading = ({ template, className }) => {
       case 'WeeklySummary':
         return (
           <Container fluid="sm" className={darkMode ? 'bg-space-cadet' : ''}>
-            <div className="skeleton-loading-weekly-summary" />
+            <div className={`${styles.skeletonLoadingWeeklySummary}`} />
           </Container>
         );
       case 'WeeklySummariesReport':
         for (let i = 0; i < 10; i++) {
           reportItems.push(
             <div key={i} className={darkMode ? 'bg-yinmn-blue' : ''}>
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item mt-5" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem} mt-5`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
               <hr />
             </div>,
           );
@@ -80,14 +80,14 @@ const SkeletonLoading = ({ template, className }) => {
         for (let i = 0; i < 10; i++) {
           reportItems.push(
             <div key={i} className={darkMode ? 'bg-yinmn-blue' : ''}>
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item mt-5" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
-              <div className="skeleton-loading-weekly-summaries-report-item" />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem} mt-5`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
+              <div className={`${styles.skeletonLoadingWeeklySummariesReportItem}`} />
               <hr />
             </div>,
           );
@@ -118,41 +118,47 @@ const SkeletonLoading = ({ template, className }) => {
           >
             <div style={{ margin: '3rem 3rem 0 16rem' }}>
               <div
-                className="skeleton-loading-user-profile-picture"
+                className={`${styles.skeletonLoadingUserProfilePicture}`}
                 style={{ marginBottom: '16rem' }}
               />
-              <div className="skeleton-loading-user-profile-picture" />
+              <div className={`${styles.skeletonLoadingUserProfilePicture}`} />
             </div>
             <div className="mx-5" style={{ marginTop: '6rem' }}>
-              <div className="skeleton-loading-user-profile-item" />
-              <div className="skeleton-loading-user-profile-item mt-5" />
-              <div className="skeleton-loading-user-profile-item" style={{ height: '16rem' }} />
-              <div className="skeleton-loading-user-profile-item" style={{ marginTop: '4rem' }} />
-              <div className="skeleton-loading-user-profile-item mt-3" />
-              <div className="skeleton-loading-user-profile-item mt-3" />
-              <div className="skeleton-loading-user-profile-item mt-3" />
-              <div className="skeleton-loading-user-profile-item mt-3" />
-              <div className="skeleton-loading-user-profile-item mt-3" />
-              <div className="skeleton-loading-user-profile-item mt-3" />
-              <div className="skeleton-loading-user-profile-item mt-3" />
-              <div className="skeleton-loading-user-profile-item mt-3" />
-              <div className="skeleton-loading-user-profile-item mt-3" />
-              <div className="skeleton-loading-user-profile-item mt-3" />
-              <div className="skeleton-loading-user-profile-item mt-3" />
+              <div className={`${styles.skeletonLoadingUserProfileItem}`} />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-5`} />
+              <div
+                className={`${styles.skeletonLoadingUserProfileItem}`}
+                style={{ height: '16rem' }}
+              />
+              <div
+                className={`${styles.skeletonLoadingUserProfileItem}`}
+                style={{ marginTop: '4rem' }}
+              />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-3`} />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-3`} />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-3`} />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-3`} />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-3`} />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-3`} />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-3`} />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-3`} />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-3`} />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-3`} />
+              <div className={`${styles.skeletonLoadingUserProfileItem} mt-3`} />
             </div>
           </Container>
         );
       case 'UserManagement':
         for (let i = 0; i < 17; i++) {
           userManagementItems.push(
-            <div key={i} className="skeleton-loading-user-management-item" />,
+            <div key={i} className={`${styles.skeletonLoadingUserManagementItem}`} />,
           );
         }
         return <div>{userManagementItems}</div>;
       case 'WeeklyVolunteerSummary':
         return (
           <Container fluid="sm" className={darkMode ? 'bg-space-cadet' : ''}>
-            <div className="skeleton-loading-weekly-summary" />
+            <div className={`${styles.skeletonLoadingWeeklySummary}`} />
           </Container>
         );
       default:

--- a/src/components/common/SkeletonLoading/SkeletonLoading.module.css
+++ b/src/components/common/SkeletonLoading/SkeletonLoading.module.css
@@ -1,6 +1,6 @@
 /* Skeleton Loading for Timelog */
 
-.skeleton-loading-timelog {
+.skeletonLoadingTimelog {
   display: flex;
   flex-direction: column;
   border: 1px solid rgba(0, 0, 0, 0.125);
@@ -8,7 +8,7 @@
   background-color: #f3f4f6;
 }
 
-.skeleton-loading-item-timelog {
+.skeletonLoadingItemTimelog {
   background: linear-gradient(90deg, #a0a0a0 0%, #c0c0c0 50%, #a0a0a0 100%);
   background-size: 200% 100%;
   animation: skeleton-loading-animation 1.5s ease-in-out infinite;
@@ -17,7 +17,7 @@
   margin: 0.625rem 18.75rem 0.125rem 2.5rem;
 }
 
-.skeleton-loading-item-add-intangible {
+.skeletonLoadingItemAddIntangible {
   background: linear-gradient(90deg, #a0a0a0 0%, #c0c0c0 50%, #a0a0a0 100%);
   background-size: 200% 100%;
   animation: skeleton-loading-animation 3s ease-in-out infinite;
@@ -29,13 +29,13 @@
 
 /* Skeleton Loading for Timelog Filter */
 
-.skeleton-loading-timelog-filter {
+.skeletonLoadingTimelogFilter {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-.skeleton-loading-timelog-filter-item {
+.skeletonLoadingTimelogFilterItem {
   background: linear-gradient(90deg, #a0a0a0 0%, #c0c0c0 50%, #a0a0a0 100%);
   background-size: 200% 100%;
   animation: skeleton-loading-animation 1.5s ease-in-out infinite;
@@ -48,7 +48,7 @@
 
 /* Skeleton Loading for Team Member Tasks */
 
-.skeleton-loading-team-member-tasks-row {
+.skeletonLoadingTeamMemberTasksRow {
   background: linear-gradient(90deg, #a0a0a0 0%, #c0c0c0 50%, #a0a0a0 100%);
   background-size: 200% 100%;
   height: 60px;
@@ -57,7 +57,7 @@
 
 /* Skeleton Loading for Weekly Summary Due Date (click to add) */
 
-.skeleton-loading-weekly-summary {
+.skeletonLoadingWeeklySummary {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -74,7 +74,7 @@
 
 /* Skeleton Loading for Weekly Summaries Report Page */
 
-.skeleton-loading-weekly-summaries-report {
+.skeletonLoadingWeeklySummariesReport {
   display: flex;
   flex-direction: column;
   border: 1px solid rgba(0, 0, 0, 0.125);
@@ -83,7 +83,7 @@
   padding-top: 1rem;
 }
 
-.skeleton-loading-weekly-summaries-report-item {
+.skeletonLoadingWeeklySummariesReportItem {
   border: 1px solid rgba(0, 0, 0, 0.125);
   background-color: #f3f4f6;
   width: 35rem;
@@ -97,7 +97,7 @@
 
 /* Skeleton Loading for User Profile Page */
 
-.skeleton-loading-user-profile-picture {
+.skeletonLoadingUserProfilePicture {
   display: flex;
   flex-direction: column;
   border: 1px solid rgba(0, 0, 0, 0.125);
@@ -111,7 +111,7 @@
   border-radius: 5px;
 }
 
-.skeleton-loading-user-profile-item {
+.skeletonLoadingUserProfileItem {
   background: linear-gradient(90deg, #a0a0a0 0%, #c0c0c0 50%, #a0a0a0 100%);
   background-size: 200% 100%;
   animation: skeleton-loading-animation 1.5s ease-in-out infinite;
@@ -123,7 +123,7 @@
 
 /* Skeleton Loading for User Management */
 
-.skeleton-loading-user-management-item {
+.skeletonLoadingUserManagementItem {
   background: linear-gradient(90deg, #a0a0a0 0%, #c0c0c0 50%, #a0a0a0 100%);
   background-size: 200% 100%;
   animation: skeleton-loading-animation 1.5s ease-in-out infinite;

--- a/src/components/common/Stub/Stub.jsx
+++ b/src/components/common/Stub/Stub.jsx
@@ -1,9 +1,9 @@
 import { GiHollowCat } from 'react-icons/gi';
-import './Stub.css';
+import styles from './Stub.module.css';
 
 // eslint-disable-next-line import/prefer-default-export, react/function-component-definition
 export const Stub = ({ darkMode }) => (
-  <div className="stub-wrapper">
+  <div className={`${styles.stubWrapper}`}>
     <GiHollowCat size={72} />
     <div className={`stub-hint ${darkMode ? 'text-light' : ''}`}>
       Nothing&apos;s here at the moment

--- a/src/components/common/Stub/Stub.module.css
+++ b/src/components/common/Stub/Stub.module.css
@@ -1,4 +1,4 @@
-.stub-wrapper {
+.stubWrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -8,6 +8,6 @@
   color: #d1cfd4;
 }
 
-.stub-hint {
+.stubHint {
   color: rgba(0, 0, 0, 0.4);
 }

--- a/src/components/common/TwoWayToggleSwitch/TwoWayToggleSwitch.jsx
+++ b/src/components/common/TwoWayToggleSwitch/TwoWayToggleSwitch.jsx
@@ -1,18 +1,18 @@
-import './TwoWayToggleSwitch.css'; // Asegúrate de crear este archivo CSS
+import styles from './TwoWayToggleSwitch.module.css'; // Asegúrate de crear este archivo CSS
 
 function TwoWayToggleSwitch({ isOn, handleToggle }) {
   return (
-    <div className="two-way-toggle-switch">
+    <div className={`${styles.twoWayToggleSwitch}`}>
       <input
         checked={isOn}
         onChange={handleToggle}
-        className="toggle-switch-checkbox"
+        className={`${styles.toggleSwitchCheckbox}`}
         id="toggle-switch-new"
         type="checkbox"
       />
-      <label className="toggle-switch-label" htmlFor="toggle-switch-new">
-        <span className="toggle-switch-inner" />
-        <span className="toggle-switch-switch" />
+      <label className={`${styles.toggleSwitchLabel}`} htmlFor="toggle-switch-new">
+        <span className={`${styles.toggleSwitchInner}`} />
+        <span className={`${styles.toggleSwitchSwitch}`} />
       </label>
     </div>
   );

--- a/src/components/common/TwoWayToggleSwitch/TwoWayToggleSwitch.module.css
+++ b/src/components/common/TwoWayToggleSwitch/TwoWayToggleSwitch.module.css
@@ -1,4 +1,4 @@
-.two-way-toggle-switch {
+.twoWayToggleSwitch {
   position: relative;
   width: 90px;
   display: inline-block;
@@ -8,11 +8,11 @@
   transform: translate(-50%, -50%);
 }
 
-.toggle-switch-checkbox {
+.toggleSwitchCheckbox {
   display: none;
 }
 
-.toggle-switch-label {
+.toggleSwitchLabel {
   display: block;
   overflow: hidden;
   cursor: pointer;
@@ -20,15 +20,15 @@
   border-radius: 20px;
 }
 
-.toggle-switch-inner {
+.toggleSwitchInner {
   display: block;
   width: 200%;
   margin-left: -100%;
   transition: margin 0.3s ease-in 0s;
 }
 
-.toggle-switch-inner:before,
-.toggle-switch-inner:after {
+.toggleSwitchInner:before,
+.toggleSwitchInner:after {
   display: block;
   float: left;
   width: 50%;
@@ -41,7 +41,7 @@
   box-sizing: border-box;
 }
 
-.toggle-switch-inner:before {
+.toggleSwitchInner:before {
   content: "All";
   padding-left: 2px;
   background-color: #2FCCFF;
@@ -49,7 +49,7 @@
   text-align: center;
 }
 
-.toggle-switch-inner:after {
+.toggleSwitchInner:after {
   content: "Select";
   padding-left: 10px;
   background-color: #FF3B3F;
@@ -57,7 +57,7 @@
   text-align: center;
 }
 
-.toggle-switch-switch {
+.toggleSwitchSwitch {
   display: block;
   width: 15px;
   top: 4px;
@@ -71,10 +71,10 @@
   transition: all 0.3s ease-in 0s;
 }
 
-.toggle-switch-checkbox:checked + .toggle-switch-label .toggle-switch-inner {
+.toggleSwitchCheckbox:checked + .toggleSwitchLabel .toggleSwitchInner {
   margin-left: 0;
 }
 
-.toggle-switch-checkbox:checked + .toggle-switch-label .toggle-switch-switch {
+.toggleSwitchCheckbox:checked + .toggleSwitchLabel .toggleSwitchSwitch {
   right: 0px;
 }


### PR DESCRIPTION


# Description
This PR addresses potential UI inconsistencies by converting **shared and collaboration-related CSS files** to CSS Modules.  
Affected files were located in:  
- `src/components/common/`
- `src/components/Collaboration/`

Renaming these files from `.css` to `.module.css` and updating their imports ensures style encapsulation, prevents global style bleeding, and improves maintainability.


## Related PRS (if any):
None

## Main changes explained:
- Renamed component `.css` files to `.module.css`
- Updated all component imports to use CSS Modules format
- Replaced static `className="..."` usage with `className={styles...}`
- Ensured no logic or functional changes were introduced

### Key components affected:
- `Checkbox`
- `Clipboard`
- `DragAndDrop`
- `Input`
- `NewModal`
- `Paging`
- `PhoneInput`
- `PieChart` and `UserProjectPieChart`
- `SkeletonLoading`
- `Stub`
- `TwoWayToggleSwitch`
- `JobFormBuilder`
## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an **admin** user
5. Navigate through commonly used flows involving shared components, for example:
   - Dashboard
   - Weekly Summaries
   - Profile pages
   - Project/Task modals
6. Compare visuals with the `development` branch to confirm:
   - Layouts and styles are consistent
   - No visual regressions or broken UI components

**Focus is on visual consistency, not functionality.**

## Note:
There are no functional changes. This PR strictly modularizes CSS to prevent global conflicts.
Please double-check for any missed imports or broken visuals.