### PR TITLE
Ramsundar Update current week only on own page

### DIFF
--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -242,10 +242,18 @@ export const deleteTimeEntry = timeEntry => {
   };
 };
 
+
 const updateTimeEntries = (timeEntry, oldDateOfWork) => {
   const startOfWeek = moment().startOf('week');
+  
+  return async (dispatch, getState) => {
+    const state = getState();
+    const currentlyViewedUserId = state.userProfile._id;
 
-  return async dispatch => {
+    if (timeEntry.personId !== currentlyViewedUserId) {
+      return; // Don't update Redux if viewing a different user's page
+    }
+
     if (oldDateOfWork) {
       const oldOffset = Math.ceil(startOfWeek.diff(oldDateOfWork, 'week', true));
       dispatch(getTimeEntriesForWeek(timeEntry.personId, oldOffset));
@@ -258,6 +266,25 @@ const updateTimeEntries = (timeEntry, oldDateOfWork) => {
     }
   };
 };
+
+
+
+// const updateTimeEntries = (timeEntry, oldDateOfWork) => {
+//   const startOfWeek = moment().startOf('week');
+
+//   return async dispatch => {
+//     if (oldDateOfWork) {
+//       const oldOffset = Math.ceil(startOfWeek.diff(oldDateOfWork, 'week', true));
+//       dispatch(getTimeEntriesForWeek(timeEntry.personId, oldOffset));
+//     }
+
+//     const offset = Math.ceil(startOfWeek.diff(timeEntry.dateOfWork, 'week', true));
+
+//     if (offset <= 2 && offset >= 0) {
+//       dispatch(getTimeEntriesForWeek(timeEntry.personId, offset));
+//     }
+//   };
+// };
 
 // export const setTimeEntriesForWeek = (data, offset) => ({
 //   type: GET_TIME_ENTRIES_WEEK,


### PR DESCRIPTION
# Description
<img width="791" height="427" alt="Screenshot 2025-07-11 at 11 30 30 PM" src="https://github.com/user-attachments/assets/6d0bca72-8910-4966-a156-48348968ae91" />

<img width="772" height="410" alt="Screenshot 2025-07-11 at 11 30 40 PM" src="https://github.com/user-attachments/assets/041d3d75-a8c1-48a9-9902-72cc99d0652b" />

Video Link: https://www.loom.com/share/5e27c7b0b61144d68c433044c7e97350?sid=60bac4c4-4432-4fd9-84c6-cd1a9447df30

## Related PRS (if any):
This frontend PR is related to the latest Development backend branch. 

## Main changes explained:
Issue:
You're on User B's timelog page, but when you log time:
- Your timer data temporarily appears in User B's timelog entries
- User B's "Current Week" shows your logged time (ex: 0.53hrs) instead of their time
- Refresh fixes it because it reloads the correct data from the server

Fixes:
- Added a check to ensure time entries are only re-fetched if the personId of the entry matches the currently displayed user ID.
- If the logged entry belongs to a different user than the one currently being viewed, the function exits early and skips dispatching any updates to the timeEntries slice.
- By blocking the Redux state update for unrelated users, we prevent User A’s time data from being shown in User B’s UI when User A logs time.


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard
6. Start timer -> Click any other teammate timelog
7. In another teammate's timelog, log your time and check if your own "Current Week" is showing there.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/68673a77-2c83-4014-b211-1bbff7dd3dc7




## Note:
Include the information the reviewers need to know.
