### PR TITLE
Diya 🔥 (bcc):added default bcc recipient on blue square assignment

### DIFF
--- a/src/components/UserProfile/BluequareEmailBBCPopUp.jsx
+++ b/src/components/UserProfile/BluequareEmailBBCPopUp.jsx
@@ -56,7 +56,31 @@ const BluequareEmailAssignmentPopUp = React.memo(props => {
     }
   });
 
+  const DEFAULT_RECIPIENT = {
+    _id: '63feae337186de1898fa8f51',
+    email: 'jae@onecommunityglobal.org',
+    assignedTo: {
+      firstName: 'Jae',
+      lastName: 'Sabol',
+      role: 'Owner',
+      isActive: true,
+    },
+    locked: true,
+  };
 
+  const assignmentsWithDefault = useMemo(() => {
+    const list = blueSquareEmailAssignments || [];
+    const hasDefault = list.some(
+    a => (a.email || '').toLowerCase() === DEFAULT_RECIPIENT.email.toLowerCase()
+  );
+  const withLockFlag = list.map(a => ({
+    ...a,
+    locked:
+      a.locked ||
+      (a.email || '').toLowerCase() === DEFAULT_RECIPIENT.email.toLowerCase(),
+  }));
+  return hasDefault ? withLockFlag : [DEFAULT_RECIPIENT, ...withLockFlag];
+  }, [blueSquareEmailAssignments]);
   
   
   const handleAddBCC = (e) =>{
@@ -129,8 +153,8 @@ const BluequareEmailAssignmentPopUp = React.memo(props => {
             </tr>
           </thead>
           <tbody>
-            {blueSquareEmailAssignments.length > 0 &&
-              blueSquareEmailAssignments.map((assignment, index) => {
+            {assignmentsWithDefault.length > 0 &&
+              assignmentsWithDefault.map((assignment, index) => {
                 return (
                   <tr key={assignment._id}>
                     <td>
@@ -147,6 +171,7 @@ const BluequareEmailAssignmentPopUp = React.memo(props => {
                     <td className='d-flex justify-content-center align-items-center'>
                       <Button
                         color="danger"
+                        disabled={assignment.locked}
                         onClick={()=>handleAssignementDelete(assignment._id)}
                         style={props.darkMode ? boxStyleDark : boxStyle}
                       >


### PR DESCRIPTION
# Description
Add a default, non-removable BCC recipient to the Blue square email recipients modal.
The default line is rendered as “(required)” and has no delete control. This ensures at least one org address is always BCC’d.

## Related PRS (if any):
None

## Main changes explained:
- Added a default recipient
- Made sure the recipient is not duplicated from the fetched user list. 
- Disabled the delete button for this recipient

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Login as admin user
5. User Profile > Blue Square Email BCCs
6. a. Verify Jae's name and email as required and delete button should be disabled

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/d87e4267-16e3-4397-beb3-48b618f0e467
