### PR TITLE
Diya fix(task addition): stabilize WBS numbering and disable DB alert on u…

### DIFF
--- a/src/actions/task.js
+++ b/src/actions/task.js
@@ -212,7 +212,7 @@ export const addNewTask = (newTask, wbsId, pageLoadTime) => async dispatch => {
 
     const userIds = task.resources.map(resource => resource.userID);
     await createOrUpdateTaskNotificationHTTP(task._id, {}, userIds);
-    return task._id;
+    return task;
   } catch (error) {
     status = 400;
     toast.error('Failed to add new task');

--- a/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
+++ b/src/components/Projects/WBS/WBSDetail/AddTask/AddTaskModal.jsx
@@ -74,7 +74,8 @@ function AddTaskModal(props) {
    * -------------------------------- variable declarations --------------------------------
    */
   // props from store
-  const { copiedTask, allMembers, allProjects, error, darkMode, tasks } = props;
+  const { copiedTask, allMembers, allProjects, error, darkMode } = props;
+  const tasksList = Array.isArray(props.tasks) ? props.tasks : [];
 
   const handleBestHoursChange = e => {
     setHoursBest(e.target.value);
@@ -115,19 +116,20 @@ function AddTaskModal(props) {
         });
         return filtered.length ? filtered : members; // fallback so the list isn't empty
       }, [allMembers]);
-      
-  const defaultCategory = useMemo(() => {
-    if (props.taskId) {
-      const task = tasks.find(({ _id }) => _id === props.taskId);
-      return task?.category || 'Unspecified';
-    }
-    if (props.projectId) {
-      const project = allProjects.projects.find(({ _id }) => _id === props.projectId);
-      return project?.category || 'Unspecified';
-    }
 
-    return 'Unspecified';
-  }, [props.taskId, props.projectId, tasks, allProjects.projects]);
+const projectsList = Array.isArray(allProjects?.projects) ? allProjects.projects : [];
+const defaultCategory = useMemo(() => {
+  if (props.taskId) {
+const task = tasksList.find(t => t?._id === props.taskId);
+return task?.category ?? 'Unspecified';
+}
+if (props.projectId) {
+const project = projectsList.find(p => p?._id === props.projectId);
+return project?.category ?? 'Unspecified';
+}
+return 'Unspecified';
+}, [props.taskId, props.projectId, tasksList.length, projectsList.length]);
+
 
   const [taskName, setTaskName] = useState('');
   const [priority, setPriority] = useState('Primary');
@@ -180,12 +182,10 @@ function AddTaskModal(props) {
   };
 
   const getNewNum = () => {
-    if (!Array.isArray(props.tasks)) return '1';
+    if (!tasksList.length) return '1';
     let newNum;
-    // eslint-disable-next-line no-console
-    console.log(props)
     if (props.taskId) {
-      const numOfLastInnerLevelTask = props.tasks.reduce((num, task) => {
+      const numOfLastInnerLevelTask = tasksList.reduce((num, task) => {
         if (task.mother === props.taskId) {
           const numIndexArray = task.num.split('.');
           const numOfInnerLevel = numIndexArray[props.level];
@@ -197,7 +197,7 @@ function AddTaskModal(props) {
       currentLevelIndexes[props.level] = `${numOfLastInnerLevelTask + 1}`;
       newNum = currentLevelIndexes.join('.');
     } else {
-      const numOfLastLevelOneTask = props.tasks.reduce((num, task) => {
+      const numOfLastLevelOneTask = tasksList.reduce((num, task) => {
         if (task.level === 1) {
           const numIndexArray = task.num.split('.');
           const indexOfFirstNum = numIndexArray[0];
@@ -383,7 +383,7 @@ function AddTaskModal(props) {
       setNewTaskNum(getNewNum());
     }
     // setNewTaskNum(getNewNum());
-  }, [modal]);
+  }, [modal, tasksList.length, props.taskId, props.level, props.taskNum]);
 
   useEffect(() => {
     ReactTooltip.rebuild();
@@ -392,12 +392,12 @@ function AddTaskModal(props) {
   useEffect(() => {
     if (error === 'outdated') {
       // eslint-disable-next-line no-alert
-      alert('Database changed since your page loaded , click OK to get the newest data!');
+      // alert('Database changed since your page loaded , click OK to get the newest data!');
       props.load();
     } else {
       clear();
     }
-  }, [error, tasks]);
+  }, [error, tasksList.length]);
 
   useEffect(() => {
     if (!modal) {
@@ -922,7 +922,7 @@ const mapStateToProps = state => ({
   allProjects: state.allProjects,
   error: state.tasks.error,
   darkMode: state.theme.darkMode,
-  tasks: state.tasks.taskItems,
+  // tasks: state.tasks.taskItems,
 });
 
 const mapDispatchToProps = {

--- a/src/components/Projects/WBS/WBSDetail/ControllerRow/ControllerRow.jsx
+++ b/src/components/Projects/WBS/WBSDetail/ControllerRow/ControllerRow.jsx
@@ -31,7 +31,7 @@ function ControllerRow(props) {
   const canPostTask = props.hasPermission('postTask');
 
   // props from store
-  const { role, userPermissions, roles, popupContent, darkMode } = props;
+  const { role, userPermissions, roles, popupContent, darkMode, tasks } = props;
 
   // states from hooks
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -90,6 +90,7 @@ function ControllerRow(props) {
               pageLoadTime={props.pageLoadTime}
               isOpen={props.isOpen}
               setIsOpen={props.setIsOpen}
+              tasks={tasks}
             />
           ) : null}
           <EditTaskModal

--- a/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
+++ b/src/components/Projects/WBS/WBSDetail/Task/Task.jsx
@@ -404,6 +404,7 @@ function Task(props) {
               siblings={props.siblings}
               load={props.load}
               pageLoadTime={props.pageLoadTime}
+              tasks={props.tasks}
             />
           ) : null}
         </>


### PR DESCRIPTION
# Description
This PR fixes the below 2 issues: 
1. When the WBS tasks page is open in 2 browsers. Adding a task in Browser A does not reflect immediately in Browser B until refresh. Adding a task in Browser B without refresh displays an alert "Database changed since your page loaded , click OK to get the newest data!". Clicking OK refreshes the page and then displays task added from both browsers.
2. Adding a new task on first load of browser displays WBS # 1 even if tasks already exist.

## Related PRS (if any):
None
…

## Main changes explained:
- AddTaskModal.jsx
-- Commented out the DB update alert.
-- Compute tasksList from props.tasks (no direct Redux bind) and derive defaultCategory safely.
-- Reworked getNewNum() to use tasksList and current context (taskId, level, taskNum).
-- Recalculate WBS on modal open and when tasksList.length, taskId, level, or taskNum change.
-- Hardened null checks for allProjects.projects and tasksList to avoid .find on undefined.

- ControllerRow.jsx
-- Pass the current tasks down to <AddTaskModal /> so numbering logic always has context.

- Task.jsx
-- Forward tasks to <ControllerRow /> and children; avoid directly binding tasks via mapStateToProps here.

- actions/task.js
-- Keep returning the full created task object from addNewTask (callers can use _id or other fields if needed).

## How to test:
1. Check into current branch
2. Do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Login as user who has access to create tasks
5. Duplicate this into another window as shown in video and create tasks without refreshing.
6. Verify that alert is no longer visible
7. Verify that adding a new task on first time load of the page shows wbs number +1 of how many tasks are present

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/8aa9dc22-3639-4554-8841-950f1032dc2a


## Note:
Please refer to the video of before and after changes!
