### PR TITLE
Akshay -  Fix - PeopleReport layout collapse

### DIFF
--- a/src/components/Reports/PeopleReport/PeopleReport.css
+++ b/src/components/Reports/PeopleReport/PeopleReport.css
@@ -218,7 +218,7 @@ body {
 
 .people-report-time-log-block {
   /* max-height: 100px; */
-  width: 270px;
+  width: 220px;
   white-space: nowrap;
   margin-bottom: 16px;
 }

--- a/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
+++ b/src/components/Reports/sharedComponents/ReportPage/ReportPage.css
@@ -32,12 +32,15 @@
   width: 100%;
 }
 
-@media (max-width: 1300px) {
+@media (max-width: 1100px) {
   .report-page-wrapper {
     display: flex;
     flex-direction: column;
     padding: 40px;
     align-items: center;
+  }
+  .report-page-content {
+    padding: 24px;
   }
 }
 

--- a/src/components/Reports/sharedComponents/ReportPage/components/ReportHeader/ReportHeader.css
+++ b/src/components/Reports/sharedComponents/ReportPage/components/ReportHeader/ReportHeader.css
@@ -3,6 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-top: 20px;
 }
 
 .report-header-details {


### PR DESCRIPTION
# Description
<img width="730" height="227" alt="image" src="https://github.com/user-attachments/assets/b6dedc34-2f54-4de8-ae7e-e74b7086a108" />

## Related PRS (if any):
This frontend PR is not related to any backend PR.


## Main changes explained:
- Update ReportPage.css to delay the layout collapse



## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links→ User Management
6. Open any user’s People Report and verify that the layout collapse occurs at a smaller screen width than before.
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/3f787b9e-79df-458c-9a09-93ca79ddcadc


