### PR TITLE
Strallia - fix layout of total org summary page

### DIFF
--- a/src/components/TotalOrgSummary/AccordianWrapper/AccordianWrapper.css
+++ b/src/components/TotalOrgSummary/AccordianWrapper/AccordianWrapper.css
@@ -4,6 +4,8 @@
   border-radius: 15px;
   margin: 10px;
   box-shadow: 1px 1px #e0e0e0;
+  margin-left: 20px;
+  margin-right: 20px;
 }
 
 .Collapsible__contentInner {

--- a/src/components/TotalOrgSummary/AnniversaryCelebrated/AnniversaryCelebrated.jsx
+++ b/src/components/TotalOrgSummary/AnniversaryCelebrated/AnniversaryCelebrated.jsx
@@ -119,7 +119,7 @@ export default function AnniversaryCelebrated({ isLoading, data, darkMode }) {
       )}
 
       {/* List of anniversaries */}
-      <ul className="w-90 overflow-auto" style={{ maxHeight: '220px' }}>
+      <ul className="w-90 overflow-auto" style={{ maxHeight: '410px' }}>
         {sixMonthsData.users.map(item => getAnniversaryListItem(item, 6))}
         {oneYearData.users.map(item => getAnniversaryListItem(item, 12))}
       </ul>

