### PR TITLE
Namitha - fix(Analytics): Add missing route for participation report page

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -650,6 +650,12 @@ export default (
         <Route path="/educationportal/login" component={EPLogin} />
 
         <CPProtectedRoute
+          path="/communityportal/reports/participation"
+          exact
+          component={EventParticipation}
+        />
+
+        <CPProtectedRoute
           path="/communityportal/reports/event/personalization"
           exact
           component={EventStats}


### PR DESCRIPTION
Description

- Registration by Event Type and Location – After PR merge, testing the provided link only shows the month/year view of events and the registered events list. The event registration form/page is not accessible. 
- Added CPProtectedRoute for /communityportal/reports/participation in routes.jsx so that EventParticipation page renders correctly instead of 404.

Related PRS (if any):
This frontend PR is related to the #XXX backend PR.
To test this backend PR you need to checkout the #XXX frontend PR.

Main changes explained:
- Inserted CPProtectedRoute in communityportal route block
- Verified import path for EventParticipation is correct

How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard
6. navigate to /communityportal/reports/participation
3. Page should render without page-not-found error

Screenshots or videos of changes:
<img width="1919" height="945" alt="Screenshot 2025-09-08 164830" src="https://github.com/user-attachments/assets/afc39730-ce72-435b-b735-ab831cce79b9" />

https://github.com/user-attachments/assets/7be4de26-b1b0-4937-9357-3d06abaa6a26


