### PR TITLE
Geeta - Fixed width issue for people report

### DIFF
--- a/src/components/Reports/PeopleReport/PeopleReport.css
+++ b/src/components/Reports/PeopleReport/PeopleReport.css
@@ -214,12 +214,26 @@ body {
   color: white;
 }
 
-.people-report-time-log-block {
+
+/*.people-report-time-log-block {
   max-height: 100px;
   width: 270px;
   white-space: nowrap;
   margin-bottom: 16px;
+}*/
+
+.people-report-time-log-block {
+  flex: 1 1 220px;
+  min-width: 100px;
+  padding: 12px;
+  box-sizing: border-box;
+  margin-bottom: 16px;
+  white-space: normal;         /* allow text wrapping */
+  overflow: visible;           /* don't crop or scroll content */
 }
+
+
+
 
 @media (min-width: 850px) {
   .people-report-time-logs-wrapper {
@@ -282,6 +296,7 @@ body {
 }
 
 .report-stats {
+  
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -299,3 +314,61 @@ body {
     align-items: flex-start;
   }
 }
+
+.people-report-header-layout {
+  
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+  gap: 100px;
+}
+
+.people-report-header-layout .report-header {
+  flex: 1 1 350px;
+  min-width: 300px;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+
+/* Left side (summary blocks) */
+.people-report-time-logs-wrapper {
+  flex: 1 1 50%;
+}
+
+/* Right side (profile info) */
+.container-people-wrapper .report-header {
+  flex: 1 1 50%;
+  max-width: 50%;
+}
+
+/* Collapse to vertical layout on small screens */
+@media (max-width: 768px) {
+  .people-report-header-layout {
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .container-people-wrapper .report-header {
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .people-report-time-logs-wrapper {
+    width: 100%;
+  }
+}
+
+.report-stats {
+  padding-left: 24px;
+  
+}
+
+@media (max-width: 768px) {
+  .report-stats {
+    padding-left: 0;
+  }
+}
+

--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -432,12 +432,17 @@ class PeopleReport extends Component {
       const { profilePic, role, jobTitle, endDate, _id, startDate } = userProfile;
 
       return (
+        <div className="profile-info-inner">
+        
         <ReportPage.ReportHeader
           src={profilePic}
           avatar={profilePic ? undefined : <FiUser />}
           isActive={isActive}
           darkMode={darkMode}
         >
+          
+          
+
           <div className={`report-stats ${darkMode ? 'text-light' : ''}`}>
             <p>
               <Link to={`/userProfile/${_id}`}
@@ -491,7 +496,11 @@ class PeopleReport extends Component {
               ) : null}
             </div>
           </div>
+          
+          
         </ReportPage.ReportHeader>
+        </div>
+       
       );
     };
 
@@ -521,8 +530,11 @@ class PeopleReport extends Component {
 
     return (
       <div className={`container-people-wrapper ${darkMode ? 'bg-oxford-blue' : ''}`}>
-        <ReportPage renderProfile={renderProfileInfo} darkMode={darkMode}>
+        <ReportPage renderProfile={() => null} darkMode={darkMode}>
+          <div className="people-report-header-layout">
+          {renderProfileInfo()}
           <div className={`people-report-time-logs-wrapper ${tangibleHoursReportedThisWeek === 0 && !Number.isNaN(tangibleHoursReportedThisWeek)? "auto-width-report-time-logs-wrapper" : ""}`}>
+            
             <ReportPage.ReportBlock
               firstColor="#ff5e82"
               secondColor="#e25cb2"
@@ -565,6 +577,7 @@ class PeopleReport extends Component {
               <h3 className="text-light">{totalTangibleHrsRound}</h3>
               <p>Total Hours Logged</p>
             </ReportPage.ReportBlock>
+          </div>
           </div>
 
           <PeopleTasksPieChart darkMode={darkMode} />


### PR DESCRIPTION
# Description
<img width="670" alt="Screenshot 2025-07-08 at 10 49 16 PM" src="https://github.com/user-attachments/assets/850ceb4d-b662-4ae3-af74-a2cf9d318010" />

## Main changes explained:
- Updated PeopleReport.jsx and PeopleReport.css
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ Reports→ Reports→ People → Choose OR just click the “R” icon at the top of any Profile OR by name in Dashboard→Tasks tab
6. verify width for half screen, if you can see both report detail and time log information.
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots of changes:

![Screenshot 2025-07-08 at 10 53 50 PM](https://github.com/user-attachments/assets/79105209-7d77-4ca0-abfe-66f5d71b63dc)
