### PR TITLE
Venkataramanan. Remove unwanted dot in Blue Squares tile

### DIFF
--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -552,7 +552,7 @@ class PeopleReport extends Component {
               secondColor="#928aef"
               className="people-report-time-log-block"
               darkMode={darkMode}
-            >. 
+            >
               <h3 className="text-light">{infringements.length}</h3>
               <p>Blue squares</p>
             </ReportPage.ReportBlock>


### PR DESCRIPTION
# Description
This PR fixes the formatting issue in the Blue Square tile in People Reports.

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change file src/components/Reports/PeopleReport/PeopleReport.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports -> People -> Choose a person
6. Check if the formatting is good in Blue Squares tile.

## Screenshots or videos of changes:
<img width="1022" height="148" alt="image" src="https://github.com/user-attachments/assets/aa387118-fcb7-4328-a6d1-b0427a1a18d7" />