### PR TITLE
Humemah Add Set Final Day permission functionality

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -98,7 +98,8 @@ export function Header(props) {
     props.hasPermission('postUserProfile', !isAuthUser && canInteractWithViewingUser) ||
     props.hasPermission('deleteUserProfile', !isAuthUser && canInteractWithViewingUser) ||
     props.hasPermission('changeUserStatus', !isAuthUser && canInteractWithViewingUser) ||
-    props.hasPermission('getUserProfiles', !isAuthUser && canInteractWithViewingUser);
+    props.hasPermission('getUserProfiles', !isAuthUser && canInteractWithViewingUser) ||
+    props.hasPermission('setFinalDay', !isAuthUser && canInteractWithViewingUser);
 
   // Badges
   const canAccessBadgeManagement =
@@ -470,58 +471,55 @@ export function Header(props) {
                 <NavItem className="responsive-spacing">
                   <BellNotification userId={displayUserId} />
                 </NavItem>
-                {(canAccessUserManagement ||
-                  canAccessBadgeManagement ||
-                  canAccessProjects ||
-                  canAccessTeams ||
-                  canAccessPopups ||
-                  canAccessSendEmails ||
-                  canAccessPermissionsManagement) && (
-                  <UncontrolledDropdown nav inNavbar className="responsive-spacing">
-                    <DropdownToggle nav caret>
-                      <span className="dashboard-text-link">{OTHER_LINKS}</span>
-                    </DropdownToggle>
-                    <DropdownMenu className={darkMode ? 'bg-yinmn-blue' : ''}>
-                      {canAccessUserManagement && (
-                        <DropdownItem tag={Link} to="/usermanagement" className={fontColor}>
-                          {USER_MANAGEMENT}
-                        </DropdownItem>
-                      )}
-                      {canAccessBadgeManagement && (
-                        <DropdownItem tag={Link} to="/badgemanagement" className={fontColor}>
-                          {BADGE_MANAGEMENT}
-                        </DropdownItem>
-                      )}
-                      {canAccessProjects && (
-                        <DropdownItem tag={Link} to="/projects" className={fontColor}>
-                          {PROJECTS}
-                        </DropdownItem>
-                      )}
-                      {canAccessTeams && (
-                        <DropdownItem tag={Link} to="/teams" className={fontColor}>
-                          {TEAMS}
-                        </DropdownItem>
-                      )}
-                      {canAccessSendEmails && (
-                        <DropdownItem tag={Link} to="/announcements" className={fontColor}>
-                          {SEND_EMAILS}
-                        </DropdownItem>
-                      )}
-                      {canAccessPermissionsManagement && (
-                        <>
-                          <DropdownItem divider />
-                          <DropdownItem
-                            tag={Link}
-                            to="/permissionsmanagement"
-                            className={fontColor}
-                          >
-                            {PERMISSIONS_MANAGEMENT}
-                          </DropdownItem>
-                        </>
-                      )}
-                    </DropdownMenu>
-                  </UncontrolledDropdown>
-                )}
+              
+                  {(canAccessUserManagement ||
+  canAccessBadgeManagement ||
+  canAccessProjects ||
+  canAccessTeams ||
+  canAccessPopups ||
+  canAccessSendEmails ||
+  canAccessPermissionsManagement) && (
+  <UncontrolledDropdown nav inNavbar className="responsive-spacing">
+    <DropdownToggle nav caret>
+      <span className="dashboard-text-link">{OTHER_LINKS}</span>
+    </DropdownToggle>
+    <DropdownMenu className={darkMode ? 'bg-yinmn-blue' : ''}>
+      {canAccessUserManagement && (
+        <DropdownItem tag={Link} to="/usermanagement" className={fontColor}>
+          {USER_MANAGEMENT}
+        </DropdownItem>
+      )}
+      {canAccessBadgeManagement && (
+        <DropdownItem tag={Link} to="/badgemanagement" className={fontColor}>
+          {BADGE_MANAGEMENT}
+        </DropdownItem>
+      )}
+      {canAccessProjects && (
+        <DropdownItem tag={Link} to="/projects" className={fontColor}>
+          {PROJECTS}
+        </DropdownItem>
+      )}
+      {canAccessTeams && (
+        <DropdownItem tag={Link} to="/teams" className={fontColor}>
+          {TEAMS}
+        </DropdownItem>
+      )}
+      {canAccessSendEmails && (
+        <DropdownItem tag={Link} to="/announcements" className={fontColor}>
+          {SEND_EMAILS}
+        </DropdownItem>
+      )}
+      {canAccessPermissionsManagement && (
+        <>
+          <DropdownItem divider />
+          <DropdownItem tag={Link} to="/permissionsmanagement" className={fontColor}>
+            {PERMISSIONS_MANAGEMENT}
+          </DropdownItem>
+        </>
+      )}
+    </DropdownMenu>
+  </UncontrolledDropdown>
+)}
                 <NavItem className="responsive-spacing">
                   <NavLink tag={Link} to={`/userprofile/${displayUserId}`}>
                     <div
@@ -561,14 +559,14 @@ export function Header(props) {
                       props.userProfile.email,
                       props.userProfile.email,
                     ) && (
-                      <DropdownItem
-                        tag={Link}
-                        to={`/updatepassword/${displayUserId}`}
-                        className={fontColor}
-                      >
-                        {UPDATE_PASSWORD}
-                      </DropdownItem>
-                    )}
+                        <DropdownItem
+                          tag={Link}
+                          to={`/updatepassword/${displayUserId}`}
+                          className={fontColor}
+                        >
+                          {UPDATE_PASSWORD}
+                        </DropdownItem>
+                      )}
                     <DropdownItem className={fontColor}>
                       <DarkModeButton />
                     </DropdownItem>

