### PR TITLE
Sundar: Fix TimeEntryForm date issue

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -23,11 +23,11 @@ import { isEmpty, isEqual } from 'lodash';
 import { Editor } from '@tinymce/tinymce-react';
 import { toast } from 'react-toastify';
 import ReactTooltip from 'react-tooltip';
-import { getUserProfile } from 'actions/userProfile';
 import axios from 'axios';
-import hasPermission from 'utils/permissions';
-import { boxStyle, boxStyleDark } from 'styles';
 import { useDispatch } from 'react-redux';
+import { boxStyle, boxStyleDark } from '../../../styles';
+import hasPermission from '../../../utils/permissions';
+import { getUserProfile } from '../../../actions/userProfile';
 import { postTimeEntry, editTimeEntry, getTimeEntriesForWeek } from '../../../actions/timeEntries';
 import AboutModal from './AboutModal';
 import TangibleInfoModal from './TangibleInfoModal';
@@ -544,20 +544,17 @@ function TimeEntryForm(props) {
     }
   };
 
-const getActualDate = async () => {
+  const getActualDate = () => {
     try {
-        const fetchedActualDate = await Promise.any([
-            fetch(`http://worldtimeapi.org/api/timezone/${userTimeZone}`).then((res) => res.json()),
-            fetch(`https://timeapi.io/api/Time/current/zone?timeZone=${userTimeZone}`).then((res) => res.json()),
-        ]);
-        
-        setActualDate(fetchedActualDate.utc_datetime || fetchedActualDate.dateTime);
+      const now = moment()
+        .tz(userTimeZone)
+        .toISOString();
+      setActualDate(now);
     } catch (error) {
-        setActualDate(null);  // Clear previous date
-        toast.error("Failed to fetch the actual date. Please refresh and try logging time again ");
-      
+      setActualDate(null);
+      toast.error('Failed to fetch the actual date. Please refresh and try logging time again');
     }
-};
+  };
 
   /* ---------------- useEffects -------------- */
   useEffect(() => {
@@ -825,7 +822,7 @@ TimeEntryForm.propTypes = {
 
 const mapStateToProps = state => ({
   authUser: state.auth.user,
-  darkMode: state.theme.darkMode
+  darkMode: state.theme.darkMode,
 });
 
 export default connect(mapStateToProps, {


### PR DESCRIPTION
# Description
Fixed the TimeEntryForm date fetching from the external api's [worldtimeapi, timeapi.io], as depending on them is causing trouble with timeouts. Whoever, this functioanlity can simply be achieved using the moment library.

## Related PRS:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3335

## Main changes explained:
- Removed dependency on external api's for fetching the current time based on the user's timezone.
- Added moment library to get the required date data.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as any user
5. go to the dashboard→ Try adding Tangible or Intangible time
6. Verify logging of time is successful without any errors.

## Screenshots or videos of changes:
### Previously, this api was taking a lot of time to reply average of 30 seconds, which caused a timeout error and an error thrown back.

<img width="1351" alt="Screenshot 2025-06-29 at 4 15 29 PM" src="https://github.com/user-attachments/assets/45c52492-c04b-41a9-8c5f-9bfca5cce997" />

<img width="1723" alt="Screenshot 2025-06-29 at 4 19 14 PM" src="https://github.com/user-attachments/assets/bae7d11d-44c9-449a-a382-a1f9e216121d" />

## Note:
None
