### PR TITLE
fixing the listings text error and image error in listings page

### DIFF
--- a/src/components/LBDashboard/Home/Home.jsx
+++ b/src/components/LBDashboard/Home/Home.jsx
@@ -342,14 +342,14 @@ function Home() {
             {/* Tabs Section */}
             <div className={`${styles.lbTabsSection}`}>
               <button className={styles.lbTab} onClick={() => setActiveTab('listings')}>
-                Listings
+                Listings Page
               </button>
               <button
                 type="button"
                 className={styles.lbTab}
-                onClick={() => setActiveTab('listings')}
+                onClick={() => setActiveTab('biddings')}
               >
-                Listings
+                Biddings Page
               </button>
             </div>
 
@@ -389,30 +389,43 @@ function Home() {
         {/* Properties Container */}
         {!isLoading && !error && (
           <div className={`${styles.lbPropertiesContainer} ${styles[`lb${viewMode}View`]}`}>
-            {currentItems.map(unit => (
-              <div
-                key={unit.id}
-                className={`${styles.lbPropertyCard}`}
-                onClick={() => handlePropertySelect(unit)}
-              >
-                <div className={`${styles.lbPropertyImage}`}>
-                  <img src={unit.images[0]} alt={unit.title} />
-                </div>
-                <div className={`${styles.lbPropertyDetails}`}>
-                  <div>
-                    <h3>{unit.title}</h3>
-                    <p>
-                      {unit.village} {unit.village !== 'City Center' ? 'Village' : ''}
-                    </p>
+            {currentItems.map(unit => {
+              const firstImage =
+                Array.isArray(unit.images) && unit.images.length ? unit.images[0] : DEFAULT_IMAGE;
+
+              return (
+                <div
+                  key={unit.id}
+                  className={styles.lbPropertyCard}
+                  onClick={() => handlePropertySelect(unit)}
+                >
+                  <div className={styles.lbPropertyImage}>
+                    <img
+                      src={firstImage}
+                      alt={unit.title || 'Unit'}
+                      loading="lazy"
+                      onError={e => {
+                        if (e.currentTarget.src !== DEFAULT_IMAGE)
+                          e.currentTarget.src = DEFAULT_IMAGE;
+                      }}
+                    />
                   </div>
-                  <div
-                    className={`${styles.lbPrice} ${unit.isBidding ? styles.lbBiddingPrice : ''}`}
-                  >
-                    ${unit.price}/{unit.perUnit}
+                  <div className={styles.lbPropertyDetails}>
+                    <div>
+                      <h3>{unit.title}</h3>
+                      <p>
+                        {unit.village} {unit.village !== 'City Center' ? 'Village' : ''}
+                      </p>
+                    </div>
+                    <div
+                      className={`${styles.lbPrice} ${unit.isBidding ? styles.lbBiddingPrice : ''}`}
+                    >
+                      ${unit.price}/{unit.perUnit}
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
 


### PR DESCRIPTION
# Description
Issues need to be fixed: 
/lbdashboard/listingshome page onLoad there are some console errors related to image GET method.
Fix the tab headings on the home page.
Expected: Listings Page , Biddings Page
Actual: Listings, Listings

## Related PRS (if any):
this PR is related to backend development branch 
…

## Main changes explained:
-  changing listings text from listings and listings to listings and biddings
- checking for image src before updating the fallback

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as any user
5. go to /lbdashboard/listingshome and check for the changes 
## Screenshots or videos of changes:

https://github.com/user-attachments/assets/ad9cafd6-332e-4548-a5e0-e58e98d33930




