### PR TITLE
feat: adding donut chart for planned cost breakdown_frontend

### DIFF
--- a/src/components/PlannedCostDonutChart/PlannedCostDonutChart.css
+++ b/src/components/PlannedCostDonutChart/PlannedCostDonutChart.css
@@ -1,0 +1,342 @@
+.planned-cost-container {
+  padding: 2rem;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  margin: 1rem 0;
+  transition: all 0.3s ease;
+  overflow: visible;
+  height: auto;
+  min-height: auto;
+}
+
+.planned-cost-container.dark-mode {
+  background: #2d3748;
+  color: #e2e8f0;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+.chart-title {
+  text-align: center;
+  margin-bottom: 2rem;
+  color: #2d3748;
+  font-weight: 600;
+  font-size: 1.75rem;
+}
+
+.dark-mode .chart-title {
+  color: #e2e8f0;
+}
+
+.filter-section {
+  margin-bottom: 2rem;
+  padding: 1rem;
+  background: #f7fafc;
+  border-radius: 8px;
+}
+
+.dark-mode .filter-section {
+  background: #4a5568;
+}
+
+.filter-section label {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #4a5568;
+}
+
+.dark-mode .filter-section label {
+  color: #e2e8f0;
+}
+
+.project-select {
+  border: 2px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0.75rem;
+  font-size: 1rem;
+  transition: border-color 0.3s ease;
+}
+
+.project-select:focus {
+  border-color: #4299e1;
+  box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.1);
+  outline: none;
+}
+
+.dark-mode .project-select {
+  background: #4a5568;
+  border-color: #718096;
+  color: #e2e8f0;
+}
+
+.dark-mode .project-select:focus {
+  border-color: #63b3ed;
+}
+
+.chart-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: visible;
+}
+
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  padding: 2rem;
+  color: #718096;
+}
+
+.dark-mode .loading-container {
+  color: #a0aec0;
+}
+
+.loading-container p {
+  margin-top: 1rem;
+  font-size: 1.1rem;
+}
+
+.no-data-container,
+.select-project-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  padding: 2rem;
+  color: #718096;
+  font-size: 1.1rem;
+  text-align: center;
+}
+
+.dark-mode .no-data-container,
+.dark-mode .select-project-container {
+  color: #a0aec0;
+}
+
+/* Chart center info styling */
+.chart-center-info {
+  text-align: center;
+  margin: 1rem 0;
+}
+
+.total-cost-display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.total-label {
+  font-size: 1rem;
+  color: #718096;
+  font-weight: 500;
+}
+
+.dark-mode .total-label {
+  color: #a0aec0;
+}
+
+.total-amount {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #2d3748;
+}
+
+.dark-mode .total-amount {
+  color: #e2e8f0;
+}
+
+/* Legend styling */
+.legend-container {
+  margin-top: 2rem;
+  width: 100%;
+  max-width: 600px;
+}
+
+.legend-container h4 {
+  text-align: center;
+  margin-bottom: 1rem;
+  color: #2d3748;
+  font-weight: 600;
+}
+
+.dark-mode .legend-container h4 {
+  color: #e2e8f0;
+}
+
+.legend-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem;
+  background: #f7fafc;
+  border-radius: 6px;
+  transition: transform 0.2s ease;
+}
+
+.legend-item:hover {
+  transform: translateY(-2px);
+}
+
+.dark-mode .legend-item {
+  background: #4a5568;
+}
+
+.legend-color {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  margin-right: 0.75rem;
+  flex-shrink: 0;
+}
+
+.legend-label {
+  font-weight: 600;
+  color: #2d3748;
+  margin-right: auto;
+  min-width: 80px;
+}
+
+.dark-mode .legend-label {
+  color: #e2e8f0;
+}
+
+.legend-value {
+  color: #718096;
+  font-size: 0.9rem;
+  text-align: right;
+}
+
+.dark-mode .legend-value {
+  color: #a0aec0;
+}
+
+/* Tooltip styling */
+.planned-cost-tooltip {
+  background: rgba(0, 0, 0, 0.9);
+  color: white;
+  padding: 0.75rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+.tooltip-category {
+  font-weight: 600;
+  margin: 0 0 0.5rem 0;
+  color: #ffffff;
+}
+
+.tooltip-cost {
+  margin: 0 0 0.25rem 0;
+  color: #e2e8f0;
+}
+
+.tooltip-percentage {
+  margin: 0;
+  color: #a0aec0;
+}
+
+/* Ensure no unnecessary scrollbars */
+html, body {
+  overflow-x: hidden;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .planned-cost-container {
+    padding: 1rem;
+    margin: 0.5rem 0;
+  }
+
+  .chart-title {
+    font-size: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .filter-section {
+    margin-bottom: 1.5rem;
+    padding: 0.75rem;
+  }
+
+  .legend-items {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .legend-item {
+    padding: 0.5rem;
+  }
+
+  .legend-label {
+    min-width: 60px;
+    font-size: 0.9rem;
+  }
+
+  .legend-value {
+    font-size: 0.8rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .planned-cost-container {
+    padding: 0.75rem;
+  }
+
+  .chart-title {
+    font-size: 1.25rem;
+    margin-bottom: 1rem;
+  }
+
+  .filter-section {
+    padding: 0.5rem;
+  }
+
+  .project-select {
+    padding: 0.5rem;
+    font-size: 0.9rem;
+  }
+}
+
+/* Animation for chart loading */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.chart-area > * {
+  animation: fadeIn 0.5s ease-out;
+}
+
+/* Hover effects for interactive elements */
+.project-select:hover {
+  border-color: #cbd5e0;
+}
+
+.dark-mode .project-select:hover {
+  border-color: #a0aec0;
+}
+
+/* Focus states for accessibility */
+.project-select:focus-visible {
+  outline: 2px solid #4299e1;
+  outline-offset: 2px;
+}
+
+.dark-mode .project-select:focus-visible {
+  outline-color: #63b3ed;
+}

--- a/src/components/PlannedCostDonutChart/PlannedCostDonutChart.jsx
+++ b/src/components/PlannedCostDonutChart/PlannedCostDonutChart.jsx
@@ -1,0 +1,293 @@
+import React, { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+import { Input, Label, Row, Col, Alert, Spinner } from 'reactstrap';
+import { fetchProjects, fetchPlannedCostBreakdown } from './plannedCostService';
+import './PlannedCostDonutChart.css';
+
+const COLORS = {
+  Plumbing: '#FF6384',
+  Electrical: '#36A2EB',
+  Structural: '#FFCE56',
+  Mechanical: '#4BC0C0',
+};
+
+const RADIAN = Math.PI / 180;
+
+const CustomTooltip = ({ active, payload, totalCost }) => {
+  if (active && payload && payload.length) {
+    const data = payload[0];
+    const percentage = ((data.value / totalCost) * 100).toFixed(1);
+
+    return (
+      <div className="planned-cost-tooltip">
+        <p className="tooltip-category">{data.name}</p>
+        <p className="tooltip-cost">Planned Cost: ${data.value.toLocaleString()}</p>
+        <p className="tooltip-percentage">Percentage: {percentage}%</p>
+      </div>
+    );
+  }
+  return null;
+};
+
+const PlannedCostDonutChart = () => {
+  const [selectedProject, setSelectedProject] = useState('');
+  const [chartData, setChartData] = useState([]);
+  const [totalCost, setTotalCost] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [projects, setProjects] = useState([]);
+
+  const darkMode = useSelector(state => state.theme?.darkMode);
+
+  // Fetch projects list
+  useEffect(() => {
+    const getProjects = async () => {
+      try {
+        const projectsData = await fetchProjects();
+        setProjects(projectsData);
+      } catch (err) {
+        setError(err.message);
+      }
+    };
+
+    getProjects();
+  }, []);
+
+  // Fetch planned cost breakdown when project changes
+  useEffect(() => {
+    if (!selectedProject) {
+      setChartData([]);
+      setTotalCost(0);
+      return;
+    }
+
+    const getPlannedCostBreakdown = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const breakdown = await fetchPlannedCostBreakdown(selectedProject);
+
+        // Transform data for the chart - handle both array and object formats
+        let transformedData = [];
+        let total = 0;
+
+        if (Array.isArray(breakdown)) {
+          // If backend returns array of objects like [{category: 'Plumbing', plannedCost: 5500}, ...]
+          const categoryMap = {};
+          breakdown.forEach(item => {
+            if (item.category && typeof item.plannedCost === 'number') {
+              categoryMap[item.category] = item.plannedCost;
+            }
+          });
+
+          transformedData = [
+            { name: 'Plumbing', value: categoryMap.Plumbing || 0 },
+            { name: 'Electrical', value: categoryMap.Electrical || 0 },
+            { name: 'Structural', value: categoryMap.Structural || 0 },
+            { name: 'Mechanical', value: categoryMap.Mechanical || 0 },
+          ];
+
+          total = Object.values(categoryMap).reduce((sum, cost) => sum + cost, 0);
+        } else {
+          // If backend returns object like {total: 90000, breakdown: {plumbing: 5500, ...}}
+          if (breakdown.total && breakdown.breakdown) {
+            // Use the total from backend and breakdown for chart data
+            // Handle case-insensitive matching
+            const breakdownData = breakdown.breakdown;
+
+            // Check if we actually have valid data
+            const hasValidData = Object.values(breakdownData).some(
+              value => typeof value === 'number' && value > 0,
+            );
+
+            if (hasValidData) {
+              transformedData = [
+                { name: 'Plumbing', value: breakdownData.Plumbing || breakdownData.plumbing || 0 },
+                {
+                  name: 'Electrical',
+                  value: breakdownData.Electrical || breakdownData.electrical || 0,
+                },
+                {
+                  name: 'Structural',
+                  value: breakdownData.Structural || breakdownData.structural || 0,
+                },
+                {
+                  name: 'Mechanical',
+                  value: breakdownData.Mechanical || breakdownData.mechanical || 0,
+                },
+              ];
+
+              total = breakdown.total; // Use the total from backend
+            } else {
+              // No valid data available
+              transformedData = [];
+              total = 0;
+            }
+          } else {
+            // Fallback to old format
+            transformedData = [
+              { name: 'Plumbing', value: breakdown.plumbing || 0 },
+              { name: 'Electrical', value: breakdown.electrical || 0 },
+              { name: 'Structural', value: breakdown.structural || 0 },
+              { name: 'Mechanical', value: breakdown.mechanical || 0 },
+            ];
+
+            total = Object.values(breakdown).reduce((sum, cost) => sum + (cost || 0), 0);
+          }
+        }
+
+        setChartData(transformedData);
+        setTotalCost(total);
+      } catch (err) {
+        setError(err.message);
+        setChartData([]);
+        setTotalCost(0);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    getPlannedCostBreakdown();
+  }, [selectedProject]);
+
+  const renderCustomizedLabel = ({
+    cx,
+    cy,
+    midAngle,
+    innerRadius,
+    outerRadius,
+    percent,
+    value,
+  }) => {
+    if (value === 0) return null;
+
+    const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+    const x = cx + radius * Math.cos(-midAngle * RADIAN);
+    const y = cy + radius * Math.sin(-midAngle * RADIAN);
+
+    return (
+      <text
+        x={x}
+        y={y}
+        fill="white"
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize="12"
+        fontWeight="bold"
+      >
+        {percent > 0.05 ? `${(percent * 100).toFixed(0)}%` : ''}
+      </text>
+    );
+  };
+
+  if (error && !selectedProject) {
+    return (
+      <div className="planned-cost-container">
+        <Alert color="danger">{error}</Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`planned-cost-container ${darkMode ? 'dark-mode' : ''}`}>
+      <h2 className="chart-title">Planned Cost Breakdown by Type of Expenditure</h2>
+
+      {/* Project Filter */}
+      <Row className="filter-section">
+        <Col md="6">
+          <Label for="project-select">Select Project</Label>
+          <Input
+            id="project-select"
+            type="select"
+            value={selectedProject}
+            onChange={e => setSelectedProject(e.target.value)}
+            className="project-select"
+          >
+            <option value="">Choose a project...</option>
+            {projects.map(project => (
+              <option key={project._id} value={project._id}>
+                {project.name || project.projectName}
+              </option>
+            ))}
+          </Input>
+        </Col>
+      </Row>
+
+      {/* Chart Area */}
+      <div className="chart-area">
+        {loading ? (
+          <div className="loading-container">
+            <Spinner color="primary" />
+            <p>Loading planned cost data...</p>
+          </div>
+        ) : selectedProject && chartData.length > 0 && totalCost > 0 ? (
+          <>
+            <ResponsiveContainer width="100%" height={400}>
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={80}
+                  outerRadius={150}
+                  paddingAngle={2}
+                  dataKey="value"
+                  label={renderCustomizedLabel}
+                  labelLine={false}
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={COLORS[entry.name]} />
+                  ))}
+                </Pie>
+
+                <Tooltip content={<CustomTooltip totalCost={totalCost} />} />
+              </PieChart>
+            </ResponsiveContainer>
+
+            {/* Center display showing total */}
+            <div className="chart-center-info">
+              <div className="total-cost-display">
+                <span className="total-label">Total Planned Cost</span>
+                <span className="total-amount">${totalCost.toLocaleString()}</span>
+              </div>
+            </div>
+
+            {/* Legend */}
+            <div className="legend-container">
+              <div className="legend-items">
+                {chartData.map((entry, index) => (
+                  <div key={entry.name} className="legend-item">
+                    <div className="legend-color" style={{ backgroundColor: COLORS[entry.name] }} />
+                    <span className="legend-label">{entry.name}</span>
+                    <span className="legend-value">
+                      ${entry.value.toLocaleString()} (
+                      {((entry.value / totalCost) * 100).toFixed(1)}%)
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        ) : selectedProject ? (
+          <div className="no-data-container">
+            <p>No planned cost data available for this project.</p>
+          </div>
+        ) : (
+          <div className="select-project-container">
+            <p>Please select a project to view the planned cost breakdown.</p>
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <Alert color="danger" className="mt-3">
+          {error}
+        </Alert>
+      )}
+    </div>
+  );
+};
+
+export default PlannedCostDonutChart;

--- a/src/components/PlannedCostDonutChart/index.js
+++ b/src/components/PlannedCostDonutChart/index.js
@@ -1,0 +1,1 @@
+export { default } from './PlannedCostDonutChart';

--- a/src/components/PlannedCostDonutChart/plannedCostService.js
+++ b/src/components/PlannedCostDonutChart/plannedCostService.js
@@ -1,0 +1,133 @@
+import axios from 'axios';
+
+const API_BASE_URL = process.env.REACT_APP_APIENDPOINT || 'http://localhost:4500/api';
+
+/**
+ * Fetch all available projects
+ * @returns {Promise<Array>} Array of projects
+ */
+export const fetchProjects = async () => {
+  try {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      throw new Error('No authentication token found');
+    }
+
+    const response = await axios.get(`${API_BASE_URL}/projects`, {
+      headers: { Authorization: token },
+    });
+
+    return response.data || [];
+  } catch (error) {
+    console.error('Error fetching projects:', error);
+    throw new Error('Failed to fetch projects');
+  }
+};
+
+/**
+ * Fetch planned cost breakdown for a specific project
+ * @param {string} projectId - The project ID
+ * @returns {Promise<Object>} Planned cost breakdown data
+ */
+export const fetchPlannedCostBreakdown = async projectId => {
+  try {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      throw new Error('No authentication token found');
+    }
+
+    const response = await axios.get(
+      `${API_BASE_URL}/projects/${projectId}/planned-cost-breakdown`,
+      {
+        headers: { Authorization: token },
+      },
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching planned cost breakdown:', error);
+    throw new Error(error.response?.data?.message || 'Failed to fetch planned cost breakdown');
+  }
+};
+
+/**
+ * Create or update planned cost for a project category
+ * @param {string} projectId - The project ID
+ * @param {string} category - The category (Plumbing, Electrical, Structural, Mechanical)
+ * @param {number} plannedCost - The planned cost amount
+ * @returns {Promise<Object>} Response data
+ */
+export const createOrUpdatePlannedCost = async (projectId, category, plannedCost) => {
+  try {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      throw new Error('No authentication token found');
+    }
+
+    const response = await axios.post(
+      `${API_BASE_URL}/projects/${projectId}/planned-costs`,
+      {
+        category,
+        plannedCost,
+      },
+      {
+        headers: { Authorization: token },
+      },
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error('Error creating/updating planned cost:', error);
+    throw new Error(error.response?.data?.message || 'Failed to create/update planned cost');
+  }
+};
+
+/**
+ * Delete planned cost for a project category
+ * @param {string} projectId - The project ID
+ * @param {string} category - The category to delete
+ * @returns {Promise<Object>} Response data
+ */
+export const deletePlannedCost = async (projectId, category) => {
+  try {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      throw new Error('No authentication token found');
+    }
+
+    const response = await axios.delete(
+      `${API_BASE_URL}/projects/${projectId}/planned-costs/${category}`,
+      {
+        headers: { Authorization: token },
+      },
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error('Error deleting planned cost:', error);
+    throw new Error(error.response?.data?.message || 'Failed to delete planned cost');
+  }
+};
+
+/**
+ * Get all planned costs for a project (detailed view)
+ * @param {string} projectId - The project ID
+ * @returns {Promise<Array>} Array of planned cost records
+ */
+export const getAllPlannedCostsForProject = async projectId => {
+  try {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      throw new Error('No authentication token found');
+    }
+
+    const response = await axios.get(`${API_BASE_URL}/projects/${projectId}/planned-costs`, {
+      headers: { Authorization: token },
+    });
+
+    return response.data || [];
+  } catch (error) {
+    console.error('Error fetching all planned costs:', error);
+    throw new Error(error.response?.data?.message || 'Failed to fetch planned costs');
+  }
+};

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -42,7 +42,7 @@ import TSAFormPage7 from './components/TSAForm/pages/TSAFormPage7';
 import TSAFormPage8 from './components/TSAForm/pages/TSAFormPage8';
 import Timelog from './components/Timelog';
 import UserProfileEdit from './components/UserProfile/UserProfileEdit';
-
+import PlannedCostDonutChart from './components/PlannedCostDonutChart';
 import Dashboard from './components/Dashboard';
 import Logout from './components/Logout/Logout';
 import Login from './components/Login';
@@ -749,7 +749,7 @@ export default (
           exact
           component={PromotionEligibility}
         />
-
+        <ProtectedRoute path="/planned-costs" exact component={PlannedCostDonutChart} />
         <Route path="*" component={NotFoundPage} />
       </Switch>
     </>


### PR DESCRIPTION
# Description
Summary Dashboard: Create a Donut Chart showing Planned Cost Breakdown by Type of Expenditure (WIP Sai Krishna)

The chart should display four categories: Plumbing, Electrical, Structural, and Mechanical, each represented by a different color. 
The percentage of the total cost for each category should be displayed next to it in hover text. 
Include two filters:  
A Project filter to view the cost breakdown for a specific project.  
Frontend Requirements
Donut Chart Component:
Use chart library like Recharts, Chart.js, or Nivo.
Four fixed segments:
Plumbing
Electrical
Structural
Mechanical
Distinct color for each.
Tooltip / Hover Text:
Show:
Category Name
Planned Cost
Percentage of Total Planned Cost
Filters:
Dropdown for:
Project Filter (list of available projects)
Legend:
Color-coded legend mapping category to color.
Title:
"Planned Cost Breakdown by Type of Expenditure"
API Integration:
Fetch planned cost data based on selected project.
## Related PRS (if any):
This frontend PR is related to the #1699 backend PR.
…
## Main changes explained:
- Added Plannedcostdonutchart.jsx, Plannedcostdonutchart.css, plannedcostservice.js, index.js
- updated routes.js
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to http://localhost:5173/planned-costs
6. select the project from the dropdown with the data
7. You should be able to see the donut chart
8. On hovering the chart you should be able to see the legend and data related to the type in that legend

## Screenshots or videos of changes:
<img width="1906" height="971" alt="Screenshot 2025-08-29 191741" src="https://github.com/user-attachments/assets/69edc1f5-4292-4633-a81b-1cf68db17a30" />
<img width="1909" height="966" alt="Screenshot 2025-08-29 191752" src="https://github.com/user-attachments/assets/a5f116bb-6d5d-4483-a123-eacc69de8cfd" />
<img width="1906" height="964" alt="Screenshot 2025-08-29 191808" src="https://github.com/user-attachments/assets/d191686c-11d9-42cf-bffa-3f58a839a5ea" />
<img width="1902" height="962" alt="Screenshot 2025-08-29 191819" src="https://github.com/user-attachments/assets/72851a72-4291-4d0b-b2ba-fe56a41ccb74" />

