### PR TITLE
Venkataramanan - Fix border and justification issues in profile page 

### DIFF
--- a/src/components/Collaboration/Collaboration.css
+++ b/src/components/Collaboration/Collaboration.css
@@ -1,4 +1,4 @@
-.container,
+.collaboration-container,
 .job-landing .header img {
   width: 60%;
   max-width: 1000px;
@@ -8,7 +8,8 @@
 .job-ad {
   text-align: center;
 }
-.container {
+
+.collaboration-container {
   margin: 0 auto 50px;
   flex-direction: column;
   align-items: center;

--- a/src/components/Collaboration/Collaboration.jsx
+++ b/src/components/Collaboration/Collaboration.jsx
@@ -152,7 +152,7 @@ function Collaboration() {
             <img src={OneCommunityImage} alt="One Community Logo" />
           </a>
         </div>
-        <div className="container">
+        <div className="collaboration-container">
           <nav className="job-navbar">
             <div className="job-navbar-left">
               <form className="search-form">
@@ -292,7 +292,7 @@ function Collaboration() {
           <img src={OneCommunityImage} alt="One Community Logo" />
         </a>
       </div>
-      <div className="container">
+      <div className="collaboration-container">
         <nav className="job-navbar">
           <div className="job-navbar-left">
             <form className="search-form">

--- a/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.css
+++ b/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.css
@@ -32,8 +32,6 @@
 }
 
 .projects-and-tasks-header {
-  background-color: #e9ecef;
-  border: 1px solid #ced4da;
   margin-bottom: 10px;
 }
 

--- a/src/components/UserProfile/TimeEntryEditHistory.jsx
+++ b/src/components/UserProfile/TimeEntryEditHistory.jsx
@@ -40,7 +40,7 @@ const TimeEntryEditHistory = props => {
 
   return (
     <>
-      <p className={darkMode ? 'text-light' : ''}>Time Entry Edit History</p>
+      <p className={darkMode ? 'text-light' : ''} style={{textAlign: 'left'}}>Time Entry Edit History</p>
       <table className={`table table-bordered ${darkMode ? 'text-light' : ''}`} width="100%">
         <thead>
           <tr style={tabletView ? {fontSize: "10px"} : {}}>

--- a/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
+++ b/src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx
@@ -451,7 +451,7 @@ const ViewTab = props => {
           </Label>
         </Col>
         <Col md="6">
-          <p className={`hours-totalTangible-thisWeek ${darkMode ? 'text-azure' : ''}`}>
+          <p className={`hours-totalTangible-thisWeek ${darkMode ? 'text-azure' : ''}`} style={{textAlign: 'left'}}>
             {totalTangibleHoursThisWeek}
           </p>
         </Col>


### PR DESCRIPTION
# Description
This PR addresses the following issues:
1.⁠ ⁠Remove border in profile page.
2.⁠ ⁠⁠0.00 in Volunteer times -> left justify
3.⁠ ⁠⁠Projects / Assign Project Fix.
4.⁠ ⁠⁠Time Entry Edit History Left justify.

## Related PRS (if any):
This PR is not related to any backend PRs.

## Main changes explained:
Files Changed:
- src/components/Collaboration/Collaboration.css
- src/components/Collaboration/Collaboration.jsx
- src/components/UserProfile/TeamsAndProjects/UserProjectsTable.css
- src/components/UserProfile/TimeEntryEditHistory.jsx
- src/components/UserProfile/VolunteeringTimeTab/VolunteeringTimeTab.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as any user.
5. go to dashboard→ View Profile
6. Verify if the border in the profile page is not present.
7. Verify if "Total Tangible Hours This Week" in Volunteer Times tab and "Time Entry Edit History" in Edit History tab is left justified.
8. Verify if "Projects" and "Assign Projects" are properly aligned.
## Screenshots or videos of changes:
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/fb3c2159-50e7-4414-b5e7-803691184a6b" />
<img width="571" alt="image" src="https://github.com/user-attachments/assets/16f6dcc2-ce01-4555-8c66-3b9b165bf1b4" />
<img width="1214" alt="image" src="https://github.com/user-attachments/assets/dbfc1b02-3b73-4c53-a684-84804d32f334" />
<img width="622" alt="image" src="https://github.com/user-attachments/assets/117d7693-ca67-4f40-a69d-8975e8e67a8e" />
<img width="649" alt="image" src="https://github.com/user-attachments/assets/d7091092-2c8d-4cfa-841f-faa22e1ad733" />
<img width="649" alt="image" src="https://github.com/user-attachments/assets/3cc2d499-9702-4416-a5f8-cc2447b5d35b" />
<img width="674" alt="image" src="https://github.com/user-attachments/assets/bfa8529f-4a03-4756-affb-11e5276c9048" />
