### PR TITLE
Kedarnath - change .css to .module.css in  /promotiontable

### DIFF
--- a/src/components/QuestionnaireDashboard/PromotionTable.jsx
+++ b/src/components/QuestionnaireDashboard/PromotionTable.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import styles from './PromotionTable.module.css';
 
 const names = ['Alice', 'Bob', 'Charlie'];
 const dummyMembers = Array.from({ length: 45 }, (_, i) => ({
@@ -33,20 +34,20 @@ function PromotionTable() {
   if (loading) return <div>Loading promotions...</div>;
 
   return (
-    <div className="container">
-      <div className="header">
+    <div className={styles.container}>
+      <div className={styles.header}>
         <h1>Promotion Eligibility</h1>
-        <div className="actions">
-          <button type="button" className="btn btn-secondary">
+        <div className={styles.actions}>
+          <button type="button" className={`${styles.btn} ${styles.btnSecondary}`}>
             Review for this week
           </button>
-          <button type="button" className="btn btn-primary">
+          <button type="button" className={`${styles.btn} ${styles.btnPrimary}`}>
             Process Promotions
           </button>
         </div>
       </div>
 
-      <table className="promotion-table">
+      <table className={styles.promotionTable}>
         <thead>
           <tr>
             <th style={{ width: '15%' }}>Existing member/ New member</th>
@@ -60,43 +61,51 @@ function PromotionTable() {
         </thead>
         <tbody>
           {/* --- New Members Section --- */}
-          <tr className="section-header">
+          <tr className={styles.sectionHeader}>
             <td colSpan="7">New Members</td>
           </tr>
           {newMembers.map(user => (
             <tr key={user.id}>
               <td />
               <td>{user.reviewer}</td>
-              <td className={user.hasMetWeekly ? 'status-met' : 'status-not-met'}>
-                <span className="status-icon">{user.hasMetWeekly ? '✓' : '✗'}</span>
+              <td className={user.hasMetWeekly ? styles.statusMet : styles.statusNotMet}>
+                <span className={styles.statusIcon}>{user.hasMetWeekly ? '✓' : '✗'}</span>
                 {user.hasMetWeekly ? 'Has Met' : 'Has not Met'}
               </td>
               <td>{user.requiredPRs}</td>
               <td>{user.totalReviews}</td>
               <td>{user.remainingWeeks}</td>
               <td>
-                <input className="promote-checkbox" type="checkbox" defaultChecked={user.promote} />
+                <input
+                  className={styles.promoteCheckbox}
+                  type="checkbox"
+                  defaultChecked={user.promote}
+                />
               </td>
             </tr>
           ))}
 
           {/* --- Existing Members Section --- */}
-          <tr className="section-header">
+          <tr className={styles.sectionHeader}>
             <td colSpan="7">Existing Members</td>
           </tr>
           {existingMembers.map(user => (
             <tr key={user.id}>
               <td />
               <td>{user.reviewer}</td>
-              <td className={user.hasMetWeekly ? 'status-met' : 'status-not-met'}>
-                <span className="status-icon">{user.hasMetWeekly ? '✓' : '✗'}</span>
+              <td className={user.hasMetWeekly ? styles.statusMet : styles.statusNotMet}>
+                <span className={styles.statusIcon}>{user.hasMetWeekly ? '✓' : '✗'}</span>
                 {user.hasMetWeekly ? 'Has Met' : 'Has not Met'}
               </td>
               <td>{user.requiredPRs}</td>
               <td>{user.totalReviews}</td>
               <td>{user.remainingWeeks}</td>
               <td>
-                <input className="promote-checkbox" type="checkbox" defaultChecked={user.promote} />
+                <input
+                  className={styles.promoteCheckbox}
+                  type="checkbox"
+                  defaultChecked={user.promote}
+                />
               </td>
             </tr>
           ))}

--- a/src/components/QuestionnaireDashboard/PromotionTable.module.css
+++ b/src/components/QuestionnaireDashboard/PromotionTable.module.css
@@ -35,13 +35,13 @@
   cursor: pointer;
 }
 
-.btn-primary {
+.btnPrimary {
   background-color: #2c974b;
   color: #ffffff;
   border-color: #2c974b;
 }
 
-.btn-secondary {
+.btnSecondary {
   background-color: #f6f8fa;
   color: #24292e;
 }
@@ -54,48 +54,48 @@
   margin-right: 0;
 }
 
-.promotion-table {
+.promotionTable {
   width: 100%;
   border-collapse: collapse;
 }
 
-.promotion-table th,
-.promotion-table td {
+.promotionTable th,
+.promotionTable td {
   padding: 12px 16px;
   text-align: left;
   font-size: 14px;
   border-bottom: 1px solid #e1e4e8;
 }
 
-.promotion-table thead th {
+.promotionTable thead th {
   background-color: #f6f8fa;
   font-weight: 600;
 }
 
-.promotion-table tbody tr:last-child td {
+.promotionTable tbody tr:last-child td {
   border-bottom: none;
 }
 
-.section-header td {
+.sectionHeader td {
   background-color: #f6f8fa;
   font-weight: bold;
   color: #586069;
 }
 
-.status-met {
+.statusMet {
   color: #22863a;
 }
 
-.status-not-met {
+.statusNotMet {
   color: #cb2431;
 }
 
-.status-icon {
+.statusIcon {
   font-weight: bold;
   margin-right: 8px;
 }
 
-.promote-checkbox {
+.promoteCheckbox {
   width: 20px;
   height: 20px;
   cursor: pointer;


### PR DESCRIPTION
# Description
Renaming these files from .css to .module.css and updating their imports ensures style encapsulation, prevents global style bleeding, and improves maintainability.

affected path: /src/components/QuestionnaireDashboard/PromotionTable.jsx


## Related PRS (if any):
Related PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3851
Backend PR: https://github.com/OneCommunityGlobal/HGNRest/pull/1549

## Main changes explained:
Renaming these files from .css to .module.css and updating their imports ensures style encapsulation, prevents global style bleeding, and improves maintainability.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to go to /promotiontable
6. verify if UI is the same in current branch and related branch

## Screenshots or videos of changes:
<img width="1889" height="751" alt="image" src="https://github.com/user-attachments/assets/bbd2f834-b4dd-47a2-a0e4-a9685fcbc904" />

