### PR TITLE
Barnaboss-Hotfix-dropdown-menu-formatting-in-UserManagement-page

### DIFF
--- a/src/components/UserManagement/UserSearchPanel.jsx
+++ b/src/components/UserManagement/UserSearchPanel.jsx
@@ -97,6 +97,7 @@ function UserSearchPanel({
         <span className={`input-group-text ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}>{SHOW}</span>
         <select
           id="active-filter-dropdown"
+          style={{marginBottom: "0px"}}
           onChange={e => {
             onActiveFiter(e.target.value);
           }}


### PR DESCRIPTION
# Description
The Search Bar and the dropdown menu in the User Management page are misaligned with the rest of the elements in the row.

## Related PRS (if any):
This frontend PR is related to the development branch.

## Main changes explained:
- Manually set the margin of the dropdown menu to 0px, which was causing other elements to be misaligned.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links -> User Management
6. Verify if the search bar and the dropdown menu are aligned

## Screenshots or videos of changes:
Before:
![IMG_9515](https://github.com/user-attachments/assets/89f19171-cc8c-4767-8d9f-7ff48bdf2822)

After:
<img width="1440" alt="Screenshot 2025-06-24 at 1 53 18 PM" src="https://github.com/user-attachments/assets/0d4901fc-b4b9-41b3-8007-0264b3287d28" />

