### PR TITLE
Venkataramanan. Fix: team member task icons to bolder icons

### DIFF
--- a/src/components/TeamMemberTasks/FollowUpInfoModal.jsx
+++ b/src/components/TeamMemberTasks/FollowUpInfoModal.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faInfo } from '@fortawesome/free-solid-svg-icons';
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import './FollowUpInfoModal.css';
 import { useSelector } from 'react-redux';
 
@@ -25,7 +25,7 @@ function FollowUpInfoModal() {
       <button className="followup-tooltip-button" aria-label="Tooltip button" type="button">
         <FontAwesomeIcon
           className="followup-tooltip-button-icon"
-          icon={faInfo}
+          icon={faCircleInfo}
           style={{ color: darkMode ? 'silver' : 'black' }}
         />
       </button>

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -3,8 +3,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faBell,
   faCircle,
-  faCheck,
-  faTimes,
+  faCheckCircle,
+  faTimesCircle,
   faExpandArrowsAlt,
   faCompressArrowsAlt,
 } from '@fortawesome/free-solid-svg-icons';
@@ -407,7 +407,7 @@ const TeamMemberTask = React.memo(
                                       {isAllowedToResolveTasks && (
                                         <FontAwesomeIcon
                                           className="team-member-tasks-done"
-                                          icon={faCheck}
+                                          icon={faCheckCircle}
                                           title="Mark as Done"
                                           onClick={() => {
                                             handleMarkAsDoneModal(user.personId, task);
@@ -419,7 +419,7 @@ const TeamMemberTask = React.memo(
                                       {(canUpdateTask || canDeleteTask) && (
                                         <FontAwesomeIcon
                                           className="team-member-task-remove"
-                                          icon={faTimes}
+                                          icon={faTimesCircle}
                                           title="Remove User from Task"
                                           onClick={() => {
                                             handleRemoveFromTaskModal(user.personId, task);


### PR DESCRIPTION
# Description
This PR changes the icons used in team member tasks table to bolder ones.

## Related PRS (if any):
This is not related to any other PRs. 

## Main changes explained:
- Change file:
- TeamMemberTask.jsx
- FollowUpInfoModal.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Team member tasks table.
6. Verify if all icons are good.

## Screenshots or videos of changes:
<img width="1600" height="899" alt="image" src="https://github.com/user-attachments/assets/0c03d50a-28c3-49bd-9437-8df2eb96fcac" />
