### PR TITLE
Guirong-Make pop-out timer look like expanded-view timer 

### DIFF
--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -402,6 +402,155 @@ function Timer({ authUser, darkMode, isPopout }) {
   const headerBg = darkMode ? 'bg-space-cadet' : '';
   const bodyBg = darkMode ? 'bg-yinmn-blue' : '';
 
+  if (realIsPopout) {
+    return (
+      <div className={cs(css.timer, darkMode ? 'dark-mode' : '')}>
+        <div className={css.timerContent}>
+          {customReadyState === ReadyState.OPEN && (
+            <Countdown
+              message={message}
+              timerRange={{ MAX_HOURS, MIN_MINS }}
+              running={running}
+              wsMessageHandler={wsJsonMessageHandler}
+              remaining={remaining}
+              setConfirmationResetModal={setConfirmationResetModal}
+              checkBtnAvail={checkBtnAvail}
+              handleStartButton={handleStartButton}
+              handleAddButton={handleAddButton}
+              handleSubtractButton={handleSubtractButton}
+              handleStopButton={handleStopButton}
+              toggleTimer={() => window.close()}
+            />
+          )}
+          {customReadyState !== ReadyState.OPEN && (
+            <TimerStatus
+              readyState={customReadyState}
+              message={message}
+              toggleTimer={() => window.close()}
+            />
+          )}
+        </div>
+        {logTimeEntryModal && (
+          <TimeEntryForm
+            from="Timer"
+            edit={false}
+            toggle={toggleLogTimeModal}
+            isOpen={logTimeEntryModal}
+            data={logTimer}
+            sendStop={sendStop}
+          />
+        )}
+        <audio
+          ref={timeIsOverAudioRef}
+          key="timeIsOverAudio"
+          loop
+          preload="auto"
+          src="https://bigsoundbank.com/UPLOAD/mp3/2554.mp3"
+        />
+        <audio
+          ref={forcedPausedAudioRef}
+          key="forcedPausedAudio"
+          loop
+          preload="auto"
+          src="https://bigsoundbank.com/UPLOAD/mp3/1102.mp3"
+        />
+        <Modal
+          isOpen={confirmationResetModal}
+          toggle={() => setConfirmationResetModal(!confirmationResetModal)}
+          centered
+          size="md"
+          className={cs(fontColor, darkMode ? 'dark-mode' : '')}
+        >
+          <ModalHeader
+            className={darkMode ? 'bg-space-cadet' : ''}
+            toggle={() => setConfirmationResetModal(false)}
+          >
+            Reset Time
+          </ModalHeader>
+          <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
+            Are you sure you want to reset your time?
+          </ModalBody>
+          <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
+            <Button
+              color="primary"
+              onClick={() => {
+                sendClear();
+                setConfirmationResetModal(false);
+              }}
+            >
+              Yes, reset time!
+            </Button>{' '}
+          </ModalFooter>
+        </Modal>
+        <Modal
+          className={cs(fontColor, darkMode ? 'dark-mode' : '')}
+          size="md"
+          isOpen={inacModal}
+          toggle={() => setInacModal(!inacModal)}
+          centered
+        >
+          <ModalHeader className={headerBg} toggle={() => setInacModal(!inacModal)}>
+            Timer Paused
+          </ModalHeader>
+          <ModalBody className={bodyBg}>
+            The user timer has been paused due to inactivity or a lost in connection to the server.
+            Please check your internet connection and refresh the page to continue. This is to
+            ensure that our resources are being used efficiently and to improve performance for all
+            of our users.
+          </ModalBody>
+          <ModalFooter className={bodyBg}>
+            <Button
+              color="primary"
+              onClick={() => {
+                setInacModal(!inacModal);
+                sendAckForced();
+              }}
+            >
+              I understand
+            </Button>
+          </ModalFooter>
+        </Modal>
+        <Modal
+          className={cs(fontColor, darkMode ? 'dark-mode' : '')}
+          isOpen={timeIsOverModalOpen}
+          toggle={toggleTimeIsOver}
+          centered
+          size="md"
+        >
+          <ModalHeader className={headerBg} toggle={toggleTimeIsOver}>
+            Time Complete!
+          </ModalHeader>
+          <ModalBody className={bodyBg}>{`You have worked for ${
+            logHours ? `${logHours} hours` : ''
+          }${
+            logMinutes ? ` ${logMinutes} minutes` : ''
+          }. Click below if you'd like to add time or Log Time.`}</ModalBody>
+          <ModalFooter className={bodyBg}>
+            <Button
+              color="primary"
+              onClick={() => {
+                toggleTimeIsOver();
+                toggleLogTimeModal();
+              }}
+            >
+              Log Time
+            </Button>{' '}
+            <Button
+              color="secondary"
+              onClick={() => {
+                toggleTimeIsOver();
+                handleAddButton(15);
+                sendStart();
+              }}
+            >
+              Add More Time
+            </Button>{' '}
+          </ModalFooter>
+        </Modal>
+      </div>
+    );
+  }
+
   return (
     <div className={cs(css.timerContainer)}>
       <button

--- a/src/components/Timer/TimerPopout.jsx
+++ b/src/components/Timer/TimerPopout.jsx
@@ -71,7 +71,7 @@ function TimerPopout({ authUser, darkMode, TimerComponent }) {
         popup.document.head.appendChild(style);
       } catch (e) {
         // This can happen with CORS stylesheets
-        console.error('Could not copy stylesheet', e);
+        // Silently ignore CORS errors when copying stylesheets
       }
     });
 

