### PR TITLE
Peterson implemented two improvements on the 404 page.

### DIFF
--- a/src/components/Logout/Logout.jsx
+++ b/src/components/Logout/Logout.jsx
@@ -1,4 +1,4 @@
-import { Redirect } from 'react-router-dom';
+import { Redirect, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import { boxStyle, boxStyleDark } from '~/styles';
@@ -8,6 +8,7 @@ import { logoutUser } from '../../actions/authActions';
 function Logout({ setLogoutPopup, open }) {
   const darkMode = useSelector(state => state.theme.darkMode);
   const dispatch = useDispatch();
+  const redirect = useHistory();
 
   const closePopup = () => {
     setLogoutPopup(false);
@@ -22,7 +23,8 @@ function Logout({ setLogoutPopup, open }) {
 
     closePopup();
     dispatch(logoutUser());
-    return <Redirect to="/login" auth={false} />;
+    <Redirect to="/login" auth={false} />;
+    return redirect.push('/login');
   };
 
   return (

--- a/src/components/NotFound/NotFoundPage.jsx
+++ b/src/components/NotFound/NotFoundPage.jsx
@@ -12,23 +12,29 @@ function NotFoundPage() {
   const darkMode = useSelector(state => state.theme.darkMode);
 
   return (
-    <div
-      className={cn(styles.notFoundContainer, darkMode ? cn(styles.darkMode, styles.bgBlack) : '')}
-    >
-      <img
-        className={styles.notFoundImage}
-        src={darkMode ? NotFoundDarkImage : NotFoundImage}
-        alt="Page Not Found"
-      />
-      <div className={styles.notFoundText}>
-        <h1>PAGE NOT FOUND</h1>
-        <p>The rabbits have been nibbling the cables again...</p>
-        <p>
-          Maybe this will help{' '}
-          <Link to="/" className={styles.backHomeLink}>
-            Home
-          </Link>
-        </p>
+    <div className={cn(styles.notFoundContainer, darkMode ? cn(styles.darkMode) : '')}>
+      <div
+        className={styles.test}
+        //prettier-ignore
+        style={{border: `2px solid ${darkMode ? `#f1f1f1` : `#333`}`}}
+      >
+        <img
+          className={styles.notFoundImage}
+          src={darkMode ? NotFoundDarkImage : NotFoundImage}
+          alt="Page Not Found"
+        />
+        <div className={styles.notFoundText}>
+          <h1 className={darkMode ? `text-light` : `text-dark`}>PAGE NOT FOUND</h1>
+          <p className={darkMode ? `text-light` : `text-dark`}>
+            The rabbits have been nibbling the cables again...
+          </p>
+          <p className={darkMode ? `text-light` : `text-dark`}>
+            Maybe this will help{' '}
+            <Link to="/" className={styles.backHomeLink}>
+              Home
+            </Link>
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/components/NotFound/NotFoundPage.module.css
+++ b/src/components/NotFound/NotFoundPage.module.css
@@ -3,10 +3,21 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  height: 100%;
   text-align: center;
-  color: #333;
-  background-color: #fff;
+  width: 100%;
+  position: absolute;
+  top: 0;
+}
+
+body,
+html {
+  overflow: hidden;
+}
+.test{
+  padding: 5px;
+  border-radius: 20px;
+  width: 60%;
 }
 
 .notFoundImage {
@@ -42,18 +53,28 @@
 
 .darkMode {
   color: #f1f1f1;
-
-  .notFoundImage {
-    height: 38%;
-    width: auto;
-  }
-}
-
-.bgBlack {
   background-color: #121212;
 }
 
+
+
+@media (max-width: 1039px) {
+.test{
+  margin-top: 20rem;
+}
+}
+
+@media (max-width: 1200px) {
+  .test{
+    width: 92%;
+  }
+}
+
 @media (max-width: 768px) {
+  .test{
+  margin-top: 0rem;
+}
+
   .notFoundText h1 {
     font-size: 1.5em;
   }
@@ -61,4 +82,5 @@
   .notFoundText p {
     font-size: 1em;
   }
+
 }


### PR DESCRIPTION
# Description
This PR was opened to implement two improvements on the 404 page.

## Related PRS (if any):
None.

## Main changes explained:
The Projects.jsx component has been modified to implement two improvements.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as any user
5. Go to any invalid link
6. When the user logs out on the 404 page, they should be redirected to the login page. The text of the page should be black in the light theme and white in the dark theme.

## Screenshots or videos of changes:
### Before my fix
![Before my fix](https://github.com/user-attachments/assets/ceae23e3-4870-4e2f-a998-93144e428e35)


### After my fix
![After my fix](https://github.com/user-attachments/assets/7465fc22-d13a-4a84-80e6-483466670f64)

## Note:
None