### PR TITLE
Diya fix(qst): add newly assigned projects to user profile

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AssignSetupModal.jsx
@@ -37,7 +37,7 @@ function AssignSetUpModal({ isOpen, setIsOpen, title, userProfile, setUserProfil
 
     if (validation.volunteerAgree && googleDoc.length !== 0) {
       const originalTeamId = userProfile.teams.map(team => team._id);
-      const originalProjectId = userProfile.projects.map(project => project._id);
+      const originalProjectId = userProfile.projects.map(project => project.projectId);
       // If the title has team assigned, add the team to the user profile. Remove duplicate teams
       const teamsAssigned = title.teamAssiged
         ? originalTeamId.includes(title?.teamAssiged._id)
@@ -46,7 +46,7 @@ function AssignSetUpModal({ isOpen, setIsOpen, title, userProfile, setUserProfil
         : userProfile.teams;
       // If the title has project assigned, add the project to the user profile. Remove duplicate projects
       const projectAssigned = title.projectAssigned
-        ? originalProjectId.includes(title?.projectAssigned._id)
+        ? originalProjectId.includes(title?.projectAssigned.projectId)
           ? userProfile.projects
           : [...userProfile.projects, title.projectAssigned]
         : userProfile.projects;

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -772,36 +772,78 @@ const onAssignProject = assignedProject => {
     }
   };
 
-  const handleSubmit = async updatedUserProfile => {
-    for (let i = 0; i < updatedTasks.length; i += 1) {
-      const updatedTask = updatedTasks[i];
-      const url = ENDPOINTS.TASK_UPDATE(updatedTask.taskId);
-      // eslint-disable-next-line no-console
-      axios.put(url, updatedTask.updatedTask).catch(err => console.log(err));
-    }
-    try {
-       const userProfileToUpdate = {
-        ...(updatedUserProfile || userProfileRef.current),
-        projects, // Ensure projects are included in the payload
-        };
-        // eslint-disable-next-line no-console
-        console.log('Submitting UserProfile:', userProfileToUpdate); // Debugging log
-      const result = await props.updateUserProfile(userProfileToUpdate);
-      if (userProfile._id === props.auth.user.userid && props.auth.user.role !== userProfile.role) {
-        await props.refreshToken(userProfile._id);
-      }
-      await loadUserProfile();
-      await loadUserTasks();
-      setSaved(false);
-    } catch (err) {
-      if (err.response && err.response.data && err.response.data.error) {
-        const errorMessage = err.response.data.error.join('\n');
-        // eslint-disable-next-line no-alert
-        alert(errorMessage);
-      }
-      return err;
-    }
+  // const handleSubmit = async updatedUserProfile => {
+  //   for (let i = 0; i < updatedTasks.length; i += 1) {
+  //     const updatedTask = updatedTasks[i];
+  //     const url = ENDPOINTS.TASK_UPDATE(updatedTask.taskId);
+  //     // eslint-disable-next-line no-console
+  //     axios.put(url, updatedTask.updatedTask).catch(err => console.log(err));
+  //   }
+  //   try {
+  //      const userProfileToUpdate = {
+  //       ...(updatedUserProfile || userProfileRef.current),
+  //       projects, // Ensure projects are included in the payload
+  //       };
+  //       // eslint-disable-next-line no-console
+  //       console.log('Submitting UserProfile:', userProfileToUpdate); // Debugging log
+  //     const result = await props.updateUserProfile(userProfileToUpdate);
+  //     if (userProfile._id === props.auth.user.userid && props.auth.user.role !== userProfile.role) {
+  //       await props.refreshToken(userProfile._id);
+  //     }
+  //     await loadUserProfile();
+  //     await loadUserTasks();
+  //     setSaved(false);
+  //   } catch (err) {
+  //     if (err.response && err.response.data && err.response.data.error) {
+  //       const errorMessage = err.response.data.error.join('\n');
+  //       // eslint-disable-next-line no-alert
+  //       alert(errorMessage);
+  //     }
+  //     return err;
+  //   }
+  // };
+
+  const handleSubmit = async (updatedUserProfile) => {
+  // 1) Merge with the current ref FIRST
+  const merged = { ...(userProfileRef.current || {}), ...(updatedUserProfile || {}) };
+
+  // 2) Normalize projects from the merged payload (NOT from a separate variable)
+  const projectsIds = (merged.projects || [])
+    .map(p => String(p?._id ?? p?.projectId ?? p))  // supports objects or plain ids
+    .filter(Boolean);
+
+  const userProfileToUpdate = {
+    ...merged,
+    projects: projectsIds,  // single source of truth
   };
+
+  console.log('Submitting UserProfile:', userProfileToUpdate);
+
+  // update tasks (optionally await if you need sequencing)
+  for (let i = 0; i < updatedTasks.length; i += 1) {
+    const updatedTask = updatedTasks[i];
+    const url = ENDPOINTS.TASK_UPDATE(updatedTask.taskId);
+    // consider await here if order matters
+    axios.put(url, updatedTask.updatedTask).catch(err => console.log(err));
+  }
+
+  try {
+    const result = await props.updateUserProfile(userProfileToUpdate);
+    if (userProfile._id === props.auth.user.userid && props.auth.user.role !== userProfile.role) {
+      await props.refreshToken(userProfile._id);
+    }
+    await loadUserProfile();
+    await loadUserTasks();
+    setSaved(false);
+    return result;
+  } catch (err) {
+    if (err?.response?.data?.error) {
+      alert(err.response.data.error.join('\n'));
+    }
+    return err;
+  }
+};
+
 
   // Changing onSubmit for Badges component from handleSubmit to handleBadgeSubmit.
   // AssignBadgePopup already has onSubmit action to call an API to update the user badges.


### PR DESCRIPTION
# Description
Users assigned a project via Quick Setup → Assign would see the new project appear and then previously assigned projects disappear after a refresh. 
**Root cause:** The frontend payload in handleSubmit overwrote the updated projects array with a stale variable, and the Assign modal sometimes sent mixed shapes (_id vs projectId), causing the backend to retain only the last item.

This PR fixes the frontend so existing projects are preserved and new assignments are appended correctly.

Fixes: (Priority: High) – The project assignment was failing in the Quick Setup flow.

## Related PRS (if any):
None

## Main changes explained:
- Update handleSubmit (User Profile page):
-- Build the payload from the merged updatedUserProfile instead of overriding with a stale projects variable.
-- Normalize projects to a stable list of string IDs (_id or projectId) before sending to the API to avoid accidental drops.
- Update AssignSetUpModal:
-- Use project.projectId (with fallback if needed) when constructing links / payloads so the selected project’s id is consistent with the rest of the UI.

## How to test:
1. Check into current branch
2. Do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Login as a user who has access for QST
5. User Profile > Projects (keep this tab open)
6. QST > Paste a google doc link > Check the checkbox > Yes
7. Verify that the project gets updated in the Projects tab

## Screenshots or videos of changes:

