### PR TITLE
Fixed dark mode support for Building Management dashboard pages

### DIFF
--- a/src/components/BMDashboard/Issues/IssueHeader.css
+++ b/src/components/BMDashboard/Issues/IssueHeader.css
@@ -235,3 +235,66 @@
   font-style: italic;
   font-size: 14px;
 }
+
+/* Dark mode styles */
+.issue-header-container-dark .project-tab {
+  background-color: #374151;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+}
+
+.issue-header-container-dark .project-tab .tab-item {
+  color: #E5E7EB;
+}
+
+.issue-header-container-dark .project-tab .tab-item.active {
+  background-color: #4B5563;
+  color: #FFFFFF;
+}
+
+.issue-header-container-dark .project-tab .tab-item:not(.active):hover {
+  background-color: #4B5563;
+}
+
+.issue-header-container-dark .search-icon {
+  color: #9CA3AF;
+}
+
+.issue-header-container-dark .search-input {
+  background-color: #374151;
+  border: 1px solid #4B5563;
+  color: #E5E7EB;
+}
+
+.issue-header-container-dark .search-input:focus {
+  border-color: #6B7280;
+}
+
+.issue-header-container-dark .search-input::placeholder {
+  color: #9CA3AF;
+}
+
+.issue-header-container-dark .search-results {
+  background-color: #374151;
+  border: 1px solid #4B5563;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.issue-header-container-dark .search-result-item {
+  border-bottom: 1px solid #4B5563;
+}
+
+.issue-header-container-dark .search-result-item:hover {
+  background-color: #4B5563;
+}
+
+.issue-header-container-dark .result-name {
+  color: #E5E7EB;
+}
+
+.issue-header-container-dark .result-category {
+  color: #9CA3AF;
+}
+
+.issue-header-container-dark .search-no-results {
+  color: #9CA3AF;
+}

--- a/src/components/BMDashboard/Projects/ProjectDetails/ProjectDetails.css
+++ b/src/components/BMDashboard/Projects/ProjectDetails/ProjectDetails.css
@@ -15,7 +15,8 @@
 /*   margin-top: 40px;
   margin-bottom: 20px;
  */  font-weight: bold;
-  background-color: #1C1E1C;
+  background-color: #1B2A41;
+  min-height: 100vh;
 }
 
 .project-details-title {
@@ -146,6 +147,41 @@ background-color: rgb(1, 1, 38);
   width: auto;
   max-width: 100%;
   overflow: hidden;
+}
+
+/* Dark mode styles for project dashboard */
+.project-details-dark .card.cards-container {
+  background-color: #374151;
+  color: #E5E7EB;
+  border: 1px solid #4B5563;
+}
+
+.project-details-dark .card.cards-container h2 {
+  color: #60A5FA;
+}
+
+.project-details-dark .single-card {
+  background-color: #4B5563;
+  border: 1px solid #6B7280;
+  color: #E5E7EB;
+}
+
+.project-details-dark .single-card:hover {
+  box-shadow: 0 20px 20px 0 rgba(0, 0, 0, 0.4), 0 6px 20px 0 rgba(0, 0, 0, 0.4);
+}
+
+.project-details-dark .single-card__info {
+  background-color: #92400E;
+  color: #FEF3C7;
+}
+
+.project-details-dark .project-log {
+  background-color: #374151;
+  color: #E5E7EB;
+}
+
+.project-details-dark .project-log thead {
+  background-color: #4B5563;
 }
 
 .cards-container__content {


### PR DESCRIPTION
## Description
PFixed dark mode support for Building Management dashboard pages where Issues page and Project Dashboard were not properly inheriting dark mode theming when users enabled dark mode. This resulted in inconsistent user experience across the Building Management section.
Fixes critical dark mode functionality bug (priority high) identified in PR #3486 testing.

## Related PRS:
This frontend PR addresses issues identified during testing of PR #3486.
Related to: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3486

## Main changes explained:
- Update IssueHeader.css for comprehensive Issues page dark mode support
- Update ProjectDetails.css to fix Project Dashboard dark mode theming
- Add dark mode styling for search bars, project tabs, cards, and containers
- Implement CSS classes following project patterns instead of inline styles
- Add proper color contrast and hover states for all interactive elements

## How to test:

1. Check into current branch `Juhitha-bmdashboard dark mode support`
2. Do npm install && npm run start:local to run this PR locally
3. Clear site data/cache
4. Log as admin user
5. Go to Building Management dashboard → Issues (/bmdashboard/issues)
6. Toggle dark mode on/off and verify search bar, project tabs, and dropdown have proper dark styling
7. Navigate to a Project Dashboard (/bmdashboard/projects/:id)
8. Verify background is blue theme (not black) and all cards/containers have proper dark mode styling
9. Verify this feature works in dark mode across both pages

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/0b8acd2e-6329-4bba-a438-f8eafde4da62