### PR TITLE
Amalesh - Fix the issue with displaying Dashboard header message on wide screen

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -147,11 +147,11 @@
   }
 }
 
-@media screen and (min-width: 1400px) and (max-width: 1700px) {
+/*@media screen and (min-width: 1400px) and (max-width: 1700px) {
   .owner-message {
     display: none;
   }
-}
+}*/
 
 @media screen and (max-width: 769px) {
   .responsive-spacing {


### PR DESCRIPTION
# Description
<img width="681" height="124" alt="image" src="https://github.com/user-attachments/assets/dfe46e41-602b-4dca-9f0e-150d7455ec96" />

## Related PRS (if any):
This frontend PR is related to the development branch of the backend.

## Main changes explained:
Files are updated to resolve the missing dashboard message for certain screen resolutions.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as an user
5. Check if the dashboard message is displayed for all screen resolutions.

## Screenshots or videos of changes:
Before:
https://github.com/user-attachments/assets/5d5ba7ec-0990-4af0-9e61-3f33c51fe736

After:
https://github.com/user-attachments/assets/e3e590d5-a038-4e38-823d-7d2b89d838a8

