### PR TITLE
venkataramanan: change active members text in leaderboard

### DIFF
--- a/src/components/LeaderBoard/LeaderBoard.container.jsx
+++ b/src/components/LeaderBoard/LeaderBoard.container.jsx
@@ -44,7 +44,7 @@ const mapStateToProps = state => {
 
   const orgData = get(state, 'orgData', {});
 
-  orgData.name = `HGN Totals: ${orgData.memberCount} Members`;
+  orgData.name = `Active Team: ${orgData.memberCount} Members`;
   orgData.tangibletime = round(orgData.totaltangibletime_hrs, 2);
   orgData.totaltime = round(orgData.totaltime_hrs, 2);
   orgData.intangibletime = round(orgData.totalintangibletime_hrs, 2);

--- a/src/components/LeaderBoard/Leaderboard.css
+++ b/src/components/LeaderBoard/Leaderboard.css
@@ -101,6 +101,14 @@
 .leaderboard-totals-container {
   display: flex;
   flex-direction: column;
+  align-items: center !important;
+  justify-content: center !important;
+  text-align: center !important;
+}
+
+.leaderboard-totals-container > * {
+  text-align: center;
+  margin: 0 auto;
 }
 
 @media screen and (max-width: 544px) {

--- a/src/components/LeaderBoard/Leaderboard.jsx
+++ b/src/components/LeaderBoard/Leaderboard.jsx
@@ -717,7 +717,7 @@ function LeaderBoard({
                         <span>{stateOrganizationData.name}</span>
                         {viewZeroHouraMembers(loggedInUser.role) && (
                           <span className="leaderboard-totals-title">
-                            0 hrs Totals:{' '}
+                            0-hrs Mentors:{' '}
                             {filteredUsers.filter(user => user.weeklycommittedHours === 0).length}{' '}
                             Members
                           </span>
@@ -731,7 +731,7 @@ function LeaderBoard({
                         <span>{stateOrganizationData.name}</span>
                         {viewZeroHouraMembers(loggedInUser.role) && (
                           <span className="leaderboard-totals-title">
-                            0 hrs Totals:{' '}
+                            0-hrs Mentors:{' '}
                             {filteredUsers.filter(user => user.weeklycommittedHours === 0).length}{' '}
                             Members
                           </span>


### PR DESCRIPTION
# Description
This PR changes the text in leaderboard from HGN totals to Active Team and 0 Hrs Totals to 0-hrs Mentors

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change files Leaderboard.container.jsx, Leaderboard.jsx and Leaderboard.css

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Leaderboard
6. Check if the text is changed.

## Screenshots or videos of changes:
<img width="420" height="344" alt="image" src="https://github.com/user-attachments/assets/a9b9ddbc-f9da-4cd4-80c7-5bfe7dd8d993" />

