### PR TITLE
jaissica-added-summary-dashboard-reducer

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -5,10 +5,8 @@ import storage from 'redux-persist/lib/storage'; // defaults to localStorage for
 import thunk from 'redux-thunk';
 import { userPreferencesReducer } from 'reducers/lbdashboard/userPreferencesReducer';
 import { messagingReducer } from 'reducers/lbdashboard/messagingReducer';
-import { localReducers, sessionReducers } from './reducers';
 import { weeklyProjectSummaryReducer } from 'reducers/bmdashboard/weeklyProjectSummaryReducer';
-
-
+import { localReducers, sessionReducers } from './reducers';
 
 const middleware = [thunk];
 const initialState = {};
@@ -50,4 +48,3 @@ const store = createStore(
 const persistor = persistStore(store);
 
 export { store, persistor };
-

--- a/src/store.js
+++ b/src/store.js
@@ -6,6 +6,8 @@ import thunk from 'redux-thunk';
 import { userPreferencesReducer } from 'reducers/lbdashboard/userPreferencesReducer';
 import { messagingReducer } from 'reducers/lbdashboard/messagingReducer';
 import { localReducers, sessionReducers } from './reducers';
+import { weeklyProjectSummaryReducer } from 'reducers/bmdashboard/weeklyProjectSummaryReducer';
+
 
 
 const middleware = [thunk];
@@ -17,6 +19,7 @@ const devTools = window.__REDUX_DEVTOOLS_EXTENSION__
 export const rootReducers = combineReducers({
   userPreferences: userPreferencesReducer,
   messages: messagingReducer,
+  weeklyProjectSummary: weeklyProjectSummaryReducer,
   ...localReducers,
   ...sessionReducers,
 });
@@ -47,3 +50,4 @@ const store = createStore(
 const persistor = persistStore(store);
 
 export { store, persistor };
+


### PR DESCRIPTION
# Description
Added a reducer for the Summary dashboard to make it work through the development branch.
Resolves error:
<img width="616" alt="Screenshot 2025-07-05 at 4 46 42 PM" src="https://github.com/user-attachments/assets/3ea042d4-e0dc-4c32-b42e-3260d915be7d" />


## Related PRS (if any):
- NA

## Main changes explained:
- Declared Summary dashboard in store.js to make the dashboard work through the development branch.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Try loading http://localhost:3000/bmdashboard/totalconstructionsummary

## Screenshots or videos of changes:
<img width="1428" alt="Screenshot 2025-07-05 at 4 44 22 PM" src="https://github.com/user-attachments/assets/a207a7af-0cc7-47e3-9e90-8b45e6f9a6d9" />

## Note:
NA
