### PR TITLE
Venkataramanan. change save changes when profile photo is uploaded

### DIFF
--- a/src/components/UserProfile/UserProfileEdit/UserProfileEdit.jsx
+++ b/src/components/UserProfile/UserProfileEdit/UserProfileEdit.jsx
@@ -39,6 +39,7 @@ class UserProfileEdit extends Component {
   state = {
     showWarning: false,
     isLoading: true,
+    isSavingImage: false,
     formValid: {
       firstName: true,
       lastName: true,
@@ -287,54 +288,78 @@ class UserProfileEdit extends Component {
 
   handleImageUpload = async e => {
     e.preventDefault();
-
-    const file = e.target.files[0];
-
-    const allowedTypesString = 'image/png,image/jpeg, image/jpg';
-    const allowedTypes = allowedTypesString.split(',');
-    let isValid = true;
-    let imageUploadError = '';
+  
+    const file = e.target.files && e.target.files[0];
+    if (!file) return;
+  
+    // Normalize and validate type
+    const allowedTypes = ['image/png', 'image/jpeg', 'image/jpg'];
     if (!allowedTypes.includes(file.type)) {
-      imageUploadError = `File type must be ${allowedTypesString}.`;
-      isValid = false;
-
+      const imageUploadError = `File type must be ${allowedTypes.join(', ')}.`;
       return this.setState({
         type: 'image',
         imageUploadError,
-        isValid,
+        isValid: false,
         showModal: true,
         modalTitle: 'Profile Pic Error',
         modalMessage: imageUploadError,
       });
     }
+  
+    // Validate size (<= 50KB)
     const filesizeKB = file.size / 1024;
     if (filesizeKB > 50) {
-      imageUploadError = `\nThe file you are trying to upload exceeds the maximum size of 50KB. You can either 
-														choose a different file, or use an online file compressor.`;
-      isValid = false;
-
+      const imageUploadError =
+        'The file you are trying to upload exceeds the maximum size of 50KB. ' +
+        'Choose a different file or use an online image compressor.';
       return this.setState({
         type: 'image',
         imageUploadError,
-        isValid,
+        isValid: false,
         showModal: true,
         modalTitle: 'Profile Pic Error',
         modalMessage: imageUploadError,
       });
     }
-
+  
     const reader = new FileReader();
-    reader.readAsDataURL(file);
+  
     reader.onloadend = () => {
-      this.setState({
-        imageUploadError: '',
-        userProfile: {
-          ...this.state.userProfile,
-          profilePic: reader.result,
-        },
-      });
+      const base64 = reader.result;
+  
+      // 1) Optimistically update local state so the preview updates immediately
+      this.setState(
+        prev => ({
+          imageUploadError: '',
+          isSavingImage: true,
+          userProfile: {
+            ...prev.userProfile,
+            profilePic: base64,
+          },
+        }),
+        // 2) Then persist to the server right away (auto-save)
+        async () => {
+          try {
+            await this.props.updateUserProfile(this.state.userProfile);
+            // (Optional) toast/modal success
+            // this.setState({ showModal: true, modalTitle: 'Profile Photo', modalMessage: 'Updated!' });
+          } catch (err) {
+            // If save fails, you can revert or just show an error
+            this.setState({
+              showModal: true,
+              modalTitle: 'Profile Photo',
+              modalMessage: 'Failed to save profile photo. Please try again.',
+              type: 'message',
+            });
+          } finally {
+            this.setState({ isSavingImage: false });
+          }
+        }
+      );
     };
-  };
+  
+    reader.readAsDataURL(file);
+  };  
 
   handleTeam = (type, newTeam) => {
     const { userProfile } = this.state;
@@ -630,24 +655,41 @@ class UserProfileEdit extends Component {
           <Container className="emp-profile">
             <Row>
               <Col md="4" id="profileContainer">
-                <div className="profile-img">
-                  <Image
-                    src={profilePic || '/defaultprofilepic.png'}
-                    alt="Profile Picture"
-                    roundedCircle
-                    className="profilePicture"
-                  />
-                  <div className="file btn btn-lg btn-primary">
-                    Change Photo
-                    <Input
-                      type="file"
-                      name="newProfilePic"
-                      id="newProfilePic"
-                      onChange={this.handleImageUpload}
-                      accept="image/png,image/jpeg, image/jpg"
-                    />
+              <div className="profile-img" style={{ position: 'relative' }}>
+                <Image
+                  src={profilePic || '/defaultprofilepic.png'}
+                  alt="Profile Picture"
+                  roundedCircle
+                  className="profilePicture"
+                />
+                {this.state.isSavingImage && (
+                  <div
+                    style={{
+                      position: 'absolute',
+                      inset: 0,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      background: 'rgba(255,255,255,0.6)',
+                      borderRadius: '50%',
+                    }}
+                  >
+                    <Loading />
                   </div>
+                )}
+                <div className="file btn btn-lg btn-primary">
+                  Change Photo
+                  <Input
+                    type="file"
+                    name="newProfilePic"
+                    id="newProfilePic"
+                    onChange={this.handleImageUpload}
+                    accept="image/png,image/jpeg,image/jpg"
+                    disabled={this.state.isSavingImage}
+                  />
                 </div>
+              </div>
+
               </Col>
               <Col md="8">
                 <div className="profile-head">


### PR DESCRIPTION
# Description
This PR changes the functionality of profile picture upload where the changes are saved immediately after the profile picture is updated. This is in the User Profile page.

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change file UserProfileEdit.jsx and UserProfile.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ View Profile
6. Upload a new profile picture and make sure it saves without clicking "Save Changes" button.
