### PR TITLE
Diya Hotfix: user fetch for BCC

### DIFF
--- a/src/components/UserProfile/BluequareEmailBBCPopUp.jsx
+++ b/src/components/UserProfile/BluequareEmailBBCPopUp.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {getAllBlueSquareEmailAssignements , setBlueSquareEmailAssignement ,deleteBlueSquareEmailAssignement} from '../../actions/blueSquareEmailBCCAction'
 import {
@@ -18,6 +18,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 import { boxStyle, boxStyleDark } from '~/styles';
+import { getAllUserProfile } from '~/actions/userManagement';
 
 // eslint-disable-next-line react/display-name
 const BluequareEmailAssignmentPopUp = React.memo(props => {
@@ -43,15 +44,18 @@ const BluequareEmailAssignmentPopUp = React.memo(props => {
       const searchWordLast = splitWords[1];
       return (
         user.firstName.toLowerCase().includes(searchWordFirst.toLowerCase()) &&
-        user.lastName.toLowerCase().includes(searchWordLast.toLowerCase())
+        user.lastName.toLowerCase().includes(searchWordLast.toLowerCase()) &&
+        user.email.toLowerCase().includes(searchWord.toLowerCase())
       );
     } else {
       return (
         user.firstName.toLowerCase().includes(searchWord.toLowerCase()) ||
-        user.lastName.toLowerCase().includes(searchWord.toLowerCase())
+        user.lastName.toLowerCase().includes(searchWord.toLowerCase()) ||
+        user.email.toLowerCase().includes(searchWord.toLowerCase())
       );
     }
   });
+
 
   
   
@@ -64,9 +68,10 @@ const BluequareEmailAssignmentPopUp = React.memo(props => {
     dispatch(deleteBlueSquareEmailAssignement(id))
   }
 
-  useEffect(()=>{
-    dispatch(getAllBlueSquareEmailAssignements())
-  },[])
+  useEffect(() => {
+    dispatch(getAllUserProfile());
+    dispatch(getAllBlueSquareEmailAssignements());
+  }, []);
 
   return (
     <Modal isOpen={props.isOpen} toggle={closePopup} size='lg' className={darkMode ? 'dark-mode text-light' : ''}>


### PR DESCRIPTION
# Description
**Bug:** In the Blue Square BCC modal, typing in the search input didn’t show any results and the dropdown appeared “missing.”
**Root cause:** state.allUserProfiles.userProfiles was never loaded, so activeUsers was empty and the dropdown rendered no items.

## Related PRS (if any):
None

## Main changes explained:
- Updated BluequareEmailAssignmentPopUp.jsx
-- Imported allUserProfiles from userManagement.js
-- Dispatching userProfiles on load (useEffect addition)
-- Updated filteredUsers to filter according to email along with existing filters.

## How to test:
1. Check into current branch
2. Clear site data/cache
3. Login as Owner (or any other user who has permission to assign blue squares)
4. User Profile > Blue Square Email BCCs
5. Enter any User name or email
6. Drop down should appear, select a user and add them to the list.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/0cc62b55-63bb-4266-9d0c-e478f47f0207


