### PR TITLE
Strallia- update Blue Square Stats chart

### DIFF
--- a/src/components/TotalOrgSummary/BlueSquareStats/BlueSquareStats.jsx
+++ b/src/components/TotalOrgSummary/BlueSquareStats/BlueSquareStats.jsx
@@ -41,8 +41,6 @@ function BlueSquareStats({ isLoading, blueSquareStats, comparisonType }) {
     { label: 'Other', value: other.count },
   ];
 
-  const hasData = data.every(item => item.value !== 0);
-
   return (
     <section className="blue-square-stats">
       <div className="blue-square-stats-pie-chart">
@@ -53,7 +51,6 @@ function BlueSquareStats({ isLoading, blueSquareStats, comparisonType }) {
           data={data}
           colors={BLUE_SQUARE_STATS_COLORS}
           comparisonType={comparisonType}
-          hasData={hasData}
         />
       </div>
     </section>

--- a/src/components/TotalOrgSummary/DonutChart/DonutChart.jsx
+++ b/src/components/TotalOrgSummary/DonutChart/DonutChart.jsx
@@ -7,17 +7,7 @@ import './DonutChart.css';
 Chart.register(ArcElement);
 
 function DonutChart(props) {
-  const { title, totalCount, percentageChange, data, colors, hasData, comparisonType } = props;
-
-  if (!hasData) {
-    return (
-      <div className="donut-container">
-        <div className="donut-no-data">
-          <p className="no-data-text">No data available</p>
-        </div>
-      </div>
-    );
-  }
+  const { title, totalCount, percentageChange, data, colors, comparisonType } = props;
 
   const chartData = {
     labels: data.map(item => item.label),
@@ -100,11 +90,6 @@ DonutChart.propTypes = {
   ).isRequired,
   colors: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   comparisonType: PropTypes.string.isRequired,
-  hasData: PropTypes.bool,
-};
-
-DonutChart.defaultProps = {
-  hasData: true,
 };
 
 export default DonutChart;

--- a/src/components/TotalOrgSummary/DonutChart/DonutChart.jsx
+++ b/src/components/TotalOrgSummary/DonutChart/DonutChart.jsx
@@ -66,8 +66,8 @@ function DonutChart(props) {
             {comparisonType !== 'No Comparison' && (
               <h6 className="donut-comparison-percent" style={{ color: percentageChangeColor }}>
                 {percentageChange >= 0
-                  ? `+${percentageChange}% ${comparisonType.toUpperCase()}`
-                  : `${percentageChange}% ${comparisonType.toUpperCase()}`}
+                  ? `+${(percentageChange * 100).toFixed(0)}% ${comparisonType.toUpperCase()}`
+                  : `${(percentageChange * 100).toFixed(0)}% ${comparisonType.toUpperCase()}`}
               </h6>
             )}
           </div>


### PR DESCRIPTION
# Description
This PR removes the no-data-available screen and fixes the comparison percentage on the Blue Square Stats chart on the Total Org Summary page.

## How to test:
1. check into current branch
2. do `npm install` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ Total Org Summary
6. verify the blue square stats chart looks like the first image below
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Note:
The backend is in the progress of being updated so no data is currently available for this chart and it looks like this:

<img width="911" height="495" alt="Screenshot 2025-07-19 at 6 47 18 PM" src="https://github.com/user-attachments/assets/de4cdc13-387e-442f-8372-aeb434e3b9cb" />

Once the backend is fixed or if you enter mock data the chart should look like this:

<img width="927" height="527" alt="Screenshot 2025-07-19 at 6 46 43 PM" src="https://github.com/user-attachments/assets/921c94ac-06fe-4c7c-9839-4479018aa2ab" />