### PR TITLE
Fix: prevent user management page refresh redirection to dashboard by…

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -374,6 +374,7 @@ export default (
           exact
           component={UserManagement}
           fallback
+          allowedRoles={[UserRole.Administrator, UserRole.Owner, UserRole.Manager]}
           routePermissions={RoutePermissions.userManagement}
         />
         <ProtectedRoute


### PR DESCRIPTION
# Description
![5CCC79AB-476D-4C1B-85DF-4E366F06491F](https://github.com/user-attachments/assets/9f883d99-878e-4d93-9607-aa2e66a7a170)


## Related PRS (if any):
This frontend PR is related to the development branch of the backend.


## Main changes explained:
- Fixed an issue where the roles or permissions were initially empty on refresh, causing the old logic to falsely detect “no permission” and automatically redirect users back to /dashboard.
- This ensures that valid roles (Admin, Manager, User) with proper permissions can still access the User Management page after a browser reload.


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links →User Management→ reload the page(refresh)
6. verify the user management page reloads with no issue.
7. verify on refresh it is not directed to dashboard

## Screenshots or videos of changes:

Issue: Before fix

https://www.loom.com/share/a7793ad0f89e47189cb625e9d8bf8f16?sid=f818b55d-6686-4b54-a71d-3a81718ea3e1


Post Fix:

User Management Refresh Post Fix.mp4

https://github.com/user-attachments/assets/da3a1869-4728-4e46-9e9b-575e77d8ee1d


