### PR TITLE
Sai Siri Sudheeksha Vavila: Switch /totalorgsummary to CSS Modules an…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "chart.js": "^4.1.1",
         "chartjs-plugin-datalabels": "^2.2.0",
         "classnames": "^2.2.6",
+        "clsx": "^2.1.1",
         "cross-spawn": "^7.0.6",
         "crypto-browserify": "^3.12.1",
         "d3": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chart.js": "^4.1.1",
     "chartjs-plugin-datalabels": "^2.2.0",
     "classnames": "^2.2.6",
+    "clsx": "^2.1.1",
     "cross-spawn": "^7.0.6",
     "crypto-browserify": "^3.12.1",
     "d3": "^7.8.5",

--- a/src/components/TotalOrgSummary/NumbersVolunteerWorked/NumbersVolunteerWorked.jsx
+++ b/src/components/TotalOrgSummary/NumbersVolunteerWorked/NumbersVolunteerWorked.jsx
@@ -1,14 +1,18 @@
-import '../TotalOrgSummary.css';
-
+import styles from '../TotalOrgSummary.module.css';
+import cx from 'clsx';
 export default function NumbersVolunteerWorked({ isLoading, data, darkMode }) {
   return (
     <div>
       <p
-        className={`${
-          darkMode ? 'text-light' : 'text-dark'
-        } component-border component-pie-chart-label p-2`}
+        data-pdf-label
+        className={cx(
+          darkMode ? 'text-light' : 'text-dark',
+          styles.componentBorder,
+          styles.componentPieChartLabel,
+          'p-2',
+        )}
       >
-        {isLoading ? '...' : data.count} Volunteers worked 1+ hours over assigned time
+        {isLoading ? '...' : data?.count ?? 0} Volunteers worked 1+ hours over assigned time
       </p>
     </div>
   );

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable testing-library/no-node-access */
 import { connect } from 'react-redux';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import {
   Alert,
   Col,
@@ -28,9 +28,8 @@ import hasPermission from '~/utils/permissions';
 import { getTotalOrgSummary } from '~/actions/totalOrgSummary';
 
 import '../Header/DarkMode.css';
-import './TotalOrgSummary.css';
-
-// components
+import styles from './TotalOrgSummary.module.css';
+import { clsx } from 'clsx';
 import VolunteerHoursDistribution from './VolunteerHoursDistribution/VolunteerHoursDistribution';
 import AccordianWrapper from './AccordianWrapper/AccordianWrapper';
 import VolunteerStatus from './VolunteerStatus/VolunteerStatus';
@@ -125,6 +124,7 @@ function TotalOrgSummary(props) {
   const [endDate, setEndDate] = useState(null);
   const [currentFromDate, setCurrentFromDate] = useState(fromDate);
   const [currentToDate, setCurrentToDate] = useState(toDate);
+  const rootRef = useRef(null);
 
   useEffect(() => {
     const fetchVolunteerStats = async () => {
@@ -225,20 +225,18 @@ function TotalOrgSummary(props) {
       pdfContainer.style.margin = '0';
 
       // Clone the main content area
-      const originalContent = document.querySelector('.container-total-org-wrapper');
+      const originalContent = rootRef.current;
       const clonedContent = originalContent.cloneNode(true);
 
       // Remove interactive or unwanted elements from the clone
       clonedContent
-        .querySelectorAll('button, .share-pdf-btn, .controls, .no-print')
+        .querySelectorAll('[data-pdf-hide], .controls, .no-print')
         .forEach(el => el.remove());
 
       // Adjust title row styling for a clean layout
-      const titleRow = clonedContent.querySelector(
-        '.row.d-flex.justify-content-between.align-items-center',
-      );
+      const titleRow = clonedContent.querySelector('[data-pdf-title-row]');
       if (titleRow) {
-        const titleCol = titleRow.querySelector('.col');
+        const titleCol = titleRow.querySelector('[data-pdf-title-col]');
         if (titleCol) {
           titleCol.style.width = '100%';
         }
@@ -255,7 +253,7 @@ function TotalOrgSummary(props) {
       // Create a style element for the PDF container
       const styleElem = document.createElement('style');
       styleElem.textContent = `
-        .container-total-org-wrapper {
+        [data-pdf-root] {
           padding: 20px !important;
           margin: 0 !important;
           box-shadow: none !important;
@@ -263,7 +261,8 @@ function TotalOrgSummary(props) {
           width: 100% !important;
           min-height: 100% !important;
         }
-        .row.d-flex.justify-content-between.align-items-center {
+
+        [data-pdf-title-row] {
           display: flex !important;
           justify-content: space-between !important;
           align-items: center !important;
@@ -271,45 +270,48 @@ function TotalOrgSummary(props) {
           width: 100% !important;
           padding: 0 !important;
         }
-        .component-container {
+
+        /* Merges old .component-container + .component-border rules */
+        [data-pdf-block] {
           page-break-inside: avoid;
           break-inside: avoid;
           margin: 15px 0 !important;
           padding: 20px !important;
-          border: 1px solid #eee !important;
-          border-radius: 8px !important;
-          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
-        }
-        .component-border {
           background-color: #fff !important;
           border: 1px solid #e0e0e0 !important;
           border-radius: 10px !important;
-          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05) !important;
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08) !important;
           overflow: hidden !important;
         }
+
         img, svg {
           max-width: 100% !important;
           height: auto !important;
           page-break-inside: avoid !important;
         }
+
         .recharts-wrapper {
           width: 100% !important;
           height: auto !important;
         }
+
         table {
           page-break-inside: avoid !important;
         }
+
         .Collapsible__trigger {
           background-color: ${darkMode ? '#1C2541' : '#fff'} !important;
           color: ${darkMode ? '#fff' : '#000'} !important;
         }
-        .volunteer-status-grid {
+
+        .volunteerStatusGrid {
           display: grid !important;
           grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)) !important;
           gap: 1.5rem !important;
           width: 100% !important;
           margin-top: 15px !important;
         }
+
         .component-pie-chart-label {
           font-size: 12px !important;
           font-weight: 600 !important;
@@ -317,7 +319,8 @@ function TotalOrgSummary(props) {
           overflow: hidden !important;
           text-overflow: ellipsis !important;
         }
-        .total-org-chart-title p {
+
+        [data-pdf-title] p {
           font-size: 1.5em !important;
           font-weight: bold !important;
           text-align: center !important;
@@ -422,7 +425,12 @@ function TotalOrgSummary(props) {
 
   if (error || isVolunteerFetchingError) {
     return (
-      <Container className={`container-wsr-wrapper ${darkMode ? 'bg-oxford-blue' : ''}`}>
+      <Container
+        className={clsx(
+          styles.containerTotalOrgWrapper,
+          darkMode && 'bg-oxford-blue', // keep global theme utility if needed
+        )}
+      >
         <Row
           className="align-self-center pt-2"
           data-testid="error"
@@ -439,306 +447,418 @@ function TotalOrgSummary(props) {
   return (
     <Container
       fluid
-      className={`container-total-org-wrapper py-3 mb-5 ${
-        darkMode ? 'bg-oxford-blue text-light' : 'cbg--white-smoke'
-      }`}
+      className={clsx(
+        styles.containerTotalOrgWrapper,
+        'py-3 mb-5',
+        darkMode ? 'bg-oxford-blue text-light' : 'cbg--white-smoke', // or add .whiteSmoke
+      )}
     >
-      <Row className="total-org-report-header-row">
-        <div className="report-header-title">
-          <h3 className="my-0">Total Org Summary</h3>
-        </div>
-        <div className="report-header-actions">
-          <Dropdown
-            isOpen={dateRangeDropdownOpen}
-            toggle={() => setDateRangeDropdownOpen(!dateRangeDropdownOpen)}
-          >
-            <DropdownToggle caret>{selectedDateRange}</DropdownToggle>
-            <DropdownMenu>
-              <DropdownItem onClick={() => handleDateRangeSelect('Current Week')}>
-                Current Week
-              </DropdownItem>
-              <DropdownItem onClick={() => handleDateRangeSelect('Previous Week')}>
-                Previous Week
-              </DropdownItem>
-              <DropdownItem onClick={() => handleDateRangeSelect('Select Date Range')}>
-                Select Date Range
-              </DropdownItem>
-            </DropdownMenu>
-          </Dropdown>
-          <Dropdown
-            isOpen={comparisonDropdownOpen}
-            toggle={() => setComparisonDropdownOpen(!comparisonDropdownOpen)}
-          >
-            <DropdownToggle caret>{selectedComparison}</DropdownToggle>
-            <DropdownMenu>
-              <DropdownItem onClick={() => setSelectedComparison('No Comparison')}>
-                No Comparison
-              </DropdownItem>
-              <DropdownItem onClick={() => setSelectedComparison('Week Over Week')}>
-                Week Over Week
-              </DropdownItem>
-              <DropdownItem onClick={() => setSelectedComparison('Month Over Month')}>
-                Month Over Month
-              </DropdownItem>
-              <DropdownItem onClick={() => setSelectedComparison('Year Over Year')}>
-                Year Over Year
-              </DropdownItem>
-            </DropdownMenu>
-          </Dropdown>
-          <Button className="share-pdf-btn" onClick={handleSaveAsPDF} disabled={isGeneratingPDF}>
-            {isGeneratingPDF ? 'Generating PDF...' : 'Save as PDF'}
-          </Button>
-        </div>
-      </Row>
-
-      <Modal isOpen={showDatePicker} toggle={() => setShowDatePicker(!showDatePicker)}>
-        <ModalHeader toggle={() => setShowDatePicker(!showDatePicker)}>
-          Select Date Range
-        </ModalHeader>
-        <ModalBody>
-          <div className="d-flex flex-column gap-4">
-            <div>
-              <label htmlFor="start-date" style={{ display: 'block', marginBottom: '1rem' }}>
-                Start Date
-              </label>
-              <div style={{ padding: '0.5rem 0' }}>
-                <DatePicker
-                  id="start-date"
-                  selected={startDate}
-                  onChange={date => setStartDate(date)}
-                  className="form-control"
-                  dateFormat="MM/dd/yyyy"
-                  placeholderText="Select start date"
-                />
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor="end-date" style={{ display: 'block', marginBottom: '1rem' }}>
-                End Date
-              </label>
-              <div style={{ padding: '0.5rem 0' }}>
-                <DatePicker
-                  id="end-date"
-                  selected={endDate}
-                  onChange={date => setEndDate(date)}
-                  className="form-control"
-                  dateFormat="MM/dd/yyyy"
-                  placeholderText="Select end date"
-                  minDate={startDate}
-                />
-              </div>
-            </div>
+      <div ref={rootRef} data-pdf-root>
+        <Row className={styles.totalOrgReportHeaderRow} data-pdf-title-row>
+          <div className={styles.reportHeaderTitle} data-pdf-title-col>
+            <h3 className="my-0">Total Org Summary</h3>
           </div>
-        </ModalBody>
-        <ModalFooter>
-          <Button color="secondary" onClick={() => setShowDatePicker(false)}>
-            Cancel
-          </Button>
-          <Button
-            color="primary"
-            onClick={handleDatePickerSubmit}
-            disabled={!startDate || !endDate}
-          >
-            Apply
-          </Button>
-        </ModalFooter>
-      </Modal>
+          <div className={styles.reportHeaderActions}>
+            <Dropdown
+              isOpen={dateRangeDropdownOpen}
+              toggle={() => setDateRangeDropdownOpen(!dateRangeDropdownOpen)}
+            >
+              <DropdownToggle caret>{selectedDateRange}</DropdownToggle>
+              <DropdownMenu>
+                <DropdownItem onClick={() => handleDateRangeSelect('Current Week')}>
+                  Current Week
+                </DropdownItem>
+                <DropdownItem onClick={() => handleDateRangeSelect('Previous Week')}>
+                  Previous Week
+                </DropdownItem>
+                <DropdownItem onClick={() => handleDateRangeSelect('Select Date Range')}>
+                  Select Date Range
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+            <Dropdown
+              isOpen={comparisonDropdownOpen}
+              toggle={() => setComparisonDropdownOpen(!comparisonDropdownOpen)}
+            >
+              <DropdownToggle caret>{selectedComparison}</DropdownToggle>
+              <DropdownMenu>
+                <DropdownItem onClick={() => setSelectedComparison('No Comparison')}>
+                  No Comparison
+                </DropdownItem>
+                <DropdownItem onClick={() => setSelectedComparison('Week Over Week')}>
+                  Week Over Week
+                </DropdownItem>
+                <DropdownItem onClick={() => setSelectedComparison('Month Over Month')}>
+                  Month Over Month
+                </DropdownItem>
+                <DropdownItem onClick={() => setSelectedComparison('Year Over Year')}>
+                  Year Over Year
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+            <Button
+              className={styles.sharePdfBtn}
+              data-pdf-hide
+              onClick={handleSaveAsPDF}
+              disabled={isGeneratingPDF}
+            >
+              {isGeneratingPDF ? 'Generating PDF...' : 'Save as PDF'}
+            </Button>
+          </div>
+        </Row>
 
-      <hr />
-      <AccordianWrapper title="Volunteer Status">
-        <Row>
-          <Col lg={{ size: 12 }}>
-            <VolunteerStatus
-              isLoading={isLoading}
-              volunteerNumberStats={volunteerStats?.volunteerNumberStats}
-              totalHoursWorked={volunteerStats?.totalHoursWorked}
-              comparisonType={selectedComparison}
-            />
-          </Col>
-        </Row>
-      </AccordianWrapper>
-      <AccordianWrapper title="Volunteer Activities">
-        <Row>
-          <Col lg={{ size: 12 }}>
-            <VolunteerActivities
-              isLoading={isLoading}
-              totalSummariesSubmitted={volunteerStats?.totalSummariesSubmitted}
-              completedAssignedHours={volunteerStats?.completedAssignedHours}
-              totalBadgesAwarded={volunteerStats?.totalBadgesAwarded}
-              tasksStats={volunteerStats?.tasksStats}
-              totalActiveTeams={volunteerStats?.totalActiveTeams}
-              comparisonType={selectedComparison}
-            />
-          </Col>
-        </Row>
-      </AccordianWrapper>
-      <AccordianWrapper title="Global Distribution and Volunteer Status Overview">
-        <Row>
-          <Col lg={{ size: 6 }}>
-            <div className="component-container component-border">
-              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
-                <p>Global Volunteer Network: Uniting Communities Worldwide</p>
+        <Modal isOpen={showDatePicker} toggle={() => setShowDatePicker(!showDatePicker)}>
+          <ModalHeader toggle={() => setShowDatePicker(!showDatePicker)}>
+            Select Date Range
+          </ModalHeader>
+          <ModalBody>
+            <div className="d-flex flex-column gap-4">
+              <div>
+                <label htmlFor="start-date" style={{ display: 'block', marginBottom: '1rem' }}>
+                  Start Date
+                </label>
+                <div style={{ padding: '0.5rem 0' }}>
+                  <DatePicker
+                    id="start-date"
+                    selected={startDate}
+                    onChange={date => setStartDate(date)}
+                    className="form-control"
+                    dateFormat="MM/dd/yyyy"
+                    placeholderText="Select start date"
+                  />
+                </div>
               </div>
-              <GlobalVolunteerMap isLoading={isLoading} locations={volunteerStats?.userLocations} />
-            </div>
-          </Col>
-          <Col lg={{ size: 6 }}>
-            <div className="component-container component-border">
-              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
-                <p>Volunteer Status</p>
-              </div>
-              <VolunteerStatusChart
-                isLoading={isLoading}
-                volunteerNumberStats={volunteerStats?.volunteerNumberStats}
-                comparisonType={selectedComparison}
-              />
-            </div>
-          </Col>
-        </Row>
-      </AccordianWrapper>
-      <AccordianWrapper title="Volunteer Workload and Task Completion Analysis">
-        <Row>
-          <Col lg={{ size: 6 }}>
-            <div className="component-container component-border">
-              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
-                <p>Volunteer Hours Distribution</p>
-              </div>
-              <div
-                className="d-flex flex-column justify-content-center mt-4 gap-3"
-                style={{ gap: '20px' }}
-              >
-                <VolunteerHoursDistribution
-                  isLoading={isLoading}
-                  darkMode={darkMode}
-                  hoursData={volunteerStats?.volunteerHoursStats}
-                  totalHoursData={volunteerStats?.totalHoursWorked}
-                  comparisonType={selectedComparison}
-                />
-                <div className="d-flex flex-column align-items-center justify-content-center">
-                  <NumbersVolunteerWorked
-                    isLoading={isLoading}
-                    data={volunteerStats?.volunteersOverAssignedTime}
-                    darkMode={darkMode}
+
+              <div>
+                <label htmlFor="end-date" style={{ display: 'block', marginBottom: '1rem' }}>
+                  End Date
+                </label>
+                <div style={{ padding: '0.5rem 0' }}>
+                  <DatePicker
+                    id="end-date"
+                    selected={endDate}
+                    onChange={date => setEndDate(date)}
+                    className="form-control"
+                    dateFormat="MM/dd/yyyy"
+                    placeholderText="Select end date"
+                    minDate={startDate}
                   />
                 </div>
               </div>
             </div>
-          </Col>
-          <Col lg={{ size: 3 }}>
-            <div className="component-container component-border">
-              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
-                <p>Task Completed</p>
-              </div>
-              <div className="mt-4">
-                <TaskCompletedBarChart
+          </ModalBody>
+          <ModalFooter>
+            <Button color="secondary" onClick={() => setShowDatePicker(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="primary"
+              onClick={handleDatePickerSubmit}
+              disabled={!startDate || !endDate}
+            >
+              Apply
+            </Button>
+          </ModalFooter>
+        </Modal>
+
+        <hr />
+        <AccordianWrapper title="Volunteer Status">
+          <Row>
+            <Col lg={{ size: 12 }}>
+              <VolunteerStatus
+                isLoading={isLoading}
+                volunteerNumberStats={volunteerStats?.volunteerNumberStats}
+                totalHoursWorked={volunteerStats?.totalHoursWorked}
+                comparisonType={selectedComparison}
+              />
+            </Col>
+          </Row>
+        </AccordianWrapper>
+        <AccordianWrapper title="Volunteer Activities">
+          <Row>
+            <Col lg={{ size: 12 }}>
+              <VolunteerActivities
+                isLoading={isLoading}
+                totalSummariesSubmitted={volunteerStats?.totalSummariesSubmitted}
+                completedAssignedHours={volunteerStats?.completedAssignedHours}
+                totalBadgesAwarded={volunteerStats?.totalBadgesAwarded}
+                tasksStats={volunteerStats?.tasksStats}
+                totalActiveTeams={volunteerStats?.totalActiveTeams}
+                comparisonType={selectedComparison}
+              />
+            </Col>
+          </Row>
+        </AccordianWrapper>
+        <AccordianWrapper title="Global Distribution and Volunteer Status Overview">
+          <Row>
+            <Col lg={{ size: 6 }}>
+              <div
+                className={clsx(styles.componentContainer, styles.componentBorder)}
+                data-pdf-block
+              >
+                <div
+                  className={clsx(
+                    styles.totalOrgChartTitle,
+                    darkMode && styles.totalOrgChartTitleDark,
+                  )}
+                  data-pdf-title
+                >
+                  <p>Global Volunteer Network: Uniting Communities Worldwide</p>
+                </div>
+                <GlobalVolunteerMap
                   isLoading={isLoading}
-                  data={volunteerStats?.tasksStats}
-                  darkMode={darkMode}
+                  locations={volunteerStats?.userLocations}
                 />
               </div>
-            </div>
-          </Col>
-          <Col lg={{ size: 3 }}>
-            <div className="component-container component-border">
-              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
-                <p>Hours Completed</p>
-              </div>
-              <div className="mt-4">
-                <HoursCompletedBarChart
+            </Col>
+            <Col lg={{ size: 6 }}>
+              <div
+                className={clsx(styles.componentContainer, styles.componentBorder)}
+                data-pdf-block
+              >
+                <div
+                  className={clsx(
+                    styles.totalOrgChartTitle,
+                    darkMode && styles.totalOrgChartTitleDark,
+                  )}
+                  data-pdf-title
+                >
+                  <p>Volunteer Status</p>
+                </div>
+                <VolunteerStatusChart
                   isLoading={isLoading}
-                  data={volunteerStats?.taskAndProjectStats}
+                  volunteerNumberStats={volunteerStats?.volunteerNumberStats}
+                  comparisonType={selectedComparison}
+                />
+              </div>
+            </Col>
+          </Row>
+        </AccordianWrapper>
+        <AccordianWrapper title="Volunteer Workload and Task Completion Analysis">
+          <Row>
+            <Col lg={{ size: 6 }}>
+              <div
+                className={clsx(styles.componentContainer, styles.componentBorder)}
+                data-pdf-block
+              >
+                <div
+                  className={clsx(
+                    styles.totalOrgChartTitle,
+                    darkMode && styles.totalOrgChartTitleDark,
+                  )}
+                  data-pdf-title
+                >
+                  <p>Volunteer Hours Distribution</p>
+                </div>
+                <div
+                  className="d-flex flex-column justify-content-center mt-4 gap-3"
+                  style={{ gap: '20px' }}
+                >
+                  <VolunteerHoursDistribution
+                    isLoading={isLoading}
+                    darkMode={darkMode}
+                    hoursData={volunteerStats?.volunteerHoursStats}
+                    totalHoursData={volunteerStats?.totalHoursWorked}
+                    comparisonType={selectedComparison}
+                  />
+                  <div className="d-flex flex-column align-items-center justify-content-center">
+                    <NumbersVolunteerWorked
+                      isLoading={isLoading}
+                      data={volunteerStats?.volunteersOverAssignedTime}
+                      darkMode={darkMode}
+                    />
+                  </div>
+                </div>
+              </div>
+            </Col>
+            <Col lg={{ size: 3 }}>
+              <div
+                className={clsx(styles.componentContainer, styles.componentBorder)}
+                data-pdf-block
+              >
+                <div
+                  className={clsx(
+                    styles.totalOrgChartTitle,
+                    darkMode && styles.totalOrgChartTitleDark,
+                  )}
+                  data-pdf-title
+                >
+                  <p>Task Completed</p>
+                </div>
+                <div className="mt-4">
+                  <TaskCompletedBarChart
+                    isLoading={isLoading}
+                    data={volunteerStats?.tasksStats}
+                    darkMode={darkMode}
+                  />
+                </div>
+              </div>
+            </Col>
+            <Col lg={{ size: 3 }}>
+              <div
+                className={clsx(styles.componentContainer, styles.componentBorder)}
+                data-pdf-block
+              >
+                <div
+                  className={clsx(
+                    styles.totalOrgChartTitle,
+                    darkMode && styles.totalOrgChartTitleDark,
+                  )}
+                  data-pdf-title
+                >
+                  <p>Hours Completed</p>
+                </div>
+                <div className="mt-4">
+                  <HoursCompletedBarChart
+                    isLoading={isLoading}
+                    data={volunteerStats?.taskAndProjectStats}
+                    darkMode={darkMode}
+                    comparisonType={selectedComparison}
+                  />
+                </div>
+              </div>
+            </Col>
+          </Row>
+        </AccordianWrapper>
+        <AccordianWrapper title="Volunteer Engagement Trends and Milestones">
+          <Row>
+            <Col lg={{ size: 7 }}>
+              <div
+                className={clsx(styles.componentContainer, styles.componentBorder)}
+                data-pdf-block
+              >
+                <div
+                  className={clsx(
+                    styles.totalOrgChartTitle,
+                    darkMode && styles.totalOrgChartTitleDark,
+                  )}
+                  data-pdf-title
+                >
+                  <p>Volunteer Trends by Time</p>
+                </div>
+                <VolunteerTrendsLineChart darkMode={darkMode} />
+              </div>
+            </Col>
+            <Col lg={{ size: 5 }}>
+              <div
+                className={clsx(styles.componentContainer, styles.componentBorder)}
+                data-pdf-block
+              >
+                <div
+                  className={clsx(
+                    styles.totalOrgChartTitle,
+                    darkMode && styles.totalOrgChartTitleDark,
+                  )}
+                  data-pdf-title
+                >
+                  <p>Anniversary Celebrated</p>
+                </div>
+                <AnniversaryCelebrated
+                  isLoading={isLoading}
+                  data={volunteerStats?.anniversaryStats}
                   darkMode={darkMode}
                   comparisonType={selectedComparison}
                 />
               </div>
-            </div>
-          </Col>
-        </Row>
-      </AccordianWrapper>
-      <AccordianWrapper title="Volunteer Engagement Trends and Milestones">
-        <Row>
-          <Col lg={{ size: 7 }}>
-            <div className="component-container component-border">
-              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
-                <p>Volunteer Trends by Time</p>
+            </Col>
+          </Row>
+        </AccordianWrapper>
+        <AccordianWrapper title="Volunteer Roles and Team Dynamics">
+          <Row>
+            <Col lg={{ size: 7 }}>
+              <div
+                className={clsx(styles.componentContainer, styles.componentBorder)}
+                data-pdf-block
+              >
+                <div
+                  className={clsx(
+                    styles.totalOrgChartTitle,
+                    darkMode && styles.totalOrgChartTitleDark,
+                  )}
+                  data-pdf-title
+                >
+                  <p>Work Distribution</p>
+                </div>
+                <WorkDistributionBarChart
+                  isLoading={isLoading}
+                  workDistributionStats={volunteerStats?.workDistributionStats}
+                  comparisonType={selectedComparison}
+                />
               </div>
-              <VolunteerTrendsLineChart darkMode={darkMode} />
-            </div>
-          </Col>
-          <Col lg={{ size: 5 }}>
-            <div className="component-container component-border">
-              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
-                <p>Anniversary Celebrated</p>
+            </Col>
+            <Col lg={{ size: 5 }}>
+              <div
+                className={clsx(styles.componentContainer, styles.componentBorder)}
+                data-pdf-block
+              >
+                <div
+                  className={clsx(
+                    styles.totalOrgChartTitle,
+                    darkMode && styles.totalOrgChartTitleDark,
+                  )}
+                  data-pdf-title
+                >
+                  <p>Role Distribution</p>
+                </div>
+                <RoleDistributionPieChart
+                  isLoading={isLoading}
+                  roleDistributionStats={volunteerStats?.roleDistributionStats}
+                  darkMode={darkMode}
+                  comparisonType={selectedComparison}
+                />
               </div>
-              <AnniversaryCelebrated
-                isLoading={isLoading}
-                data={volunteerStats?.anniversaryStats}
-                darkMode={darkMode}
-                comparisonType={selectedComparison}
-              />
-            </div>
-          </Col>
-        </Row>
-      </AccordianWrapper>
-      <AccordianWrapper title="Volunteer Roles and Team Dynamics">
-        <Row>
-          <Col lg={{ size: 7 }}>
-            <div className="component-container component-border">
-              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
-                <p>Work Distribution</p>
+            </Col>
+          </Row>
+        </AccordianWrapper>
+        <AccordianWrapper title="Volunteer Roles and Team Dynamics">
+          <Row>
+            <Col lg={{ size: 6 }}>
+              <div
+                className={clsx(styles.componentContainer, styles.componentBorder)}
+                data-pdf-block
+              >
+                <div
+                  className={clsx(
+                    styles.totalOrgChartTitle,
+                    darkMode && styles.totalOrgChartTitleDark,
+                  )}
+                  data-pdf-title
+                >
+                  <p>Team Stats</p>
+                </div>
+                <TeamStats
+                  isLoading={isLoading}
+                  usersInTeamStats={volunteerStats?.usersInTeamStats}
+                  endDate={currentToDate}
+                  comparisonType={selectedComparison}
+                />
               </div>
-              <WorkDistributionBarChart
-                isLoading={isLoading}
-                workDistributionStats={volunteerStats?.workDistributionStats}
-                comparisonType={selectedComparison}
-              />
-            </div>
-          </Col>
-          <Col lg={{ size: 5 }}>
-            <div className="component-container component-border">
-              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
-                <p>Role Distribution</p>
+            </Col>
+            <Col lg={{ size: 6 }}>
+              <div
+                className={clsx(styles.componentContainer, styles.componentBorder)}
+                data-pdf-block
+              >
+                <div
+                  className={clsx(
+                    styles.totalOrgChartTitle,
+                    darkMode && styles.totalOrgChartTitleDark,
+                  )}
+                  data-pdf-title
+                >
+                  <p>Blue Square Stats</p>
+                </div>
+                <BlueSquareStats
+                  isLoading={isLoading}
+                  blueSquareStats={volunteerStats?.blueSquareStats}
+                  comparisonType={selectedComparison}
+                />
               </div>
-              <RoleDistributionPieChart
-                isLoading={isLoading}
-                roleDistributionStats={volunteerStats?.roleDistributionStats}
-                darkMode={darkMode}
-                comparisonType={selectedComparison}
-              />
-            </div>
-          </Col>
-        </Row>
-      </AccordianWrapper>
-      <AccordianWrapper title="Volunteer Roles and Team Dynamics">
-        <Row>
-          <Col lg={{ size: 6 }}>
-            <div className="component-container component-border">
-              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
-                <p>Team Stats</p>
-              </div>
-              <TeamStats
-                isLoading={isLoading}
-                usersInTeamStats={volunteerStats?.usersInTeamStats}
-                endDate={currentToDate}
-                comparisonType={selectedComparison}
-              />
-            </div>
-          </Col>
-          <Col lg={{ size: 6 }}>
-            <div className="component-container component-border">
-              <div className={`total-org-chart-title ${darkMode ? 'dark-mode' : ''}`}>
-                <p>Blue Square Stats</p>
-              </div>
-              <BlueSquareStats
-                isLoading={isLoading}
-                blueSquareStats={volunteerStats?.blueSquareStats}
-                comparisonType={selectedComparison}
-              />
-            </div>
-          </Col>
-        </Row>
-      </AccordianWrapper>
+            </Col>
+          </Row>
+        </AccordianWrapper>
+      </div>
+      {/* ← closes ref wrapper */}
     </Container>
   );
 }

--- a/src/components/TotalOrgSummary/TotalOrgSummary.module.css
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.module.css
@@ -1,4 +1,4 @@
-.container-total-org-wrapper {
+.containerTotalOrgWrapper {
   min-height: 100%;
   background-color: #fff;
   margin: 0;
@@ -6,68 +6,66 @@
   width: 100%;
 }
 
-.container-total-org-wrapper.bg-oxford-blue .component-border {
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .componentBorder {
   background-color: #1c2541 !important;
   border-color: #2f4157 !important;
 }
 
-.container-total-org-wrapper.bg-oxford-blue .recharts-surface {
+.containerTotalOrgWrapper:global(.bg-oxford-blue) :global(.recharts-surface) {
   background-color: #1c2541;
 }
 
-.container-total-org-wrapper.bg-oxford-blue .total-org-chart-title p {
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .totalOrgChartTitle p {
   color: #fff !important;
 }
 
-.container-total-org-wrapper.bg-oxford-blue .component-container .recharts-text,
-.container-total-org-wrapper.bg-oxford-blue .component-container .recharts-label,
-.container-total-org-wrapper.bg-oxford-blue
-  .component-container
-  .recharts-cartesian-axis-tick-value,
-.container-total-org-wrapper.bg-oxford-blue .component-container text,
-.container-total-org-wrapper.bg-oxford-blue .component-container tspan {
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .componentContainer :global(.recharts-text),
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .componentContainer :global(.recharts-label),
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .componentContainer :global(.recharts-cartesian-axis-tick-value),
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .componentContainer text,
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .componentContainer tspan {
   fill: #fff !important;
   color: #fff !important;
 }
 
-.container-total-org-wrapper.bg-oxford-blue .recharts-text tspan,
-.container-total-org-wrapper.bg-oxford-blue .recharts-label tspan,
-.container-total-org-wrapper.bg-oxford-blue .recharts-cartesian-axis-tick-value tspan,
-.container-total-org-wrapper.bg-oxford-blue text tspan {
+.containerTotalOrgWrapper:global(.bg-oxford-blue) :global(.recharts-text) tspan,
+.containerTotalOrgWrapper:global(.bg-oxford-blue) :global(.recharts-label) tspan,
+.containerTotalOrgWrapper:global(.bg-oxford-blue) :global(.recharts-cartesian-axis-tick-value) tspan,
+.containerTotalOrgWrapper:global(.bg-oxford-blue) text tspan {
   fill: #fff !important;
 }
 
-.container-total-org-wrapper.bg-oxford-blue > .row > .col h3,
-.container-total-org-wrapper.bg-oxford-blue .Collapsible__trigger {
+.containerTotalOrgWrapper:global(.bg-oxford-blue) :global(.row) > :global(.col) h3,
+.containerTotalOrgWrapper:global(.bg-oxford-blue) :global(.Collapsible__trigger) {
   color: #fff;
 }
 
-.container-total-org-wrapper.bg-oxford-blue .component-container h3,
-.container-total-org-wrapper.bg-oxford-blue .statistics-title,
-.container-total-org-wrapper.bg-oxford-blue .volunteer-status-grid h3,
-.container-total-org-wrapper.bg-oxford-blue .component-container .recharts-text,
-.container-total-org-wrapper.bg-oxford-blue .statistics-value {
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .componentContainer h3,
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .statistics-title,
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .volunteerStatusGrid h3,
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .componentContainer :global(.recharts-text),
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .statistics-value {
   color: #000 !important;
   fill: #000 !important;
 }
 
-.container-total-org-wrapper.bg-oxford-blue .recharts-text,
-.container-total-org-wrapper.bg-oxford-blue .recharts-label,
-.container-total-org-wrapper.bg-oxford-blue .recharts-cartesian-axis-tick-value {
+.containerTotalOrgWrapper:global(.bg-oxford-blue) :global(.recharts-text),
+.containerTotalOrgWrapper:global(.bg-oxford-blue) :global(.recharts-label),
+.containerTotalOrgWrapper:global(.bg-oxford-blue) :global(.recharts-cartesian-axis-tick-value) {
   fill: #000 !important;
 }
 
-.container-total-org-wrapper.bg-oxford-blue h3 {
+.containerTotalOrgWrapper.bg-oxford-blue h3 {
   color: #fff;
 }
 
-.container-total-org-wrapper .row {
+.pageRow {
   width: 100% !important;
   margin: 1px 10px 15px 10px;
 }
 
 /* Header section styles */
-.container-total-org-wrapper .header-row {
+.totalOrgReportHeaderRow  {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -78,13 +76,13 @@
   /* Ensure button aligns absolutely inside here */
 }
 
-.container-total-org-wrapper .header-row .left-section {
+.reportHeaderTitle {
   display: flex;
   align-items: center;
   gap: 20px;
 }
 
-.container-total-org-wrapper .header-row h3 {
+.reportHeaderTitle h3 {
   margin: 0;
   font-size: 32px;
   font-weight: 600;
@@ -92,13 +90,13 @@
   color: #000;
 }
 
-.container-total-org-wrapper .header-row .controls {
+.reportHeaderActions {
   display: flex;
   align-items: center;
   gap: 12px;
 }
 
-.container-total-org-wrapper .header-row select {
+.reportHeaderActions select {
   padding: 8px 12px;
   border: 1px solid #e0e0e0;
   border-radius: 4px;
@@ -106,7 +104,7 @@
   font-size: 14px;
 }
 
-.container-total-org-wrapper .header-row button {
+.reportHeaderActions button {
   background-color: #000;
   color: #fff;
   border: none;
@@ -121,18 +119,18 @@
   justify-content: center;
 }
 
-.container-total-org-wrapper .header-row button:hover {
+.reportHeaderActions button:hover {
   background-color: #333;
 }
 
-.container-total-org-wrapper .header-row button:disabled {
+.reportHeaderActions button:disabled {
   background-color: #666;
   cursor: not-allowed;
   opacity: 0.7;
 }
 
 /* PDF button styles */
-.share-pdf-btn {
+.sharePdfBtn {
   padding: 8px 16px !important;
   height: 36px !important;
   display: flex !important;
@@ -145,12 +143,12 @@
 }
 
 /* Hover for PDF button */
-.share-pdf-btn:hover {
+.sharePdfBtn:hover {
   background-color: #333 !important;
 }
 
 /* Component containers */
-.component-container {
+.componentContainer {
   margin: 15px 0;
   padding: 20px;
   background-color: #fff;
@@ -158,7 +156,7 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.component-border {
+.componentBorder {
   border: 1px solid #e0e0e0;
   border-radius: 10px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
@@ -167,7 +165,7 @@
 }
 
 /* Grid layouts */
-.volunteer-status-grid {
+.volunteerStatusGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 1.5rem;
@@ -175,7 +173,7 @@
   margin-top: 15px;
 }
 
-.component-pie-chart-label {
+.componentPieChartLabel {
   font-size: 12px;
   font-weight: 600;
   color: #000;
@@ -183,7 +181,7 @@
   text-overflow: ellipsis;
 }
 
-.total-org-chart-title p {
+.totalOrgChartTitle p {
   font-size: 1.8rem !important;
   font-weight: bold;
   text-align: center;
@@ -193,7 +191,7 @@
 }
 
 /* Report Header Styles */
-.total-org-report-header-row {
+/* .totalOrgReportHeaderRow  {
   display: flex;
   justify-content: space-between;
   gap: 20px;
@@ -201,30 +199,33 @@
   padding: 0px 20px;
 }
 
-.report-header-title h3 {
+.reportHeaderTitle {
   margin: 0;
   font-size: 32px;
   font-weight: 600;
   color: #000;
 }
 
-.report-header-actions {
+.reportHeaderActions {
   display: flex;
   gap: 20px;
   flex-wrap: wrap;
-}
+} */
 
-@media (max-width: 600px) {
-  .container {
+/* @media (max-width: 600px) {
+  .totalOrgReportHeaderRow {
     flex-direction: column;
   }
-}
+} */
 
-.container-total-org-wrapper.bg-oxford-blue .component-container p.m-0,
-.container-total-org-wrapper.bg-oxford-blue .component-container span {
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .componentContainer p.m-0,
+.containerTotalOrgWrapper:global(.bg-oxford-blue) .componentContainer span {
   color: #fff !important;
 }
 
-.total-org-chart-title.dark-mode p {
+.totalOrgChartTitleDark p {
   color: white;
+}
+.whiteSmoke {
+  background-color: #f5f5f5;   
 }

--- a/src/components/TotalOrgSummary/VolunteerActivities/VolunteerActivities.jsx
+++ b/src/components/TotalOrgSummary/VolunteerActivities/VolunteerActivities.jsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { normalizeVolunteerActivities } from '~/utils/totalOrgSummary';
 import Loading from '~/components/common/Loading';
 import StatisticsTab from '../StatisticsTab/StatisticsTab';
-
+import styles from '../TotalOrgSummary.module.css';
 function VolunteerActivities({
   isLoading,
   totalSummariesSubmitted,
@@ -42,7 +42,7 @@ function VolunteerActivities({
 
   return (
     <div
-      className="volunteer-status-grid"
+      className={styles.volunteerStatusGrid} // ⬅️ use module class
       role="region"
       aria-label="Volunteer Activities Statistics"
     >

--- a/src/components/TotalOrgSummary/VolunteerStatus/VolunteerStatus.jsx
+++ b/src/components/TotalOrgSummary/VolunteerStatus/VolunteerStatus.jsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { normalizeVolunteerStats } from '~/utils/totalOrgSummary';
 import Loading from '~/components/common/Loading';
 import StatisticsTab from '../StatisticsTab/StatisticsTab';
-
+import styles from '../TotalOrgSummary.module.css';
 function VolunteerStatus({ isLoading, volunteerNumberStats, totalHoursWorked, comparisonType }) {
   const statsTabs = useMemo(() => normalizeVolunteerStats(volunteerNumberStats, totalHoursWorked), [
     volunteerNumberStats,
@@ -12,7 +12,7 @@ function VolunteerStatus({ isLoading, volunteerNumberStats, totalHoursWorked, co
   if (isLoading) {
     return (
       <div className="d-flex justify-content-center align-items-center">
-        <div className="w-100vh">
+        <div className={styles.fullViewportWidth}>
           <Loading />
         </div>
       </div>
@@ -20,7 +20,12 @@ function VolunteerStatus({ isLoading, volunteerNumberStats, totalHoursWorked, co
   }
 
   return (
-    <div className="volunteer-status-grid" role="region" aria-label="Volunteer Status Statistics">
+    <div
+      className={styles.volunteerStatusGrid}
+      data-pdf-grid
+      role="region"
+      aria-label="Volunteer Status Statistics"
+    >
       {statsTabs.map(tab => (
         <StatisticsTab
           key={tab.type}


### PR DESCRIPTION
…d scope styles

# Description
This PR converts the /totalorgsummary page from global CSS to CSS Modules to stop style leakage across the app . The goal is to ensure changes on this page never affect other pages again; especially things like text turning red due to global styles.

## Related PRS (if any):
…

## Main changes explained:
Renamed TotalOrgSummary.css → TotalOrgSummary.module.css.
Updated components to use styles.* classes instead of global class names. 
Removed/avoided any generic selectors that could leak
kept only necessary :global(...) hooks for third-party classes
Updated child components used on this page to reference module classes:
- VolunteerActivities.jsx now uses styles.volunteerStatusGrid.
Preserved dark mode styling inside the module under the page .
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Go to /totalorgsummary
6.Verify that /totalorgsummary renders with the expected layout (map + status chart side-by-side; “Volunteer Activities” in a grid) and no red text caused by CSS/global style bleed appears anywhere on the page. 
7. Verify that this  works in dark mode as well
## Screenshots or videos of changes:

<img width="1512" height="834" alt="image" src="https://github.com/user-attachments/assets/8c8213a0-e6a2-46ab-9e1c-afeaea9836ce" />

<img width="1512" height="834" alt="image" src="https://github.com/user-attachments/assets/7b979029-1f77-46c1-812b-92a2f53e609d" />


