### PR TITLE
Venkataramanan. Fix weekly summary report refresh issue when updating team code.

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -895,16 +895,6 @@ const WeeklySummariesReport = props => {
           })
           .filter(Boolean);
 
-        if (!selectedCodes.find(code => code.value === newTeamCode)) {
-          const ids = teamCodeWithUserId[newTeamCode];
-          if (newTeamCode !== undefined && newTeamCode.length > 0) {
-            selectedCodes.push({
-              label: `${newTeamCode} (${teamCodeCounts[newTeamCode]})`,
-              value: newTeamCode,
-              _ids: ids,
-            });
-          }
-        }
         // Sort teamCodes by label
         teamCodes
           .sort((a, b) => a.label.localeCompare(b.label))


### PR DESCRIPTION
# Description
This PR is to fix the issue in weekly summary reports page when user updates team code and the page auto refreshes and filters for the team code.

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change file WeeklySummaryReport.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports -> Weekly Summary Report
6. Update a team code and check if it updates the database and not refresh the page.
