### PR TITLE
fix: Resolved now able to see Report Page in Dark Mode also

### DIFF
--- a/src/components/Reports/Reports.jsx
+++ b/src/components/Reports/Reports.jsx
@@ -495,7 +495,7 @@ class ReportsPage extends Component {
 
     const isOxfordBlue = darkMode ? 'bg-oxford-blue' : '';
     const isYinmnBlue = darkMode ? 'bg-yinmn-blue' : '';
-    const textColor = darkMode ? 'text-light' : 'text-dark';
+    const textColor = darkMode ? 'text-blue-400' : 'text-dark';
     const boxStyling = darkMode ? boxStyleDark : boxStyle;
 
     return (


### PR DESCRIPTION
# Description
Please include the exact bug/functionality description and a summary of the changes/ related issues. Please also include any other relevant motivation and context:
In dark mode, the text was previously not visible due to its font color blending with the background. After updating the color styling based on the active mode, the text now appears in blue for dark mode and black for light mode.


## Related PRS (if any):
This frontend PR is related to the #XXX backend PR.
To test this backend PR you need to checkout the #XXX frontend PR.
…

## Main changes explained:
- Delete file A for removing unused components …
- Update file B for including new pattern …
- Create file C for introducing new components …
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ Reports→…
6. verify function “A” (feel free to include screenshot here)
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

After Changed in LightMode 
<img width="1220" height="574" alt="FontColour_LightMode" src="https://github.com/user-attachments/assets/0cf3e451-54f8-4bbc-82dd-79621abb18ca" />
After Changed in DarkMode
<img width="1514" height="680" alt="FontColour_DarkMode" src="https://github.com/user-attachments/assets/846e37f3-a54b-4177-8bdb-df075dc2993a" />


## Note:
Include the information the reviewers need to know.
