### PR TITLE
Sundar: Fix move summary between weeks

### DIFF
--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -121,6 +121,7 @@ export class WeeklySummary extends Component {
     moveSelect: '-1',
     movePopup: false,
     moveConfirm: false,
+    isSavingMove: false,
   };
 
   // Minimum word count of 50 (handle words that also use non-ASCII characters by counting whitespace rather than word character sequences).
@@ -181,6 +182,7 @@ export class WeeklySummary extends Component {
 
     wordCount: Joi.number()
       .min(50)
+      .allow(0)
       .label('word count must be greater than 50 words'),
 
     summaryLastWeek: Joi.string()
@@ -338,8 +340,8 @@ export class WeeklySummary extends Component {
     }
   };
 
-  toggleMovePopup = showPopup => {
-    this.setState({ movePopup: !showPopup });
+  toggleMovePopup = () => {
+    this.setState(prev => ({ movePopup: !prev.movePopup }));
   };
 
   toggleShowPopup = showPopup => {
@@ -404,8 +406,6 @@ export class WeeklySummary extends Component {
           break;
       }
     }
-    // confitm move or not
-    this.toggleMovePopup(movePopup);
     // eslint-disable-next-line consistent-return
     return newformElements;
   };
@@ -545,7 +545,7 @@ export class WeeklySummary extends Component {
     this.setState({ formElements, errors });
   };
 
