### PR TITLE
Julia - Create Total Material Cost Per Project Bar Chart

### DIFF
--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.css
@@ -30,3 +30,34 @@
 .total-material-cost-per-project .select__menu {
   font-size: 12px;
 }
+
+/* Dark mode for the Select Dropdown */
+.dark-mode .material-cost-per-project-dropdown .select__control {
+  background-color: var(--section-bg) !important;
+  border-color: var(--section-title-bg) !important;
+  color: var(--text-color) !important;
+}
+
+.dark-mode .material-cost-per-project-dropdown .select__menu {
+  background-color: var(--section-bg) !important;
+}
+
+.dark-mode .material-cost-per-project-dropdown .select__option:hover {
+  background-color: #0d55b3;
+}
+
+.dark-mode .material-cost-per-project-dropdown .select__option--is-focused{
+  background-color: #0d55b3;
+}
+
+.dark-mode .material-cost-per-project-dropdown .select__multi-value {
+  background-color: #375071;
+}
+
+.dark-mode .material-cost-per-project-dropdown .select__multi-value__label {
+  color: white;
+}
+
+.dark-mode .material-cost-per-project-dropdown .css-tj5bde-Svg:hover {
+  fill: white;
+}

--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.css
@@ -1,0 +1,36 @@
+.total-material-cost-per-project{
+  height: 300px;
+}
+
+.total-material-cost-per-project-chart-title {
+  font-size: medium;
+  font-weight: bold;
+  color: var(--text-color);
+  margin-bottom: 10px;
+}
+
+.total-material-cost-per-project .select__value-container {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  overflow-x: auto;
+  white-space: nowrap;
+  flex-wrap: nowrap;
+  max-width: 100%;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  position: relative;
+}
+
+.total-material-cost-per-project .select__multi-value {
+  max-width: none;
+  flex-shrink: 0;
+}
+
+.total-material-cost-per-project .select__multi-value__label {
+  font-size: 12px;
+}
+
+.total-material-cost-per-project .select__menu {
+  font-size: 12px;
+}

--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.css
@@ -1,7 +1,3 @@
-.total-material-cost-per-project{
-  height: 300px;
-}
-
 .total-material-cost-per-project-chart-title {
   font-size: medium;
   font-weight: bold;

--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
@@ -89,8 +89,6 @@ function TotalMaterialCostPerProject() {
           value: project.projectId,
           label: project.projectName,
         }));
-        // eslint-disable-next-line no-console
-        console.log(projectsFilteredData);
         setSelectedProjects(projectsFilteredData);
         setAllProjects(projectsFilteredData);
 
@@ -104,8 +102,6 @@ function TotalMaterialCostPerProject() {
           acc[item.projectId] = item.totalCostK;
           return acc;
         }, {});
