### PR TITLE
Nikhil Routh Migrate src/components/JobCCDashboard css to module css

### DIFF
--- a/refactor-css-classes.js
+++ b/refactor-css-classes.js
@@ -1,0 +1,134 @@
+// updated on june 11
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+const postcss = require('postcss');
+const safeParser = require('postcss-safe-parser');
+
+// Helper to convert kebab-case, snake_case, pascalcase to camelCase
+const toCamelCase = str => {
+  const formatted = str.replace(/[-_](\w)/g, (_, char) => char.toUpperCase());
+  return formatted.charAt(0).toLowerCase() + formatted.slice(1);
+};
+
+const classMap = {}; // e.g. { "my-class": "myClass" }
+
+// Step 1: Convert class names in .css files
+const convertCSSFile = filePath => {
+  const css = fs.readFileSync(filePath, 'utf8');
+  const root = postcss.parse(css, { parser: safeParser });
+
+  root.walkRules(rule => {
+    const updated = rule.selectors.map(selector => {
+      return selector.replace(/\.(\w[\w-]*)/g, (_, className) => {
+        const camel = toCamelCase(className);
+        classMap[className] = camel;
+        return `.${camel}`;
+      });
+    });
+    // eslint-disable-next-line no-param-reassign
+    rule.selectors = updated;
+  });
+
+  fs.writeFileSync(filePath, root.toString());
+  // eslint-disable-next-line no-console
+  console.log(`✅ Updated CSS: ${filePath}`);
+  // eslint-disable-next-line no-console
+  // console.log('classMap after CSS processing:', classMap);
+};
+
+// Step 2: Replace import statement for CSS module in JSX
+const replaceImportStatement = code => {
+  const importRegex = /import\s+['"](.+\/)?([a-zA-Z0-9_-]+)\.css['"];/;
+  // eslint-disable-next-line default-param-last
+  return code.replace(importRegex, (_, pathPrefix = '', cssFileName) => {
+    return `import styles from '${pathPrefix}${cssFileName}.module.css';`;
+  });
+};
+
+// Step 3: Replace kebab-case classes in JSX code with styles.camelCase
+const replaceInCodeFile = filePath => {
+  let code = fs.readFileSync(filePath, 'utf8');
+  const originalCode = code;
+
+  console.log(`Processing code file: ${filePath}`);
+
+  // Step 1: Update import statement
+  code = replaceImportStatement(code);
+  console.log(`✅ Updated import`);
+
+  if (Object.keys(classMap).length === 0) {
+    console.log('classMap is empty, please check the refactor script!');
+    return;
+  }
+
+  // Step 2: Replace className="text-light input-file-upload" → className={styles.textLight + " " + styles.inputFileUpload}
+  code = code.replace(/className\s*=\s*["']([^"']+)["']/g, (_, classStr) => {
+    const classList = classStr.trim().split(/\s+/);
+
+    // Skip transforming if no class in classList exists in classMap
+    if (classList.every(cls => !classMap[cls])) {
+      return `className="${classStr}"`;
+    }
+    const mapped = classList.map(cls => {
+      const camel = classMap[cls];
+      return camel ? `\${styles.${camel}}` : cls;
+    });
+    return `className={\`${mapped.join(' ')}\`}`;
+  });
+
+  if (code !== originalCode) {
+    fs.writeFileSync(filePath, code, 'utf8');
+    console.log(`✅ Updated code in: ${filePath}`);
+  } else {
+    console.log('⚠️  No className replacements made.');
+  }
+};
+
+const cssFiles = []; // To collect all CSS files
+const codeFiles = []; // To collect all JS/JSX files
+
+// Step 3: Walk through project and process files
+const walkDir = dir => {
+  // First pass: Collect files into two separate arrays
+  fs.readdirSync(dir).forEach(file => {
+    const fullPath = path.join(dir, file);
+    const stats = fs.statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      walkDir(fullPath);
+    } else if (file.endsWith('.css')) {
+      cssFiles.push(fullPath); // Add CSS file path to the array
+    } else if (
+      file.endsWith('.js') ||
+      file.endsWith('.jsx') ||
+      file.endsWith('.ts') ||
+      file.endsWith('.tsx') ||
+      file.endsWith('.html')
+    ) {
+      codeFiles.push(fullPath); // Add JS/JSX file path to the array
+    }
+  });
+
+  // Now process CSS files first
+  cssFiles.forEach(cssFile => {
+    console.log('Processing CSS file:', cssFile);
+    convertCSSFile(cssFile); // Process CSS files
+  });
+
+  // Then process code files (JS/JSX, etc.)
+  codeFiles.forEach(codeFile => {
+    console.log('Processing code file:', codeFile);
+    replaceInCodeFile(codeFile); // Process JS/JSX files
+  });
+};
+
+// 🚀 Start here: Replace with your actual project folder path
+const rootDir = 'src/components/JobCCDashboard';
+walkDir(rootDir);
+
+// const mapPath = path.join(__dirname, 'class-map.json');
+// fs.writeFileSync(mapPath, JSON.stringify(classMap, null, 2));
+// // eslint-disable-next-line no-console
+// console.log(`🗺️  Class map written to ${mapPath}`);

