### PR TITLE
Jaden Taking Over For Peterson: Implement No Teams Found Message - Teams Page (DONE Jaden)

### DIFF
--- a/src/components/Teams/Team.module.css
+++ b/src/components/Teams/Team.module.css
@@ -134,3 +134,11 @@ tr.darkModeRow:hover {
   display: flex !important;
   gap: 10px;
 }
+
+.teamNotFoundContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+}

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -30,6 +30,7 @@ import DeleteTeamPopup from './DeleteTeamPopup';
 import TeamStatusPopup from './TeamStatusPopup';
 import AddTeamPopup from '../UserProfile/TeamsAndProjects/AddTeamPopup';
 import CreateNewTeamPopup from './CreateNewTeamPopup';
+import styles from './Team.module.css';
 // constants
 const FILTER_ALL = 'all';
 const FILTER_ACTIVE = 'active';
@@ -241,15 +242,32 @@ class Teams extends React.PureComponent {
     }
 
     if (this.state.teams.length === 0) {
+      const { wildCardSearchText } = this.state;
       return (
         <div
           className={`d-flex justify-content-center align-items-center py-5 ${
             darkMode ? 'dark-mode' : ''
           }`}
         >
-          <h1 className="warning-text">
-            <strong>Team Not Found</strong>
-          </h1>
+          {wildCardSearchText ? (
+            <div className={styles.teamNotFoundContainer}>
+              <p className={darkMode ? 'text-light' : 'text-dark'}>
+                No team found matching &quot;{wildCardSearchText}&quot;, but you can create it by
+                clicking the button below.
+              </p>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={this.onCreateNewTeamFromSearch}
+              >
+                Create Team
+              </button>
+            </div>
+          ) : (
+            <h1 className="warning-text">
+              <strong>Team Not Found</strong>
+            </h1>
+          )}
         </div>
       );
     }
@@ -363,6 +381,7 @@ class Teams extends React.PureComponent {
           open={this.state.createNewTeamPopupOpen}
           onClose={this.onCreateNewTeamPopupClose}
           onOkClick={this.onCreateNewTeamOkClick}
+          teamName={this.state.createNewTeamName}
         />
       </>
     );
@@ -435,11 +454,18 @@ class Teams extends React.PureComponent {
   };
 
   onCreateNewTeamShow = () => {
-    this.setState({ createNewTeamPopupOpen: true });
+    this.setState({ createNewTeamPopupOpen: true, createNewTeamName: '' });
+  };
+
+  onCreateNewTeamFromSearch = () => {
+    this.setState({
+      createNewTeamPopupOpen: true,
+      createNewTeamName: this.state.wildCardSearchText,
+    });
   };
 
   onCreateNewTeamPopupClose = () => {
-    this.setState({ createNewTeamPopupOpen: false });
+    this.setState({ createNewTeamPopupOpen: false, createNewTeamName: '' });
   };
 
   onCreateNewTeamOkClick = async teamName => {

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -458,10 +458,10 @@ class Teams extends React.PureComponent {
   };
 
   onCreateNewTeamFromSearch = () => {
-    this.setState({
+    this.setState(prevState => ({
       createNewTeamPopupOpen: true,
-      createNewTeamName: this.state.wildCardSearchText,
-    });
+      createNewTeamName: prevState.wildCardSearchText,
+    }));
   };
 
   onCreateNewTeamPopupClose = () => {


### PR DESCRIPTION
Jaden Taking Over For Peterson: Implement No Teams Found Message - Teams Page (DONE Jaden) #3928

# Description
This open PR was created to implement a message when no team is found in the teams table.

## Related PRS (if any):
None

## Main changes explained:
The CreateNewTeamPopup.jsx component has been modified to fix the bug.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an admin or owner user.
5. Go to Other Links → Teams
6. Click on the input above the table, type the name of a team that doesn't exist, and a message with a button should appear. After clicking the button, a modal will open and the input should receive the name of the non-existent team.

## Screenshots or videos of changes:
<img width="1059" height="258" alt="image" src="https://github.com/user-attachments/assets/c8b8a952-1b38-46ce-91f9-0066f17cdf51" />
<img width="938" height="364" alt="image" src="https://github.com/user-attachments/assets/dd6f274c-303e-41ed-9a1e-d3c2e1cb778f" />
<img width="1008" height="353" alt="image" src="https://github.com/user-attachments/assets/cf31176c-b2e0-4dbc-a771-28180ca3ee2f" />
https://github.com/user-attachments/assets/b27b8f8f-7111-4bc1-9dca-0e151720e584