### PR TITLE
Shashank Madan make delete button visible if user has delete task permission

### DIFF
--- a/src/components/Projects/WBS/SingleTask/SingleTask.jsx
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.jsx
@@ -40,6 +40,7 @@ function SingleTask(props) {
   const [modalDelete, setModalDelete] = useState(false);
   const toggleModel = () => setModal(!modal);
   const canPostProject = props.hasPermission('postProject');
+  const canDeleteTask = props.hasPermission('deleteTask');
 
   const history = useHistory();
   useEffect(() => {
@@ -162,9 +163,7 @@ function SingleTask(props) {
                       level={task.level}
                       setTask={setTask}
                     />
-                    {user.role === 'Volunteer' ? (
-                      ''
-                    ) : (
+                    {canDeleteTask && (
                       <>
                         <Button
                           type="button"


### PR DESCRIPTION
# Description
<img width="780" height="266" alt="image" src="https://github.com/user-attachments/assets/ac828b86-543e-4dfb-9802-0027652c5601" />


## Related PRS (if any):
This PR is related to the development branch of the backend

## Main changes explained:
- Refactored logic that conditionally renders the delete button to render if user has permission to delete task (Previously was rendering for all except volunteer roles) 

## How to test:
1. check into current branch
2. do `yarn install` and `yarn start` to run this PR locally
3. Clear site data/cache
4. log in as owner/admin user and assign delete task permission to a volunteer user
5. Now log in as the volunteer user with the delete task permission
6. Click on a task under some user, verify that the delete button is now visible

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/34a9d03a-bcf1-4b95-bc47-7591aec08637


