### PR TITLE
Mohan - fix: Add missing role info popups on Weekly Summaries Reports page

### DIFF
--- a/src/components/UserProfile/EditableModal/RoleInfoModal.jsx
+++ b/src/components/UserProfile/EditableModal/RoleInfoModal.jsx
@@ -1,20 +1,23 @@
-
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector, connect } from 'react-redux';
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader, Col, Row} from 'reactstrap';
-import { updateInfoCollection } from '../../../actions/information'
+import { updateInfoCollection, addInfoCollection } from '../../../actions/information'
 import { boxStyle, boxStyleDark } from 'styles';
 import { useEffect } from 'react';
 import { toast } from 'react-toastify';
 import RichTextEditor from './RichTextEditor';
 
-const RoleInfoModal = ({ info, auth}) => {
+const RoleInfoModal = ({ info, auth, roleName}) => {
   const darkMode = useSelector(state => state.theme.darkMode);
   const [isOpen, setOpen] = useState(false);
   const [canEditInfoModal, setCanEditInfoModal] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
-  const { infoContent, CanRead } = { ...info };
+  
+  // Handle case where info doesn't exist in database
+  const infoContent = info?.infoContent || 'Please input information!';
+  const CanRead = info?.CanRead !== undefined ? info.CanRead : true; // Default to true if not specified
+  
   const [infoContentModal, setInfoContentModal] = useState('');
   const dispatch = useDispatch();
 
@@ -60,8 +63,21 @@ const RoleInfoModal = ({ info, auth}) => {
     }
 
     const updateInfo = {infoContent: infoContentModal}
+    let saveResult;
 
-    let saveResult = await dispatch(updateInfoCollection(info._id, updateInfo));
+    // If info doesn't exist in database, create new record
+    if (!info || !info._id) {
+      const newInfo = {
+        infoName: roleName || 'UnknownRoleInfo',
+        infoContent: infoContentModal,
+        visibility: '0'
+      };
+      saveResult = await dispatch(addInfoCollection(newInfo));
+    } else {
+      // Update existing record
+      saveResult = await dispatch(updateInfoCollection(info._id, updateInfo));
+    }
+    
     setInfoContentModal(infoContentModal);
 
     if (saveResult === 200 || saveResult === 201) {
@@ -69,7 +85,6 @@ const RoleInfoModal = ({ info, auth}) => {
     } else {
       handleSaveError();
     }
-
   }
 
   if (CanRead) {
@@ -121,8 +136,12 @@ const RoleInfoModal = ({ info, auth}) => {
 };
 
 RoleInfoModal.propTypes = {
+  info: PropTypes.object,
+  auth: PropTypes.object,
+  roleName: PropTypes.string,
   fetchError: PropTypes.any,
   updateInfoCollection: PropTypes.func.isRequired,
+  addInfoCollection: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = ({ infoCollections }) => ({
@@ -134,7 +153,8 @@ const mapStateToProps = ({ infoCollections }) => ({
 const mapDispatchToProps = dispatch => {
   return {
     updateInfoCollection: (infoId, updatedInfo) => dispatch(updateInfoCollection(infoId, updatedInfo)),
+    addInfoCollection: (newInfo) => dispatch(addInfoCollection(newInfo)),
   };
 };
 
-export default connect(mapDispatchToProps, mapStateToProps)(RoleInfoModal);
+export default connect(mapStateToProps, mapDispatchToProps)(RoleInfoModal);

--- a/src/components/UserProfile/EditableModal/__tests__/roleInfoModal.test.js
+++ b/src/components/UserProfile/EditableModal/__tests__/roleInfoModal.test.js
@@ -7,6 +7,12 @@ import RoleInfoModal from '../RoleInfoModal';
 
 const mockStore = configureStore([]);
 
+// Mock the action functions to return plain objects instead of functions
+jest.mock('../../../../actions/information', () => ({
+  updateInfoCollection: jest.fn(() => ({ type: 'UPDATE_INFO_COLLECTION' })),
+  addInfoCollection: jest.fn(() => ({ type: 'ADD_INFO_COLLECTION' })),
+}));
+
 describe('RoleInfoModal component Test cases', () => {
   test('Test case 1 : Renders without crashing', () => {
     const store = mockStore({
@@ -65,5 +71,50 @@ describe('RoleInfoModal component Test cases', () => {
 
     const modalTitle = queryByText('Welcome to Information Page!');
     expect(modalTitle).not.toBeInTheDocument();
+  });
+
+  it('Test case 5 : Shows default message when info is undefined', () => {
+    const store = mockStore({
+      theme: themeMock,
+    });
+
+    const { getByTitle, getByText } = render(
+      <Provider store={store}>
+        <RoleInfoModal info={undefined} roleName="MentorInfo" />
+      </Provider>
+    );
+    
+    const infoIcon = getByTitle('Click for user class information');
+    expect(infoIcon).toBeInTheDocument();
+    
+    fireEvent.click(infoIcon);
+    const modalTitle = getByText('Welcome to Information Page!');
+    expect(modalTitle).toBeInTheDocument();
+    
+    const defaultMessage = getByText('Please input information!');
+    expect(defaultMessage).toBeInTheDocument();
+  });
+
+  it('Test case 6 : Shows default message when info has no content', () => {
+    const store = mockStore({
+      theme: themeMock,
+    });
+
+    const info = {
+      CanRead: true,
+      infoContent: '',
+    };
+
+    const { getByTitle, getByText } = render(
+      <Provider store={store}>
+        <RoleInfoModal info={info} roleName="MentorInfo" />
+      </Provider>
+    );
+    
+    const infoIcon = getByTitle('Click for user class information');
+    fireEvent.click(infoIcon);
+    
+    const defaultMessage = getByText('Please input information!');
+    expect(defaultMessage).toBeInTheDocument();
   });
 });

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -701,6 +701,7 @@ function Index({ summary, weekIndex, allRoleInfo, auth, handleSpecialColorDotCli
             <RoleInfoModal
               info={allRoleInfo.find(item => item.infoName === `${summary.role}Info`)}
               auth={auth}
+              roleName={`${summary.role}Info`}
             />
           )}
         </div>


### PR DESCRIPTION
# Description
![Screenshot 2025-07-05 234500](https://github.com/user-attachments/assets/62b9269e-1f9d-4021-903b-33d702d8538c)
![Screenshot 2025-07-05 234522](https://github.com/user-attachments/assets/bafd74dd-d342-407d-9897-039fe48f80df)

## Main changes explained:
- Fixed RoleInfoModal component to properly handle missing database entries for role information
- Added support for creating new role info collections when they don't exist in the database
- Enhanced RoleInfoModal with proper null safety checks and default values for missing data
- Added roleName prop to RoleInfoModal to identify which role info to create when missing
- Updated FormattedReport component to pass the roleName prop for proper role identification
- Ensured "i" icons now appear for all roles (Core Team, Manager, Mentor, Assistant Manager) even when no database entry exists
- Added comprehensive test coverage for the new functionality including edge cases
- Maintained backward compatibility with existing role info entries
…

## How to test:
1. check into current branch
2. do `npm install`, and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. Log as owner user
5. Navigate to Reports → Weekly Summaries Reports
6. Verify that "i" icons appear to the right of Google Doc links for all roles except "Volunteer"
7. Click on the "i" icons to verify they open the information modal
8. Test with Owner role to verify you can create/edit role information when none exists
9. Verify that existing role information still works correctly
10. Test on both roles with existing database entries and roles without database entries

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/573135bf-4120-468c-a78c-48cf4f908691

## Note:
Clear site data/cache If your unable to see changes.
