### PR TITLE
Taariq fix weekly summary reports team code changes on refresh

### DIFF
--- a/src/components/Badge/__tests__/NewBadges.test.js
+++ b/src/components/Badge/__tests__/NewBadges.test.js
@@ -151,7 +151,7 @@ describe('NewBadges component', () => {
     expect(badgeImages).toHaveLength(3);
 
     fireEvent.mouseEnter(badgeImages[0]);
-    screen.findByText(/Early Bird/);
+    await screen.findByText(/Early Bird/);
   });
 
   it('should filter out badges earned older than a week', async () => {

--- a/src/components/Projects/WBS/wbs.test.jsx
+++ b/src/components/Projects/WBS/wbs.test.jsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
@@ -7,8 +8,6 @@ import axios from 'axios';
 import configureStore from 'redux-mock-store';
 import WBS from './wbs';
 import { setWBSStart, setWBS } from '../../../actions/wbs';
-
-
 
 jest.mock('../../../actions/wbs', () => ({
   addNewWBS: jest.fn(),
@@ -45,7 +44,7 @@ describe('WBS Component', () => {
           frontPermissions: ['deleteWbs', 'addWbs', 'fetchAllWBS'],
           backPermissions: [],
         },
-        role: "Manager",
+        role: 'Manager',
       },
     },
     role: { roles: [] },
@@ -74,6 +73,7 @@ describe('WBS Component', () => {
   });
 
   it('dispatches setWBSStart and setWBS when fetchAllWBS is called on mount', async () => {
+    jest.setTimeout(10000);
     const mockWBSData = [{ _id: 'wbs1', wbsName: 'WBS 1' }];
     axios.get.mockResolvedValueOnce({ data: mockWBSData });
 
@@ -82,10 +82,10 @@ describe('WBS Component', () => {
     expect(store.dispatch).toHaveBeenCalledWith(setWBSStart());
 
     await waitFor(() => {
+      expect(store.dispatch).toHaveBeenCalledWith(setWBSStart());
       expect(store.dispatch).toHaveBeenCalledWith(setWBS(mockWBSData));
     });
   });
-
 
   it('renders AddWBS component', () => {
     renderComponent();
@@ -114,5 +114,4 @@ describe('WBS Component', () => {
     expect(screen.getByText('#')).toBeInTheDocument();
     expect(screen.getByText('Name')).toBeInTheDocument();
   });
-  
 });

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -207,92 +207,27 @@ const WeeklySummariesReport = props => {
     }
   };
 
-  // Initial data loading
   const createIntialSummaries = async () => {
     try {
-      const {
-        allBadgeData,
-        getWeeklySummariesReport,
-        fetchAllBadges,
-        hasPermission,
-        auth,
-        setTeamCodes,
-      } = props;
+      const initialTabIndex = 0;
+      const activeTab = navItems[initialTabIndex];
 
-      // Get the active tab from session storage or use default
-      const activeTab =
-        sessionStorage.getItem('tabSelection') === null
-          ? navItems[1]
-          : sessionStorage.getItem('tabSelection');
-
-      // Get the week index for the active tab
-      const weekIndex = navItems.indexOf(activeTab);
-
-      // console.log(`Initial load: Fetching data for tab ${activeTab} with weekIndex ${weekIndex}`);
-
-      // Set initial loading and active tab state
-      setState(prevState => ({
-        ...prevState,
-        loading: true,
-        activeTab,
-        tabsLoading: {
-          ...prevState.tabsLoading,
-          [activeTab]: true,
-        },
-      }));
-
-      // Get permissions
-      const badgeStatusCode = await fetchAllBadges();
-      setPermissionState(prev => ({
-        ...prev,
-        bioEditPermission: hasPermission('putUserProfileImportantInfo'),
-        canEditSummaryCount: hasPermission('putUserProfileImportantInfo'),
-        codeEditPermission:
-          hasPermission('editTeamCode') ||
-          auth.user.role === 'Owner' ||
-          auth.user.role === 'Administrator',
-        canSeeBioHighlight: hasPermission('highlightEligibleBios'),
-      }));
-
-      // Fetch data for the active tab only
-      const res = await getWeeklySummariesReport(weekIndex);
-      // console.log('API response:', res);
-      // console.log('Response data:', res?.data);
-      // console.log('Data is array:', Array.isArray(res?.data));
-      // console.log('Data length:', res?.data?.length);
+      const res = await props.getWeeklySummariesReport(initialTabIndex);
       const summaries = res?.data ?? [];
 
-      if (!Array.isArray(summaries) || summaries.length === 0) {
-        setState(prevState => ({
-          ...prevState,
-          loading: false,
-          tabsLoading: {
-            ...prevState.tabsLoading,
-            [activeTab]: false,
-          },
-        }));
-        return null;
-      }
-
-      // Process the data
-      const teamCodeGroup = {};
-      const teamCodes = [];
-
-      // Shallow copy and sort
       let summariesCopy = [...summaries];
       summariesCopy = alphabetize(summariesCopy);
 
-      // Add new key of promised hours by week
       summariesCopy = summariesCopy.map(summary => {
         const promisedHoursByWeek = weekDates.map(weekDate =>
           getPromisedHours(weekDate.toDate, summary.weeklycommittedHoursHistory),
         );
-
         const filterColor = summary.filterColor || null;
-
         return { ...summary, promisedHoursByWeek, filterColor };
       });
 
+      const teamCodeGroup = {};
+      const teamCodes = [];
       const colorOptionGroup = new Set();
       const colorOptions = [];
       const COLORS = [
@@ -318,7 +253,6 @@ const WeeklySummariesReport = props => {
         '#C8A2C8',
       ];
 
-      // Process team codes and colors
       summariesCopy.forEach(summary => {
         const code = summary.teamCode || 'noCodeLabel';
         if (teamCodeGroup[code]) {
@@ -327,7 +261,9 @@ const WeeklySummariesReport = props => {
           teamCodeGroup[code] = [summary];
         }
 
-        if (summary.weeklySummaryOption) colorOptionGroup.add(summary.weeklySummaryOption);
+        if (summary.weeklySummaryOption) {
+          colorOptionGroup.add(summary.weeklySummaryOption);
+        }
       });
 
       Object.keys(teamCodeGroup).forEach(code => {
@@ -335,62 +271,50 @@ const WeeklySummariesReport = props => {
           teamCodes.push({
             value: code,
             label: `${code} (${teamCodeGroup[code].length})`,
-            _ids: teamCodeGroup[code]?.map(item => item._id),
+            _ids: teamCodeGroup[code].map(item => item._id),
           });
         }
       });
 
-      setTeamCodes(teamCodes);
+      if (teamCodeGroup.noCodeLabel?.length > 0) {
+        teamCodes.push({
+          value: '',
+          label: `Select All With NO Code (${teamCodeGroup.noCodeLabel.length})`,
+          _ids: teamCodeGroup.noCodeLabel.map(item => item._id),
+        });
+      }
 
       colorOptionGroup.forEach(option => {
-        colorOptions.push({
-          value: option,
-          label: option,
-        });
+        colorOptions.push({ value: option, label: option });
       });
 
-      colorOptions.sort((a, b) => `${a.label}`.localeCompare(`${b.label}`));
-      teamCodes
-        .sort((a, b) => `${a.label}`.localeCompare(`${b.label}`))
-        .push({
-          value: '',
-          label: `Select All With NO Code (${teamCodeGroup.noCodeLabel?.length || 0})`,
-          _ids: teamCodeGroup?.noCodeLabel?.map(item => item._id),
-        });
+      colorOptions.sort((a, b) => a.label.localeCompare(b.label));
+      teamCodes.sort((a, b) => a.label.localeCompare(b.label));
 
       const chartData = [];
 
-      // Store the data in the tab-specific state
       setState(prevState => ({
         ...prevState,
         loading: false,
-        allRoleInfo: [],
+        activeTab,
         summaries: summariesCopy,
-        loadedTabs: [activeTab],
-        summariesByTab: {
-          [activeTab]: summariesCopy,
-        },
-        badges: allBadgeData,
-        hasSeeBadgePermission: badgeStatusCode === 200,
         filteredSummaries: summariesCopy,
+        loadedTabs: [activeTab],
+        summariesByTab: { [activeTab]: summariesCopy },
         tableData: teamCodeGroup,
         chartData,
         COLORS,
         colorOptions,
         teamCodes,
         teamCodeWarningUsers: summariesCopy.filter(s => s.teamCodeWarning),
-        auth,
-        tabsLoading: {
-          [activeTab]: false,
-        },
+        tabsLoading: { ...prevState.tabsLoading, [activeTab]: false },
       }));
 
-      // Now load info collections
+      // 🔐 Now load info collections
       await intialInfoCollections(summariesCopy);
-
-      return summariesCopy;
     } catch (error) {
-      // console.error('Error in createInitialSummaries:', error);
+      // eslint-disable-next-line no-console
+      console.error('Error in createInitialSummaries:', error);
       setState(prevState => ({
         ...prevState,
         loading: false,
@@ -399,7 +323,6 @@ const WeeklySummariesReport = props => {
           [prevState.activeTab]: false,
         },
       }));
-      return null;
     }
   };
 
@@ -763,10 +686,20 @@ const WeeklySummariesReport = props => {
   };
 
   const handleSelectCodeChange = event => {
-    setState(prev => ({
-      ...prev,
-      selectedCodes: event,
-    }));
+    setState(prev => {
+      const selectedValues = event.map(e => e.value);
+      // Move selected codes to the front of the dropdown list
+      const reorderedTeamCodes = [
+        ...prev.teamCodes.filter(code => selectedValues.includes(code.value)), // selected first
+        ...prev.teamCodes.filter(code => !selectedValues.includes(code.value)), // then the rest
+      ];
+
+      return {
+        ...prev,
+        selectedCodes: event,
+        teamCodes: reorderedTeamCodes,
+      };
+    });
   };
 
   const handleOverHoursToggleChange = () => {
@@ -1068,10 +1001,12 @@ const WeeklySummariesReport = props => {
     let isMounted = true;
     window._isMounted = isMounted;
 
-    // console.log('Initial useEffect running');
-
-    // Only load the initial tab, nothing else
-    createIntialSummaries();
+    // Wrap createIntialSummaries in an async fn so we can await it
+    const loadInitialData = async () => {
+      await createIntialSummaries();
+    };
+    // Kick off the async load on mount
+    loadInitialData();
 
     return () => {
       isMounted = false;
@@ -1103,6 +1038,37 @@ const WeeklySummariesReport = props => {
     state.summaries,
     state.activeTab,
   ]);
+
+  useEffect(() => {
+    // On mount: fetch all badges before deriving permissions
+    const fetchInitialPermissions = async () => {
+      try {
+        // Fetch all badges first so we can derive up‑to‑date permissions
+        await props.fetchAllBadges();
+        setPermissionState(prev => ({
+          ...prev,
+          bioEditPermission: props.hasPermission('putUserProfileImportantInfo'),
+          // codeEditPermission: props.hasPermission('replaceTeamCodes'),
+          // allow team‑code edits for specific roles or permissions
+          codeEditPermission:
+            props.hasPermission('editTeamCode') ||
+            props.auth?.user?.role === 'Owner' ||
+            props.auth?.user?.role === 'Administrator',
+          // Permit editing of summary hour counts if the user has that badge
+          canEditSummaryCount: props.hasPermission('editSummaryHoursCount'),
+          // Show bio highlights only to users with that permission
+          canSeeBioHighlight: props.hasPermission('highlightEligibleBios'),
+        }));
+      } catch (error) {
+        // log failure fetching badges or permissions
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch badges or permissions', error);
+      }
+    };
+
+    fetchInitialPermissions();
+  }, []);
+
   const { role, darkMode } = props;
   const { error } = props;
   const hasPermissionToFilter = role === 'Owner' || role === 'Administrator';


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/c1c145a8-8903-4166-81b9-154e2ec042df)

## Related PRS (if any):
This frontend PR is related to the [#1509](https://github.com/OneCommunityGlobal/HGNRest/pull/1509) branch of the backend.

## Main changes explained:
- Updated permissions hook (useEffect).
- Refactored createInitialSummaries startup logic.
- Moved chosen code to the front of the dropdown for clarity.
- Fixed the part of the code where old team code was showing up on the press of the refresh button on the browser.

## How to test:
1. Check into the current branch
2. Do npm install and npm run start:local to run this PR locally
3. Clear site data/cache
4. Log as Admin user
5. Go to dashboard→ Reports → Weekly Summaries Report → Select the tab Last Week → Select Existing Team Code 
6. Replace with a new code → Click Replace Button → Refresh → Check again if the new code shows up or not.
7. Verify this new feature works in [dark mode].

## Screenshots or videos of changes:
After Changes: 

https://github.com/user-attachments/assets/6a5ae126-88ed-45a0-be25-98d9521d4e41

Latest Changes to the video showed on the backend PR branch. Kindly check out that video:
**_[Link](https://github.com/OneCommunityGlobal/HGNRest/pull/1509)_**


## Note:
This fix is just a fix for the functionality of the new team code replacing the old team code with/without pressing the refresh button.