### PR TITLE
Venkataramanan - 🔥 Weekly summary report to show only active team codes and refresh…

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -97,6 +97,7 @@ function FormattedReport({
   darkMode,
   handleTeamCodeChange,
   handleSpecialColorDotClick,
+  getWeeklySummariesReport,
 }) {
   const dispatch = useDispatch();
   const isEditCount = dispatch(hasPermission('totalValidWeeklySummaries'));
@@ -168,6 +169,7 @@ function FormattedReport({
               auth={auth}
               handleSpecialColorDotClick={handleSpecialColorDotClick}
               isFinalWeek={isFinalWeek}
+              getWeeklySummariesReport={getWeeklySummariesReport}
             />
           );
         })}
@@ -285,6 +287,7 @@ function ReportDetails({
   handleTeamCodeChange,
   auth,
   handleSpecialColorDotClick,
+  getWeeklySummariesReport,
   isFinalWeek, // new prop
 }) {
   const [filteredBadges, setFilteredBadges] = useState([]);
@@ -324,6 +327,7 @@ function ReportDetails({
                 summary={summary}
                 handleTeamCodeChange={handleTeamCodeChange}
                 darkMode={darkMode}
+                getWeeklySummariesReport={getWeeklySummariesReport}
               />
             </ListGroupItem>
             <ListGroupItem darkMode={darkMode}>
@@ -432,10 +436,17 @@ function WeeklySummaryMessage({ summary, weekIndex }) {
   );
 }
 
-function TeamCodeRow({ canEditTeamCode, summary, handleTeamCodeChange, darkMode }) {
+function TeamCodeRow({
+  canEditTeamCode,
+  summary,
+  handleTeamCodeChange,
+  darkMode,
+  getWeeklySummariesReport,
+}) {
   const [teamCode, setTeamCode] = useState(summary.teamCode);
   const [hasError, setHasError] = useState(false);
   const fullCodeRegex = /^.{5,7}$/;
+  const dispatch = useDispatch();
 
   const handleOnChange = async (userProfileSummary, newStatus) => {
     const url = ENDPOINTS.USERS_ALLTEAMCODE_CHANGE;
@@ -444,6 +455,7 @@ function TeamCodeRow({ canEditTeamCode, summary, handleTeamCodeChange, darkMode 
       handleTeamCodeChange(userProfileSummary.teamCode, newStatus, {
         [userProfileSummary._id]: true,
       }); // Update the team code dynamically
+      await dispatch(getWeeklySummariesReport());
     } catch (err) {
       // eslint-disable-next-line no-alert
       alert(

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -277,7 +277,7 @@ const WeeklySummariesReport = props => {
       // Shallow copy and sort
       let summariesCopy = [...summaries];
       summariesCopy = alphabetize(summariesCopy);
-
+      summariesCopy = summariesCopy.filter(summary => summary?.isActive !== false);
       // Add new key of promised hours by week
       summariesCopy = summariesCopy.map(summary => {
         const promisedHoursByWeek = weekDates.map(weekDate =>
@@ -1538,6 +1538,7 @@ const WeeklySummariesReport = props => {
                               darkMode={darkMode}
                               handleTeamCodeChange={handleTeamCodeChange}
                               loadTrophies={state.loadTrophies}
+                              getWeeklySummariesReport={getWeeklySummariesReport}
                               handleSpecialColorDotClick={handleSpecialColorDotClick}
                             />
                           </Col>


### PR DESCRIPTION
# Description
This PR fixes the issue where inactive team codes were present in the dropdown and also adds a refresh everytime the team code is updated.

## Related PRS (if any):
This PR is not related to any other PR.

## Main changes explained:
- Change file WeeklySummariesReport.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Report -> Weekly summary report
6. Check if active team codes are only present in the dropdown.
7. Check if team code updates properly.