### PR TITLE
Zhifan - Fixed inaccurate start date

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -551,9 +551,14 @@ const TeamMemberTasks = React.memo(props => {
                   }`}
                   title={`Timelogs submitted in the past ${days} days`}
                   style={{
-                    color: selectedPeriod === days && isTimeFilterActive ? `${darkMode ? color : 'white'}` : `${darkMode ? 'white' : color}`,
+                    color:
+                      selectedPeriod === days && isTimeFilterActive
+                        ? `${darkMode ? color : 'white'}`
+                        : `${darkMode ? 'white' : color}`,
                     backgroundColor:
-                      selectedPeriod === days && isTimeFilterActive ? `${darkMode ? 'white' : color}` : `${darkMode ? color : 'white'}` ,
+                      selectedPeriod === days && isTimeFilterActive
+                        ? `${darkMode ? 'white' : color}`
+                        : `${darkMode ? color : 'white'}`,
                     border: `1px solid ${color}`,
                   }}
                   onClick={() => selectPeriod(days)}
@@ -571,9 +576,12 @@ const TeamMemberTasks = React.memo(props => {
                 value={selectedPeriod || ''}
                 title={`Timelogs submitted in the past ${selectedPeriod} days`}
                 style={{
-                  color: isTimeFilterActive ? `${darkMode ? hrsFilterBtnColorMap[selectedPeriod] : 'white'}` : `${darkMode ? 'white' : hrsFilterBtnColorMap[selectedPeriod]}`,
+                  color: isTimeFilterActive
+                    ? `${darkMode ? hrsFilterBtnColorMap[selectedPeriod] : 'white'}`
+                    : `${darkMode ? 'white' : hrsFilterBtnColorMap[selectedPeriod]}`,
                   backgroundColor: isTimeFilterActive
-                    ? `${darkMode ? 'white' : hrsFilterBtnColorMap[selectedPeriod]}` : `${darkMode ? hrsFilterBtnColorMap[selectedPeriod] : '#007BFF'}` ,
+                    ? `${darkMode ? 'white' : hrsFilterBtnColorMap[selectedPeriod]}`
+                    : `${darkMode ? hrsFilterBtnColorMap[selectedPeriod] : '#007BFF'}`,
                   border: `1px solid ${hrsFilterBtnColorMap[selectedPeriod]}`,
                 }}
               >
@@ -741,7 +749,9 @@ const TeamMemberTasks = React.memo(props => {
                       <th className={`team-task-progress ${darkMode ? 'bg-space-cadet' : ''}`}>
                         Progress
                       </th>
-                      {displayUser.role === 'Administrator' ? <th className={darkMode ? 'bg-space-cadet' : ''}>Status</th> : null}
+                      {displayUser.role === 'Administrator' ? (
+                        <th className={darkMode ? 'bg-space-cadet' : ''}>Status</th>
+                      ) : null}
                     </tr>
                   </thead>
                 </Table>

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -77,7 +77,7 @@ function TimeEntryForm(props) {
 
   const initialFormValues = {
     dateOfWork: moment()
-      .tz(userTimeZone)
+      .tz('America/Los_Angeles')
       .format('YYYY-MM-DD'),
     personId: viewingUser.userId ?? authUser.userid,
     projectId: '',
@@ -587,7 +587,7 @@ function TimeEntryForm(props) {
       setFormValues({
         ...formValues,
         dateOfWork: moment(actualDate)
-          .tz(userTimeZone)
+          .tz('America/Los_Angeles')
           .format('YYYY-MM-DD'),
       });
     }

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -544,16 +544,15 @@ function TimeEntryForm(props) {
     }
   };
 
-  const getActualDate = async () => {
+const getActualDate = async () => {
     try {
-        const actualDate = await Promise.any([
+        const fetchedActualDate = await Promise.any([
             fetch(`http://worldtimeapi.org/api/timezone/${userTimeZone}`).then((res) => res.json()),
             fetch(`https://timeapi.io/api/Time/current/zone?timeZone=${userTimeZone}`).then((res) => res.json()),
         ]);
         
