### PR TITLE
Kedarnath - PR Admin Dashboard: Change .css to .module.css in /pr-dashboard

### DIFF
--- a/src/components/PRDashboard.jsx
+++ b/src/components/PRDashboard.jsx
@@ -1,8 +1,11 @@
+/* eslint-disable react/no-unescaped-entities */
+import styles from './PRDashboard.module.css';
+
 function PRDashboard() {
   return (
-    <div style={{ padding: '2rem' }}>
+    <div className={styles.container}>
       <h1>PR Team Dashboard</h1>
-      <p>This is the PR Team’s dashboard view. Add content here as needed.</p>
+      <p>This is the PR Team's dashboard view. Add content here as needed.</p>
     </div>
   );
 }

--- a/src/components/PRDashboard.module.css
+++ b/src/components/PRDashboard.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 2rem;
+}


### PR DESCRIPTION
# Description

<img width="677" height="282" alt="image" src="https://github.com/user-attachments/assets/67d36257-f660-40fc-b07d-c62532d8e5f1" />

Renaming these files from .css to .module.css and updating their imports ensures style encapsulation, prevents global style bleeding, and improves maintainability.

affected path: 
src/components/PRDashboard.jsx


## Related PRS (if any):
Related PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3782

…

## Main changes explained:
Renaming these files from .css to .module.css and updating their imports ensures style encapsulation, prevents global style bleeding, and improves maintainability.

## How to test:

1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log in as admin
5. Go to http://localhost:3000/pr-dashboard
6. This should automatically return you to main dashboard (This is because permission to view dashboard is not yet set)
7. To add permission, go to http://localhost:3000/permissionsmanagement and click on the manage user permission.
8. From the drop down , select your user name and try adding the "See/Edit Pr team dashboard" permission. Confirm the changes
9. Log out and log back in using that account where permissions were toggled. Now /pr-dashboard should render a dummy dashboard.
10. check if UI in currect PR for http://localhost:3000/pr-dashboard is same as in the Related PR


