### PR TITLE
Carlos PR Admin Dashboard: Change .css to .module.css in profile/skills

### DIFF
--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/components/UserSkillsProfile.jsx
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/components/UserSkillsProfile.jsx
@@ -95,10 +95,10 @@ function UserSkillsProfile() {
   }
 
   return (
-    <div className="user-profile-home">
-      <div className="dashboard-container">
+    <div className={styles.userProfileHome}>
+      <div className={styles.dashboardContainer}>
         <LeftSection />
-        <div className="vertical-separator" />
+        <div className={styles.verticalSeparator} />
         <RightSection />
       </div>
     </div>


### PR DESCRIPTION
# Description
<img width="633" height="298" alt="image" src="https://github.com/user-attachments/assets/9bb12347-54d7-41ed-8d9b-52c00378a2ae" />

This pull request fixes the formatting after changing to module css on the User Profile Skills page.

## Related PRS (if any):
This front end PR is not related to any back end PR

## Main changes explained:
- Update `UserSkillsProfile.jsx`

## How to test:
1. check into current branch
2. do `yarn install` and `yarn start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to [http://localhost:5173/hgn/profile/skills](http://localhost:5173/hgn/profile/skills)
6. verify user profile skills page has all classes properly changed over to module.css

## Screenshots or videos of changes:
Before
<img width="1920" height="958" alt="image" src="https://github.com/user-attachments/assets/729be7dd-fa27-40bf-8113-9598c51cc6ce" />


After
<img width="1145" height="918" alt="image" src="https://github.com/user-attachments/assets/1c7bf27f-722f-4909-8fad-39225e11e15c" />
