### PR TITLE
Ramsundar - Fixed editable fields issue on task edit modal

### DIFF
--- a/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/EditTask/EditTaskModal.jsx
@@ -353,14 +353,14 @@ function EditTaskModal(props) {
     ReactTooltip.rebuild();
   }, [links]);
 
-  useEffect(() => {
-    if (!modal) {
-      setStartedDate('');
-      setDueDate('');
-      setStartDateError(false);
-      setEndDateError(false);
-    }
-  }, [modal]);
+  // useEffect(() => {
+  //   if (!modal) {
+  //     setStartedDate('');
+  //     setDueDate('');
+  //     setStartDateError(false);
+  //     setEndDateError(false);
+  //   }
+  // }, [modal]);
 
   useEffect(() => {
     let isMounted = true;


### PR DESCRIPTION
# Description
<img width="746" height="161" alt="Screenshot 2025-08-16 at 5 50 54 PM" src="https://github.com/user-attachments/assets/f150888c-6e74-4f0d-96e7-3773b7309d70" />

The second issue involved the edit modal, where the Update button appeared only during the first edit attempt and was missing on subsequent edits, leaving only the Cancel option available.

Please review this https://github.com/OneCommunityGlobal/HGNRest/pull/1628. 

## Related PRS (if any):
This frontend PR is related to the #XXX backend PR.
To test this backend PR you need to checkout the #XXX frontend PR.
…

## Main changes explained:
- Corrected backend validation logic so that it only rejects negative values instead of blocking all positive values, allowing tasks with filled “Best-case,” “Worst-case,” and “Most-case” fields to be edited.
- Removed the date reset useEffect in the edit modal so values persist across modal sessions, ensuring the Update button is available on every edit attempt.

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks
6. Try editing a task that already has nonzero values in “Best-case,” “Worst-case,” and “Most-case” fields, including changing the task name and description
7. Verify that all fields can be edited and saved successfully

## Screenshots or videos of changes:
Before:
https://www.loom.com/share/88eedc9c7e5344e081089a04d3343f52?sid=62c07f0f-5200-4d09-aacd-cac96233ebf6
After:
https://www.loom.com/share/138bf8c90c1c4cfe916c23bef7f0f465?sid=5dc2b505-e6ac-48f7-91a5-8a2c84b562fa

## Note:
Include the information the reviewers need to know.