--- a/src/components/TotalOrgSummary/HoursCompleted/HoursCompletedBarChart.jsx
+++ b/src/components/TotalOrgSummary/HoursCompleted/HoursCompletedBarChart.jsx
@@ -136,8 +136,8 @@ export default function HoursCompletedBarChart({ isLoading, data, darkMode }) {
   return (
     <div
       style={{
-        height: '548px',
-        minHeight: '548px',
+        height: '380px',
+        minHeight: '300px',
         maxHeight: '548px',
         display: 'flex',
         flexDirection: 'column',

--- a/src/components/TotalOrgSummary/HoursCompleted/HoursCompletedBarChart.jsx
+++ b/src/components/TotalOrgSummary/HoursCompleted/HoursCompletedBarChart.jsx
@@ -149,13 +149,14 @@ export default function HoursCompletedBarChart({ isLoading, data, darkMode }) {
             fontSize: '13px',
             fontWeight: 500,
             color: darkMode ? 'white' : '#222',
-            marginTop: 4,
-            marginBottom: 8,
             display: 'grid',
+            justifyItems: 'center',
           }}
         >
-          {`${data.hoursSubmittedToTasksPercentage *
-            100}% of Total Tangible Hours Submitted to Tasks`}
+          <span style={{ maxWidth: 200 }}>
+            {`${data.hoursSubmittedToTasksPercentage *
+              100}% of Total Tangible Hours Submitted to Tasks`}
+          </span>
           {(() => {
             const isPositive = data.hoursSubmittedToTasksComparisonPercentage >= 0;
             let color;

--- a/src/components/TotalOrgSummary/TaskCompleted/TaskCompletedBarChart.jsx
+++ b/src/components/TotalOrgSummary/TaskCompleted/TaskCompletedBarChart.jsx
@@ -71,8 +71,8 @@ export default function TaskCompletedBarChart({ isLoading, data, darkMode }) {
   return (
     <div
       style={{
-        height: '548px',
-        minHeight: '548px',
+        height: '380px',
+        minHeight: '300px',
         maxHeight: '548px',
         display: 'flex',
         flexDirection: 'column',

--- a/src/components/TotalOrgSummary/TaskCompleted/TaskCompletedBarChart.jsx
+++ b/src/components/TotalOrgSummary/TaskCompleted/TaskCompletedBarChart.jsx
@@ -79,7 +79,6 @@ export default function TaskCompletedBarChart({ isLoading, data, darkMode }) {
       }}
     >
       <div style={{ textAlign: 'center', marginBottom: 0 }} />
-      <div style={{ height: 47 }} />
       <div style={{ flex: 1, minHeight: 0 }}>
         {isLoading ? (
           <div className="d-flex justify-content-center align-items-center">

--- a/src/components/TotalOrgSummary/TinyBarChart.jsx
+++ b/src/components/TotalOrgSummary/TinyBarChart.jsx
@@ -59,7 +59,7 @@ export default function TinyBarChart(props) {
   } = props;
 
   return (
-    <ResponsiveContainer maxWidth={600} maxHeight={600} minWidth={180} minHeight={340}>
+    <ResponsiveContainer maxWidth={600} maxHeight={400} minWidth={180} minHeight={340}>
       <BarChart
         data={chartData}
         margin={{

--- a/src/components/TotalOrgSummary/TinyBarChart.jsx
+++ b/src/components/TotalOrgSummary/TinyBarChart.jsx
@@ -59,7 +59,7 @@ export default function TinyBarChart(props) {
   } = props;
 
   return (
-    <ResponsiveContainer maxWidth={600} maxHeight={340} minWidth={180} minHeight={340}>
+    <ResponsiveContainer maxWidth={600} maxHeight={600} minWidth={180} minHeight={340}>
       <BarChart
         data={chartData}
         margin={{

--- a/src/components/TotalOrgSummary/TotalOrgSummary.css
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.css
@@ -196,6 +196,8 @@
   display: flex;
   justify-content: space-between;
   gap: 20px;
+  margin: 0 !important;
+  padding: 0px 20px;
 }
 
 .report-header-title h3 {
@@ -224,4 +226,9 @@
 
 .chart-title.dark-mode p {
   color: white;
+}
+
+.Collapsible {
+  margin-left: 20px !important;
+  margin-right: 20px !important;
 }

--- a/src/components/TotalOrgSummary/TotalOrgSummary.css
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.css
@@ -184,11 +184,12 @@
 }
 
 .chart-title p {
-  font-size: 1.5em !important;
+  font-size: 1.8rem !important;
   font-weight: bold;
   text-align: center;
   margin: 10px;
   color: #333;
+  line-height: 1.3 !important;
 }
 
 /* Report Header Styles */

--- a/src/components/TotalOrgSummary/TotalOrgSummary.css
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.css
@@ -193,7 +193,7 @@
 }
 
 /* Report Header Styles */
-.report-header-row {
+.total-org-report-header-row {
   display: flex;
   justify-content: space-between;
   gap: 20px;
@@ -227,9 +227,4 @@
 
 .chart-title.dark-mode p {
   color: white;
-}
-
-.Collapsible {
-  margin-left: 20px !important;
-  margin-right: 20px !important;
 }

--- a/src/components/TotalOrgSummary/TotalOrgSummary.css
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.css
@@ -15,7 +15,7 @@
   background-color: #1c2541;
 }
 
-.container-total-org-wrapper.bg-oxford-blue .chart-title p {
+.container-total-org-wrapper.bg-oxford-blue .total-org-chart-title p {
   color: #fff !important;
 }
 
@@ -183,7 +183,7 @@
   text-overflow: ellipsis;
 }
 
-.chart-title p {
+.total-org-chart-title p {
   font-size: 1.8rem !important;
   font-weight: bold;
   text-align: center;
@@ -225,6 +225,6 @@
   color: #fff !important;
 }
 
-.chart-title.dark-mode p {
+.total-org-chart-title.dark-mode p {
   color: white;
 }

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -318,7 +318,7 @@ function TotalOrgSummary(props) {
           overflow: hidden !important;
           text-overflow: ellipsis !important;
         }
-        .chart-title p {
+        .total-org-chart-title p {
           font-size: 1.5em !important;
           font-weight: bold !important;
           text-align: center !important;
@@ -571,7 +571,7 @@ function TotalOrgSummary(props) {
         <Row>
           <Col lg={{ size: 6 }}>
             <div className="component-container component-border">
-              <div className={`chart-title ${darkMode ? 'dark-mode' : ''}`}>
+              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
                 <p>Global Volunteer Network: Uniting Communities Worldwide</p>
               </div>
               <GlobalVolunteerMap isLoading={isLoading} locations={volunteerStats?.userLocations} />
@@ -579,7 +579,7 @@ function TotalOrgSummary(props) {
           </Col>
           <Col lg={{ size: 6 }}>
             <div className="component-container component-border">
-              <div className={`chart-title ${darkMode ? 'dark-mode' : ''}`}>
+              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
                 <p>Volunteer Status</p>
               </div>
               <VolunteerStatusChart
@@ -595,7 +595,7 @@ function TotalOrgSummary(props) {
         <Row>
           <Col lg={{ size: 6 }}>
             <div className="component-container component-border">
-              <div className={`chart-title ${darkMode ? 'dark-mode' : ''}`}>
+              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
                 <p>Volunteer Hours Distribution</p>
               </div>
               <div
@@ -621,7 +621,7 @@ function TotalOrgSummary(props) {
           </Col>
           <Col lg={{ size: 3 }}>
             <div className="component-container component-border">
-              <div className={`chart-title ${darkMode ? 'dark-mode' : ''}`}>
+              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
                 <p>Task Completed</p>
               </div>
               <div className="mt-4">
@@ -635,7 +635,7 @@ function TotalOrgSummary(props) {
           </Col>
           <Col lg={{ size: 3 }}>
             <div className="component-container component-border">
-              <div className={`chart-title ${darkMode ? 'dark-mode' : ''}`}>
+              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
                 <p>Hours Completed</p>
               </div>
               <div className="mt-4">
@@ -654,7 +654,7 @@ function TotalOrgSummary(props) {
         <Row>
           <Col lg={{ size: 7 }}>
             <div className="component-container component-border">
-              <div className={`chart-title ${darkMode ? 'dark-mode' : ''}`}>
+              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
                 <p>Volunteer Trends by Time</p>
               </div>
               <VolunteerTrendsLineChart darkMode={darkMode} />
@@ -662,7 +662,7 @@ function TotalOrgSummary(props) {
           </Col>
           <Col lg={{ size: 5 }}>
             <div className="component-container component-border">
-              <div className={`chart-title ${darkMode ? 'dark-mode' : ''}`}>
+              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
                 <p>Anniversary Celebrated</p>
               </div>
               <AnniversaryCelebrated
@@ -679,7 +679,7 @@ function TotalOrgSummary(props) {
         <Row>
           <Col lg={{ size: 7 }}>
             <div className="component-container component-border">
-              <div className={`chart-title ${darkMode ? 'dark-mode' : ''}`}>
+              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
                 <p>Work Distribution</p>
               </div>
               <WorkDistributionBarChart
@@ -691,7 +691,7 @@ function TotalOrgSummary(props) {
           </Col>
           <Col lg={{ size: 5 }}>
             <div className="component-container component-border">
-              <div className={`chart-title ${darkMode ? 'dark-mode' : ''}`}>
+              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
                 <p>Role Distribution</p>
               </div>
               <RoleDistributionPieChart
@@ -708,7 +708,7 @@ function TotalOrgSummary(props) {
         <Row>
           <Col lg={{ size: 6 }}>
             <div className="component-container component-border">
-              <div className={`chart-title ${darkMode ? 'dark-mode' : ''}`}>
+              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
                 <p>Team Stats</p>
               </div>
               <TeamStats
@@ -721,7 +721,7 @@ function TotalOrgSummary(props) {
           </Col>
           <Col lg={{ size: 6 }}>
             <div className="component-container component-border">
-              <div className={`chart-title ${darkMode ? 'dark-mode' : ''}`}>
+              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
                 <p>Blue Square Stats</p>
               </div>
               <BlueSquareStats

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -444,7 +444,7 @@ function TotalOrgSummary(props) {
         darkMode ? 'bg-oxford-blue text-light' : 'cbg--white-smoke'
       }`}
     >
-      <Row className="report-header-row">
+      <Row className="total-org-report-header-row">
         <div className="report-header-title">
           <h3 className="my-0">Total Org Summary</h3>
         </div>

--- a/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsLineChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsLineChart.jsx
@@ -1,10 +1,10 @@
 import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts';
-import './styles.css';
 import { useEffect, useState } from 'react';
 import { ENDPOINTS } from 'utils/URL';
 import axios from 'axios';
 import Loading from 'components/common/Loading';
 import DatePicker from 'react-datepicker';
+import styles from './VolunteerTrendsStyles.module.css';
 import 'react-datepicker/dist/react-datepicker.css';
 
 const formatChartData = rawData => {
@@ -201,9 +201,9 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
   }
 
   return (
-    <div className="chart-container">
+    <div className={styles.chartContainer}>
       {/* DATE FILTERS */}
-      <div className="date-filter-container">
+      <div className={styles.dateFilterContainer}>
         <select name="timeframe-filter" id="timeframe-filter" onChange={setTimeframeFilter}>
           <option value="years1">This year</option>
           <option value="years2">Last 2 years</option>
@@ -221,24 +221,26 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
       </div>
 
       {/* DATE PICKER */}
-      <div className="date-picker-container">
-        {showDatePicker && (
-          <DatePicker
-            selected={customStartDate}
-            onChange={handleCustomDateRange}
-            startDate={customStartDate}
-            endDate={customEndDate}
-            selectsRange
-            inline
-            dateFormat="MM-dd-yyyy"
-            className="date-picker"
-          />
-        )}
+      <div className={styles.datePickerContainer}>
+        <div className={styles.datePickerPostion}>
+          {showDatePicker && (
+            <DatePicker
+              selected={customStartDate}
+              onChange={handleCustomDateRange}
+              startDate={customStartDate}
+              endDate={customEndDate}
+              selectsRange
+              inline
+              dateFormat="MM-dd-yyyy"
+              className="date-picker"
+            />
+          )}
+        </div>
       </div>
 
       {/* CUSTOM DATE RANGE */}
       {customDateRange.every(date => date) && (
-        <div className="custom-date-range">
+        <div className={styles.customDateRange}>
           <span>{dateToYYYYMMDD(customDateRange[0])}</span> to{' '}
           <span>{dateToYYYYMMDD(customDateRange[1])}</span>
         </div>

--- a/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsStyles.module.css
+++ b/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsStyles.module.css
@@ -1,15 +1,15 @@
-.date-picker-container {
+.datePickerContainer {
   position: relative;
 }
 
-.react-datepicker {
+.datePickerPostion {
   position: absolute !important;
   z-index: 1;
-  transform: translateX(-50%);
-  box-shadow: 2px 4px 8px rgba(0, 0, 0, 0.2);
+  transform: translateX(25%);
+  height: min-content;
 }
 
-.chart-container {
+.chartContainer {
   display: grid;
   justify-content: center;
   text-align: center;
@@ -18,28 +18,28 @@
   margin-top: 15px;
 }
 
-.custom-date-range {
+.customDateRange {
   margin-top: 8px;
 }
 
-.custom-date-range > span {
+.customDateRange > span {
   font-weight: bold;
 }
 
-.date-filter-container {
+.dateFilterContainer {
   display: flex;
   gap: 10px;
   align-items: center;
   justify-content: center;
 }
 
-.date-filter-container > select {
+.dateFilterContainer > select {
   margin-top: 0;
   width: min-content;
 }
 
 @media (max-width: 500px) {
-  .chart-container {
+  .chartContainer {
     justify-content: start;
     overflow: scroll;
   }

--- a/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsStyles.module.css
+++ b/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsStyles.module.css
@@ -5,7 +5,8 @@
 .datePickerPostion {
   position: absolute !important;
   z-index: 1;
-  transform: translateX(25%);
+  left: 50%;
+  transform: translateX(-50%);
   height: min-content;
 }
 


### PR DESCRIPTION
# Description
This PR fixes the overall layout of components on the Total Org Summary page. Fixes include:
- Margin/padding around entire page
- Font size and overlapping of title text
- Hidden components on Volunteer Trends by Time chart
- Height of multiple charts

<img width="727" height="511" alt="Screenshot 2025-07-25 at 3 34 10 PM" src="https://github.com/user-attachments/assets/c94139b8-12cb-49c5-b785-7df3e1a77122" />

<img width="723" height="330" alt="Screenshot 2025-07-25 at 3 38 40 PM" src="https://github.com/user-attachments/assets/56db2d86-1b1d-4b0c-a853-2ce5c8339415" />


<img width="726" height="406" alt="Screenshot 2025-07-25 at 3 33 52 PM" src="https://github.com/user-attachments/assets/45a4b1cd-9c17-4771-aeed-7aa2fec944fd" />

## How to test:
1. check into current branch
2. do `npm install` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Repots → Total Org Summary
6. verify the relevant component/charts looks like the images above.

