### PR TITLE
Fix formatting of the 'SUMMARY' text in the header box

### DIFF
--- a/src/components/SummaryBar/SummaryBar.css
+++ b/src/components/SummaryBar/SummaryBar.css
@@ -208,12 +208,27 @@
   }
 }
 
+@media (min-width: 992px) and (max-width: 1199px) {
+  .large_text_summary {
+    font-size: 2rem !important;
+  }
+  
+  .summary-label {
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0 8px;
+  }
+}
+
 /* Custom media query for screen widths between 1200px and 1330px */
 @media (min-width: 1200px) and (max-width: 1330px) {
   .med_text_summary {
     font-size: 0.8rem;
   }
 }
+
 
 /* XLarge devices (landscape phones, 544px and down) */
 @media (max-width: 1200px) {
@@ -257,8 +272,11 @@
 }
 
 .text-center{
+
   display: flex;
   justify-content: center;
+  align-items: center;
+  text-align: center;
 }
 
 .sortable-container {

--- a/src/components/SummaryBar/SummaryBar.jsx
+++ b/src/components/SummaryBar/SummaryBar.jsx
@@ -462,7 +462,7 @@ const SummaryBar = React.forwardRef((props, ref) => {
           ) : (
             <p className="text-center summary-toggle large_text_summary text-danger">!</p>
           )}
-          <font className="text-center" size="3">
+          <font className="text-center summary-label" size="3">
             SUMMARY
           </font>
           <div className="py-2"> </div>


### PR DESCRIPTION
# Description
The SUMMARY text in the header box is not responsive and breaks out of its container at medium screen widths (~1024px).
Fix:
Applied responsive CSS (likely using flex-wrap, text-overflow, media queries, or similar) to ensure the text stays within the bounds of the container at all screen sizes.

## Related PRS (if any):
This frontend PR is not related to any backend PR.

…

## Main changes explained:
Fixed responsive layout styles for the SUMMARY header box on Dashboard
Updated CSS/JSX to prevent overflow at 1024px width
Verified dark mode compatibility
…

## How to test:
Checkout this branch
Run npm install
Clear site data/cache
Log in 
Navigate: Dashboard → Tasks → Task

Verify:

“SUMMARY” text remains inside its container at all screen sizes, including around 1024px
## Screenshots or videos of changes:
before
![image](https://github.com/user-attachments/assets/59ec4244-7c78-43ff-8acc-c381449118f6)
After
![WhatsApp Image 2025-06-09 at 7 11 00 AM](https://github.com/user-attachments/assets/06316c66-d8fd-44b2-9bb0-2c5f47b66b01)



## Note:
Include the information the reviewers need to know.
