### PR TITLE
Akshay - Fix - TimeLogger-in-BMDashboard

### DIFF
--- a/src/components/BMDashboard/BMTimeLogger/BMTimeLogCard.jsx
+++ b/src/components/BMDashboard/BMTimeLogger/BMTimeLogCard.jsx
@@ -21,9 +21,9 @@ function BMTimeLogCard(props) {
   }, [props.selectedProject, dispatch]);
 
   useEffect(() => {
-    if (projectInfo && projectInfo.members) {
-      setMemberList(projectInfo.members);
-      setFilteredMembers(projectInfo.members);
+    if (projectInfo && projectInfo.members.members) {
+      setMemberList(projectInfo.members.members);
+      setFilteredMembers(projectInfo.members.members);
       setIsMemberFetched(true);
     }
   }, [projectInfo]);

--- a/src/components/BMDashboard/BMTimeLogger/BMTimeLogDisplayMember.jsx
+++ b/src/components/BMDashboard/BMTimeLogger/BMTimeLogDisplayMember.jsx
@@ -6,9 +6,10 @@ import styles from './BMTimeLogCard.module.css';
 function BMTimeLogDisplayMember({ firstName, lastName, role, memberId, projectId }) {
   const roleColors = {
     volunteer: '#78bdda', // light blue
-    core: '#ecb16c', // light orange
-    manager: '#6cc3b2', // light green
-    mentor: '#6cc3b2', // light green
+    'core team': '#6cc3b2', // light green
+    manager: '#ecb16c', // light orange
+    mentor: '#ecb16c', // light orange
+    admin: '#c36c6c', // light red
     owner: '#c36c6c', // light red
   };
 


### PR DESCRIPTION
# Description
This PR is created to address the feedback received for the [PR3299](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3299)
This page can be accessed via two ways (limited to the users with authorization):
- Link in the dropdown menu of the navigation bar.
- Button on the section of the BM dashboard (project specific).

Below is the further explanation related to each callout number:

- By selecting a specific project, the manager can view the users assigned to the project.
- The top bar shows the name of the user. The color may change according to the user’s role. For example, light blue for volunteers, orange for managers, red for core team.
- The “start”, “stop” or “clear” buttons are the same as the buttons used for time log in the phase one system.

A select dropdown for the manager to monitor. The value here will be the default/pre-select value passed to the time log form to save. 


## Related PRS (if any):
This frontend PR is not related to any backend PR.


## Main changes explained:
- Delete file A for removing unused components …
- Update file B for including new pattern …
- Create file C for introducing new components …
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ task→…
6. verify function “A” (feel free to include screenshot here)
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

## Note:
PR in development
