### PR TITLE
peterson-implement-no-teams-found-message-teams-page

### DIFF
--- a/src/components/Teams/CreateNewTeamPopup.jsx
+++ b/src/components/Teams/CreateNewTeamPopup.jsx
@@ -10,6 +10,9 @@ export const CreateNewTeamPopup = React.memo(props => {
 
   const [newTeam, setNewName] = useState('');
 
+  //prettier-ignore
+  setTimeout(() => props.isInputFilled && setNewName(props.nonexistentTeamName), 900);
+
   const closePopup = () => {
     props.onClose();
   };

--- a/src/components/Teams/CreateNewTeamPopup.jsx
+++ b/src/components/Teams/CreateNewTeamPopup.jsx
@@ -10,7 +10,7 @@ export const CreateNewTeamPopup = React.memo(props => {
 
   const [newTeam, setNewName] = useState('');
 
-  //prettier-ignore
+  // prettier-ignore
   setTimeout(() => props.isInputFilled && setNewName(props.nonexistentTeamName), 900);
 
   const closePopup = () => {

--- a/src/components/Teams/Team.css
+++ b/src/components/Teams/Team.css
@@ -1,3 +1,14 @@
+.team-not-found-message-container {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  align-items: center;
+}
+
+.team-not-found-message-container p {
+  margin-top: 20px;
+}
+
 thead {
   background: aliceblue;
 }
@@ -11,7 +22,7 @@ thead {
 }
 
 #teams__active {
-  width: 50px;  /* Increase to provide space */
+  width: 50px; /* Increase to provide space */
   text-align: center;
 }
 
@@ -52,12 +63,9 @@ thead {
   height: 100%;
 }
 
-
-
 .teams__overview--top {
   background: transparent;
 }
-
 
 .teams__overview--top .card {
   width: 200px;
@@ -109,7 +117,6 @@ thead {
 .isNotActive i {
   color: #dee2e6;
   margin-top: 0px;
-
 }
 
 .isNotActive {

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/sort-comp */
 import React from 'react';
 import { connect } from 'react-redux';
 import { Container } from 'reactstrap';
@@ -26,12 +25,15 @@ import CreateNewTeamPopup from './CreateNewTeamPopup';
 import DeleteTeamPopup from './DeleteTeamPopup';
 import TeamStatusPopup from './TeamStatusPopup';
 import EditableInfoModal from '../UserProfile/EditableModal/EditableInfoModal';
+import { Button } from 'reactstrap';
 
 class Teams extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
       teamNameSearchText: '',
+      nonexistentTeamName: '',
+      isInputFilled: false,
       teamMembersPopupOpen: false,
       deleteTeamPopupOpen: false,
       createNewTeamPopupOpen: false,
@@ -171,12 +173,43 @@ class Teams extends React.PureComponent {
     );
   }
 
+  openCreateTeamModal = () => {
+    this.setState({
+      isInputFilled: true,
+      nonexistentTeamName: this.state.wildCardSearchText,
+      createNewTeamPopupOpen: true,
+    });
+  };
+
   /**
    * Creates the table body elements after applying the search filter and return it.
    */
   teamTableElements = allTeams => {
+    const { darkMode } = this.props.state.theme;
     if (allTeams && allTeams.length > 0) {
       const teamSearchData = this.filteredTeamList(allTeams);
+      if (teamSearchData.length === 0) {
+        // Se nenhum time for encontrado, retorna uma linha de mensagem
+
+        this.nonexistentTeamName = this.state.wildCardSearchText;
+
+        return [
+          <tr key="no-teams">
+            <td colSpan="100%" style={{ textAlign: 'center' }}>
+              <div className="team-not-found-message-container">
+                <p className={`${darkMode ? 'text-light' : 'text-black'}`}>
+                  No team found, but you can create this team by clicking the blue button named
+                  "Create Team".
+                </p>
+
+                <Button onClick={this.openCreateTeamModal} color="primary">
+                  Create Team
+                </Button>
+              </div>
+            </td>
+          </tr>,
+        ];
+      }
       /*
        * Builiding the table body for teams returns
        * the rows for currently selected page .
@@ -253,6 +286,8 @@ class Teams extends React.PureComponent {
           fetching={fetching}
         />
         <CreateNewTeamPopup
+          nonexistentTeamName={this.nonexistentTeamName}
+          isInputFilled={this.state.isInputFilled}
           open={this.state.createNewTeamPopupOpen}
           onClose={this.onCreateNewTeamClose}
           onOkClick={this.addNewTeam}
@@ -357,6 +392,7 @@ class Teams extends React.PureComponent {
    */
   onCreateNewTeamShow = () => {
     this.setState({
+      isInputFilled: false,
       createNewTeamPopupOpen: true,
       selectedTeam: '',
     });

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Container } from 'reactstrap';
 import { toast } from 'react-toastify';
 import { searchWithAccent } from 'utils/search';
 import lo from 'lodash';
@@ -25,7 +24,7 @@ import CreateNewTeamPopup from './CreateNewTeamPopup';
 import DeleteTeamPopup from './DeleteTeamPopup';
 import TeamStatusPopup from './TeamStatusPopup';
 import EditableInfoModal from '../UserProfile/EditableModal/EditableInfoModal';
-import { Button } from 'reactstrap';
+import { Button, Container } from 'reactstrap';
 
 class Teams extends React.PureComponent {
   constructor(props) {
@@ -111,6 +110,24 @@ class Teams extends React.PureComponent {
     }
   }
 
+  toggleTeamActiveSort = () => {
+    let newSortState;
+    switch (this.state.sortTeamActiveState) {
+      case 'none':
+        newSortState = 'ascending';
+        break;
+      case 'ascending':
+        newSortState = 'descending';
+        break;
+      case 'descending':
+        newSortState = 'none';
+        break;
+      default:
+        throw new Error('Invalid sort state');
+    }
+    this.setState({ sortTeamActiveState: newSortState, sortTeamNameState: 'none' });
+  };
+
   render() {
     const { allTeams, fetching } = this.props.state.allTeamsData;
     const { darkMode } = this.props.state.theme;
@@ -174,11 +191,11 @@ class Teams extends React.PureComponent {
   }
 
   openCreateTeamModal = () => {
-    this.setState({
+    this.setState(prevState => ({
       isInputFilled: true,
-      nonexistentTeamName: this.state.wildCardSearchText,
+      nonexistentTeamName: prevState.wildCardSearchText,
       createNewTeamPopupOpen: true,
-    });
+    }));
   };
 
   /**
@@ -191,7 +208,7 @@ class Teams extends React.PureComponent {
       if (teamSearchData.length === 0) {
         // Se nenhum time for encontrado, retorna uma linha de mensagem
 
-        this.nonexistentTeamName = this.state.wildCardSearchText;
+        this.setState({ nonexistentTeamName: this.state.wildCardSearchText });
 
         return [
           <tr key="no-teams">
@@ -199,7 +216,7 @@ class Teams extends React.PureComponent {
               <div className="team-not-found-message-container">
                 <p className={`${darkMode ? 'text-light' : 'text-black'}`}>
                   No team found, but you can create this team by clicking the blue button named
-                  "Create Team".
+                  &quot;Create Team&quot;.
                 </p>
 
                 <Button onClick={this.openCreateTeamModal} color="primary">
@@ -286,7 +303,7 @@ class Teams extends React.PureComponent {
           fetching={fetching}
         />
         <CreateNewTeamPopup
-          nonexistentTeamName={this.nonexistentTeamName}
+          nonexistentTeamName={this.state.nonexistentTeamName}
           isInputFilled={this.state.isInputFilled}
           open={this.state.createNewTeamPopupOpen}
           onClose={this.onCreateNewTeamClose}
@@ -596,24 +613,6 @@ class Teams extends React.PureComponent {
         throw new Error('Invalid sort state');
     }
     this.setState({ sortTeamNameState: newSortState, sortTeamActiveState: 'none' });
-  };
-
-  toggleTeamActiveSort = () => {
-    let newSortState;
-    switch (this.state.sortTeamActiveState) {
-      case 'none':
-        newSortState = 'ascending';
-        break;
-      case 'ascending':
-        newSortState = 'descending';
-        break;
-      case 'descending':
-        newSortState = 'none';
-        break;
-      default:
-        throw new Error('Invalid sort state');
-    }
-    this.setState({ sortTeamActiveState: newSortState, sortTeamNameState: 'none' });
   };
 }
 export { Teams };

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { toast } from 'react-toastify';
 import { searchWithAccent } from 'utils/search';
 import lo from 'lodash';
+import { Button, Container } from 'reactstrap';
 import {
   getAllUserTeams,
   postNewTeam,
@@ -24,7 +25,6 @@ import CreateNewTeamPopup from './CreateNewTeamPopup';
 import DeleteTeamPopup from './DeleteTeamPopup';
 import TeamStatusPopup from './TeamStatusPopup';
 import EditableInfoModal from '../UserProfile/EditableModal/EditableInfoModal';
-import { Button, Container } from 'reactstrap';
 
 class Teams extends React.PureComponent {
   constructor(props) {
@@ -128,6 +128,24 @@ class Teams extends React.PureComponent {
     this.setState({ sortTeamActiveState: newSortState, sortTeamNameState: 'none' });
   };
 
+  toggleTeamNameSort = () => {
+    let newSortState;
+    switch (this.state.sortTeamNameState) {
+      case 'none':
+        newSortState = 'ascending';
+        break;
+      case 'ascending':
+        newSortState = 'descending';
+        break;
+      case 'descending':
+        newSortState = 'none';
+        break;
+      default:
+        throw new Error('Invalid sort state');
+    }
+    this.setState({ sortTeamNameState: newSortState, sortTeamActiveState: 'none' });
+  };
+
   render() {
     const { allTeams, fetching } = this.props.state.allTeamsData;
     const { darkMode } = this.props.state.theme;
@@ -208,7 +226,7 @@ class Teams extends React.PureComponent {
       if (teamSearchData.length === 0) {
         // Se nenhum time for encontrado, retorna uma linha de mensagem
 
-        this.setState({ nonexistentTeamName: this.state.wildCardSearchText });
+        this.setState(prevState => ({ nonexistentTeamName: prevState.wildCardSearchText }));
 
         return [
           <tr key="no-teams">
@@ -595,24 +613,6 @@ class Teams extends React.PureComponent {
         props: { ...team.props, index },
       }));
     this.setState({ sortedTeams });
-  };
-
-  toggleTeamNameSort = () => {
-    let newSortState;
-    switch (this.state.sortTeamNameState) {
-      case 'none':
-        newSortState = 'ascending';
-        break;
-      case 'ascending':
-        newSortState = 'descending';
-        break;
-      case 'descending':
-        newSortState = 'none';
-        break;
-      default:
-        throw new Error('Invalid sort state');
-    }
-    this.setState({ sortTeamNameState: newSortState, sortTeamActiveState: 'none' });
   };
 }
 export { Teams };

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -146,6 +146,41 @@ class Teams extends React.PureComponent {
     this.setState({ sortTeamNameState: newSortState, sortTeamActiveState: 'none' });
   };
 
+  sortTeams = () => {
+    const { teams, sortTeamNameState, sortTeamActiveState } = this.state;
+
+    if (!Array.isArray(teams)) {
+      return;
+    }
+    const sortedTeams = [...teams]
+      .sort((a, b) => {
+        const dateA = new Date(a.props.team.modifiedDatetime);
+        const dateB = new Date(b.props.team.modifiedDatetime);
+        const nameA = a.props.name;
+        const nameB = b.props.name;
+        const activeA = a.props.active;
+        const activeB = b.props.active;
+        if (sortTeamNameState === 'ascending') {
+          return nameA.localeCompare(nameB);
+        }
+        if (sortTeamNameState === 'descending') {
+          return nameB.localeCompare(nameA);
+        }
+        if (sortTeamActiveState === 'ascending') {
+          return activeA - activeB;
+        }
+        if (sortTeamActiveState === 'descending') {
+          return activeB - activeA;
+        }
+        return dateB - dateA;
+      })
+      .map((team, index) => ({
+        ...team,
+        props: { ...team.props, index },
+      }));
+    this.setState({ sortedTeams });
+  };
+
   render() {
     const { allTeams, fetching } = this.props.state.allTeamsData;
     const { darkMode } = this.props.state.theme;
@@ -578,41 +613,6 @@ class Teams extends React.PureComponent {
    */
   onDeleteTeamMember = deletedUserId => {
     this.props.deleteTeamMember(this.state.selectedTeamId, deletedUserId);
-  };
-
-  sortTeams = () => {
-    const { teams, sortTeamNameState, sortTeamActiveState } = this.state;
-
-    if (!Array.isArray(teams)) {
-      return;
-    }
-    const sortedTeams = [...teams]
-      .sort((a, b) => {
-        const dateA = new Date(a.props.team.modifiedDatetime);
-        const dateB = new Date(b.props.team.modifiedDatetime);
-        const nameA = a.props.name;
-        const nameB = b.props.name;
-        const activeA = a.props.active;
-        const activeB = b.props.active;
-        if (sortTeamNameState === 'ascending') {
-          return nameA.localeCompare(nameB);
-        }
-        if (sortTeamNameState === 'descending') {
-          return nameB.localeCompare(nameA);
-        }
-        if (sortTeamActiveState === 'ascending') {
-          return activeA - activeB;
-        }
-        if (sortTeamActiveState === 'descending') {
-          return activeB - activeA;
-        }
-        return dateB - dateA;
-      })
-      .map((team, index) => ({
-        ...team,
-        props: { ...team.props, index },
-      }));
-    this.setState({ sortedTeams });
   };
 }
 export { Teams };


### PR DESCRIPTION
# Description
This open PR was created to implement a message when no team is found in the teams table.

## Related PRS (if any):
None

## Main changes explained:
The CreateNewTeamPopup.jsx component has been modified to fix the bug.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an admin or owner user.
5. Go to Other Links → Teams
6. Click on the input above the table, type the name of a team that doesn't exist, and a message with a button should appear. After clicking the button, a modal will open and the input should receive the name of the non-existent team.

## Screenshots or videos of changes:
### Before my fix:
![Before my fix](https://github.com/user-attachments/assets/4a4510d4-43be-4b33-8c81-fcd3ca7bc5d2)

### After my fix:
![After my fix](https://github.com/user-attachments/assets/0c12e033-ac3d-4fb6-9a0b-80e9518d5930)

## Note:
None