--- a/src/components/JobCCDashboard/JobCCDashboard.jsx
+++ b/src/components/JobCCDashboard/JobCCDashboard.jsx
@@ -3,10 +3,10 @@ import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import axios from 'axios';
 import { Table, Button, FormGroup, Label, Input } from 'reactstrap';
-import './JobCCDashboard.css';
 import { ENDPOINTS } from 'utils/URL';
 import JobCCModal from './JobCCModal'; // Modal for managing CC list
 import JobCategoryCCModal from './JobCategoryCCModal';
+import styles from './JobCCDashboard.module.css';
 
 function JobCCDashboard() {
   const [jobs, setJobs] = useState([]);
@@ -85,7 +85,7 @@ function JobCCDashboard() {
       className={`job-cc-dashboard ${darkMode ? 'dark-mode-job-cc-dashboard' : ''}`}
       style={{ height: '100%' }}
     >
-      <h1 className="dashboard-title">Job CC Dashboard</h1>
+      <h1 className={`${styles.dashboardTitle}`}>Job CC Dashboard</h1>
       <div className="filters-container">
         <FormGroup>
           <Label for="filter" className={`${darkMode ? 'text-light' : 'text-dark'}`}>
@@ -137,7 +137,7 @@ function JobCCDashboard() {
         </div>
       </div>
 
-      <Table striped bordered hover className="job-cc-dashboard-table">
+      <Table striped bordered hover className={`${styles.jobCcDashboardTable}`}>
         <thead>
           <tr>
             <th>Job Title</th>

--- a/src/components/JobCCDashboard/JobCCDashboard.module.css
+++ b/src/components/JobCCDashboard/JobCCDashboard.module.css
@@ -1,21 +1,21 @@
-.job-cc-dashboard {
+.jobCcDashboard {
   padding: 20px;
   font-family: 'Arial', sans-serif;
 }
 
-.dark-mode-job-cc-dashboard {
+.darkModeJobCcDashboard {
   /*  #2c2f33 */
   background-color: #1b2a41;
   color: #ffffff;
 }
 
-.dashboard-title {
+.dashboardTitle {
   font-size: 2rem;
   margin-bottom: 20px;
   text-align: center;
 }
 
-.form-container {
+.formContainer {
   background-color: #f8f9fa;
   padding: 20px;
   border-radius: 8px;
@@ -23,49 +23,49 @@
   margin-bottom: 30px;
 }
 
-.dark-mode-job-cc-dashboard .form-container {
+.darkModeJobCcDashboard .formContainer {
   background-color: #3c3f44;
   color: #ffffff;
 }
 
-.form-container form {
+.formContainer form {
   max-width: 500px;
   margin: 0 auto;
 }
 
-.list-title {
+.listTitle {
   font-size: 1.5rem;
   margin-bottom: 10px;
 }
 
-.cc-list-container {
+.ccListContainer {
   background-color: #ffffff;
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
 }
 
-.dark-mode-job-cc-dashboard .cc-list-container {
+.darkModeJobCcDashboard .ccListContainer {
   background-color: #3c3f44;
 }
 
-.job-cc-dashboard-table {
+.jobCcDashboardTable {
   margin-top: 10px;
 }
 
-.job-cc-dashboard-table th {
+.jobCcDashboardTable th {
   background-color: #007bff;
   color: #ffffff;
 }
 
-.dark-mode-job-cc-dashboard .job-cc-dashboard-table th {
+.darkModeJobCcDashboard .jobCcDashboardTable th {
   background-color: #0056b3;
 }
 
-.job-cc-dashboard-table td {
+.jobCcDashboardTable td {
   vertical-align: middle;
 }
 
-.job-cc-dashboard-table button {
+.jobCcDashboardTable button {
   font-size: 0.85rem;
 }


### PR DESCRIPTION
# Description
This PR addresses potential UI inconsistencies by converting **shared and collaboration-related CSS files** to CSS Modules.  
Affected files were located in:  
- `src/components/JobCCDashboard/` 

Renaming these files from `.css` to `.module.css` and updating their imports ensures style encapsulation, prevents global style bleeding, and improves maintainability.


## Related PRS (if any):
Pull the latest backend 

## Main changes explained:
- Renamed component `.css` files to `.module.css`
- Updated all component imports to use CSS Modules format
- Replaced static `className="..."` usage with `className={styles...}`
- Ensured no logic or functional changes were introduced

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Navigate to: `http://localhost:3000/job-notification-dashboard/
6. Compare visuals with the `development` branch to confirm:
   - Layouts and styles are consistent
   - No visual regressions or broken UI components

## Note:
There are no functional changes. This PR strictly modularizes CSS to prevent global conflicts.
Please double-check for any missed imports or broken visuals.