-  handleChangeInSummary = async () => {
+  handleChangeInSummary = async (isMove = false) => {
     // Extract state variables for ease of access
     const {
       submittedDate,
@@ -557,14 +557,13 @@ export class WeeklySummary extends Component {
       dueDateBeforeLast,
       dueDateThreeWeeksAgo,
       submittedCountInFourWeeks,
-      moveConfirm,
     } = this.state;
     let newformElements = { ...formElements };
     const newOriginSummaries = { ...originSummaries };
     const newUploadDatesElements = { ...uploadDatesElements };
     const dueDates = [dueDate, dueDateLastWeek, dueDateBeforeLast, dueDateThreeWeeksAgo];
     // Move or not, if did move, update the newformElements
-    if (moveConfirm) {
+    if (isMove) {
       newformElements = this.handleMove();
     }
     // Define summaries, updateDates for easier reference
@@ -581,26 +580,22 @@ export class WeeklySummary extends Component {
     }, 0);
     const diffInSubmittedCount = currentSubmittedCount - submittedCountInFourWeeks;
     if (diffInSubmittedCount !== 0) {
-      this.setState({ summariesCountShowing: newformElements.weeklySummariesCount + 1 });
+      this.setState({
+        summariesCountShowing: newformElements.weeklySummariesCount + diffInSubmittedCount,
+      });
     }
-    // eslint-disable-next-line no-shadow
-    const updateSummary = (summary, uploadDate, dueDate) => {
-      if (newformElements[summary] !== newOriginSummaries[summary]) {
-        newOriginSummaries[summary] = newformElements[summary];
-        newUploadDatesElements[uploadDate] =
-          newformElements[summary] === '' ? dueDate : submittedDate;
-        this.setState({
-          formElements: newformElements,
-          uploadDatesElements: newUploadDatesElements,
-          originSummaries: newOriginSummaries,
-        });
-      }
-    };
-    // Loop through summaries and update state variables
-    // eslint-disable-next-line no-plusplus
     for (let i = 0; i < summaries.length; i++) {
-      updateSummary(summaries[i], uploadDates[i], dueDates[i]);
+      if (newformElements[summaries[i]] !== newOriginSummaries[summaries[i]]) {
+        newOriginSummaries[summaries[i]] = newformElements[summaries[i]];
+        newUploadDatesElements[uploadDates[i]] =
+          newformElements[summaries[i]] === '' ? dueDates[i] : submittedDate;
+      }
     }
+    this.setState({
+      formElements: newformElements,
+      uploadDatesElements: newUploadDatesElements,
+      originSummaries: newOriginSummaries,
+    });
 
     // eslint-disable-next-line no-shadow
     const { updateWeeklySummaries, displayUserId, currentUser } = this.props;
@@ -622,14 +617,8 @@ export class WeeklySummary extends Component {
 
   // Updates user profile and weekly summaries
   updateUserData = async userId => {
-    const { getUserProfile, getWeeklySummaries } = this.props;
-    if (typeof getUserProfile === 'function') {
-      await getUserProfile(userId);
-    }
-    // always refresh summaries if that exists
-    if (typeof getWeeklySummaries === 'function') {
-      await getWeeklySummaries(userId);
-    }
+    const { getWeeklySummaries } = this.props;
+    if (typeof getWeeklySummaries === 'function') await getWeeklySummaries(userId);
   };
 
   // Handler for success scenario after save
@@ -640,7 +629,7 @@ export class WeeklySummary extends Component {
       pauseOnFocusLoss: false,
       autoClose: 3000,
     });
-    await this.updateUserData(displayUserId || currentUser.userid);
+    this.updateUserData(displayUserId || currentUser.userid);
   };
 
   // Handler for error scenario after save
@@ -653,29 +642,31 @@ export class WeeklySummary extends Component {
   };
 
   // Main save handler, used by both handleMoveSave and handleSave
-  mainSaveHandler = async closeAfterSave => {
+  mainSaveHandler = async (closeAfterSave, isMove = false) => {
     const toastIdOnSave = 'toast-on-save';
     const errors = this.validate();
 
     this.setState({ errors: errors });
     if (Object.keys(errors).length > 0) {
       this.setState({ moveConfirm: false });
-      return;
+      return false;
     }
 
-    const result = await this.handleChangeInSummary();
+    const result = await this.handleChangeInSummary(isMove);
 
     if (result === 200 || result?.status === 200) {
       await this.handleSaveSuccess(toastIdOnSave);
       if (closeAfterSave) {
         this.handleClose();
       }
+      return true;
     } else {
       this.handleSaveError(toastIdOnSave);
+      return false;
     }
   };
 
-  handleMoveSave = async event => {
+  handleMoveSave = event => {
     const { isNotAllowedToEdit, displayUserEmail } = this.props;
     if (isNotAllowedToEdit) {
       if (displayUserEmail === DEV_ADMIN_ACCOUNT_EMAIL_DEV_ENV_ONLY) {
@@ -690,12 +681,16 @@ export class WeeklySummary extends Component {
     if (event) {
       event.preventDefault();
     }
-    const { moveConfirm, moveSelect } = this.state;
-    this.setState({ moveConfirm: true });
-    this.mainSaveHandler(false);
-    if (moveConfirm) {
-      this.toggleTab(moveSelect);
-    }
+    const { moveSelect } = this.state;
+    const targetTab = moveSelect; // remember where to go
+    this.setState({ moveConfirm: true, isSavingMove: true }, async () => {
+      const ok = await this.mainSaveHandler(false, /* isMove */ true);
+      if (ok) {
+        this.toggleTab(targetTab);
+        this.toggleMovePopup(); // close modal only on success
+      }
+      this.setState({ moveConfirm: false, isSavingMove: false, moveSelect: '-1' });
+    });
   };
 
   handleSave = async event => {
@@ -1040,10 +1035,18 @@ export class WeeklySummary extends Component {
                       Are you SURE you want to move the summary?
                     </ModalBody>
                     <ModalFooter className={bodyBg}>
-                      <Button onClick={this.handleMoveSave} style={boxStyling}>
-                        Confirm and Save
+                      <Button
+                        onClick={this.handleMoveSave}
+                        style={boxStyling}
+                        disabled={this.state.isSavingMove || this.state.moveSelect === '-1'}
+                      >
+                        {this.state.isSavingMove ? 'Saving…' : 'Confirm and Save'}
                       </Button>
-                      <Button onClick={this.toggleMovePopup} style={boxStyling}>
+                      <Button
+                        onClick={this.toggleMovePopup}
+                        style={boxStyling}
+                        disabled={this.state.isSavingMove}
+                      >
                         Close
                       </Button>
                     </ModalFooter>


### PR DESCRIPTION
# Description
Fixed the Weekly Summary move/save bug where the “Confirm and Save” popup required two clicks before the summary was actually moved. The modal now closes properly on the first confirmation.

## Related PRS (if any):
N/A

## Main changes explained:
WeeklySummary.jsx
- Fixed state sequencing in handleMoveSave and mainSaveHandler so that move/save executes in one click.
- Removed premature modal toggling from handleMove, modal now closes only after a successful save.
- Updated validation logic: empty summary boxes can be saved, but if content exists it must be 50+ words.
- Added button disable states (isSavingMove, moveSelect === '-1') for safer UX.
- Allowed wordCount = 0 to support empty summaries without errors.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Summary 
6. Try moving a summary from This Week to Last Week:
		On the first “Confirm and Save” click, the summary should move and the modal should close.
7. Verify you can save an empty summary box without error.
8. Verify if you type fewer than 50 words, a validation error is shown.
9. Verify that dark mode still renders correctly.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/122de2fb-edc9-4faa-8050-be4afd495aec


## Note:

- Reviewers should confirm both normal save and move flow work correctly in one click.
- Check both light and dark mode behavior.
