### PR TITLE
Carlos Add dark mode styles to UtilizationChart

### DIFF
--- a/src/components/BMDashboard/UtilizationChart/UtilizationChart.jsx
+++ b/src/components/BMDashboard/UtilizationChart/UtilizationChart.jsx
@@ -7,6 +7,7 @@ import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import axios from 'axios';
 import styles from './UtilizationChart.module.css';
+import { useSelector } from 'react-redux';
 
 ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Title);
 
@@ -17,6 +18,7 @@ function UtilizationChart() {
   const [toolFilter, setToolFilter] = useState('ALL');
   const [projectFilter, setProjectFilter] = useState('ALL');
   const [error, setError] = useState(null);
+  const darkMode = useSelector(state => state.theme.darkMode);
 
   const fetchChartData = async () => {
     try {
@@ -51,7 +53,7 @@ function UtilizationChart() {
       {
         label: 'Utilization (%)',
         data: toolsData.map(tool => tool.utilizationRate),
-        backgroundColor: '#a0e7e5',
+        backgroundColor: darkMode ? '#007bff' : '#a0e7e5',
         borderRadius: 6,
       },
     ],
@@ -61,6 +63,9 @@ function UtilizationChart() {
     indexAxis: 'y',
     responsive: true,
     plugins: {
+      legend: {
+        labels: { color: darkMode ? '#ffffff' : '#333' },
+      },
       datalabels: {
         color: '#333',
         anchor: 'end',
@@ -81,6 +86,7 @@ function UtilizationChart() {
             return `Utilization: ${tool.utilizationRate}%, Downtime: ${tool.downtime} hrs`;
           },
         },
+        footerColor: 'white',
       },
     },
     scales: {
@@ -89,19 +95,24 @@ function UtilizationChart() {
         title: {
           display: true,
           text: 'Time (%)',
+          color: darkMode ? '#ffffff' : '#333',
         },
+        ticks: { color: darkMode ? '#ffffff' : '#333' },
+        grid: { color: darkMode ? '#c7c7c7ff' : '#bebebeff' },
       },
       y: {
         ticks: {
           autoSkip: false,
+          color: darkMode ? '#ffffff' : '#333',
         },
+        grid: { color: darkMode ? '#c7c7c7ff' : '#bebebeff' },
       },
     },
   };
 
   return (
-    <div className={styles.utilizationChartContainer}>
-      <h2 className={styles.chartTitle}>Utilization Chart</h2>
+    <div className={styles.utilizationChartContainer + (darkMode ? ` bg-yinmn-blue` : '')}>
+      <h2 className={styles.chartTitle + (darkMode ? ' text-light' : '')}>Utilization Chart</h2>
 
       {error ? (
         <div className={styles.utilizationChartError}>{error}</div>
@@ -111,7 +122,7 @@ function UtilizationChart() {
             <select
               value={toolFilter}
               onChange={e => setToolFilter(e.target.value)}
-              className={styles.select}
+              className={styles.select + (darkMode ? ' bg-space-cadet text-light' : '')}
             >
               <option value="ALL">All Tools</option>
               {/* other options */}
@@ -120,7 +131,7 @@ function UtilizationChart() {
             <select
               value={projectFilter}
               onChange={e => setProjectFilter(e.target.value)}
-              className={styles.select}
+              className={styles.select + (darkMode ? ' bg-space-cadet text-light' : '')}
             >
               <option value="ALL">All Projects</option>
               {/* other options */}
@@ -130,17 +141,20 @@ function UtilizationChart() {
               selected={startDate}
               onChange={date => setStartDate(date)}
               placeholderText="Start Date"
-              className={styles.datepickerWrapper}
+              className={styles.datepickerWrapper + (darkMode ? ' bg-space-cadet text-light' : '')}
             />
 
             <DatePicker
               selected={endDate}
               onChange={date => setEndDate(date)}
               placeholderText="End Date"
-              className={styles.datepickerWrapper}
+              className={styles.datepickerWrapper + (darkMode ? ' bg-space-cadet text-light' : '')}
             />
 
-            <button onClick={handleApplyClick} className={styles.button}>
+            <button
+              onClick={handleApplyClick}
+              className={styles.button + (darkMode ? ' bg-azure text-light' : '')}
+            >
               Apply
             </button>
           </div>


### PR DESCRIPTION
# Description
<img width="659" height="218" alt="image" src="https://github.com/user-attachments/assets/4b399206-bbe4-4bd3-b4da-2822bdcdaa42" />

This PR implements dark mode styling for the Utilization Chart component.


## Related PRS (if any):
This front end PR has no associated backend PR. Use latest development branch.
Related to front end #3882 

## Main changes explained:
- Updates `UtilizationChart.jsx` to use dark mode styling when enabled by user.

## How to test:
1. check into current branch
2. temporarily hardcode test data to display component (example data shown below)
`setToolsData([
        { id: '1', name: 'Drill', utilizationRate: 75, downtime: 5 },
        { id: '2', name: 'Lathe', utilizationRate: 55, downtime: 10 },
        { id: '3', name: 'CNC', utilizationRate: 90, downtime: 2 },
      ])`
<img width="756" height="446" alt="image" src="https://github.com/user-attachments/assets/20b9f0b1-1a1c-4c6c-8594-2682d6c9041f" />

4. do `yarn install` and `yarn start:local` to run this PR locally
5. Clear site data/cache
6. log as admin user
7. go to [http://localhost:5173/utilizationchart](http://localhost:5173/utilizationchart)
8. verify this works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

Dark Mode Disabled
<img width="992" height="649" alt="image" src="https://github.com/user-attachments/assets/018e0ed6-1815-4ebe-8fe7-fca0e69bdaf3" />

Dark Mode Enabled
<img width="992" height="654" alt="image" src="https://github.com/user-attachments/assets/edbb5799-c780-4d04-ab1a-d96a8ab7de38" />

