### PR TITLE
Mohan fix task date editing crashing webpage

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -333,11 +333,15 @@ function Task(props) {
               {parseFloat(props.estimatedHours).toFixed(2)}
             </td>
             <td className="desktop-view">
-              {startedDate.getFullYear() !== 1969 ? formatDate(startedDate) : null}
+              {startedDate.getFullYear() !== 1969 ? 
+                `${startedDate.toLocaleDateString('en-US', { month: 'short' })}-${startedDate.getDate().toString().padStart(2, '0')}-${startedDate.getFullYear()}` 
+                : null}
               <br />
             </td>
             <td className="desktop-view">
-              {dueDate.getFullYear() !== 1969 ? formatDate(dueDate) : null}
+              {dueDate.getFullYear() !== 1969 ? 
+                `${dueDate.toLocaleDateString('en-US', { month: 'short' })}-${dueDate.getDate().toString().padStart(2, '0')}-${dueDate.getFullYear()}` 
+                : null}
             </td>
             <td className="desktop-view">
               {props.links.map((link, i) =>

--- a/src/components/UserProfile/EditableModal/RoleInfoModal.jsx
+++ b/src/components/UserProfile/EditableModal/RoleInfoModal.jsx
@@ -1,20 +1,23 @@
-
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector, connect } from 'react-redux';
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader, Col, Row} from 'reactstrap';
-import { updateInfoCollection } from '../../../actions/information'
+import { updateInfoCollection, addInfoCollection } from '../../../actions/information'
 import { boxStyle, boxStyleDark } from 'styles';
 import { useEffect } from 'react';
 import { toast } from 'react-toastify';
 import RichTextEditor from './RichTextEditor';
 
-const RoleInfoModal = ({ info, auth}) => {
+const RoleInfoModal = ({ info, auth, roleName}) => {
   const darkMode = useSelector(state => state.theme.darkMode);
   const [isOpen, setOpen] = useState(false);
   const [canEditInfoModal, setCanEditInfoModal] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
-  const { infoContent, CanRead } = { ...info };
+  
+  // Handle case where info doesn't exist in database
+  const infoContent = info?.infoContent || 'Please input information!';
+  const CanRead = info?.CanRead !== undefined ? info.CanRead : true; // Default to true if not specified
+  
   const [infoContentModal, setInfoContentModal] = useState('');
   const dispatch = useDispatch();
 
@@ -60,8 +63,21 @@ const RoleInfoModal = ({ info, auth}) => {
     }
 
     const updateInfo = {infoContent: infoContentModal}
+    let saveResult;
 
-    let saveResult = await dispatch(updateInfoCollection(info._id, updateInfo));
+    // If info doesn't exist in database, create new record
+    if (!info || !info._id) {
+      const newInfo = {
+        infoName: roleName || 'UnknownRoleInfo',
+        infoContent: infoContentModal,
+        visibility: '0'
+      };
+      saveResult = await dispatch(addInfoCollection(newInfo));
+    } else {
+      // Update existing record
+      saveResult = await dispatch(updateInfoCollection(info._id, updateInfo));
+    }
+    
     setInfoContentModal(infoContentModal);
 
     if (saveResult === 200 || saveResult === 201) {
@@ -69,7 +85,6 @@ const RoleInfoModal = ({ info, auth}) => {
     } else {
       handleSaveError();
     }
-
   }
 
   if (CanRead) {
@@ -121,8 +136,12 @@ const RoleInfoModal = ({ info, auth}) => {
 };
 
 RoleInfoModal.propTypes = {
+  info: PropTypes.object,
+  auth: PropTypes.object,
+  roleName: PropTypes.string,
   fetchError: PropTypes.any,
   updateInfoCollection: PropTypes.func.isRequired,
+  addInfoCollection: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = ({ infoCollections }) => ({
@@ -134,7 +153,8 @@ const mapStateToProps = ({ infoCollections }) => ({
 const mapDispatchToProps = dispatch => {
   return {
     updateInfoCollection: (infoId, updatedInfo) => dispatch(updateInfoCollection(infoId, updatedInfo)),
+    addInfoCollection: (newInfo) => dispatch(addInfoCollection(newInfo)),
   };
 };
 
-export default connect(mapDispatchToProps, mapStateToProps)(RoleInfoModal);
+export default connect(mapStateToProps, mapDispatchToProps)(RoleInfoModal);

--- a/src/components/UserProfile/EditableModal/__tests__/roleInfoModal.test.js
+++ b/src/components/UserProfile/EditableModal/__tests__/roleInfoModal.test.js
@@ -7,6 +7,12 @@ import RoleInfoModal from '../RoleInfoModal';
 
 const mockStore = configureStore([]);
 
+// Mock the action functions to return plain objects instead of functions
+jest.mock('../../../../actions/information', () => ({
+  updateInfoCollection: jest.fn(() => ({ type: 'UPDATE_INFO_COLLECTION' })),
+  addInfoCollection: jest.fn(() => ({ type: 'ADD_INFO_COLLECTION' })),
+}));
+
 describe('RoleInfoModal component Test cases', () => {
   test('Test case 1 : Renders without crashing', () => {
     const store = mockStore({
@@ -65,5 +71,50 @@ describe('RoleInfoModal component Test cases', () => {
 
     const modalTitle = queryByText('Welcome to Information Page!');
     expect(modalTitle).not.toBeInTheDocument();
+  });
+
+  it('Test case 5 : Shows default message when info is undefined', () => {
+    const store = mockStore({
+      theme: themeMock,
+    });
+
+    const { getByTitle, getByText } = render(
+      <Provider store={store}>
+        <RoleInfoModal info={undefined} roleName="MentorInfo" />
+      </Provider>
+    );
+    
+    const infoIcon = getByTitle('Click for user class information');
+    expect(infoIcon).toBeInTheDocument();
+    
+    fireEvent.click(infoIcon);
+    const modalTitle = getByText('Welcome to Information Page!');
+    expect(modalTitle).toBeInTheDocument();
+    
+    const defaultMessage = getByText('Please input information!');
+    expect(defaultMessage).toBeInTheDocument();
+  });
+
+  it('Test case 6 : Shows default message when info has no content', () => {
+    const store = mockStore({
+      theme: themeMock,
+    });
+
+    const info = {
+      CanRead: true,
+      infoContent: '',
+    };
+
+    const { getByTitle, getByText } = render(
+      <Provider store={store}>
+        <RoleInfoModal info={info} roleName="MentorInfo" />
+      </Provider>
+    );
+    
+    const infoIcon = getByTitle('Click for user class information');
+    fireEvent.click(infoIcon);
+    
+    const defaultMessage = getByText('Please input information!');
+    expect(defaultMessage).toBeInTheDocument();
   });
 });

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -701,6 +701,7 @@ function Index({ summary, weekIndex, allRoleInfo, auth, handleSpecialColorDotCli
             <RoleInfoModal
               info={allRoleInfo.find(item => item.infoName === `${summary.role}Info`)}
               auth={auth}
+              roleName={`${summary.role}Info`}
             />
           )}
         </div>


### PR DESCRIPTION
# Description
<img alt="image" src="https://github.com/user-attachments/assets/9a232b7f-a564-498d-a1a2-a2081b6fa777" />

## Main changes explained:
- **Fixed date input crashes**: Added robust `parseDate()` function that gracefully handles partial input during typing without throwing exceptions
- **Added real-time validation**: Implemented `validateDateFormat()` with MM/dd/yy regex validation and immediate error feedback
- **Resolved ISO format handling**: Fixed `convertDate()` function to properly process ISO date strings without timezone conversion issues
- **Fixed one-day-off bug**: Standardized date formatting in Task.jsx to prevent timezone-related display inconsistencies after page refresh
- **Enhanced UX**: Added format error messages ("Please enter date in MM/dd/yy format") and disabled save buttons when dates are invalid
- **Improved error handling**: Replaced crash-prone date parsing with silent fallbacks using empty catch blocks
- **Cleaned up notifications**: Removed duplicate success/error toast messages that were appearing twice
- **Code quality**: Used underscore convention for unused callback parameters (`_, __`) for cleaner function signatures

## How to test:
1. Check into current branch `Mohan-fix-task-date-edit-crash`
2. Do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. Log as owner user
5. Navigate to Dashboard → Projects → WBS → Any Task
6. **Test Edit Task Modal:**
   - Click "Edit" on any task
   - Try typing in Start Date and End Date fields (especially typing '2', '1', backspace)
   - Verify no crashes occur during partial input
   - Test with existing ISO format dates (2025-01-18T00:00:00.000Z)
   - Confirm format error messages appear for invalid dates
   - Verify save button is disabled when format errors exist
7. **Test Add Task Modal:**
   - Click "Add Task" 
   - Test date input validation with various formats
   - Confirm consistent behavior with Edit modal
8. **Test date consistency:**
   - Input a date (e.g., Jan 18, 2025)
   - Save the task
   - Refresh the page
   - Verify the date still shows correctly (no one-day-off bug)

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/ff515190-7ac3-4bb3-9aa3-c54ca240870e