### PR TITLE
fix copy/pasting team codes auto select issue

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -47,6 +47,15 @@ import './WeeklySummariesReport.css';
 
 const navItems = ['This Week', 'Last Week', 'Week Before Last', 'Three Weeks Ago'];
 const fullCodeRegex = /^.{5,7}$/;
+const initialFilterState = {
+  selectedCodes: [], // this is the user’s filter preference
+  selectedColors: [],
+  selectedOverTime: false,
+  selectedBioStatus: false,
+  selectedTrophies: false,
+  selectedSpecialColors: { purple: false, green: false, navy: false },
+  chartShow: false,
+};
 const getWeekDates = () => {
   return Array.from({ length: 4 }).map((_, index) => ({
     fromDate: moment()
@@ -113,8 +122,28 @@ const intialPermissionState = {
 const WeeklySummariesReport = props => {
   const { loading, infoCollections, getInfoCollections } = props;
   const weekDates = getWeekDates();
+
+
   const [state, setState] = useState(initialState);
   const [permissionState, setPermissionState] = useState(intialPermissionState);
+  const [filterState, setFilterState] = useState({
+    selectedCodes: [],
+    selectedColors: [],
+    selectedOverTime: false,
+    selectedBioStatus: false,
+    selectedTrophies: false,
+    selectedSpecialColors: {
+      purple: false,
+      green: false,
+      navy: false,
+    },
+  });
+
+const handleSelectCodeChange = (codes) => {
+  setFilterState(prev => ({ ...prev, selectedCodes: codes }));
+};
+
+
   // Misc functionalities
   /**
    * Sort the summaries in alphabetixal order
@@ -471,14 +500,18 @@ const WeeklySummariesReport = props => {
       const {
         selectedCodes,
         selectedColors,
-        summaries,
         selectedOverTime,
         selectedBioStatus,
         selectedTrophies,
+        selectedSpecialColors,
+      } = filterState;
+      
+      const {
+        summaries,
         tableData,
         COLORS,
-        selectedSpecialColors,
       } = state;
+      
 
       // console.log('filterWeeklySummaries state:', {
       //   summariesLength: summaries?.length,
@@ -762,17 +795,10 @@ const WeeklySummariesReport = props => {
     }
   };
 
-  const handleSelectCodeChange = event => {
-    setState(prev => ({
-      ...prev,
-      selectedCodes: event,
-    }));
-  };
-
   const handleOverHoursToggleChange = () => {
-    setState(prev => ({
+    setFilterState(prev => ({
       ...prev,
-      selectedOverTime: !prev.selectedOverTime,
+      selectedOverTime: !prev.selectedOverTime
     }));
   };
 
@@ -1243,7 +1269,7 @@ const WeeklySummariesReport = props => {
                 label: `${code.padEnd(10, ' ')} (${count}`,
               };
             })}
-            value={state.selectedCodes}
+            value={filterState.selectedCodes}
             onChange={handleSelectCodeChange}
             labelledBy="Select"
           />

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -47,15 +47,6 @@ import './WeeklySummariesReport.css';
 
 const navItems = ['This Week', 'Last Week', 'Week Before Last', 'Three Weeks Ago'];
 const fullCodeRegex = /^.{5,7}$/;
-const initialFilterState = {
-  selectedCodes: [], // this is the user’s filter preference
-  selectedColors: [],
-  selectedOverTime: false,
-  selectedBioStatus: false,
-  selectedTrophies: false,
-  selectedSpecialColors: { purple: false, green: false, navy: false },
-  chartShow: false,
-};
 const getWeekDates = () => {
   return Array.from({ length: 4 }).map((_, index) => ({
     fromDate: moment()
@@ -122,8 +113,6 @@ const intialPermissionState = {
 const WeeklySummariesReport = props => {
   const { loading, infoCollections, getInfoCollections } = props;
   const weekDates = getWeekDates();
-
-
   const [state, setState] = useState(initialState);
   const [permissionState, setPermissionState] = useState(intialPermissionState);
   const [filterState, setFilterState] = useState({
@@ -139,10 +128,9 @@ const WeeklySummariesReport = props => {
     },
   });
 
-const handleSelectCodeChange = (codes) => {
-  setFilterState(prev => ({ ...prev, selectedCodes: codes }));
-};
-
+  const handleSelectCodeChange = codes => {
+    setFilterState(prev => ({ ...prev, selectedCodes: codes }));
+  };
 
   // Misc functionalities
   /**
@@ -505,14 +493,7 @@ const handleSelectCodeChange = (codes) => {
         selectedTrophies,
         selectedSpecialColors,
       } = filterState;
-      
-      const {
-        summaries,
-        tableData,
-        COLORS,
-      } = state;
-      
-
+      const { summaries, tableData, COLORS } = state;
       // console.log('filterWeeklySummaries state:', {
       //   summariesLength: summaries?.length,
       //   tableDataExists: !!tableData,
@@ -798,7 +779,7 @@ const handleSelectCodeChange = (codes) => {
   const handleOverHoursToggleChange = () => {
     setFilterState(prev => ({
       ...prev,
-      selectedOverTime: !prev.selectedOverTime
+      selectedOverTime: !prev.selectedOverTime,
     }));
   };
 


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/8b56ee7d-8d1c-4832-a567-5e36988bd0bd)
Previously, when copying and pasting a team code, the team code filter was also being applied to the search.
Fix: Now, only the team code is changed on copy-paste, and the search filters remain unaffected.


## Related PRS (if any):
No related PR
…

## Main changes explained:
- Ensured team code replacements update summaries without modifying user filter selection
- Preserved user-selected filters even after a team code is updated
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Weekly Summaries → copy team code one summary to another summary
6. page should not filter results based on the pasted text.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/efbcfde9-f14d-4f56-8770-64c168587131