-        // eslint-disable-next-line no-console
-        console.log(projectCostsData);
         setProjectCosts(projectCostsData);
       } catch (error) {
         toast.error(`Error fetching data: ${error.message}`);
@@ -142,19 +138,21 @@ function TotalMaterialCostPerProject() {
       </h2>
       {dataLoaded ? (
         <>
-          <Select
-            isMulti
-            isSearchable
-            options={allProjects}
-            value={selectedProjects}
-            onChange={setSelectedProjects}
-            className="basic-multi-select"
-            classNamePrefix="select"
-            defaultValue={allProjects}
-            placeholder="Select Projects"
-            closeMenuOnSelect={false}
-            hideSelectedOptions={false}
-          />
+          <div data-testid="select-projects-dropdown">
+            <Select
+              isMulti
+              isSearchable
+              options={allProjects}
+              value={selectedProjects}
+              onChange={setSelectedProjects}
+              className="basic-multi-select"
+              classNamePrefix="select"
+              defaultValue={allProjects}
+              placeholder="Select Projects"
+              closeMenuOnSelect={false}
+              hideSelectedOptions={false}
+            />
+          </div>
           <div style={{ overflowX: 'auto' }}>
             <div style={{ minWidth: `${selectedProjects.length * 20}px`, minHeight: '300px' }}>
               <Bar data={data} options={options} />

--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
@@ -54,6 +54,10 @@ const options = {
         font: {
           size: 11,
         },
+        callback(val) {
+          const label = this.getLabelForValue(val);
+          return label.length > 20 ? `${label.slice(0, 20)}…` : label;
+        },
       },
     },
   },

--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import Select from 'react-select';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import './TotalMaterialCostPerProject.css';
+
+// Register required components
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+const allProjects = [
+  { label: 'Website Redesign', value: '1' },
+  { label: 'Mobile App', value: '2' },
+  { label: 'API Development', value: '3' },
+  { label: 'Marketing Campaign', value: '4' },
+];
+
+const projectCosts = {
+  '1': 1200,
+  '2': 2500,
+  '3': 1800,
+  '4': 900,
+};
+
+const options = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      position: 'top',
+    },
+    title: {
+      display: false,
+    },
+  },
+};
+
+function TotalMaterialCostPerProject() {
+  const [selectedProjects, setSelectedProjects] = useState(allProjects);
+
+  const data = {
+    labels: selectedProjects.map(p => p.label),
+    datasets: [
+      {
+        label: 'Total Material Cost (*1000$)',
+        data: selectedProjects.map(p => projectCosts[p.value]),
+        backgroundColor: 'rgba(20, 137, 175, 1)',
+        borderRadius: 10,
+      },
+    ],
+  };
+
+  return (
+    <div className="total-material-cost-per-project">
+      <h2 className="total-material-cost-per-project-chart-title">
+        Total Material Cost Per Project
+      </h2>
+      <Select
+        isMulti
+        isSearchable
+        options={allProjects}
+        value={selectedProjects}
+        onChange={setSelectedProjects}
+        className="basic-multi-select"
+        classNamePrefix="select"
+        defaultValue={allProjects}
+        placeholder="All Projects"
+        closeMenuOnSelect={false}
+        hideSelectedOptions={false}
+      />
+      <Bar data={data} options={options} />
+    </div>
+  );
+}
+
+export default TotalMaterialCostPerProject;

