### PR TITLE
Fatima IssueBreakdownChart to module CSS

### DIFF
--- a/src/components/BMDashboard/WeeklyProjectSummary/IssueBreakdownChart.module.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/IssueBreakdownChart.module.css
@@ -2,11 +2,10 @@
   box-sizing: border-box;
   position: relative;
   width: 100%;
-  max-width: 1400px;
-  margin: 32px auto;
-  background: #fafbfc;
+  height: 100%;
+  background: var(--card-bg, #fafbfc);
   border-radius: 18px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 2px 12px var(--card-shadow, rgba(0, 0, 0, 0.06));
   padding: 32px;
   display: flex;
   flex-direction: column;
@@ -32,7 +31,7 @@
   margin: 0;
   font-size: 36px;
   font-weight: 400;
-  color: #888;
+  color: var(--text-color, #888);
   margin-bottom: 16px;
 }
 
@@ -57,7 +56,7 @@
 }
 
 .legendLabel {
-  color: #666;
+  color: var(--text-color, #666);
   font-size: 22px;
 }
 
@@ -65,4 +64,6 @@
   width: 100%;
   height: 500px;
   margin-top: 20px;
+  background: var(--section-bg, transparent);
+  border-radius: 12px;
 }

--- a/src/components/BMDashboard/WeeklyProjectSummary/IssuesBreakdownChart.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/IssuesBreakdownChart.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   BarChart,
   Bar,
@@ -22,6 +23,12 @@ export default function IssuesBreakdownChart() {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const darkMode = useSelector(state => state.theme.darkMode);
+
+  const rootStyles = getComputedStyle(document.body);
+  const textColor = rootStyles.getPropertyValue('--text-color') || '#666';
+  const gridColor = rootStyles.getPropertyValue('--grid-color') || (darkMode ? '#444' : '#ccc');
+  const tooltipBg = rootStyles.getPropertyValue('--section-bg') || '#fff';
 
   useEffect(() => {
     const fetchData = async () => {
@@ -41,17 +48,9 @@ export default function IssuesBreakdownChart() {
     fetchData();
   }, []);
 
-  if (loading) {
-    return <div>Loading...</div>;
-  }
-
-  if (error) {
-    return <div>Error: {error}</div>;
-  }
-
-  if (!data || data.length === 0) {
-    return <div>No data available</div>;
-  }
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error}</div>;
+  if (!data || data.length === 0) return <div>No data available</div>;
 
   return (
     <div className={styles.container}>
@@ -59,6 +58,7 @@ export default function IssuesBreakdownChart() {
         <div className={styles.headerRow}>
           <h2 className={styles.heading}>Issues breakdown by Type</h2>
         </div>
+
         <div className={styles.legend}>
           <span className={styles.legendItem}>
             <span
@@ -77,21 +77,29 @@ export default function IssuesBreakdownChart() {
           </span>
         </div>
       </div>
+
       <div className={styles.chartContainer}>
         <ResponsiveContainer>
           <BarChart data={data} margin={{ top: 30, right: 30, left: 0, bottom: 30 }} barGap={8}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="projectName" />
-            <YAxis allowDecimals={false} />
-            <Tooltip />
+            <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
+            <XAxis dataKey="projectName" tick={{ fill: textColor }} />
+            <YAxis allowDecimals={false} tick={{ fill: textColor }} />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: tooltipBg,
+                border: 'none',
+                borderRadius: '8px',
+                color: textColor,
+              }}
+            />
             <Bar dataKey="equipmentIssues" name="Equipment Issues" fill={COLORS.equipmentIssues}>
-              <LabelList dataKey="equipmentIssues" position="top" />
+              <LabelList dataKey="equipmentIssues" position="top" fill={textColor} />
             </Bar>
             <Bar dataKey="laborIssues" name="Labor Issues" fill={COLORS.laborIssues}>
-              <LabelList dataKey="laborIssues" position="top" />
+              <LabelList dataKey="laborIssues" position="top" fill={textColor} />
             </Bar>
             <Bar dataKey="materialIssues" name="Materials Issues" fill={COLORS.materialIssues}>
-              <LabelList dataKey="materialIssues" position="top" />
+              <LabelList dataKey="materialIssues" position="top" fill={textColor} />
             </Bar>
           </BarChart>
         </ResponsiveContainer>

--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
@@ -235,9 +235,9 @@ function WeeklyProjectSummary() {
       {
         title: 'Issues Breakdown',
         key: 'Issues Breakdown',
-        className: 'large',
+        className: 'full',
         content: (
-          <div className="weekly-project-summary-card normal-card">
+          <div className={`${styles.weeklyProjectSummaryCard} ${styles.fullCard}`}>
             <IssuesBreakdownChart />
           </div>
         ),

--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.module.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.module.css
@@ -168,6 +168,12 @@
 
 }
 
+.fullCard {
+  width: 100%;
+  min-height: 250px;
+  grid-column: span 4;
+}
+
 .wideCard {
   width: 100%;
   min-height: 250px;


### PR DESCRIPTION
# Description
<img width="700" height="425" alt="image" src="https://github.com/user-attachments/assets/0963938e-488d-41cf-bd10-1ecc2dbc09b6" />

## Related PRS (if any):
This frontend PR is related to the #[3606](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3606) frontend PR.
…

## Main changes explained:
- Create IssuesBreakdownChart.module.css
- Update import in IssuesBreakdownChart.jsx:
 import styles from './IssuesBreakdownChart.module.css'
- Move any styles used by this chart from global files (e.g., BMDashboard.css, WeeklyProjectSummary.css) into the module

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to http://localhost:3000/bmdashboard/totalconstructionsummary
6. verify no logic or functional changes are introduced and visual similarity to development branch 
7. NOTE 9/21: Updated the styling and added dark mode, so that it looks better.  Make sure these changes havent altered anything besides the card being wider and dark mode working.


## Screenshots or videos of changes:
<img width="2424" height="828" alt="image" src="https://github.com/user-attachments/assets/efdc7770-910d-4739-93f0-6311c8bb0920" />

<img width="2421" height="821" alt="image" src="https://github.com/user-attachments/assets/07eea159-de93-4e4d-b079-0bd5a963b5e2" />

## Note:
