### PR TITLE
Ramsundar - HotFix Timelog formatting error

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -77,6 +77,7 @@ const startOfWeek = offset => {
 const endOfWeek = offset => {
   return moment()
     .tz('America/Los_Angeles')
+    .endOf('week')
     .subtract(offset, 'weeks')
     .format('YYYY-MM-DD');
 };
@@ -381,14 +382,14 @@ function Timelog(props) {
     }
     if (timeLogState.activeTab === 4) {
       return (
-        <p className={`ml-1 responsive-font-size ${darkMode ? 'text-light' : ''}`}>
+        <p className={`ml-1 responsive-font-size ${darkMode ? 'text-light' : ''}`} style={{textAlign: 'left'}} >
           Viewing time Entries from <b>{formatDate(timeLogState.fromDate)}</b> to{' '}
           <b>{formatDate(timeLogState.toDate)}</b>
         </p>
       );
     }
     return (
-      <p className={`ml-1 responsive-font-size ${darkMode ? 'text-light' : ''}`}>
+      <p className={`ml-1 responsive-font-size ${darkMode ? 'text-light' : ''}`} style={{textAlign: 'left'}}>
         Viewing time Entries from <b>{formatDate(startOfWeek(timeLogState.activeTab - 1))}</b> to{' '}
         <b>{formatDate(endOfWeek(timeLogState.activeTab - 1))}</b>
       </p>


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/9eec15ed-a42e-4107-8534-1b836baeba87)
1. The issue is with the "Viewing time Entries from date to date" text that appears above the time log entries in the Timelog component. 
2. This text is currently displaying with center alignment instead of the expected left alignment.
3. Also, This was working as expected about two weeks ago, so a recent pull request may have introduced this change. I'm looking into identifying which PR might have caused it.

## Related PRS (if any):
This frontend PR is related to the latest backend development branch. 

## Main changes explained:
-  Got the PR #3610 and the endOfWeek function correctly calculates weekly end dates using offset parameters (0 for current week, 1 for last week) and only affects the date range display text, not the actual time entry data or functionality. 
- Added Left Alignment Styling.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard -> Task and timelog -> Current week timelog 
6. check the "Viewing time Entries from date to date"

## Screenshots or videos of changes:
<img width="1470" alt="Screenshot 2025-07-04 at 2 36 46 PM" src="https://github.com/user-attachments/assets/277758f3-2ee2-409a-aa98-b4171bae7866" />

## Note:
Include the information the reviewers need to know.
