### PR TITLE
Carlos - Add dark mode styles to MaterialSummary

### DIFF
--- a/src/components/MaterialSummary/MaterialSummary.jsx
+++ b/src/components/MaterialSummary/MaterialSummary.jsx
@@ -3,6 +3,7 @@ import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { Pie } from 'react-chartjs-2';
 import { mockProjects, mockMaterialData, chartColors } from './Data';
 import styles from './MaterialSummary.module.css';
+import { useSelector } from 'react-redux';
 
 // Register ChartJS components
 ChartJS.register(ArcElement, Tooltip, Legend);
@@ -14,6 +15,8 @@ export default function MaterialUsageDashboard() {
   const [chartData, setChartData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [increasePercentage, setIncreasePercentage] = useState(0);
+
+  const darkMode = useSelector(state => state.theme.darkMode);
 
   // Update the updateChartData function to handle the new material types with appropriate colors
   const updateChartData = () => {
@@ -105,6 +108,7 @@ export default function MaterialUsageDashboard() {
         const fontSize = (height / 240).toFixed(2); // Smaller font size
         ctx.font = `${fontSize}em sans-serif`;
         ctx.textBaseline = 'middle';
+        ctx.fillStyle = darkMode ? '#ffffff' : '#000000';
 
         const text = 'Materials';
         const textX = Math.round((width - ctx.measureText(text).width) / 2);
@@ -117,25 +121,32 @@ export default function MaterialUsageDashboard() {
   ];
 
   return (
-    <div className={styles.dashboardWrapper}>
-      <h1 className={styles.dashboardTitle}>Material Usage Dashboard</h1>
+    <div className={styles.dashboardWrapper + (darkMode ? ' bg-oxford-blue' : '')}>
+      <h1 className={styles.dashboardTitle + (darkMode ? ' text-light' : '')}>
+        Material Usage Dashboard
+      </h1>
       <div className={styles.gridContainer}>
         {/* Filters Section */}
         <div className={styles.filterPanel}>
-          <div className={styles.filterCard}>
+          <div className={styles.filterCard + (darkMode ? ' bg-space-cadet' : '')}>
             <div style={{ marginBottom: '16px' }}>
-              <h2 className={styles.filterCardTitle}>Filters</h2>
-              <p className={styles.filterCardDesc}>Select options to filter the chart data</p>
+              <h2 className={styles.filterCardTitle + (darkMode ? ' text-light' : '')}>Filters</h2>
+              <p className={styles.filterCardDesc + (darkMode ? ' text-light' : '')}>
+                Select options to filter the chart data
+              </p>
             </div>
             <div className={styles.filterFields}>
               {/* Project Filter */}
               <div className={styles.fieldGroup}>
-                <label htmlFor="project" className={styles.fieldLabel}>
+                <label
+                  htmlFor="project"
+                  className={styles.fieldLabel + (darkMode ? ' text-light' : '')}
+                >
                   Project
                 </label>
                 <select
                   id="project"
-                  className={styles.selectInput}
+                  className={styles.selectInput + (darkMode ? ' bg-yinmn-blue text-light' : '')}
                   value={selectedProject}
                   onChange={e => setSelectedProject(Number.parseInt(e.target.value, 10))}
                 >
@@ -149,12 +160,15 @@ export default function MaterialUsageDashboard() {
 
               {/* Material Type Filter */}
               <div className={styles.fieldGroup}>
-                <label htmlFor="material" className={styles.fieldLabel}>
+                <label
+                  htmlFor="material"
+                  className={styles.fieldLabel + (darkMode ? ' text-light' : '')}
+                >
                   Material Type
                 </label>
                 <select
                   id="material"
-                  className={styles.selectInput}
+                  className={styles.selectInput + (darkMode ? ' bg-yinmn-blue text-light' : '')}
                   value={selectedMaterial}
                   onChange={e => setSelectedMaterial(e.target.value)}
                 >
@@ -178,7 +192,10 @@ export default function MaterialUsageDashboard() {
                   onChange={e => setShowIncreaseOnly(e.target.checked)}
                   className={styles.checkboxInput}
                 />
-                <label htmlFor="increase" className={styles.checkboxLabel}>
+                <label
+                  htmlFor="increase"
+                  className={styles.checkboxLabel + (darkMode ? ' text-light' : '')}
+                >
                   Show only materials with increased usage
                 </label>
               </div>
@@ -187,8 +204,10 @@ export default function MaterialUsageDashboard() {
 
           {/* Increase Counter */}
           {showIncreaseOnly && increasePercentage !== 0 && (
-            <div className={styles.increaseCard}>
-              <div className={styles.increaseCardTitle}>Usage Trend</div>
+            <div className={styles.increaseCard + (darkMode ? ' bg-space-cadet' : '')}>
+              <div className={styles.increaseCardTitle + (darkMode ? ' text-light' : '')}>
+                Usage Trend
+              </div>
               <div className={styles.increaseTrendRow}>
                 <span
                   className={
@@ -199,7 +218,7 @@ export default function MaterialUsageDashboard() {
                 >
                   {increasePercentage > 0 ? '↑' : '↓'} {Math.abs(increasePercentage).toFixed(1)}%
                 </span>
-                <span className={styles.increaseText}>
+                <span className={styles.increaseText + (darkMode ? ' text-light' : '')}>
                   {increasePercentage > 0
                     ? 'Increase in material usage'
                     : 'Decrease in material usage'}{' '}
@@ -212,14 +231,14 @@ export default function MaterialUsageDashboard() {
 
         {/* Chart Section */}
         <div>
-          <div className={styles.chartPanel}>
+          <div className={styles.chartPanel + (darkMode ? ' bg-space-cadet' : '')}>
             <div style={{ marginBottom: '16px' }}>
-              <h2 className={styles.chartPanelTitle}>
+              <h2 className={styles.chartPanelTitle + (darkMode ? ' text-light' : '')}>
                 Material Usage Breakdown
                 {selectedMaterial !== 'all' &&
                   ` - ${selectedMaterial.charAt(0).toUpperCase() + selectedMaterial.slice(1)}`}
               </h2>
-              <p className={styles.chartPanelDesc}>
+              <p className={styles.chartPanelDesc + (darkMode ? ' text-light' : '')}>
                 {mockProjects.find(p => p.id === selectedProject)?.name}
               </p>
             </div>
@@ -227,7 +246,7 @@ export default function MaterialUsageDashboard() {
               {loading && (
                 <div className={styles.loadingArea}>
                   <div className={styles.loadingSpinner} />
-                  <p>Loading data...</p>
+                  <p className={darkMode ? ' text-light' : ''}>Loading data...</p>
                 </div>
               )}
               {!loading && chartData && (
@@ -262,7 +281,7 @@ export default function MaterialUsageDashboard() {
                   />
                 </div>
               )}
-              {!loading && !chartData && <p>No data available</p>}
+              {!loading && !chartData && <p className=" text-light">No data available</p>}
             </div>
             {/* Material Breakdown List */}
             {chartData && !loading && (
@@ -275,16 +294,35 @@ export default function MaterialUsageDashboard() {
                     return (
                       <div
                         key={`${chartData.labels[index]}-${value}`}
-                        className={styles.materialBreakdownItem}
+                        className={
+                          styles.materialBreakdownItem + (darkMode ? ' bg-yinmn-blue' : '')
+                        }
                       >
                         <div
                           className={styles.materialBreakdownDot}
                           style={{ backgroundColor: color }}
                         />
                         <div>
-                          <p className={styles.materialBreakdownName}>{label}</p>
-                          <p className={styles.materialBreakdownValue}>
-                            {value} <span className={styles.materialBreakdownUnit}>units</span>
+                          <p
+                            className={
+                              styles.materialBreakdownName + (darkMode ? ' text-light' : '')
+                            }
+                          >
+                            {label}
+                          </p>
+                          <p
+                            className={
+                              styles.materialBreakdownValue + (darkMode ? ' text-light' : '')
+                            }
+                          >
+                            {value}{' '}
+                            <span
+                              className={
+                                styles.materialBreakdownUnit + (darkMode ? ' text-light' : '')
+                              }
+                            >
+                              units
+                            </span>
                           </p>
                         </div>
                       </div>


### PR DESCRIPTION
# Description
This pull request implements dark mode styling for the material usage dashboard component.
<img width="684" height="224" alt="image" src="https://github.com/user-attachments/assets/7a6755b7-7512-45d4-be5e-05be3e38d8d6" />


## Related PRS (if any):
This frontend PR is not related to any backend PR. Use latest development branch for back end

## Main changes explained:
- Added dark mode styling for entire component

## How to test:
1. check into current branch
2. do `npm install` and  `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. enable dark mode
6. go to [http://localhost:5173/MaterialSummary](http://localhost:5173/MaterialSummary)
7. verify all MaterialSummary elements have been styled

## Screenshots or videos of changes:
Dark mode disabled
<img width="2560" height="1352" alt="materialWorkingInLightMode" src="https://github.com/user-attachments/assets/027b8acd-5a92-4dd2-b8db-d2b87b2277f2" />


Dark Mode Enabled
<img width="1188" height="672" alt="image" src="https://github.com/user-attachments/assets/96ca1585-4b7a-4f52-a7b2-57df95abb5a7" />

## Note:
This is merely a component on a temporary test route. Header and footer will be missing.
