### PR TITLE
Fix Profile Page data justification and WBS task numbers when added a…

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -39,7 +39,7 @@ function AddTaskModal(props) {
    * -------------------------------- variable declarations --------------------------------
    */
   // props from store
-  const { tasks, copiedTask, allMembers, allProjects, error, darkMode } = props;
+  const { copiedTask, allMembers, allProjects, error, darkMode, tasks } = props;
 
   const handleBestHoursChange = e => {
     setHoursBest(e.target.value);
@@ -69,8 +69,8 @@ function AddTaskModal(props) {
   // states from hooks
 
   const defaultCategory = useMemo(() => {
-  if (props.taskId) {
-    const task = tasks.find(({ _id }) => _id === props.taskId);
+  if (props.taskId && Array.isArray(props.tasks)) {
+    const task = props.tasks.find(({ _id }) => _id === props.taskId);
     return task?.category || 'Unspecified';
   } 
   if (props.projectId) {
@@ -79,7 +79,7 @@ function AddTaskModal(props) {
   }
 
   return 'Unspecified';
-}, [props.taskId, props.projectId, tasks, allProjects.projects]);
+}, [props.taskId, props.projectId, props.tasks, allProjects.projects]);
 
 
 
@@ -134,9 +134,11 @@ function AddTaskModal(props) {
   };
 
   const getNewNum = () => {
+    if (!Array.isArray(props.tasks)) return '1';
     let newNum;
+    console.log(props)
     if (props.taskId) {
-      const numOfLastInnerLevelTask = tasks.reduce((num, task) => {
+      const numOfLastInnerLevelTask = props.tasks.reduce((num, task) => {
         if (task.mother === props.taskId) {
           const numIndexArray = task.num.split('.');
           const numOfInnerLevel = numIndexArray[props.level];
@@ -148,7 +150,7 @@ function AddTaskModal(props) {
       currentLevelIndexes[props.level] = `${numOfLastInnerLevelTask + 1}`;
       newNum = currentLevelIndexes.join('.');
     } else {
-      const numOfLastLevelOneTask = tasks.reduce((num, task) => {
+      const numOfLastLevelOneTask = props.tasks.reduce((num, task) => {
         if (task.level === 1) {
           const numIndexArray = task.num.split('.');
           const indexOfFirstNum = numIndexArray[0];
@@ -330,7 +332,10 @@ function AddTaskModal(props) {
    * -------------------------------- useEffects --------------------------------
    */
   useEffect(() => {
-    setNewTaskNum(getNewNum());
+    if (modal) {
+      setNewTaskNum(getNewNum());
+    }
+    // setNewTaskNum(getNewNum());
   }, [modal]);
 
   useEffect(() => {
@@ -820,7 +825,7 @@ function AddTaskModal(props) {
 }
 
 const mapStateToProps = state => ({
-  tasks: state.tasks.taskItems,
+  // tasks: state.tasks.taskItems,
   copiedTask: state.tasks.copiedTask,
   allMembers: state.projectMembers.members,
   allProjects: state.allProjects,

--- a/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
+++ b/src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
@@ -155,6 +155,7 @@ function WBSTasks(props) {
               load={refresh}
               pageLoadTime={pageLoadTime}
               darkMode={darkMode}
+              tasks={tasks} 
             />
           ) : null}
 

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -1254,7 +1254,7 @@ function UserProfile(props) {
             )}
           </div>
           <h6 className={darkMode ? 'text-light' : 'text-azure'}>{jobTitle}</h6>
-          <p className={`proile-rating ${darkMode ? 'text-light' : ''}`}>
+          <p className={`proile-rating ${darkMode ? 'text-light' : ''}`} style={{ textAlign: 'left' }}>
             {/* use converted date without tz otherwise the record's will updated with timezoned ts for start date.  */}
             From:{' '}
             <span className={darkMode ? 'text-light' : ''}>

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -383,7 +383,7 @@ const ViewTab = props => {
           <Label className={`hours-label ${darkMode ? 'text-light' : ''}`}>Account Created Date</Label>
         </Col>
         <Col md="6">
-          <p className={darkMode ? 'text-azure' : ''}>{formatDateMMDDYYYY(userProfile.createdDate)}</p>
+        <p className={darkMode ? 'text-azure' : ''} style={{ textAlign: 'left' }}>{formatDateMMDDYYYY(userProfile.createdDate)}</p>
         </Col>
       </Row>
       <Row className="volunteering-time-row">


### PR DESCRIPTION
# Description
1. The dates in the profile page to be justified to the left.
2. In WBS (adding a new task), when we click on the button to add a new task, the numbering was wrong. We always need to show a number which is one greater than the last task that was added.

## Related PRS (if any):
This PR is not related to any backend PRs.

## Main changes explained:
- src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
- src/components/Projects/WBS/WBSDetail/WBSTasks.jsx
- src/components/UserProfile/UserProfile.jsx
- src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
4. Clear site data/cache
5. log as admin user
6. go to dashboard→ View Profile
7. Verify if the date under "Volunteering Teams" and the date above Featured Badges are left justified.
8. Go to Projects -> WBS Task -> Add task. 
9. Verify if the number assigned after clicking "Add Task" button is correct.

## Screenshots or videos of changes:
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/6965ec90-32b1-4ce0-91ba-41161fc8e03e" />
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/864e2c72-e738-43fd-9ca4-394c305f40e2" />