-        setActualDate(actualDate.utc_datetime || actualDate.dateTime);
+        setActualDate(fetchedActualDate.utc_datetime || fetchedActualDate.dateTime);
     } catch (error) {
-        console.warn("All APIs failed. Prompting user to retry.");
         setActualDate(null);  // Clear previous date
         toast.error("Failed to fetch the actual date. Please refresh and try logging time again ");
       

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -156,7 +156,7 @@ function TimeEntryForm(props) {
   const isForAuthUser = timeEntryUserId === authUser.userid;
   const isSameDayTimeEntry =
     moment(actualDate)
-      .tz(userTimeZone)
+      .tz('America/Los_Angeles')
       .format('YYYY-MM-DD') === formValues.dateOfWork;
   const isSameDayAuthUserEdit = isForAuthUser && isSameDayTimeEntry;
   const canEditTimeEntryTime = props.hasPermission('editTimeEntryTime');

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -152,6 +152,8 @@ function UserProfile(props) {
 
   const [userStartDate, setUserStartDate] = useState('');
   const [userEndDate, setUserEndDate] = useState('');
+  const [originalStartDate, setOriginalStartDate] = useState('');
+  const [startDateMode, setStartDateMode] = useState('manual'); // 'manual' or 'calculated'
 
   const [inputAutoComplete, setInputAutoComplete] = useState([]);
   const [inputAutoStatus, setInputAutoStatus] = useState();
@@ -358,32 +360,15 @@ function UserProfile(props) {
 
       setUserProfile(profileWithFormattedDates);
       setOriginalUserProfile(profileWithFormattedDates);
+      setOriginalStartDate(profileWithFormattedDates.startDate);
       setIsRehireable(newUserProfile.isRehireable);
 
       // run after main profile is loaded
       const teamId = newUserProfile?.teams[0]?._id;
       loadSummaryIntroDetails(teamId, newUserProfile);
 
-      // fetch start date separately tonot block main profile rendering
-      dispatch(
-        getTimeStartDateEntriesByPeriod(userId, newUserProfile.createdDate, newUserProfile.toDate),
-      ).then(startDate => {
-        if (startDate !== 'N/A') {
-          const formattedStartDate = startDate.split('T')[0];
-          setUserStartDate(formattedStartDate);
-
-          // Update start date if needed
-          const createdDate = newUserProfile?.createdDate
-            ? newUserProfile.createdDate.split('T')[0]
-            : null;
-
-          if (createdDate && new Date(startDate) < new Date(createdDate)) {
-            setUserProfile(prev => ({ ...prev, startDate: createdDate }));
-          } else {
-            setUserProfile(prev => ({ ...prev, startDate: formattedStartDate }));
-          }
-        }
-      });
+      // Note: Removed automatic getTimeStartDateEntriesByPeriod call to prevent overwriting manual startDate changes
+      // Users can now toggle between manual and calculated startDate via button
 
       checkIsProjectsEqual();
       setShowLoading(false);
@@ -934,6 +919,42 @@ function UserProfile(props) {
     setUserEndDate(endDate);
   };
 
+  const toggleStartDateMode = async () => {
+    if (startDateMode === 'manual') {
+      // Switch to calculated mode - fetch from time entries
+      setStartDateMode('calculated');
+      const userId = props?.match?.params?.userId;
+      if (userId && userProfile) {
+        try {
+          const startDate = await dispatch(
+            getTimeStartDateEntriesByPeriod(userId, userProfile.createdDate, userProfile.toDate),
+          );
+          if (startDate !== 'N/A') {
+            const formattedStartDate = startDate.split('T')[0];
+            setUserStartDate(formattedStartDate);
+
+            // Update start date if needed
+            const createdDate = userProfile?.createdDate
+              ? userProfile.createdDate.split('T')[0]
+              : null;
+
+            if (createdDate && new Date(startDate) < new Date(createdDate)) {
+              setUserProfile(prev => ({ ...prev, startDate: createdDate }));
+            } else {
+              setUserProfile(prev => ({ ...prev, startDate: formattedStartDate }));
+            }
+          }
+        } catch (error) {
+          console.error('Error fetching calculated start date:', error);
+        }
+      }
+    } else {
+      // Switch to manual mode - restore original database value
+      setStartDateMode('manual');
+      setUserProfile(prev => ({ ...prev, startDate: originalStartDate }));
+    }
+  };
+
   return (
     <div className={darkMode ? 'bg-oxford-blue' : ''} style={{ minHeight: '100%' }}>
       <ActiveInactiveConfirmationPopup
@@ -1345,6 +1366,8 @@ function UserProfile(props) {
                   canEdit={canEditUserProfile}
                   canUpdateSummaryRequirements={canUpdateSummaryRequirements}
                   onStartDate={handleStartDate}
+                  startDateMode={startDateMode}
+                  toggleStartDateMode={toggleStartDateMode}
                   darkMode={darkMode}
                 />
               </TabPane>
@@ -1649,6 +1672,8 @@ function UserProfile(props) {
                     canEdit={canEditUserProfile}
                     canUpdateSummaryRequirements={canUpdateSummaryRequirements}
                     onStartDate={handleStartDate}
+                    startDateMode={startDateMode}
+                    toggleStartDateMode={toggleStartDateMode}
                     darkMode={darkMode}
                   />
                 </ModalBody>

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -352,7 +352,7 @@ function UserProfile(props) {
         createdDate: formatDateYYYYMMDD(newUserProfile?.createdDate),
         ...(newUserProfile?.endDate &&
           newUserProfile.endDate !== '' && { 
-            endDate: moment.utc(newUserProfile.endDate).format('YYYY-MM-DD')
+            endDate: formatDateYYYYMMDD(newUserProfile.endDate)
           }),
       };
 

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -25,7 +25,7 @@ const StartDate = props => {
   if (!props.canEdit) {
     return (
       <p className={darkMode ? 'text-azure' : ''}>
-        {!props.userProfile.startDate ? 'N/A' : formatDateYYYYMMDD(props.userProfile.startDate)}
+        {!props.userProfile.startDate ? 'N/A' : formatDate(props.userProfile.startDate)}
       </p>
     );
   }
@@ -44,7 +44,7 @@ const StartDate = props => {
         }}
         placeholder="Start Date"
         invalid={!props.canEdit}
-        max={props.userProfile.endDate ? formatDateYYYYMMDD(props.userProfile.endDate) : '9999-12-31'}
+        max={props.userProfile.endDate || '9999-12-31'}
       />
       {startDateAlert && (
         <FormFeedback style={{ display: 'block' }}>{startDateAlert}</FormFeedback>
@@ -59,7 +59,7 @@ const EndDate = props => {
   if (!props.canEdit) {
     return (
       <p className={darkMode ? 'text-azure' : ''}>
-        {props.userProfile.endDate ? formatDateYYYYMMDD(props.userProfile.endDate) : 'N/A'}
+        {props.userProfile.endDate ? formatDate(props.userProfile.endDate) : 'N/A'}
       </p>
     );
   }

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -389,17 +389,41 @@ const ViewTab = props => {
       <Row className="volunteering-time-row">
         <Col md="6">
           <Label className={`hours-label ${darkMode ? 'text-light' : ''}`}>Start Date</Label>
+          {canEdit && props.toggleStartDateMode && (
+            <div>
+              <small className={`text-muted ${darkMode ? 'text-light' : ''}`}>
+                {props.startDateMode === 'manual' ? 'Manual Entry' : 'Calculated from Time Entries'}
+              </small>
+            </div>
+          )}
         </Col>
         <Col md="6">
-          <StartDate
-            role={role}
-            userProfile={userProfile}
-            setUserProfile={setUserProfile}
-            canEdit={canEdit}
-            onStartDateComponent={handleStartDates}
-            darkMode={darkMode}
-            startDateAlert={startDateAlert}
-          />
+          <div className="d-flex align-items-center">
+            <div className="flex-grow-1">
+              <StartDate
+                role={role}
+                userProfile={userProfile}
+                setUserProfile={setUserProfile}
+                canEdit={canEdit}
+                onStartDateComponent={handleStartDates}
+                darkMode={darkMode}
+                startDateAlert={startDateAlert}
+              />
+            </div>
+            {canEdit && props.toggleStartDateMode && (
+              <Button
+                size="sm"
+                color="info"
+                className="ml-2 start-date-toggle-btn"
+                onClick={props.toggleStartDateMode}
+                style={darkMode ? boxStyleDark : boxStyle}
+              >
+                {props.startDateMode === 'manual'
+                  ? 'Switch to Auto'
+                  : 'Switch to Manual'}
+              </Button>
+            )}
+          </div>
         </Col>
       </Row>
 

--- a/src/components/UserProfile/VolunteeringTimeTab/timeTab.css
+++ b/src/components/UserProfile/VolunteeringTimeTab/timeTab.css
@@ -33,3 +33,15 @@
   margin-right: 16px;
   cursor: pointer;
 }
+
+.start-date-toggle-btn {
+  padding-left: 2px !important;
+  padding-right: 2px !important;
+  border-radius: 4px !important;
+  white-space: nowrap !important;
+}
+
+.flex-grow-1 input[type="date"] {
+  padding-left: 8px !important;
+  padding-right: 8px !important;
+}


### PR DESCRIPTION
# Description
<img width="431" alt="Screenshot 2025-06-26 at 7 34 58 PM" src="https://github.com/user-attachments/assets/ab097103-e0e1-4fd0-a957-fe904e666b65" />

## Related PRS (if any):
This frontend PR is not related to backend PR.

…

## Main changes explained:
- Updated Time Entry Form to use Pacific Time instead of user's time zone for dateOfWork field
- Implemented a new button that allows switching the start date between a manually set value and automatically generated value from the first time entry.
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. go to database and look for your time entry in the timeEntries collection
5. find the first time entry and check if the dateOfWork matches the start date in volunteering times tab in user profile
6. change the start date manually and check if the change reflected in userProfiles collection for startDate field
7. delete all of your time entries from database
8. Start the timer and log time. (For example, if you’re on the East Coast, try logging time after 12 PM—since the system uses Pacific Time, the logged time will still fall on the previous calendar day in Pacific Time, which helps test this edge case)
9. check if start date generated based on first time entry matches the date you logged first time entry

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/162c012b-7fbc-4e03-92ec-2d52f6d23624


## Note:
Include the information the reviewers need to know.