--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import Select from 'react-select';
 import {
   Chart as ChartJS,
@@ -13,8 +14,6 @@ import { Bar } from 'react-chartjs-2';
 import { toast } from 'react-toastify';
 import axios from 'axios';
 import './TotalMaterialCostPerProject.css';
-import { useEffect } from 'react';
-import { useMemo } from 'react';
 import { ENDPOINTS } from 'utils/URL';
 import Loading from 'components/common/Loading';
 
@@ -43,37 +42,49 @@ const projectDemoCosts = {
   '8': 876,
 };
 
-const options = {
-  responsive: true,
-  maintainAspectRatio: false,
-  plugins: {
-    legend: {
-      position: 'top',
-    },
-    title: {
-      display: false,
-    },
-  },
-  scales: {
-    x: {
-      ticks: {
-        font: {
-          size: 11,
-        },
-        callback(val) {
-          const label = this.getLabelForValue(val);
-          return label.length > 20 ? `${label.slice(0, 20)}…` : label;
-        },
-      },
-    },
-  },
-};
-
 function TotalMaterialCostPerProject() {
   const [dataLoaded, setDataLoaded] = useState(false);
   const [allProjects, setAllProjects] = useState([]);
   const [projectCosts, setProjectCosts] = useState({});
   const [selectedProjects, setSelectedProjects] = useState([]);
+  const darkMode = useSelector(state => state.theme.darkMode);
+  const textColor = darkMode ? '#ffffff' : '#666';
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        position: 'top',
+        labels: { color: textColor },
+      },
+      title: {
+        display: false,
+      },
+    },
+    scales: {
+      x: {
+        grid: { display: false },
+        ticks: {
+          color: textColor,
+          font: {
+            size: 11,
+          },
+          callback(val) {
+            // eslint-disable-next-line react/no-this-in-sfc
+            const label = this.getLabelForValue(val);
+            return label.length > 20 ? `${label.slice(0, 20)}…` : label;
+          },
+        },
+      },
+      y: {
+        grid: { color: '#ccc' },
+        ticks: {
+          color: textColor,
+        },
+      },
+    },
+  };
 
   useEffect(() => {
     const fetchData = async () => {
@@ -124,7 +135,7 @@ function TotalMaterialCostPerProject() {
         {
           label: 'Total Material Cost (*1000$)',
           data: selectedProjects.map(p => projectCosts[p.value]),
-          backgroundColor: 'rgba(20, 137, 175, 1)',
+          backgroundColor: 'rgb(23, 154, 197)',
           borderRadius: 10,
         },
       ],
@@ -132,7 +143,7 @@ function TotalMaterialCostPerProject() {
   }, [selectedProjects, projectCosts]);
 
   return (
-    <div className="total-material-cost-per-project">
+    <div className={`total-material-cost-per-project ${darkMode ? 'dark-mode' : ''}`}>
       <h2 className="total-material-cost-per-project-chart-title">
         Total Material Cost Per Project
       </h2>
@@ -145,7 +156,7 @@ function TotalMaterialCostPerProject() {
               options={allProjects}
               value={selectedProjects}
               onChange={setSelectedProjects}
-              className="basic-multi-select"
+              className="material-cost-per-project-dropdown basic-multi-select"
               classNamePrefix="select"
               defaultValue={allProjects}
               placeholder="Select Projects"

--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
@@ -22,14 +22,14 @@ import Loading from 'components/common/Loading';
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
 const allDemoProjects = [
-  { label: 'Website Redesign', value: '1' },
-  { label: 'Mobile App', value: '2' },
-  { label: 'API Development Marketing Campaign Marketing Campaign', value: '3' },
-  { label: 'Marketing Campaign', value: '4' },
-  { label: 'Website', value: '5' },
-  { label: 'Mobile', value: '6' },
-  { label: 'API', value: '7' },
-  { label: 'Marketing', value: '8' },
+  { label: 'Project 1', value: '1' },
+  { label: 'Project 2', value: '2' },
+  { label: 'Project 3', value: '3' },
+  { label: 'Project 4', value: '4' },
+  { label: 'Project 5', value: '5' },
+  { label: 'Project 6', value: '6' },
+  { label: 'Project 7', value: '7' },
+  { label: 'Project 8', value: '8' },
 ];
 
 const projectDemoCosts = {
@@ -48,12 +48,7 @@ const options = {
   maintainAspectRatio: false,
   plugins: {
     legend: {
-      // display: true,
       position: 'top',
-      // align: 'start', // Align legend to the left
-      // labels: {
-      //   padding: 10, // Padding inside legend box (around labels)
-      // },
     },
     title: {
       display: false,

--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
@@ -11,11 +11,13 @@ import {
 } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 import './TotalMaterialCostPerProject.css';
+import { useEffect } from 'react';
+import { useMemo } from 'react';
 
 // Register required components
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
-const allProjects = [
+const allDemoProjects = [
   { label: 'Website Redesign', value: '1' },
   { label: 'Mobile App', value: '2' },
   { label: 'API Development Marketing Campaign Marketing Campaign', value: '3' },
@@ -64,43 +66,66 @@ const options = {
 };
 
 function TotalMaterialCostPerProject() {
-  const [selectedProjects, setSelectedProjects] = useState(allProjects);
+  const [dataLoaded, setDataLoaded] = useState(false);
+  const [allProjects, setAllProjects] = useState([]);
+  const [selectedProjects, setSelectedProjects] = useState([]);
 
-  const data = {
-    labels: selectedProjects.map(p => p.label),
-    datasets: [
-      {
-        label: 'Total Material Cost (*1000$)',
-        data: selectedProjects.map(p => projectCosts[p.value]),
-        backgroundColor: 'rgba(20, 137, 175, 1)',
-        borderRadius: 10,
-      },
-    ],
-  };
+  // eslint-disable-next-line no-promise-executor-return
+  const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+  useEffect(() => {
+    const run = async () => {
+      await sleep(3000);
+      setSelectedProjects(allDemoProjects);
+      setAllProjects(allDemoProjects);
+      setDataLoaded(true);
+    };
+    run();
+  }, []);
+
+  const data = useMemo(() => {
+    return {
+      labels: selectedProjects.map(p => p.label),
+      datasets: [
+        {
+          label: 'Total Material Cost (*1000$)',
+          data: selectedProjects.map(p => projectCosts[p.value]),
+          backgroundColor: 'rgba(20, 137, 175, 1)',
+          borderRadius: 10,
+        },
+      ],
+    };
+  }, [selectedProjects]);
 
   return (
     <div className="total-material-cost-per-project">
       <h2 className="total-material-cost-per-project-chart-title">
         Total Material Cost Per Project
       </h2>
-      <Select
-        isMulti
-        isSearchable
-        options={allProjects}
-        value={selectedProjects}
-        onChange={setSelectedProjects}
-        className="basic-multi-select"
-        classNamePrefix="select"
-        defaultValue={allProjects}
-        placeholder="All Projects"
-        closeMenuOnSelect={false}
-        hideSelectedOptions={false}
-      />
-      <div style={{ overflowX: 'auto' }}>
-        <div style={{ minWidth: `${selectedProjects.length * 20}px`, minHeight: '300px' }}>
-          <Bar data={data} options={options} />
-        </div>
-      </div>
+      {dataLoaded ? (
+        <>
+          <Select
+            isMulti
+            isSearchable
+            options={allProjects}
+            value={selectedProjects}
+            onChange={setSelectedProjects}
+            className="basic-multi-select"
+            classNamePrefix="select"
+            defaultValue={allProjects}
+            placeholder="Select Projects"
+            closeMenuOnSelect={false}
+            hideSelectedOptions={false}
+          />
+          <div style={{ overflowX: 'auto' }}>
+            <div style={{ minWidth: `${selectedProjects.length * 20}px`, minHeight: '300px' }}>
+              <Bar data={data} options={options} />
+            </div>
+          </div>
+        </>
+      ) : (
+        <p>Loading data...</p>
+      )}
     </div>
   );
 }

--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/TotalMaterialCostPerProject.jsx
@@ -18,8 +18,12 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
 const allProjects = [
   { label: 'Website Redesign', value: '1' },
   { label: 'Mobile App', value: '2' },
-  { label: 'API Development', value: '3' },
+  { label: 'API Development Marketing Campaign Marketing Campaign', value: '3' },
   { label: 'Marketing Campaign', value: '4' },
+  { label: 'Website', value: '5' },
+  { label: 'Mobile', value: '6' },
+  { label: 'API', value: '7' },
+  { label: 'Marketing', value: '8' },
 ];
 
 const projectCosts = {
@@ -27,6 +31,10 @@ const projectCosts = {
   '2': 2500,
   '3': 1800,
   '4': 900,
+  '5': 3424,
+  '6': 5433,
+  '7': 454,
+  '8': 876,
 };
 
 const options = {
@@ -38,6 +46,15 @@ const options = {
     },
     title: {
       display: false,
+    },
+  },
+  scales: {
+    x: {
+      ticks: {
+        font: {
+          size: 11,
+        },
+      },
     },
   },
 };
@@ -75,7 +92,11 @@ function TotalMaterialCostPerProject() {
         closeMenuOnSelect={false}
         hideSelectedOptions={false}
       />
-      <Bar data={data} options={options} />
+      <div style={{ overflowX: 'auto' }}>
+        <div style={{ minWidth: `${selectedProjects.length * 20}px`, minHeight: '300px' }}>
+          <Bar data={data} options={options} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/__tests__/TotalMaterialCostPerProject.test.js
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/__tests__/TotalMaterialCostPerProject.test.js
@@ -1,0 +1,129 @@
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
+import axios from 'axios';
+import { toast } from 'react-toastify';
+import userEvent from '@testing-library/user-event';
+import TotalMaterialCostPerProject from '../TotalMaterialCostPerProject';
+
+// Mocks
+jest.mock('axios');
+jest.mock('react-toastify', () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
+
+// The real <Bar /> component renders into a <canvas> (not DOM-readable),
+// so this mock gives you an easy way to verify data without relying on canvas rendering,
+jest.mock('react-chartjs-2', () => ({
+  Bar: ({ data }) => (
+    <div data-testid="bar-chart">
+      {data.labels.join(',')} | {data.datasets[0].data.join(',')}
+    </div>
+  ),
+}));
+
+const mockProjects = [
+  { projectId: 1, projectName: 'Project A' },
+  { projectId: 2, projectName: 'Project B' },
+];
+
+const mockCosts = [
+  { projectId: 1, totalCostK: 100 },
+  { projectId: 2, totalCostK: 200 },
+];
+
+describe('TotalMaterialCostPerProject', () => {
+  beforeEach(() => {
+    axios.get.mockImplementation(url => {
+      if (url.includes('/totalProjects')) {
+        return Promise.resolve({ data: mockProjects });
+      }
+      if (url.includes('/material-costs')) {
+        return Promise.resolve({ data: mockCosts });
+      }
+      return Promise.reject(new Error('not found'));
+    });
+  });
+
+  it('shows loading spinner on initial render and hide the spinner when data loads', async () => {
+    const { getByTestId } = render(<TotalMaterialCostPerProject />);
+    const loadingSpinner = getByTestId('loading');
+    expect(loadingSpinner).toBeInTheDocument();
+
+    await waitFor(() => expect(loadingSpinner).not.toBeInTheDocument());
+  });
+
+  it('renders bar chart when data loads successfully', async () => {
+    render(<TotalMaterialCostPerProject />);
+    await waitFor(() => {
+      // The slash help test partial content
+      expect(screen.getByText(/Project A,Project B/)).toBeInTheDocument();
+    });
+  });
+
+  it('render selector when data loads successfully', async () => {
+    render(<TotalMaterialCostPerProject />);
+    await waitFor(() => {
+      expect(screen.getByText('Project A')).toBeInTheDocument();
+    });
+
+    const control = document.querySelector('.select__control');
+
+    expect(control).toBeInTheDocument();
+    expect(within(control).getByText('Project A')).toBeInTheDocument();
+  });
+
+  it('when select or deselect items in selector, the bar chart updates too', async () => {
+    render(<TotalMaterialCostPerProject />);
+    await waitFor(() => {
+      expect(screen.getByText('Project A')).toBeInTheDocument();
+    });
+
+    // Remove option Project A
+    userEvent.click(screen.getByRole('button', { name: 'Remove Project A' }));
+    const barChart = screen.getByTestId('bar-chart');
+    expect(within(barChart).queryByText(/Project A/)).not.toBeInTheDocument();
+
+    // Select Project A using the dropdown
+    const mySelectComponent = screen.queryByTestId('select-projects-dropdown');
+
+    fireEvent.keyDown(mySelectComponent.firstChild, { key: 'ArrowDown' });
+    await waitFor(() => screen.getByText('Project A'));
+    fireEvent.click(screen.getByText('Project A'));
+    expect(within(barChart).queryByText(/Project A/)).toBeInTheDocument();
+
+    // De-Select Project A in the dropdown
+    fireEvent.keyDown(mySelectComponent.firstChild, { key: 'ArrowDown' });
+    await waitFor(() => document.querySelector('#react-select-5-option-0'));
+    fireEvent.click(document.querySelector('#react-select-5-option-0'));
+    expect(within(barChart).queryByText(/Project A/)).not.toBeInTheDocument();
+  });
+
+  it('shows error toast when failed to load projects from api', async () => {
+    axios.get.mockImplementation(url => {
+      if (url.includes('/totalProjects')) {
+        return Promise.reject(new Error('API error'));
+      }
+      if (url.includes('/material-costs')) {
+        return Promise.resolve({ data: mockCosts });
+      }
+      return Promise.reject(new Error('not found'));
+    });
+    render(<TotalMaterialCostPerProject />);
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+  });
+
+  it('shows error toast when failed to load projects cost from api', async () => {
+    axios.get.mockImplementation(url => {
+      if (url.includes('/totalProjects')) {
+        return Promise.resolve({ data: mockProjects });
+      }
+      if (url.includes('/material-costs')) {
+        return Promise.reject(new Error('API error'));
+      }
+      return Promise.reject(new Error('not found'));
+    });
+    render(<TotalMaterialCostPerProject />);
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+  });
+});

--- a/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/__tests__/TotalMaterialCostPerProject.test.js
+++ b/src/components/BMDashboard/WeeklyProjectSummary/TotalMaterialCostPerProject/__tests__/TotalMaterialCostPerProject.test.js
@@ -2,6 +2,8 @@ import { render, screen, waitFor, within, fireEvent } from '@testing-library/rea
 import axios from 'axios';
 import { toast } from 'react-toastify';
 import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 import TotalMaterialCostPerProject from '../TotalMaterialCostPerProject';
 
 // Mocks
@@ -21,6 +23,12 @@ jest.mock('react-chartjs-2', () => ({
     </div>
   ),
 }));
+
+const mockStore = configureStore([]);
+const store = mockStore({
+  theme: { darkMode: false }, // Mock dark mode value
+  // Include other necessary mock slices if needed
+});
 
 const mockProjects = [
   { projectId: 1, projectName: 'Project A' },
@@ -46,7 +54,11 @@ describe('TotalMaterialCostPerProject', () => {
   });
 
   it('shows loading spinner on initial render and hide the spinner when data loads', async () => {
-    const { getByTestId } = render(<TotalMaterialCostPerProject />);
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <TotalMaterialCostPerProject />
+      </Provider>,
+    );
     const loadingSpinner = getByTestId('loading');
     expect(loadingSpinner).toBeInTheDocument();
 
@@ -54,7 +66,11 @@ describe('TotalMaterialCostPerProject', () => {
   });
 
   it('renders bar chart when data loads successfully', async () => {
-    render(<TotalMaterialCostPerProject />);
+    render(
+      <Provider store={store}>
+        <TotalMaterialCostPerProject />
+      </Provider>,
+    );
     await waitFor(() => {
       // The slash help test partial content
       expect(screen.getByText(/Project A,Project B/)).toBeInTheDocument();
@@ -62,7 +78,11 @@ describe('TotalMaterialCostPerProject', () => {
   });
 
   it('render selector when data loads successfully', async () => {
-    render(<TotalMaterialCostPerProject />);
+    render(
+      <Provider store={store}>
+        <TotalMaterialCostPerProject />
+      </Provider>,
+    );
     await waitFor(() => {
       expect(screen.getByText('Project A')).toBeInTheDocument();
     });
@@ -74,7 +94,11 @@ describe('TotalMaterialCostPerProject', () => {
   });
 
   it('when select or deselect items in selector, the bar chart updates too', async () => {
-    render(<TotalMaterialCostPerProject />);
+    render(
+      <Provider store={store}>
+        <TotalMaterialCostPerProject />
+      </Provider>,
+    );
     await waitFor(() => {
       expect(screen.getByText('Project A')).toBeInTheDocument();
     });
@@ -109,7 +133,11 @@ describe('TotalMaterialCostPerProject', () => {
       }
       return Promise.reject(new Error('not found'));
     });
-    render(<TotalMaterialCostPerProject />);
+    render(
+      <Provider store={store}>
+        <TotalMaterialCostPerProject />
+      </Provider>,
+    );
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
   });
 
@@ -123,7 +151,11 @@ describe('TotalMaterialCostPerProject', () => {
       }
       return Promise.reject(new Error('not found'));
     });
-    render(<TotalMaterialCostPerProject />);
+    render(
+      <Provider store={store}>
+        <TotalMaterialCostPerProject />
+      </Provider>,
+    );
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
   });
 });

--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
@@ -9,6 +9,7 @@ import WeeklyProjectSummaryHeader from './WeeklyProjectSummaryHeader';
 import PaidLaborCost from './PaidLaborCost/PaidLaborCost';
 import { fetchAllMaterials } from '../../../actions/bmdashboard/materialsActions';
 import QuantityOfMaterialsUsed from './QuantityOfMaterialsUsed/QuantityOfMaterialsUsed';
+import TotalMaterialCostPerProject from './TotalMaterialCostPerProject/TotalMaterialCostPerProject';
 
 const projectStatusButtons = [
   {
@@ -175,14 +176,18 @@ export default function WeeklyProjectSummary() {
         key: 'Material Consumption',
         className: 'large',
         content: [1, 2, 3].map((_, index) => {
+          let content;
+          if (index === 1) {
+            content = <QuantityOfMaterialsUsed data={quantityOfMaterialsUsedData} />;
+          } else if (index === 2) {
+            content = <TotalMaterialCostPerProject />;
+          } else {
+            content = <p>📊 Card</p>;
+          }
           const uniqueId = uuidv4();
           return (
             <div key={uniqueId} className="weekly-project-summary-card normal-card">
-              {index === 1 ? (
-                <QuantityOfMaterialsUsed data={quantityOfMaterialsUsedData} />
-              ) : (
-                '📊 Card'
-              )}
+              {content}
             </div>
           );
         }),

--- a/src/components/Projects/WBS/WBSDetail/components/__tests__/TagsSearch.test.js
+++ b/src/components/Projects/WBS/WBSDetail/components/__tests__/TagsSearch.test.js
@@ -120,8 +120,8 @@ describe('TagsSearch Component', () => {
 
     // Check if addResources was called with the correct arguments
     await waitFor(() => {
-      expect(addResources).toHaveBeenCalledWith('aaa123', 'aaa', 'volunteer');
-      expect(addResources).toHaveBeenCalledWith('aaa067', 'aaa', 'owner');
+      expect(addResources).toHaveBeenCalledWith('aaa123', 'aaa', 'volunteer', undefined);
+      expect(addResources).toHaveBeenCalledWith('aaa067', 'aaa', 'owner', undefined);
     });
   });
 

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -222,6 +222,8 @@ export const ENDPOINTS = {
   BM_EQUIPMENT_PURCHASE: `${APIEndpoint}/bm/equipment/purchase`,
   BM_PROJECTS: `${APIEndpoint}/bm/projects`,
   BM_PROJECT_BY_ID: projectId => `${APIEndpoint}/bm/project/${projectId}`,
+  BM_PROJECTS_LIST_FOR_MATERIALS_COST: `${APIEndpoint}/totalProjects `,
+  BM_PROJECT_MATERIALS_COST: `${APIEndpoint}/material-costs`,
   BM_UPDATE_MATERIAL: `${APIEndpoint}/bm/updateMaterialRecord`,
   BM_UPDATE_MATERIAL_BULK: `${APIEndpoint}/bm/updateMaterialRecordBulk`,
   BM_UPDATE_MATERIAL_STATUS: `${APIEndpoint}/bm/updateMaterialStatus`,


### PR DESCRIPTION
# Description
Implemented the Bar Chart for Total Material Cost Per Project. 
![Screenshot 2025-06-12 130931](https://github.com/user-attachments/assets/31daf59e-12e2-47e4-951b-57b1c3eac3c7)
![Screenshot 2025-06-12 130609](https://github.com/user-attachments/assets/27d22d35-4cc4-4c85-960b-0fd4e01a4011)



## Related PRS (if any):
This frontend PR may be related to upcoming backend updates for total material cost per project

## Main changes explained:
 - Create a bar chart for total material cost per project
 -  Add a multi-select dropdown so user can select which project to show
 - Add a spinner when data is loading
 - If data fails to load, a toast will show up
 - Add 6 tests to ensure the correctness of the component
## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log as admin user
5. Go to:
 - Dashboard → Reports → Total Construction Summary
 - or http://localhost:3000/bmdashboard/totalconstructionsummary
6. Open the tab Material Consumption
6. Verify:
 - A spinner shows up when data is loading
 - A toast shows up informing that the data fails to load, using demo data instead
 - A bar chart shows up, when you hover over the bar you can see the detail information
 - Select different projects in the dropdown
 - Verify that the chart shows up good in mobile
 - Test in dark mode
7. Stop the frontend, and run 'npm test TotalMaterialCostPerProject.test.js'
 - Verify that all tests pass
## Screenshots or videos of changes:

https://github.com/user-attachments/assets/b2e6b971-7889-46c8-bd41-1d21df3d257b


https://github.com/user-attachments/assets/b62972b7-aa38-4cd6-b1ba-e8fd16baba7a


## Note:
:)
