### PR TITLE
Zhifan - hotfix Hours displayed in volunteering times tab mismatch

### DIFF
--- a/src/components/common/PieChart/PieChart.jsx
+++ b/src/components/common/PieChart/PieChart.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable testing-library/no-node-access */
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import * as d3 from 'd3';
 
 import { CHART_RADIUS, CHART_SIZE } from './constants';


### PR DESCRIPTION
# Description
  - Time entries used wrong project IDs - causing hours to go to wrong categories or "unassigned"

## Related PRS (if any):
This frontend PR is related to the #XXX backend PR.
…

## Main changes explained:
in TimeEntryController.js
  - `tangibleCalculationHelper`:
        Now uses Task → WBS → Project hierarchy instead of direct projectId
  - `updateUserprofileCategoryHrs`:
        Added error handling for missing projects
  - All call sites of `updateUserprofileCategoryHrs`:
        All now resolve correct project ID before updating categories
  - `resolveProjectId`: 
        New helper function that finds correct project by traversing Task → WBS → Project chain
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Reports→ Reports→ People→…
6. find yourself and look for the projects you have logged time as well as their category
7. go to View Profile → Volunteering Times 
8. check if the Total Tangible Hours match with People Report page as well as the hours for each category

_Optional:_
if mismatch then send POST request to this endpoint with Authorization Token
`http://localhost:4500/api/TimeEntry/recalculateHoursAllUsers/tangible`
check the recalculation process with this endpoint
`http://localhost:4500/api/TimeEntry/checkStatus/{taskId}`

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/a3a885a0-6bf3-4b87-9875-0fdb88b61584


## Note:
Include the information the reviewers need to know.
