### PR TITLE
Venkataramanan 🔥 hours logged issue in people report page

### DIFF
--- a/src/components/Reports/PeopleReport/PeopleReport.jsx
+++ b/src/components/Reports/PeopleReport/PeopleReport.jsx
@@ -131,6 +131,9 @@ class PeopleReport extends Component {
       prevState.isLoading !== this.state.isLoading) {
       // this.syncPanelHeights();
     }
+    if (prevProps.timeEntries !== this.props.timeEntries) {
+      this.setState({ timeEntries: this.props.timeEntries });
+    }
   }
 
   setStartDate(date) {


### PR DESCRIPTION
# Description
This PR fixes the Hours Logged issue in People Reports page.

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change file PeopleReport.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links -> User Management -> People Report
6. Check if Hours logged is displayed properly.
