### PR TITLE
fix(Analytics): dark-mode reacts correctly + block invalid date range…

### DIFF
--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, LabelList, ResponsiveContainer } from 'recharts';
 import DatePicker from 'react-datepicker';
 import Select from 'react-select';
@@ -6,6 +7,7 @@ import { getAllApplicantVolunteerRatios } from '../../services/applicantVoluntee
 import 'react-datepicker/dist/react-datepicker.css';
 
 function ApplicantVolunteerRatio() {
+  const darkMode = useSelector(state => state.theme.darkMode);
   const [data, setData] = useState([]);
   const [allRoles, setAllRoles] = useState([]); // Store all available roles
   const [loading, setLoading] = useState(true);
@@ -13,6 +15,7 @@ function ApplicantVolunteerRatio() {
   const [selectedRoles, setSelectedRoles] = useState([]);
   const [startDate, setStartDate] = useState(null);
   const [endDate, setEndDate] = useState(null);
+  const [validationError, setValidationError] = useState('');
 
   // Fetch all available roles (without filtering)
   useEffect(() => {
@@ -41,6 +44,17 @@ function ApplicantVolunteerRatio() {
   // Fetch filtered data based on selected roles and date range
   useEffect(() => {
     const fetchFilteredData = async () => {
+      // Validate date range: start must be before or equal to end
+      if (startDate && endDate && startDate > endDate) {
+        setValidationError('Start date must be earlier than or equal to End date.');
+        setData([]);
+        setLoading(false);
+        return;
+      }
+
+      // clear previous validation error when dates are valid
+      if (validationError) setValidationError('');
+
       if (selectedRoles.length === 0) {
         setData([]);
         return;
@@ -89,6 +103,53 @@ function ApplicantVolunteerRatio() {
     [data, selectedRoles],
   );
 
+  // Apply dark mode to document body and inject page-specific dark styles
+  useEffect(() => {
+    if (darkMode) {
+      document.body.classList.add('dark-mode-body');
+    } else {
+      document.body.classList.remove('dark-mode-body');
+    }
+
+    if (!document.getElementById('applicant-volunteer-dark-styles')) {
+      const styleElement = document.createElement('style');
+      styleElement.id = 'applicant-volunteer-dark-styles';
+      styleElement.innerHTML = `
+        /* Page-level dark background to cover gutters and root */
+        .dark-mode-body, .dark-mode-body body, .dark-mode-body #root, .dark-mode-body .App {
+          background-color: #1B2A41 !important;
+          color: #e0e0e0 !important;
+        }
+        /* Common layout wrappers that might enforce white background */
+        .dark-mode-body .header-wrapper,
+        .dark-mode-body .content-wrapper,
+        .dark-mode-body .page,
+        .dark-mode-body .container,
+        .dark-mode-body .container-fluid {
+          background-color: #1B2A41 !important;
+          color: #e0e0e0 !important;
+        }
+        .dark-mode-body .applicant-volunteer-page {
+          background-color: #1B2A41 !important;
+          color: #e0e0e0 !important;
+        }
+        .dark-mode-body .applicant-volunteer-content {
+          background-color: #1B2A41 !important;
+          color: #e0e0e0 !important;
+        }
+        .dark-mode-body .recharts-wrapper,
+        .dark-mode-body .recharts-surface {
+          background-color: #1B2A41 !important;
+        }
+      `;
+      document.head.appendChild(styleElement);
+    }
+
+    return () => {
+      document.body.classList.remove('dark-mode-body');
+    };
+  }, [darkMode]);
+
   if (loading) {
     return (
       <div style={{ maxWidth: 900, margin: '0 auto', padding: 24 }}>
@@ -107,89 +168,118 @@ function ApplicantVolunteerRatio() {
     );
   }
 
+  const darkModeStyles = darkMode
+    ? {
+        backgroundColor: '#1B2A41',
+        color: '#e0e0e0',
+      }
+    : {};
+
   return (
-    <div style={{ maxWidth: 900, margin: '0 auto', padding: 24 }}>
-      <h2>Number of People Hired vs. Total Applications</h2>
-      <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
-        <div>
-          <label htmlFor="start-date" style={{ fontWeight: 500 }}>
-            Date Range:{' '}
-          </label>
-          <DatePicker
-            id="start-date"
-            selected={startDate}
-            onChange={date => setStartDate(date)}
-            selectsStart
-            startDate={startDate}
-            endDate={endDate}
-            placeholderText="Start Date"
-            dateFormat="yyyy/MM/dd"
-            style={{ marginRight: 8 }}
-          />
-          <span> to </span>
-          <DatePicker
-            id="end-date"
-            selected={endDate}
-            onChange={date => setEndDate(date)}
-            selectsEnd
-            startDate={startDate}
-            endDate={endDate}
-            minDate={startDate}
-            placeholderText="End Date"
-            dateFormat="yyyy/MM/dd"
-          />
+    <div
+      className={`applicant-volunteer-page ${darkMode ? 'dark-mode' : ''}`}
+      style={{ maxWidth: 900, margin: '0 auto', padding: 24 }}
+    >
+      <div className="applicant-volunteer-content" style={darkMode ? darkModeStyles : {}}>
+        <h2 className={darkMode ? 'text-light' : ''}>
+          Number of People Hired vs. Total Applications
+        </h2>
+        <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
+          <div>
+            <label
+              htmlFor="start-date"
+              style={{ fontWeight: 500 }}
+              className={darkMode ? 'text-light' : ''}
+            >
+              Date Range:{' '}
+            </label>
+            <DatePicker
+              id="start-date"
+              selected={startDate}
+              onChange={date => setStartDate(date)}
+              selectsStart
+              startDate={startDate}
+              endDate={endDate}
+              placeholderText="Start Date"
+              dateFormat="yyyy/MM/dd"
+              style={{ marginRight: 8 }}
+            />
+            <span> to </span>
+            <DatePicker
+              id="end-date"
+              selected={endDate}
+              onChange={date => setEndDate(date)}
+              selectsEnd
+              startDate={startDate}
+              endDate={endDate}
+              minDate={startDate}
+              placeholderText="End Date"
+              dateFormat="yyyy/MM/dd"
+            />
+            {validationError && (
+              <div style={{ color: '#ffcc00', marginTop: 8, fontWeight: 'bold' }} role="alert">
+                {validationError}
+              </div>
+            )}
+          </div>
+          <div style={{ minWidth: 220 }}>
+            <label
+              htmlFor="role-select"
+              style={{ fontWeight: 500 }}
+              className={darkMode ? 'text-light' : ''}
+            >
+              Role:{' '}
+            </label>
+            <Select
+              id="role-select"
+              isMulti
+              options={allRoles} // Use allRoles for the dropdown
+              value={selectedRoles}
+              onChange={setSelectedRoles}
+              placeholder="Select roles..."
+              className={darkMode ? 'dark-select' : ''}
+              classNamePrefix="custom-select"
+            />
+          </div>
         </div>
-        <div style={{ minWidth: 220 }}>
-          <label htmlFor="role-select" style={{ fontWeight: 500 }}>
-            Role:{' '}
-          </label>
-          <Select
-            id="role-select"
-            isMulti
-            options={allRoles} // Use allRoles for the dropdown
-            value={selectedRoles}
-            onChange={setSelectedRoles}
-            placeholder="Select roles..."
-          />
-        </div>
+        {chartData.length > 0 ? (
+          <ResponsiveContainer width="100%" height={400}>
+            <BarChart
+              data={chartData}
+              layout="vertical"
+              margin={{ top: 20, right: 40, left: 80, bottom: 20 }}
+              barCategoryGap={24}
+            >
+              <XAxis
+                type="number"
+                label={{
+                  value: 'Percentage of People Hired vs. Total Applications',
+                  position: 'insideBottom',
+                  offset: -5,
+                }}
+                allowDecimals={false}
+              />
+              <YAxis
+                dataKey="role"
+                type="category"
+                width={180}
+                label={{ value: 'Name of Role', angle: -90, position: 'insideLeft' }}
+              />
+              <Tooltip />
+              <Bar dataKey="applicants" fill="#1976d2" name="Total Applicants">
+                <LabelList dataKey="applicants" position="right" />
+              </Bar>
+              <Bar dataKey="hired" fill="#43a047" name="Total Hired">
+                <LabelList dataKey="hired" position="right" />
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div style={{ textAlign: 'center', padding: '40px 0' }}>
+            No data available. Please add some applicant volunteer ratio data.
+          </div>
+        )}
       </div>
-      {chartData.length > 0 ? (
-        <ResponsiveContainer width="100%" height={400}>
-          <BarChart
-            data={chartData}
-            layout="vertical"
-            margin={{ top: 20, right: 40, left: 80, bottom: 20 }}
-            barCategoryGap={24}
-          >
-            <XAxis
-              type="number"
-              label={{
-                value: 'Percentage of People Hired vs. Total Applications',
-                position: 'insideBottom',
-                offset: -5,
-              }}
-              allowDecimals={false}
-            />
-            <YAxis
-              dataKey="role"
-              type="category"
-              width={180}
-              label={{ value: 'Name of Role', angle: -90, position: 'insideLeft' }}
-            />
-            <Tooltip />
-            <Bar dataKey="applicants" fill="#1976d2" name="Total Applicants">
-              <LabelList dataKey="applicants" position="right" />
-            </Bar>
-            <Bar dataKey="hired" fill="#43a047" name="Total Hired">
-              <LabelList dataKey="hired" position="right" />
-            </Bar>
-          </BarChart>
-        </ResponsiveContainer>
-      ) : (
-        <div style={{ textAlign: 'center', padding: '40px 0' }}>
-          No data available. Please add some applicant volunteer ratio data.
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
# Description
Bug / Functionality: On Job Posting Page Analytics → Applicant→Volunteer conversion ratio,
Dark mode did not update the chart/containers after theme toggle.
Data rendered for invalid/overlapping date ranges (e.g., Start > End) instead of warning the user.
Fixes # (PRIORITY HIGH) — “Job Posting Page Analytics: Dark mode not updating & overlapping dates should show a warning.”

## Related PRS (if any):
…

## Main changes explained:

- Wired theme: read `state.theme.darkMode` via `useSelector`.
- Body toggle: add/remove `dark-mode-body` on `document.body` when theme changes.
- Dark styles: inject page-scoped CSS to darken `body/#root/.App`, layout wrappers and `.recharts-surface`.
- Component tweaks: apply `text-light` / `dark-select` and wrapper `darkModeStyles`.
- Validation guard: if `startDate > endDate` set validationError, `setData([])`, `setLoading(false)` and skip fetch.
- UX polish: show inline validation banner and clear it when dates are valid; clear data when no roles selected.

## How to test:
1. check into current branch:  `git checkout fix/analytics-date-warning-darkmode`
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to [dashboard→ Tasks→ task→…](http://localhost:5173/applicant-volunteer-ratio)
6. Verify the below functions:
- Dark mode: Toggle light↔dark → chart/axes/legend/tooltip update; no layout shift.
- Invalid range: Set Start > End → warning shows; no fetch; chart empty.
- Valid range: Fix dates → warning clears; data renders.
- Role filter: Clear all roles → chart clears; no errors.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/71dcd60e-2054-4d69-a77c-437210308d38

