### PR TITLE
Fatima costpredictionchart to module css

### DIFF
--- a/src/components/BMDashboard/WeeklyProjectSummary/CostPredictionChart.module.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/CostPredictionChart.module.css
@@ -1,12 +1,20 @@
-.container{
-    width: '100%';
-    height: '100%';
-    padding: '20px'
+.container {
+  width: 100%;
+  height: 100%;
+  padding: 20px;
+  background-color: var(--card-bg);
+  color: var(--text-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .title {
-    text-align: 'center';
-    margin-bottom: '40px';
-    font-size: '24px';
-    font-weight: 'normal',
+  text-align: center;
+  margin-bottom: 40px;
+  font-size: 24px;
+  font-weight: normal;
+  color: var(--text-color);
+}
+
+.dark {
+  color: #ffffff;
 }


### PR DESCRIPTION
# Description
<img width="757" height="348" alt="image" src="https://github.com/user-attachments/assets/f4c2aebf-146e-4e21-ab0d-c7f2677acfe9" />

## Related PRS (if any):
This frontend PR is related to the [#3514](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3514/) frontend pr
…

## Main changes explained:
- Create CostPredictionChart.module.css
- Update the component to import styles via:
 import styles from './CostPredictionChart.module.css'
-Replace any className="..." usage with className={styles...} as needed


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to http://localhost:5173/bmdashboard/totalconstructionsummary
6. Click the financials tracking section, a chart should be visible
7. Hover over the lines and verify if the planned and actual costs are visible for each month
8. Ensure no logic or functional changes are introduced compared to the related frontend PR, visually similar, and no global styles are used

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