--- a/src/components/PermissionsManagement/PermissionsConst.jsx
+++ b/src/components/PermissionsManagement/PermissionsConst.jsx
@@ -1,4 +1,4 @@
-// recursive function that returns the permission keys given an array of permission objects (from permissionLabels below)
+//// recursive function that returns the permission keys given an array of permission objects (from permissionLabels below)
 const getAllSubpermissionKeys = permissions => {
   const keys = [];
   permissions.forEach(permission => {

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -67,6 +67,7 @@ const UserTableDataComponent = (props) => {
   const resetPasswordStatus = props.hasPermission('resetPassword');
   const updatePasswordStatus = props.hasPermission('updatePassword');
   const canChangeUserStatus = props.hasPermission('changeUserStatus');
+  const canSetFinalDay = props.hasPermission('setFinalDay');
   const canSeeReports = props.hasPermission('getReports');
   const toggleDeleteTooltip = () => setTooltipDelete(!tooltipDeleteOpen);
   const togglePauseTooltip = () => setTooltipPause(!tooltipPauseOpen);
@@ -474,7 +475,7 @@ const UserTableDataComponent = (props) => {
       <td>
         {!isCurrentUser && (
           <>
-            {!canChangeUserStatus ? (
+            {!canSetFinalDay ? (
               <Tooltip
                 placement="bottom"
                 isOpen={tooltipFinalDayOpen}
@@ -486,13 +487,15 @@ const UserTableDataComponent = (props) => {
             ) : (
               ''
             )}
-            <SetUpFinalDayButton
+                       <SetUpFinalDayButton
               userProfile={props.user}
               darkMode={darkMode}
               onFinalDaySave={updatedUser => {
                 // Update the user object in the parent state
                 props.onUserUpdate(updatedUser);
               }}
+              id={`btn-final-day-${props.user._id}`}
+              disabled={!canSetFinalDay}
             />
           </>
         )}

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -5,7 +5,8 @@ import moment from 'moment';
 import PhoneInput from 'react-phone-input-2';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
-// import 'react-phone-input-2/lib/style.css';
+
+//// import 'react-phone-input-2/lib/style.css';
 import PauseAndResumeButton from '~/components/UserManagement/PauseAndResumeButton';
 import TimeZoneDropDown from '../TimeZoneDropDown';
 import { connect } from 'react-redux';


### PR DESCRIPTION
# Description
<img width="998" height="489" alt="image" src="https://github.com/user-attachments/assets/d830a92e-448f-4c6a-b8e9-af6cdf734a7a" />


## Related PRS (if any):
This frontend PR is related to the[ #3245](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3245)


## Main changes explained:
Updated src/components/Header/Header.jsx - Added setFinalDay permission to user management access check
Updated src/components/PermissionsManagement/PermissionsConst.jsx - Added new "Set Final Day" permission definition
Updated src/components/UserManagement/UserTableData.jsx - Added SetFinalDayButton component with permission check
Updated src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx - Added button visibility based on permission

## How to test:
Check out this branch: git checkout Humemah-Updated-final-day
Run npm install and npm start to run locally
Clear site data/cache
Log in as admin/owner user
Go to → Other Links → Permission Management → User Roles
Verify that only Owner and Admin users have this permission by default
Go to → Other Links → Permission Management → Manage User Permission
Verify the permission can be added to other users that are not Admin nor Owner
Go to any user's Profile → Basic Information → End Date section
Verify users with permission can see and interact with the "Set Final Day" button

Verify users without permission cannot see the button
## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