--- a/src/components/Timer/TimerPopout.jsx
+++ b/src/components/Timer/TimerPopout.jsx
@@ -53,25 +53,27 @@ function TimerPopout({ authUser, darkMode, TimerComponent }) {
       <html>
         <head>
           <title>Timer</title>
-          <link rel="stylesheet" href="${window.location.origin}/Timer.module.css">
-          ${darkMode ? '<style>body { background-color: #1a1a2e; color: white; }</style>' : ''}
-          <style>
-            [class^="Countdown_countdown__"], [class*=" Countdown_countdown__"] {
-              width: 90vw !important;
-              height: 90vw !important;
-              max-width: 480px !important;
-              max-height: 600px !important;
-              min-width: 180px !important;
-              min-height: 180px !important;
-            }
-          </style>
         </head>
         <body class="timer-popout-body">
-          <h1 style="text-align: center;">Timer</h1>
           <div id="timer-root"></div>
         </body>
       </html>
     `);
+
+    // Add all stylesheets from the main window to the popout window
+    Array.from(window.document.styleSheets).forEach(styleSheet => {
+      try {
+        const cssRules = Array.from(styleSheet.cssRules)
+          .map(rule => rule.cssText)
+          .join('');
+        const style = popup.document.createElement('style');
+        style.textContent = cssRules;
+        popup.document.head.appendChild(style);
+      } catch (e) {
+        // This can happen with CORS stylesheets
+        console.error('Could not copy stylesheet', e);
+      }
+    });
 
     const root = popup.document.getElementById('timer-root');
     const { store } = createStore();


### PR DESCRIPTION
# Description
Tried to implement a feature that pops out the timer into a separate window on top. I managed to open the timer with all its components in a separate window. Couldn't figure out how to make it stay on top all the time (like YouTube's Picture in picture feature).


## Related PRS (if any):
This frontend PR is related to the development backend PR.


## Main changes explained:
- Added a new file (TimerPopout.jsx) to implement the Timer popout feature.
- Integrated the TimerPopout in Timer.jsx…

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Dashboard -> click on the popout (external link symbol)
6. Check if the Timer is opening in a separate window or not.
7. Check with different browsers.
8. 

## Screenshots or videos of changes:
![timer-1](https://github.com/user-attachments/assets/c036c352-ada7-4898-9980-51cc22c624bd)

## Note:
Due to browser security restrictions, the web version cannot implement a system-level "always on top" window (such as YouTube PiP floating on top of all applications). This PR implements a clean new window/tab containing only the Timer component after clicking the Timer pop-up button, allowing users to check the timer at any time. If we need to pin the timer system-wide, we need to use desktop applications (such as Electron) or third-party tools.
