### PR TITLE
Carlos Add dark mode styles to QuantityOfMaterialsUsed

### DIFF
--- a/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
@@ -594,7 +594,8 @@ function QuantityOfMaterialsUsed({ data }) {
           </li>
           <li>Hover over bars or dots to view exact quantities.</li>
           <li>
-            <strong>Click on a bar</strong> to view detailed usage:
+            <strong className={darkMode ? 'text-light' : ''}>Click on a bar </strong> to view
+            detailed usage:
             <ul style={{ paddingLeft: '16px' }}>
               <li>Usage timeline (date-wise quantity)</li>
               <li>Project where it was used the most</li>
@@ -618,13 +619,13 @@ function QuantityOfMaterialsUsed({ data }) {
             Legend colors match chart bars. Dots are color-coded based on change:
             <ul style={{ paddingLeft: '16px' }}>
               <li>
-                <strong>Red</strong> – Increase in usage
+                <strong className={darkMode ? 'text-light' : ''}>Red</strong> – Increase in usage
               </li>
               <li>
-                <strong>Green</strong> – Decrease in usage
+                <strong className={darkMode ? 'text-light' : ''}>Green</strong> – Decrease in usage
               </li>
               <li>
-                <strong>Gray</strong> – No change
+                <strong className={darkMode ? 'text-light' : ''}>Gray</strong> – No change
               </li>
             </ul>
           </li>
@@ -642,9 +643,9 @@ function QuantityOfMaterialsUsed({ data }) {
           onChange={selectedOptions =>
             setSelectedMaterials(selectedOptions.map(({ value }) => value))
           }
-          placeholder="All Materials"
+          placeholder="All Materials testing"
           classNamePrefix="custom-select"
-          className={`quantity-of-materials-used-dropdown-item ${styles.dropdownItem} custom-scrollbar ${styles.multiSelect}`}
+          className={`quantity-of-materials-used-dropdown-item ${styles.dropdownItem} custom-scrollbar ${styles.multiSelect}}`}
           menuPosition="fixed"
           menuPlacement={isSmallScreen ? 'top' : 'auto'}
           closeMenuOnSelect={false}
@@ -865,7 +866,7 @@ function QuantityOfMaterialsUsed({ data }) {
             color: 'var(--text-color)',
           }}
         >
-          <strong>
+          <strong className={darkMode ? 'text-light' : ''}>
             Visible Top {Math.min(10, visibleRange[1] - visibleRange[0])} of {selectedDate}:{' '}
           </strong>
           {chartData.datasets[0].data

--- a/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
@@ -1008,11 +1008,11 @@ function QuantityOfMaterialsUsed({ data }) {
 
               return (
                 <>
-                  <p>
-                    <strong>Highest Usage in:</strong> {details.project}
+                  <p className="text-light">
+                    <strong className="text-light">Highest Usage in:</strong> {details.project}
                   </p>
-                  <p>
-                    <strong>Total Quantity:</strong> {details.total}
+                  <p className="text-light">
+                    <strong className="text-light">Total Quantity:</strong> {details.total}
                   </p>
 
                   <h4 className={`${styles.quantityModalSubheading}`}>📅 Usage Timeline</h4>

--- a/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
@@ -1008,19 +1008,25 @@ function QuantityOfMaterialsUsed({ data }) {
 
               return (
                 <>
-                  <p className="text-light">
-                    <strong className="text-light">Highest Usage in:</strong> {details.project}
+                  <p className={darkMode ? 'text-light' : ''}>
+                    <strong className={darkMode ? 'text-light' : ''}>Highest Usage in:</strong>{' '}
+                    {details.project}
                   </p>
-                  <p className="text-light">
-                    <strong className="text-light">Total Quantity:</strong> {details.total}
+                  <p className={darkMode ? 'text-light' : ''}>
+                    <strong className={darkMode ? 'text-light' : ''}>Total Quantity:</strong>{' '}
+                    {details.total}
                   </p>
 
                   <h4 className={`${styles.quantityModalSubheading}`}>📅 Usage Timeline</h4>
                   <div className={`${styles.quantityModalTimeline}`}>
                     {details.timeline.map(item => (
                       <div key={uuidv4()} className={`${styles.timelineRow}`}>
-                        <span className={`${styles.timelineDate}`}>{item.date}</span>
-                        <span className={`${styles.timelineQty}`}>{item.quantity}</span>
+                        <span className={`${styles.timelineDate} ${darkMode ? ' text-light' : ''}`}>
+                          {item.date}
+                        </span>
+                        <span className={`${styles.timelineQty} ${darkMode ? ' text-light' : ''}`}>
+                          {item.quantity}
+                        </span>
                       </div>
                     ))}
                   </div>

--- a/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
@@ -83,6 +83,87 @@ function QuantityOfMaterialsUsed({ data }) {
 
   const [isSmallScreen, setIsSmallScreen] = useState(false);
 
+  const selectStyles = useMemo(
+    () => ({
+      control: base => ({
+        ...base,
+        backgroundColor: darkMode ? '#22272e' : '#fff',
+        borderColor: darkMode ? '#375071' : '#ccc',
+        color: darkMode ? '#fff' : '#232323',
+        minHeight: 38,
+        boxShadow: 'none',
+        borderRadius: 8,
+      }),
+      menu: base => ({
+        ...base,
+        backgroundColor: darkMode ? '#22272e' : '#fff',
+        fontSize: 12,
+        zIndex: 10001,
+        borderRadius: 8,
+        marginTop: 2,
+        color: darkMode ? '#fff' : '#232323',
+      }),
+      menuList: base => ({
+        ...base,
+        maxHeight: 400,
+        overflowY: 'auto',
+        backgroundColor: darkMode ? '#22272e' : '#fff',
+        color: darkMode ? '#fff' : '#232323',
+        padding: 0,
+      }),
+      option: (base, state) => ({
+        ...base,
+        backgroundColor: state.isSelected
+          ? '#0d55b3'
+          : state.isFocused
+          ? '#0d55b3'
+          : darkMode
+          ? '#22272e'
+          : '#fff',
+        color: state.isSelected ? '#fff' : darkMode ? '#fff' : '#232323',
+        fontSize: 13,
+        padding: '10px 16px',
+        cursor: 'pointer',
+      }),
+      multiValue: base => ({
+        ...base,
+        backgroundColor: darkMode ? '#375071' : '#e2e7ee',
+        borderRadius: 6,
+        fontSize: 12,
+        marginRight: 4,
+      }),
+      multiValueLabel: base => ({
+        ...base,
+        color: darkMode ? '#fff' : '#333',
+        fontSize: 12,
+        padding: '2px 6px',
+      }),
+      multiValueRemove: base => ({
+        ...base,
+        color: darkMode ? '#fff' : '#333',
+        ':hover': {
+          backgroundColor: darkMode ? '#0d55b3' : '#e2e7ee',
+          color: '#fff',
+        },
+        borderRadius: 4,
+        padding: 2,
+      }),
+      singleValue: base => ({
+        ...base,
+        color: darkMode ? '#fff' : base.color,
+      }),
+      input: base => ({
+        ...base,
+        color: darkMode ? '#fff' : base.color,
+      }),
+      placeholder: base => ({
+        ...base,
+        color: darkMode ? '#fff' : base.color,
+      }),
+    }),
+    [darkMode],
+  );
+
   useEffect(() => {
     const handleResize = () => {
       setIsSmallScreen(window.innerWidth <= 1200);
@@ -645,11 +726,12 @@ function QuantityOfMaterialsUsed({ data }) {
           }
           placeholder="All Materials testing"
           classNamePrefix="custom-select"
-          className={`quantity-of-materials-used-dropdown-item ${styles.dropdownItem} custom-scrollbar ${styles.multiSelect}}`}
+          className={`quantity-of-materials-used-dropdown-item ${styles.dropdownItem} custom-scrollbar ${styles.multiSelect}`}
           menuPosition="fixed"
           menuPlacement={isSmallScreen ? 'top' : 'auto'}
           closeMenuOnSelect={false}
           hideSelectedOptions={false}
+          styles={selectStyles}
         />
 
         <Select
@@ -660,6 +742,7 @@ function QuantityOfMaterialsUsed({ data }) {
           classNamePrefix="custom-select"
           className={`quantity-of-materials-used-dropdown-item ${styles.dropdownItem}`}
           // isDisabled
+          styles={selectStyles}
         />
         <Select
           options={dateOptions}
@@ -674,6 +757,7 @@ function QuantityOfMaterialsUsed({ data }) {
           placeholder="Date"
           classNamePrefix="custom-select"
           className={`quantity-of-materials-used-dropdown-item ${styles.dropdownItem}`}
+          styles={selectStyles}
         />
       </div>
 


### PR DESCRIPTION
# Description
<img width="690" height="238" alt="image" src="https://github.com/user-attachments/assets/67d4582c-5a46-4f0b-a9c5-05f4d1597bb8" />


This pull request requests implements dark mode styling for the QuantityOfMaterialsUsed component.

## Related PRS (if any):
This frontend PR is not related to any backend branches. Use latest development branch.

## Main changes explained:
- Added dark mode styling classes to all components when dark mode is enabled by the user.

## How to test:
1. check into current branch
2. do `yarn install` and `yarn start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to [http://localhost:5173/bmdashboard/totalconstructionsummary](http://localhost:5173/bmdashboard/totalconstructionsummary)
6. open "Material Consumption" dropdown
8. verify this component works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
Dark Mode Disabled
<img width="431" height="442" alt="image" src="https://github.com/user-attachments/assets/2cd011dd-1654-4b22-9f0e-8c694536098e" />

Dark Mode Enabled
<img width="442" height="472" alt="image" src="https://github.com/user-attachments/assets/1d32934f-fd1e-4344-aa99-fafcea367388" />
