### PR TITLE
misc: changed application port from 5173 to 3000

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,9 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   return {
+    server: {
+      port: 3000,
+    },
     resolve: {
       alias: {
         '~': resolve('src/'),


### PR DESCRIPTION
# Description
Our cloud backend is currently configured to only accept requests from http://localhost:3000/. After the Node 20 upgrade, the frontend dev server defaults to http://localhost:5173/ (Vite), which blocks the app from connecting to the backend (CORS/origin mismatch).
This PR restores the older 3000 workflow so local development can talk to the cloud backend without extra backend changes.

## Main changes explained:

- Configure local dev server to run on port 3000 (older workflow) to match backend allowed origin.
- Update scripts/docs/env samples to ensure localhost:3000 is the default during development.

## How to test:
1. check into current branch
2. change the environment variable in the .env file `REACT_APP_APIENDPOINT="https://api-staging.highestgood.com/api"`
3. do `npm install` and `npm start`
5. the application should run on http://localhost:3000/

## Note:
Include the information the reviewers need to know.
