### PR TITLE
Ramsundar - Check and Finish the X button under task name in dashboard

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -91,6 +91,7 @@ const TeamMemberTask = React.memo(
       rolesAllowedToResolveTasks.includes(userRole) || dispatch(hasPermission('getReports'));
     const canUpdateTask = dispatch(hasPermission('updateTask'));
     const canDeleteTask = dispatch(hasPermission('canDeleteTask'));
+    const canRemoveUserFromTask = dispatch(hasPermission('removeUserFromTask'));
     const numTasksToShow = isTruncated ? NUM_TASKS_SHOW_TRUNCATE : activeTasks.length;
 
     const colorsObjs = {
@@ -419,7 +420,9 @@ const TeamMemberTask = React.memo(
                                           data-testid={`tick-${task.taskName}`}
                                         />
                                       )}
-                                      {(canUpdateTask || canDeleteTask) && (
+                                      {(canUpdateTask ||
+                                        canDeleteTask ||
+                                        canRemoveUserFromTask) && (
                                         <FontAwesomeIcon
                                           className="team-member-task-remove"
                                           icon={faTimesCircle}


### PR DESCRIPTION
# Description
Check and Fix the ‘X’ button on the dashboard under task name. The Owner account is able to delete a task, but other accounts like volunteer that are assigned the ‘View and Interact with Task "X" on Dashboards" permissions are able to delete the task.

Have a look at this PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3497

## Related PRS (if any):
This frontend PR is related to the #1672 backend PR.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Initially, log as owner user
5. go to Other Links → Permissions Management → Manage User Permissions → Choose your volunteer account → click on Add button beside the ‘View and Interact with Task "X" on Dashboards’ permission → Scroll down then submit
6. Log in to your volunteer account, try to click the red ‘X’ button beside tasks. Now, you can remove the task and you get a user has been removed sucessfully. 

## Screenshots or videos of changes:
Before:
<img width="1318" height="652" alt="image" src="https://github.com/user-attachments/assets/3c5e5c2a-35f6-4a6e-94f6-7051a205a8e7" />

After:
https://www.loom.com/share/de9905b888734d32bb49e84986caacbc

## Note:
Include the information the reviewers need to know.
