### PR TITLE
Venkataramanan Fix: timelog links to be blue in tasks timelog

### DIFF
--- a/src/components/Timelog/Timelog.css
+++ b/src/components/Timelog/Timelog.css
@@ -111,7 +111,7 @@
 }
 
 /* Hotfix: Prevent red color for project name and notes in Timelog */
-.notes-section, .notes-section *,
+.notes-section, .notes-section *:not(a),
 .text-success, .text-light, .text-muted, .dark-text-info, .dark-text-muted {
   color: #222 !important;
 }


### PR DESCRIPTION
# Description
This PR fixes the issue with links not appearing blue in the timelogs page.

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change file Timelog.css

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Timelog -> Tasks summary
6. Check if links are appearing blue.