### PR TITLE
Reina link skills to app new frontend

### DIFF
--- a/src/components/HGNForm/questionpages/InfoForm.jsx
+++ b/src/components/HGNForm/questionpages/InfoForm.jsx
@@ -164,7 +164,6 @@ function InfoForm() {
             pattern=".{2,}"
             title="Name must be at least 2 characters long"
             placeholder="Your First and Last Name"
-            disabled={!!(userProfile !== undefined || userProfile !== null)}
           />
           {showError && (
             <span className={`${styles.errorMessage}`}>

--- a/src/components/HGNForm/questionpages/InfoForm.jsx
+++ b/src/components/HGNForm/questionpages/InfoForm.jsx
@@ -9,7 +9,7 @@ function InfoForm() {
   const formData = useSelector(state => state.hgnForm);
   const dispatch = useDispatch();
   const user = useSelector(state => state.auth.user);
-  const isOwner = user.role === 'Owner';
+  const isOwner = user.role === 'Owner' || 'Administrator' || 'Manager' || 'Volunteer';
   const { userProfilesBasicInfo } = useSelector(state => state.allUserProfilesBasicInfo);
   const userProfile = userProfilesBasicInfo.find(profile => profile._id === user.userid);
   const [newVolunteer, setNewVolunteer] = useState({
@@ -41,19 +41,20 @@ function InfoForm() {
   }, [newVolunteer.name, newVolunteer.slack]);
 
   useEffect(() => {
-    if (user && userProfile && formData) {
+    if (user && formData) {
       setNewVolunteer(prevState => ({
         ...formData,
-        ...prevState, // This preserves any user input
-        name: `${userProfile?.firstName} ${userProfile?.lastName}`,
+        ...prevState,
+        name: userProfile
+          ? `${userProfile.firstName || ''} ${userProfile.lastName || ''}`.trim()
+          : prevState.name,
         email: user.email,
-        github: prevState.github || formData.github || '', // Preserve GitHub value
-        slack: prevState.slack || formData.slack || '', // Preserve
+        github: prevState.github || formData.github || '',
+        slack: prevState.slack || formData.slack || '',
       }));
       setLoading(false);
     }
   }, [userProfile, user, formData]);
-
   const handleSlackChange = e => {
     const { checked } = e.target;
     setNewVolunteer({

--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/components/BackendSkills.jsx
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/components/BackendSkills.jsx
@@ -1,36 +1,90 @@
+import { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import axios from 'axios';
+import { toast } from 'react-toastify';
+import { Spinner } from 'reactstrap';
+import { ENDPOINTS } from '~/utils/URL';
 import styles from '../styles/SkillsSection.module.css';
 
-function BackendSkills({ profileData }) {
-  const safeProfileData = profileData || {};
-  const skillInfo = safeProfileData.skillInfo || {};
-  const backend = skillInfo.backend || {};
-  const general = skillInfo.general || {};
-  const frontend = skillInfo.frontend || {};
+function BackendSkills() {
+  const [userSkillsData, setUserSkillsData] = useState(null);
+  const [skillsLoading, setSkillsLoading] = useState(true);
+  const currentUser = useSelector(state => state.auth.user);
 
-  const skills = [
-    { value: backend.Overall, label: 'Overall Backend' },
-    { value: general.mern_skills, label: 'MERN Stack' },
-    { value: backend.TestDrivenDev, label: 'Test Driven Development' },
-    { value: backend.Database, label: 'Database Setup' },
-    { value: backend.MongoDB, label: 'MongoDB' },
-    { value: backend.MongoDB_Advanced, label: 'MongoDB Advanced' },
-    { value: frontend.UnitTest, label: 'Unit Testing' },
-  ];
+  const fetchUserSkills = async () => {
+    try {
+      setSkillsLoading(true);
+      const response = await axios.get(`${ENDPOINTS.HGN_FORM_SUBMIT}`, {
+        params: { skillsOnly: true },
+      });
+      const userSurveyData = response.data.find(
+        user => user.userInfo?.email?.toLowerCase() === currentUser.email?.toLowerCase(),
+      );
 
-  // Function to determine color based on value
+      if (userSurveyData) {
+        setUserSkillsData(userSurveyData);
+      }
+    } catch (error) {
+      toast.error('Failed to load skills data.');
+    } finally {
+      setSkillsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (currentUser?.email) {
+      fetchUserSkills();
+    } else {
+      setSkillsLoading(false);
+    }
+  }, [currentUser]);
+
+  const getSkillsArray = () => {
+    if (!userSkillsData) return [];
+
+    const backend = userSkillsData.backend || {};
+    const frontend = userSkillsData.frontend || {};
+    const general = userSkillsData.general || {};
+
+    return [
+      { value: general.mern_skills, label: 'MERN Stack' },
+      { value: backend.TestDrivenDev, label: 'Test-Driven Development' },
+      { value: backend.Database, label: 'Database Setup' },
+      { value: backend.Overall, label: 'Overall Backend' },
+      { value: frontend.UnitTest, label: 'Unit Testing' },
+      { value: backend.MongoDB, label: 'MongoDB' },
+    ];
+  };
+
   const getColorClass = value => {
-    const numValue = Number(value) || 0; // Convert to number, default to 0 if undefined
+    const numValue = Number(value) || 0;
     if (numValue <= 4) return `${styles.skillValue} ${styles.red}`;
     if (numValue <= 7) return `${styles.skillValue} ${styles.orange}`;
-    return `${styles.skillValue} ${styles.green}`; // 9-10
+    return `${styles.skillValue} ${styles.green}`;
   };
+
+  const getDisplayValue = value => {
+    const numValue = Number(value) || 0;
+
+    return numValue;
+  };
+
+  if (skillsLoading) {
+    return (
+      <div className={`${styles.skillsLoading}`}>
+        <Spinner size="sm" color="primary" />
+        <span>Loading skills...</span>
+      </div>
+    );
+  }
+  const skills = getSkillsArray();
 
   return (
     <div className={`${styles.skillSection}`}>
       <div className={`${styles.skillsRow}`}>
         {skills.map(skill => (
           <div key={skill.label} className={`${styles.skillItem}`}>
-            <span className={getColorClass(skill.value)}>{skill.value || 0}</span>
+            <span className={getColorClass(skill.value)}>{getDisplayValue(skill.value)}</span>
             <span className={`${styles.skillLabel}`}>{skill.label}</span>
           </div>
         ))}

--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/components/DeploymentSkills.jsx
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/components/DeploymentSkills.jsx
@@ -1,30 +1,93 @@
+import { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import axios from 'axios';
+import { toast } from 'react-toastify';
+import { Spinner } from 'reactstrap';
+import { ENDPOINTS } from '~/utils/URL';
 import styles from '../styles/SkillsSection.module.css';
 
 function DeploymentSkills({ profileData }) {
   const safeProfileData = profileData || {};
   const skillInfo = safeProfileData.skillInfo || {};
-  const backend = skillInfo.backend || {};
+  const deployment = skillInfo.backend || {};
 
-  const skills = [
-    { value: backend.Deployment, label: 'Deployment (Azure, Docker, etc)' },
-    { value: backend.VersionControl, label: 'Version Control' },
-    { value: backend.EnvironmentSetup, label: 'Environment Setup (Windows / Linux)' },
-  ];
+  const [userSkillsData, setUserSkillsData] = useState(null);
+  const [skillsLoading, setSkillsLoading] = useState(true);
+  const currentUser = useSelector(state => state.auth.user);
 
-  // Function to determine color based on value
+  const fetchUserSkills = async () => {
+    try {
+      setSkillsLoading(true);
+      const response = await axios.get(`${ENDPOINTS.HGN_FORM_SUBMIT}`, {
+        params: { skillsOnly: true },
+      });
+      const userSurveyData = response.data.find(
+        user => user.userInfo?.email?.toLowerCase() === currentUser.email?.toLowerCase(),
+      );
+
+      if (userSurveyData) {
+        setUserSkillsData(userSurveyData);
+      }
+    } catch (error) {
+      toast.error('Failed to load skills data.');
+    } finally {
+      setSkillsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (currentUser?.email) {
+      fetchUserSkills();
+    } else {
+      setSkillsLoading(false);
+    }
+  }, [currentUser]);
+
+  const getCurrentSkillsData = () => {
+    if (userSkillsData?.backend) {
+      return userSkillsData.backend;
+    }
+    return deployment;
+  };
+
+  const getSkillsArray = () => {
+    const currentSkills = getCurrentSkillsData();
+    return [
+      { value: currentSkills.Overall, label: 'Overall Deployment' },
+      { value: currentSkills.Deployment, label: 'Deployment' },
+      { value: currentSkills.VersionControl, label: 'Version Control' },
+      { value: currentSkills.EnvironmentSetup, label: 'Environment Setup' },
+    ];
+  };
+  // get color based on value
   const getColorClass = value => {
-    const numValue = Number(value) || 0; // Convert to number, default to 0 if undefined
+    const numValue = Number(value) || 0;
     if (numValue <= 4) return `${styles.skillValue} ${styles.red}`;
     if (numValue <= 7) return `${styles.skillValue} ${styles.orange}`;
-    return `${styles.skillValue} ${styles.green}`; // 9-10
+    return `${styles.skillValue} ${styles.green}`;
   };
+
+  const getDisplayValue = value => {
+    const numValue = Number(value) || 0;
+    return numValue;
+  };
+
+  if (skillsLoading) {
+    return (
+      <div className={`${styles.skillsLoading}`}>
+        <Spinner size="sm" color="primary" />
+        <span>Loading skills...</span>
+      </div>
+    );
+  }
+  const skills = getSkillsArray();
 
   return (
     <div className={`${styles.skillSection}`}>
       <div className={`${styles.skillsRow}`}>
         {skills.map(skill => (
           <div key={skill.label} className={`${styles.skillItem}`}>
-            <span className={getColorClass(skill.value)}>{skill.value || 0}</span>
+            <span className={getColorClass(skill.value)}>{getDisplayValue(skill.value)}</span>
             <span className={`${styles.skillLabel}`}>{skill.label}</span>
           </div>
         ))}

--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/components/FrontendSkills.jsx
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/components/FrontendSkills.jsx
@@ -1,3 +1,9 @@
+import { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import axios from 'axios';
+import { toast } from 'react-toastify';
+import { Spinner } from 'reactstrap';
+import { ENDPOINTS } from '~/utils/URL';
 import styles from '../styles/SkillsSection.module.css';
 
 function FrontendSkills({ profileData }) {
@@ -5,32 +11,99 @@ function FrontendSkills({ profileData }) {
   const skillInfo = safeProfileData.skillInfo || {};
   const frontend = skillInfo.frontend || {};
 
-  const skills = [
-    { value: frontend.overall, label: 'Overall Frontend' },
-    { value: frontend.HTML, label: 'HTML' },
-    { value: frontend.CSS, label: 'CSS' },
-    { value: frontend.Bootstrap, label: 'Bootstrap' },
-    { value: frontend.React, label: 'React' },
-    { value: frontend.Redux, label: 'Redux' },
-    { value: frontend.UIUXTools, label: 'UI/UX Design' },
-    { value: frontend.ResponsiveUI, label: 'Responsive UI' },
-    { value: frontend.WebSocketCom, label: 'Web Sockets' },
-  ];
+  const [userSkillsData, setUserSkillsData] = useState(null);
+  const [skillsLoading, setSkillsLoading] = useState(true);
+  const currentUser = useSelector(state => state.auth.user);
 
-  // Function to determine color based on value
-  const getColorClass = value => {
-    const numValue = Number(value) || 0; // Convert to number, default to 0 if undefined
-    if (numValue <= 4) return `${styles.skillValue} ${styles.red}`;
-    if (numValue <= 7) return `${styles.skillValue} ${styles.orange}`;
-    return `${styles.skillValue} ${styles.green}`; // 9-10
+  const fetchUserSkills = async () => {
+    try {
+      setSkillsLoading(true);
+      const response = await axios.get(`${ENDPOINTS.HGN_FORM_SUBMIT}`, {
+        params: { skillsOnly: true },
+      });
+      const userSurveyData = response.data.find(
+        user => user.userInfo?.email?.toLowerCase() === currentUser.email?.toLowerCase(),
+      );
+
+      if (userSurveyData) {
+        setUserSkillsData(userSurveyData);
+      }
+    } catch (error) {
+      toast.error('Failed to load skills data.');
+    } finally {
+      setSkillsLoading(false);
+    }
   };
+
+  useEffect(() => {
+    if (currentUser?.email) {
+      fetchUserSkills();
+    } else {
+      setSkillsLoading(false);
+    }
+  }, [currentUser]);
+
+  // Get the current skills data
+  const getCurrentSkillsData = () => {
+    if (userSkillsData?.frontend) {
+      return userSkillsData.frontend;
+    }
+    return frontend;
+  };
+
+  // skills array based on current skills data
+  const getSkillsArray = () => {
+    const currentSkills = getCurrentSkillsData();
+
+    return [
+      { value: currentSkills.overall, label: 'Overall Frontend' },
+      { value: currentSkills.HTML, label: 'HTML' },
+      { value: currentSkills.CSS, label: 'CSS' },
+      { value: currentSkills.Bootstrap, label: 'Bootstrap' },
+      { value: currentSkills.React, label: 'React' },
+      { value: currentSkills.Redux, label: 'Redux' },
+      { value: currentSkills.UIUXTools, label: 'UI/UX Design' },
+      { value: currentSkills.ResponsiveUI, label: 'Responsive UI' },
+      { value: currentSkills.WebSocketCom, label: 'Web Sockets' },
+    ];
+  };
+
+  // determine color class based on skill value
+  const getColorClass = value => {
+    const numValue = Number(value) || 0;
+
+    let scaledValue = numValue;
+    if (userSkillsData?.frontend) {
+      scaledValue = numValue * 2;
+    }
+
+    if (scaledValue <= 4) return `${styles.skillValue} ${styles.red}`;
+    if (scaledValue <= 8) return `${styles.skillValue} ${styles.orange}`;
+    return `${styles.skillValue} ${styles.green}`;
+  };
+
+  const getDisplayValue = value => {
+    const numValue = Number(value) || 0;
+    return numValue;
+  };
+
+  if (skillsLoading) {
+    return (
+      <div className={`${styles.skillsLoading}`}>
+        <Spinner size="sm" color="primary" />
+        <span>Loading skills...</span>
+      </div>
+    );
+  }
+
+  const skills = getSkillsArray();
 
   return (
     <div className={`${styles.skillSection}`}>
       <div className={`${styles.skillsRow}`}>
         {skills.map(skill => (
           <div key={skill.label} className={`${styles.skillItem}`}>
-            <span className={getColorClass(skill.value)}>{skill.value || 0}</span>
+            <span className={getColorClass(skill.value)}>{getDisplayValue(skill.value)}</span>
             <span className={`${styles.skillLabel}`}>{skill.label}</span>
           </div>
         ))}

--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/components/LeftSection.jsx
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/components/LeftSection.jsx
@@ -1,11 +1,24 @@
 import styles from '../styles/LeftSection.module.css';
 import profilePic from './profile.jpg';
 
-function LeftSection({ profileData }) {
+function LeftSection({ profileData, darkMode }) {
   return (
-    <div className={`${styles.leftSection}`}>
+    <div
+      className={`${styles.leftSection} ${darkMode ? styles.dark : ''}`}
+      style={{
+        background: darkMode ? '#303b4fff' : '#fff',
+        color: darkMode ? '#f7fafc' : '#3e4c66ff',
+        transition: 'background 0.3s, color 0.3s',
+      }}
+    >
       <img src={profilePic} alt="Profile" className={`${styles.profilePic}`} />
-      <h1>{profileData.name.displayName || 'Unknown User'}</h1>
+      <h1
+        style={{
+          color: darkMode ? '#6c8ea7ff' : '#3182ce',
+        }}
+      >
+        {profileData.name.displayName || 'Unknown User'}
+      </h1>
       <h3>{profileData.jobTitle?.[0] || 'Job Title - N/A'}</h3>
     </div>
   );

--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/components/ProfileDetails.jsx
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/components/ProfileDetails.jsx
@@ -1,6 +1,153 @@
+import { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import axios from 'axios';
+import { toast } from 'react-toastify';
+import { Spinner } from 'reactstrap';
+import { ENDPOINTS } from '~/utils/URL';
 import styles from '../styles/ProfileDetails.module.css';
 
 function ProfileDetails({ profileData }) {
+  const [userSkillsData, setUserSkillsData] = useState(null);
+  const [skillsLoading, setSkillsLoading] = useState(true);
+  const currentUser = useSelector(state => state.auth.user);
+  const userProfile = useSelector(state => state.userProfile);
+
+  const fetchUserSkills = async () => {
+    try {
+      setSkillsLoading(true);
+      const response = await axios.get(`${ENDPOINTS.HGN_FORM_SUBMIT}`, {
+        params: { skillsOnly: true },
+      });
+      const userSurveyData = response.data.find(
+        user => user.userInfo?.email?.toLowerCase() === currentUser.email?.toLowerCase(),
+      );
+      if (userSurveyData) {
+        setUserSkillsData(userSurveyData);
+      }
+    } catch (error) {
+      toast.error('Failed to load skills data.');
+    } finally {
+      setSkillsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (currentUser?.email) {
+      fetchUserSkills();
+    } else {
+      setSkillsLoading(false);
+    }
+  }, [currentUser]);
+
+  // privacy detection
+  const getPrivacySettings = () => {
+    const profileSource = userProfile || profileData;
+    if (!profileSource || !profileSource.privacySettings) {
+      return { emailPrivate: false, phonePrivate: false, source: 'no-data' };
+    }
+    const settings = {
+      emailPrivate: profileSource.privacySettings.email === false,
+      phonePrivate:
+        profileSource.privacySettings.phoneNumber === false ||
+        profileSource.privacySettings.phone === false,
+      source: 'privacySettings',
+    };
+    return settings;
+  };
+
+  const isOwnProfile = () => {
+    const profileSource = userProfile || profileData;
+    const targetUserId = profileSource?._id || profileSource?.userId;
+    const currentUserId = currentUser?._id;
+    const isOwn = currentUserId === targetUserId;
+    return isOwn;
+  };
+
+  // should contact info be private?
+  const getContactValue = (value, isPrivate) => {
+    if (isOwnProfile()) {
+      return value || 'N/A';
+    }
+    // Hide if private
+    if (isPrivate) {
+      return '🔒 Private';
+    }
+    return value || 'N/A';
+  };
+
+  const privacySettings = getPrivacySettings();
+
+  const renderSkillsList = skills => {
+    if (!skills || (Array.isArray(skills) && skills.length === 0)) {
+      return <span className={`${styles.value}`}>No skills data available</span>;
+    }
+    if (Array.isArray(skills)) {
+      return (
+        <div className={`${styles.skillsList}`}>
+          {skills.map((skill, index) => {
+            // Create a unique key using skill properties or fallback to index
+            const key = skill.id || skill.name || `skill-${index}`;
+            return (
+              <div key={key} className={`${styles.skillItem}`}>
+                <strong>{skill.name}</strong>
+                {skill.description && (
+                  <p className={`${styles.skillDescription}`}>{skill.description}</p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+    return <span className={`${styles.value}`}>Skills data format not supported</span>;
+  };
+
+  const renderSkillsSection = () => {
+    if (skillsLoading) {
+      return (
+        <div className={`${styles.skillsLoading}`}>
+          <Spinner size="sm" color="primary" />
+          <span>Loading skills...</span>
+        </div>
+      );
+    }
+    if (!userSkillsData) {
+      return (
+        <div className={`${styles.skillsInfo}`}>
+          <span>
+            <strong>Skills:</strong>{' '}
+            <span className={`${styles.value}`}>
+              Complete the skills survey to view your skills
+            </span>
+          </span>
+        </div>
+      );
+    }
+    const skills = userSkillsData.followUp || {};
+    return (
+      <div className={`${styles.skillsInfo}`}>
+        {skills.programming && (
+          <div className={`${styles.teamInfo}`}>
+            <strong>Programming Languages:</strong>
+            {renderSkillsList(skills.programming || skills.programmingLanguages)}
+          </div>
+        )}
+        {skills.other_skills && (
+          <div className={`${styles.skillCategory}`}>
+            <strong className={styles.otherSkills}>Other Skills: </strong>
+            <span className={styles.value}>{skills.other_skills}</span>
+          </div>
+        )}
+        {!skills.other_skills && !skills.programming && (
+          <span>
+            <strong>Skills:</strong>{' '}
+            <span className={`${styles.value}`}>No skills data available</span>
+          </span>
+        )}
+      </div>
+    );
+  };
+
   return (
     <div className={`${styles.profileDetails}`}>
       <h3>User Profile</h3>
@@ -9,50 +156,91 @@ function ProfileDetails({ profileData }) {
         <span>
           <strong>Team Name:</strong>{' '}
           <span className={`${styles.value}`}>
-            {profileData.teams?.length > 0
-              ? profileData.teams[profileData.teams.length - 1].name
+            {(userProfile || profileData)?.teams?.length > 0
+              ? (userProfile || profileData).teams[(userProfile || profileData).teams.length - 1]
+                  .name
               : 'Not Assigned'}
           </span>
         </span>
         <span>
           <strong>Years of Experience:</strong>{' '}
           <span className={`${styles.value}`}>
-            {profileData.skillInfo?.general?.yearsOfExperience || 'N/A'}
+            {userSkillsData?.general?.period ||
+              (userProfile || profileData)?.skillInfo?.general?.yearsOfExperience ||
+              'N/A'}
           </span>
         </span>
       </div>
+      <h3>Skills</h3>
+      <hr className={`${styles.horizontalSeparator}`} />
+      {renderSkillsSection()}
       <h3>Contact Information</h3>
       <hr className={`${styles.horizontalSeparator}`} />
       <div className={`${styles.contactsInfo}`}>
         <span>
           <strong>Email:</strong>{' '}
-          <span className={`${styles.value}`}>{profileData.contactInfo.email || '🔒'}</span>
+          <span className={`${styles.value}`}>
+            {getContactValue(
+              userSkillsData?.userInfo?.email ||
+                (userProfile || profileData)?.contactInfo?.email ||
+                (userProfile || profileData)?.email,
+              privacySettings.emailPrivate,
+              'email',
+            )}
+          </span>
         </span>
         <span>
           <strong>Phone Number:</strong>{' '}
-          <span className={`${styles.value}`}>{profileData.contactInfo.phone || '🔒'}</span>
+          <span className={`${styles.value}`}>
+            {getContactValue(
+              userSkillsData?.userInfo?.phone ||
+                (userProfile || profileData)?.contactInfo?.phone ||
+                (userProfile || profileData)?.phoneNumber,
+              privacySettings.phonePrivate,
+              'phone',
+            )}
+          </span>
         </span>
         <span>
           <strong>Slack:</strong>{' '}
-          <span className={`${styles.value}`}>{profileData.socialHandles.slack || 'N/A'}</span>
+          <span className={`${styles.value}`}>
+            {userSkillsData?.userInfo?.slack ||
+              (userProfile || profileData)?.socialHandles?.slack ||
+              'N/A'}
+          </span>
         </span>
         <span>
           <strong>GitHub:</strong>{' '}
           <span className={`${styles.value}`}>
-            {profileData.socialHandles.github ? (
+            {userSkillsData?.userInfo?.github ||
+            (userProfile || profileData)?.socialHandles?.github ? (
               <a
                 href={
-                  profileData.socialHandles.github.includes('http')
-                    ? profileData.socialHandles.github
-                    : `https://github.com/${profileData.socialHandles.github}`
+                  (
+                    userSkillsData?.userInfo?.github ||
+                    (userProfile || profileData).socialHandles.github
+                  ).includes('http')
+                    ? userSkillsData?.userInfo?.github ||
+                      (userProfile || profileData).socialHandles.github
+                    : `https://github.com/${userSkillsData?.userInfo?.github ||
+                        (userProfile || profileData).socialHandles.github}`
                 }
                 target="_blank"
                 rel="noopener noreferrer"
                 className={`${styles.githubLink}`}
               >
-                {profileData.socialHandles.github.includes('http')
-                  ? profileData.socialHandles.github.split('/').pop()
-                  : profileData.socialHandles.github}
+                {(
+                  userSkillsData?.userInfo?.github ||
+                  (userProfile || profileData).socialHandles.github
+                ).includes('http')
+                  ? (
+                      userSkillsData?.userInfo?.github ||
+                      (userProfile || profileData).socialHandles.github
+                    )
+                      .split('/')
+                      .pop()
+                  : userSkillsData?.userInfo?.github ||
+                    (userProfile || profileData).socialHandles.github}
               </a>
             ) : (
               'N/A'

--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/components/RadarChart.jsx
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/components/RadarChart.jsx
@@ -1,3 +1,7 @@
+import { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import axios from 'axios';
+import { toast } from 'react-toastify';
 import { Radar } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -8,86 +12,219 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
+import { Spinner } from 'reactstrap';
+import { ENDPOINTS } from '~/utils/URL';
 import styles from '../styles/RadarChart.module.css';
 
 ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip, Legend);
 
 // Define skill mappings: label -> data source
 const SKILL_MAPPINGS = [
-  { label: 'Leadership Exp', value: g => g.leadership_experience },
-  { label: 'Leadership Skills', value: g => g.leadership_skills },
-  { label: 'Frontend & Backend Overall', value: g => g.combined_frontend_backend },
-  { label: 'MERN Stack', value: g => g.mern_skills },
-
-  { label: 'Frontend', value: f => f.overall },
-  { label: 'Figma', value: f => f.UIUXTools },
-  { label: 'Responsive UI', value: f => f.ResponsiveUI },
-  { label: 'HTML Semantics', value: f => f.HTML },
-  { label: 'Bootstrap', value: f => f.Bootstrap },
-  { label: 'CSS Advanced', value: f => f.CSS },
-  { label: 'React Advanced', value: f => f.React },
-  { label: 'Redux', value: f => f.Redux },
-  { label: 'Documentation', value: f => f.Documentation },
-  { label: 'Web Sockets', value: f => f.WebSocketCom },
-  { label: 'Testing', value: f => f.UnitTest },
-
-  { label: 'Backend', value: b => b.Overall },
-  { label: 'TDD', value: b => b.TestDrivenDev },
-  { label: 'Database', value: b => b.Database },
-  { label: 'MongoDB', value: b => b.MongoDB },
-  { label: 'MongoDB Advanced', value: b => b.MongoDB_Advanced },
-  { label: 'Deployment', value: b => b.Deployment },
-  { label: 'Version Control', value: b => b.VersionControl },
-  { label: 'Code Review', value: b => b.CodeReview },
-  { label: 'Env Setup', value: b => b.EnvironmentSetup },
-  { label: 'Advanced Coding', value: b => b.AdvancedCoding },
-  { label: 'Agile', value: b => b.AgileDevelopment },
+  { label: 'Leadership Exp', section: 'general', key: 'leadership_experience' },
+  { label: 'Leadership Skills', section: 'general', key: 'leadership_skills' },
+  { label: 'Frontend & Backend Overall', section: 'general', key: 'combined_frontend_backend' },
+  { label: 'MERN Stack', section: 'general', key: 'mern_skills' },
+  { label: 'Frontend', section: 'frontend', key: 'overall' },
+  { label: 'Figma', section: 'frontend', key: 'UIUXTools' },
+  { label: 'Responsive UI', section: 'frontend', key: 'ResponsiveUI' },
+  { label: 'HTML Semantics', section: 'frontend', key: 'HTML' },
+  { label: 'Bootstrap', section: 'frontend', key: 'Bootstrap' },
+  { label: 'CSS Advanced', section: 'frontend', key: 'CSS' },
+  { label: 'React Advanced', section: 'frontend', key: 'React' },
+  { label: 'Redux', section: 'frontend', key: 'Redux' },
+  { label: 'Documentation', section: 'frontend', key: 'Documentation' },
+  { label: 'Web Sockets', section: 'frontend', key: 'WebSocketCom' },
+  { label: 'Testing', section: 'frontend', key: 'UnitTest' },
+  { label: 'Backend', section: 'backend', key: 'overall' },
+  { label: 'TDD', section: 'backend', key: 'TestDrivenDev' },
+  { label: 'Database', section: 'backend', key: 'Database' },
+  { label: 'MongoDB', section: 'backend', key: 'MongoDB' },
+  { label: 'MongoDB Advanced', section: 'backend', key: 'MongoDB_Advanced' },
+  { label: 'Deployment', section: 'backend', key: 'Deployment' },
+  { label: 'Version Control', section: 'backend', key: 'VersionControl' },
+  { label: 'Code Review', section: 'backend', key: 'CodeReview' },
+  { label: 'Env Setup', section: 'backend', key: 'EnvironmentSetup' },
+  { label: 'Advanced Coding', section: 'backend', key: 'AdvancedCoding' },
+  { label: 'Agile', section: 'backend', key: 'AgileDevelopment' },
 ];
 
-function RadarChart({ profileData }) {
+function RadarChart({ profileData, darkMode }) {
   const safeProfileData = profileData || {};
   const skillInfo = safeProfileData.skillInfo || {};
   const general = skillInfo.general || {};
   const frontend = skillInfo.frontend || {};
   const backend = skillInfo.backend || {};
 
-  // Generate chart data dynamically
-  const chartData = {
-    labels: SKILL_MAPPINGS.map(skill => skill.label),
-    datasets: [
-      {
-        label: 'Skills',
-        data: SKILL_MAPPINGS.map(skill => {
-          const source = skill.value(general) ?? skill.value(frontend) ?? skill.value(backend) ?? 0;
-          return source;
-        }),
-        backgroundColor: 'rgba(255, 99, 132, 0.2)',
-        borderColor: 'rgba(255, 99, 132, 1)',
-        borderWidth: 2,
-      },
-    ],
+  const [userSkillsData, setUserSkillsData] = useState(null);
+  const [skillsLoading, setSkillsLoading] = useState(true);
+  const currentUser = useSelector(state => state.auth.user);
+
+  const fetchUserSkills = async () => {
+    try {
+      setSkillsLoading(true);
+      const response = await axios.get(`${ENDPOINTS.HGN_FORM_SUBMIT}`, {
+        params: { skillsOnly: true },
+      });
+      const userSurveyData = response.data.find(
+        user => user.userInfo?.email?.toLowerCase() === currentUser.email?.toLowerCase(),
+      );
+
+      if (userSurveyData) {
+        setUserSkillsData(userSurveyData);
+      }
+    } catch (error) {
+      toast.error('Failed to load skills data.');
+    } finally {
+      setSkillsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (currentUser?.email) {
+      fetchUserSkills();
+    } else {
+      setSkillsLoading(false);
+    }
+  }, [currentUser]);
+
+  // get skill value from current data submitted
+  const getSkillValue = (section, key) => {
+    let value = 0;
+
+    // user survey data first
+    if (userSkillsData) {
+      if (userSkillsData[section] && userSkillsData[section][key] !== undefined) {
+        value = Number(userSkillsData[section][key]) || 0;
+        return value;
+      }
+    }
+
+    // Fall back to profile data
+    const profileSections = { general, frontend, backend };
+    if (profileSections[section] && profileSections[section][key] !== undefined) {
+      value = Number(profileSections[section][key]) || 0;
+    }
+
+    return value;
+  };
+
+  // dynamic chart data
+  const getChartData = () => {
+    const data = SKILL_MAPPINGS.map(skill => {
+      const value = getSkillValue(skill.section, skill.key);
+      return value;
+    });
+
+    return {
+      labels: SKILL_MAPPINGS.map(skill => skill.label),
+      datasets: [
+        {
+          label: 'Skills (Profile Data)',
+          data,
+          backgroundColor: darkMode ? 'rgba(160, 240, 232, 0.2)' : 'rgba(160, 240, 232, 0.2)',
+          borderColor: darkMode ? 'rgb(107, 234, 232)' : 'rgb(107, 234, 232)',
+          borderWidth: 2,
+          pointBackgroundColor: darkMode ? 'rgb(107, 234, 232)' : 'rgb(107, 234, 232)',
+          pointBorderColor: darkMode ? '#28313fff' : '#fff',
+          pointHoverBackgroundColor: darkMode ? '#303b4f' : '#fff',
+          pointHoverBorderColor: darkMode ? 'rgb(107, 234, 232)' : 'rgb(107, 234, 232)',
+          pointRadius: 4,
+          pointHoverRadius: 6,
+        },
+      ],
+    };
   };
 
   const chartOptions = {
     scales: {
       r: {
-        angleLines: { display: true },
-        suggestedMin: 0,
-        suggestedMax: 10,
-        ticks: { stepSize: 2 },
+        angleLines: {
+          color: darkMode ? '#4a5568' : '#e2e8f0',
+          lineWidth: 1,
+          suggestedMin: 0,
+          suggestedMax: 10,
+        },
+        grid: {
+          color: darkMode ? '#4a5568' : '#e2e8f0',
+          lineWidth: 1,
+        },
+        pointLabels: {
+          color: darkMode ? '#f7fafc' : '#2d3748',
+          font: { size: 10 },
+        },
+        min: 0,
+        max: 10,
+        ticks: {
+          stepSize: 2,
+          color: darkMode ? '#f7fafc' : '#2d3748',
+          backdropColor: 'transparent',
+          callback(value) {
+            return value;
+          },
+        },
       },
     },
     plugins: {
       legend: {
-        display: false,
+        display: true,
         position: 'bottom',
+        labels: {
+          color: darkMode ? '#f7fafc' : '#2d3748',
+        },
+      },
+      tooltip: {
+        backgroundColor: darkMode ? '#303b4f' : '#fff',
+        titleColor: darkMode ? '#f7fafc' : '#2d3748',
+        bodyColor: darkMode ? '#f7fafc' : '#2d3748',
+        borderColor: darkMode ? '#4a5568' : '#e2e8f0',
+        borderWidth: 1,
+        callbacks: {
+          label(context) {
+            return `${context.dataset.label}: ${context.parsed.r}`;
+          },
+        },
+      },
+    },
+    responsive: true,
+    maintainAspectRatio: false,
+    elements: {
+      point: {
+        radius: 4,
+        hoverRadius: 6,
+      },
+      line: {
+        borderWidth: 2,
       },
     },
   };
 
+  if (skillsLoading) {
+    return (
+      <div className={`${styles.radarChart} ${styles.loading}`}>
+        <div className="d-flex justify-content-center align-items-center h-200">
+          <Spinner size="sm" color="primary" />
+          <span className="ms-2">Loading skills data...</span>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className={`${styles.radarChart}`}>
-      <Radar data={chartData} options={chartOptions} />
+    <div
+      className={`${styles.radarChart}`}
+      style={{
+        width: '500px',
+        height: '400px',
+        margin: '0 auto',
+        marginTop: '-10px',
+        background: darkMode ? '#303b4f' : '#fff',
+        color: darkMode ? '#f7fafc' : '#2d3748',
+        borderRadius: '12px',
+        transition: 'background 0.3s, color 0.3s',
+      }}
+    >
+      {userSkillsData && <div className={`${styles.dataSourceIndicator}`} />}
+      <Radar data={getChartData()} options={chartOptions} />
     </div>
   );
 }

--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/components/RightSection.jsx
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/components/RightSection.jsx
@@ -8,36 +8,42 @@ import DeploymentSkills from './DeploymentSkills';
 import SoftwarePractices from './SoftwarePractices';
 import styles from '../styles/RightSection.module.css';
 
-function RightSection({ profileData }) {
+function RightSection({ profileData, darkMode }) {
   const [selectedSkill, setSelectedSkill] = useState('Dashboard');
 
   const handleSkillClick = skill => {
-    setSelectedSkill(skill); // Update selected skill
+    setSelectedSkill(skill);
   };
 
-  // Render the appropriate component based on selectedSkill
   const renderContent = () => {
     switch (selectedSkill) {
       case 'Dashboard':
-        return <RadarChart profileData={profileData} />;
+        return <RadarChart profileData={profileData} darkMode={darkMode} />;
       case 'Frontend':
-        return <FrontendSkills profileData={profileData} />;
+        return <FrontendSkills profileData={profileData} darkMode={darkMode} />;
       case 'Backend':
-        return <BackendSkills profileData={profileData} />;
+        return <BackendSkills profileData={profileData} darkMode={darkMode} />;
       case 'Deployment & DevOps':
-        return <DeploymentSkills profileData={profileData} />;
+        return <DeploymentSkills profileData={profileData} darkMode={darkMode} />;
       case 'Software Practices':
-        return <SoftwarePractices profileData={profileData} />;
+        return <SoftwarePractices profileData={profileData} darkMode={darkMode} />;
       default:
-        return <RadarChart profileData={profileData} />;
+        return <RadarChart profileData={profileData} darkMode={darkMode} />;
     }
   };
 
   return (
-    <div className={`${styles.rightSection}`}>
-      <ProfileDetails profileData={profileData} />
+    <div
+      className={`${styles.rightSection} ${darkMode ? styles.dark : ''}`}
+      style={{
+        background: darkMode ? '#303b4fff' : '#fff',
+        color: darkMode ? '#f7fafc' : '#38445aff',
+        transition: 'background 0.3s, color 0.3s',
+      }}
+    >
+      <ProfileDetails profileData={profileData} darkMode={darkMode} />
       <div className={`${styles.skillsAndChart}`}>
-        <Skills selectedSkill={selectedSkill} onSkillClick={handleSkillClick} />
+        <Skills selectedSkill={selectedSkill} onSkillClick={handleSkillClick} darkMode={darkMode} />
         {renderContent()}
       </div>
     </div>

--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/components/UserSkillsProfile.jsx
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/components/UserSkillsProfile.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
-import { toast } from 'react-toastify';
-import { useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import axios from 'axios';
 import { ClipLoader } from 'react-spinners';
 import jwtDecode from 'jwt-decode';
@@ -12,9 +11,9 @@ function UserSkillsProfile() {
   const [profileData, setProfileData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const history = useHistory();
 
-  // Fetch data from backend on component mount
+  const darkMode = useSelector(state => state.theme.darkMode);
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -23,34 +22,20 @@ function UserSkillsProfile() {
           throw new Error('No token found. Please log in.');
         }
 
-        // Decode the token to get the user ID
         const decodedToken = jwtDecode(token);
-        // console.log('Decoded Token:', decodedToken);
         const userId = decodedToken.userid;
         if (!userId) {
           throw new Error('User ID not found in token.');
         }
 
-        const response = await axios.get(
-          // 'http://localhost:4500/api/skills/profile/665524c257ca141fe8921b41',
-          `http://localhost:4500/api/skills/profile/${userId}`,
-          {
-            headers: {
-              Authorization: `${token}`,
-            },
+        const response = await axios.get(`http://localhost:4500/api/skills/profile/${userId}`, {
+          headers: {
+            Authorization: `${token}`,
           },
-        );
+        });
 
         const { data } = response;
         if (!data) throw new Error('Failed to fetch profile data');
-
-        if (data.isPlaceholder) {
-          toast.warn('Please complete the skills survey to access the HGN Skills dashboard.');
-
-          setTimeout(() => {
-            history.push('/hgnform');
-          }, 2500);
-        }
 
         setProfileData(data);
         setLoading(false);
@@ -61,12 +46,18 @@ function UserSkillsProfile() {
     };
 
     fetchData();
-  }, []); // Empty dependency array - runs only once on mount
+  }, []);
 
   if (loading) {
     return (
-      <div className={`${styles.skillsLoader}`}>
-        <ClipLoader color="#007bff" size={70} />
+      <div
+        className={`${styles.skillsLoader} ${darkMode ? styles.dark : ''}`}
+        style={{
+          background: darkMode ? '#3a506b' : '#fff',
+          color: darkMode ? '#f7fafc' : '#2d3748',
+        }}
+      >
+        <ClipLoader color={darkMode ? '#90cdf4' : '#007bff'} size={70} />
         <p>Loading Profile...</p>
       </div>
     );
@@ -74,7 +65,13 @@ function UserSkillsProfile() {
 
   if (error) {
     return (
-      <div className={`${styles.skillsError}`}>
+      <div
+        className={`${styles.skillsError} ${darkMode ? styles.dark : ''}`}
+        style={{
+          background: darkMode ? '#3a506b' : '#fff',
+          color: darkMode ? '#f7fafc' : '#2d3748',
+        }}
+      >
         <p>Error: {error}</p>
       </div>
     );
@@ -82,18 +79,32 @@ function UserSkillsProfile() {
 
   if (!profileData) {
     return (
-      <div className={`${styles.skillsError}`}>
+      <div
+        className={`${styles.skillsError} ${darkMode ? styles.dark : ''}`}
+        style={{
+          background: darkMode ? '#3a506b' : '#fff',
+          color: darkMode ? '#f7fafc' : '#2d3748',
+        }}
+      >
         <p>No profile data available</p>
       </div>
     );
   }
 
   return (
-    <div className={`${styles.userProfileHome}`}>
+    <div
+      className={`${styles.userProfileHome} ${darkMode ? styles.dark : ''}`}
+      style={{
+        background: darkMode ? '#1B2A41' : '#fff',
+        color: darkMode ? '#f7fafc' : '#2d3748',
+        minHeight: '100vh',
+        transition: 'background 0.3s, color 0.3s',
+      }}
+    >
       <div className={`${styles.dashboardContainer}`}>
-        <LeftSection profileData={profileData} />
+        <LeftSection profileData={profileData} darkMode={darkMode} />
         <div className={`${styles.verticalSeparator}`} />
-        <RightSection profileData={profileData} />
+        <RightSection profileData={profileData} darkMode={darkMode} />
       </div>
     </div>
   );

--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/styles/ProfileDetails.module.css
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/styles/ProfileDetails.module.css
@@ -7,6 +7,7 @@
   color: #3ea0cb;
   font-size: 20px;
   margin-bottom: 10px;
+  margin-top: 20px;
 }
 
 .profileDetails h4 {
@@ -90,4 +91,9 @@ strong {
     flex-direction: column;
     gap: 5px;
   }
+}
+
+.otherSkills {
+  color: #869aa3;
+  font-weight: bold;
 }

--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/styles/RadarChart.module.css
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/styles/RadarChart.module.css
@@ -2,15 +2,18 @@
   flex: 1;
   display: flex;
   justify-content: center;
+  align-items: flex-start; 
+  margin-top: -40px; 
 }
 
 .radarChart canvas {
-  max-width: 500px;
-  max-height: 500px;
+  max-width: 700px; 
+  max-height: 700px;
 }
 
-@media (max-width: 768px) {
-  .radarChart {
-    margin-top: 0px;
+@media (max-width: 900px) {
+  .radarChart canvas {
+    max-width: 95vw;
+    max-height: 95vw;
   }
 }

--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/styles/UserSkillsProfile.module.css
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/styles/UserSkillsProfile.module.css
@@ -13,7 +13,7 @@
   border-radius: 10px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   overflow: hidden;
-  height: 80vh;
+  height: 100vh;
 }
 
 .verticalSeparator {

--- a/src/components/PermissionsManagement/__tests__/UserPermissionsPopup.test.jsx
+++ b/src/components/PermissionsManagement/__tests__/UserPermissionsPopup.test.jsx
@@ -299,5 +299,5 @@ describe('UserPermissionsPopup component', () => {
       const addButtons = screen.queryAllByRole('button', { name: /add/i });
       expect(addButtons.length).toBeGreaterThan(0);
     });
-  });
+  }, 15000);
 });

--- a/src/components/TeamLocations/TeamLocations.jsx
+++ b/src/components/TeamLocations/TeamLocations.jsx
@@ -2,7 +2,7 @@ import axios from 'axios';
 import 'leaflet/dist/leaflet.css';
 import { useEffect, useRef, useState, forwardRef } from 'react';
 import { MapContainer, TileLayer, useMapEvents } from 'react-leaflet';
-import MarkerClusterGroup from '@changey/react-leaflet-markercluster';
+import MarkerClusterGroup from 'react-leaflet-cluster';
 import { Button, Container, Spinner } from 'reactstrap';
 import './TeamLocations.css';
 

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -723,7 +723,12 @@ export default (
           exact
           fallback
           component={UserSkillsProfile}
-          allowedRoles={[UserRole.Administrator, UserRole.CoreTeam, UserRole.Owner]}
+          allowedRoles={[
+            UserRole.Administrator,
+            UserRole.CoreTeam,
+            UserRole.Owner,
+            UserRole.Volunteer,
+          ]}
           routePermissions={RoutePermissions.accessHgnSkillsDashboard}
         />
         <ProtectedRoute path="/tsaformpage1" exact component={TSAFormPage1} />

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -292,6 +292,7 @@ export const ENDPOINTS = {
   HGN_FORM_GET_QUESTION: `${APIEndpoint}/questions`,
   HGN_FORM_UPDATE_QUESTION: id => `${APIEndpoint}/questions/${id}`,
   HGN_FORM_SUBMIT: `${APIEndpoint}/hgnform`,
+  USER_SKILLS_PROFILE: userId => `${APIEndpoint}/skills/profile/${userId}`,
 
   CREATE_JOB_FORM: `${APIEndpoint}/jobforms`,
   UPDATE_JOB_FORM: `${APIEndpoint}/jobforms`,


### PR DESCRIPTION
# Description
Linked skills survey form user information to the frontend of /hgn/profile/skills.


## Related PRS (if any):
This frontend PR is related to the [#1649](https://github.com/OneCommunityGlobal/HGNRest/pull/1649) backend PR.
…

## Main changes explained:
- Populated user information from the HGN form using the API endpoint {HGN_FORM_SUBMIT}
…

## How to test:
1. check into current branch
2. do npm install and npm run start:local to run this PR locally
3. Clear site data/cache
4. fill out the form: http://localhost:5173/hgnform
5. go to http://localhost:5173/hgn/profile/skills and check that the given answers to the form are populated in the skills section and corresponding user information is correct
6. check light/dark mode

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/219b19cb-6846-4c1d-b1b0-83d289650d36


