### PR TITLE
Fixing send email tab so page would load

### DIFF
--- a/src/components/Announcements/index.jsx
+++ b/src/components/Announcements/index.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import './Announcements.css';
 import { useDispatch, useSelector } from 'react-redux';
 import { Editor } from '@tinymce/tinymce-react';


### PR DESCRIPTION
# Description
The send email page was not loading. Every time the send email tab is pressed the page would either not load or crash.

…

## Main changes explained:
- Added useRef as a react import so the code would compile correctly

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as an owner (or any user that is able to send emails)
5. go to dashboard→ Other Link → Send Email
6. verify the page actually loads and shows up

## Screenshots or videos of changes:
<img width="1440" height="818" alt="image" src="https://github.com/user-attachments/assets/fb9e3e2d-3eb1-44a9-a8ff-f24066124e30" />
<img width="1440" height="818" alt="image" src="https://github.com/user-attachments/assets/80730f96-09f7-49c3-bdfd-ff44dbbf5b3b" />

## Note:
This is just fixing the bug on the page itself not loading. The actual functionality of sending email should work as well but if it doesn't bring it up with either me or Jae privately on slack or phone.
