### PR TITLE
Ramsundar - Fix-The-Project-page-and-edit-button

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -895,7 +895,7 @@ function AddTaskModal(props) {
 }
 
 const mapStateToProps = state => ({
-  // tasks: state.tasks.taskItems,
+  tasks: state.tasks.taskItems,
   copiedTask: state.tasks.copiedTask,
   allMembers: state.projectMembers.members,
   allProjects: state.allProjects,

--- a/src/components/Projects/WBS/wbs.jsx
+++ b/src/components/Projects/WBS/wbs.jsx
@@ -46,7 +46,7 @@ const WBS = props => {
   return (
     <React.Fragment>
       <div className={darkMode ? 'bg-oxford-blue text-light' : ''} style={{minHeight: "100%"}}>
-        <div className={`container pt-2 border border-secondary rounded ${darkMode ? 'text-light' : ''}`}style={darkMode ? { backgroundColor: '#1B2A41', alignItems: 'normal' } : { alignItems: 'normal' }}>
+        <div className={`container pt-2 border rounded ${darkMode ? 'text-light' : ''}`}style={darkMode ? { backgroundColor: '#1B2A41', alignItems: 'normal' } : { alignItems: 'normal' }}>
           <nav aria-label="breadcrumb">
             <div className={`d-flex align-items-center breadcrumb ${darkMode ? 'bg-space-cadet' : ''}`} 
               style={{ 


### PR DESCRIPTION
# Description

Error Description Video: https://www.loom.com/share/e958b8c4f3ed4d2b840a39e2a6ba7503?sid=973f798f-7ca1-40db-ad65-3f555128c8f6

There are two bugs here. The first error is if we go to the dashboard, other links to Projects, if you click WBS, there was an extra border. The second error, if you go inside any WBS Task, there is a button called Edit, if you click that, it goes to an empty page.

<img width="1467" height="879" alt="Screenshot 2025-08-09 at 6 16 43 PM" src="https://github.com/user-attachments/assets/ed0e337b-0905-46a7-9712-86a12a406825" />
 
## Related PRS (if any):
This frontend PR is related to the latest development branch.


## Main changes explained:
- First issue was a CSS issue. 
- Second issue was that the crash happened because tasks wasn’t mapped from Redux, so it was undefined and caused .find() to fail. I fixed it by restoring tasks: state.tasks.taskItems in mapStateToProps, making tasks a proper array again.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other links -> projects -> WBS (check border) For the first issue
6. For the second issue: go into WBS -> Click any task -> Edit button (Check if you click the edit, it doesnt go to an empty page, a dropdown comes)

## Screenshots or videos of changes:
AFTER:
https://www.loom.com/share/91d1c00035f749dc8bd958c695b63a33?sid=83602d99-2022-4309-9f6e-02fe3e5f8264


## Note:
Include the information the reviewers need to know.
