### PR TITLE
Jaden Taking Over For Peterson: Improved The Appearance Of The Loading Message On Permissions Page (DONE Jaden)

### DIFF
--- a/src/components/PermissionsManagement/PermissionsManagement.jsx
+++ b/src/components/PermissionsManagement/PermissionsManagement.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useContext } from 'react';
 import axios from 'axios';
 
-import { Button, Modal, ModalBody, ModalHeader } from 'reactstrap';
+import { Button, Modal, ModalBody, ModalHeader, Spinner } from 'reactstrap';
 import styles from './PermissionsManagement.module.css';
 import { connect, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -261,7 +261,17 @@ function PermissionsManagement({ roles, auth, getUserRole, userProfile, darkMode
           </Modal>
         </div>
       </div>
-      {loading && <p className={styles['loading-message']}>Loading...</p>}
+      {loading && (
+        <div className={styles['loading-message-div']}>
+          <p
+            data-testid="loading-message"
+            className={`${styles['loading-message']} ${darkMode ? 'text-light' : 'text-dark'} mb-2`}
+          >
+            Loading...
+          </p>
+          <Spinner color="primary" />
+        </div>
+      )}
       {error && (
         <p data-testid="error-message" className={styles['error-message']}>
           {error}

--- a/src/components/PermissionsManagement/PermissionsManagement.module.css
+++ b/src/components/PermissionsManagement/PermissionsManagement.module.css
@@ -186,6 +186,14 @@
   background-color: #2f4157;
 }
 
+.loading-message-div {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
 .loading-message {
   font-size: 30px;
 }

--- a/src/components/PermissionsManagement/__tests__/PermissionsManagement.test.jsx
+++ b/src/components/PermissionsManagement/__tests__/PermissionsManagement.test.jsx
@@ -158,7 +158,7 @@ describe('PermissionsManagement', () => {
   it('displays loading message while fetching data', async () => {
     axios.get.mockImplementation(() => new Promise(() => {}));
     await renderComponent();
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-message')).toBeInTheDocument();
   });
 
   describe('Permission-based Rendering', () => {


### PR DESCRIPTION
Jaden Taking Over For Peterson: Improved The Appearance Of The Loading Message On Permissions Page (DONE Jaden) #3854

# Description
This open PR was created to improve the loading message on the permissions page.

## Related PRS (if any):
None.

## Main changes explained:
The PermissionsManagement.jsx component has been modified to improve the loading message.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an admin or owner user
5. go to Other Links → Permissions Management → Manage User Permissions
6. This page has a table, but before the table appears, a loading message will be shown. Check if the message text is white in dark theme or black in light theme. Furthermore, the message needs to be centered on the screen.

## Screenshots or videos of changes:
<img width="1689" height="937" alt="Screenshot 2026-07-03 at 11 43 28 PM" src="https://github.com/user-attachments/assets/bbf3e6e1-b99f-45f8-89d5-91549c6590ed" />

## Note:
None.