### PR TITLE
Venkataramanan fix people report redirection from user management page

### DIFF
--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -4,7 +4,7 @@ import { connect, useSelector, useDispatch} from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { toast } from 'react-toastify';
 // import { Link, useHistory } from 'react-router-dom';
-import { useHistory } from 'react-router-dom';
+import { useHistory, Link } from 'react-router-dom';
 import { faUser, faUsers, faShieldAlt, faBriefcase, faUserTie, faCrown, faChalkboardTeacher, faBug, faGlobe, faStar, faCopy } from '@fortawesome/free-solid-svg-icons';
 import { updateUserInfomation } from '../../actions/userManagement';
 import { getAllRoles } from '../../actions/role';
@@ -176,42 +176,50 @@ const UserTableDataComponent = (props) => {
           ''
         )}
         <span style={{ position: 'absolute', top: 0, right: 0 }}>
-          <button
-            type="button"
-            className="team-member-tasks-user-report-link"
+          <Link
+          to={`/peoplereport/${props.user._id}`}
+          onClick={(event) => {
+            if (!canSeeReports) {
+              event.preventDefault();
+              return;
+            }
+
+            if (
+              event.metaKey || event.ctrlKey ||
+              event.shiftKey || event.altKey ||
+              event.button !== 0
+            ) {
+              return;
+            }
+
+            event.preventDefault(); 
+            history.push(`/peoplereport/${props.user._id}`);
+          }}
+          style={{
+            textDecoration: 'none',
+            opacity: canSeeReports ? 1 : 0.7,
+            cursor: canSeeReports ? 'pointer' : 'not-allowed',
+            display: 'inline-block',               
+            lineHeight: 0,                        
+            padding: 0,                           
+          }}
+          title="Click to view user report"
+        >
+          <img
+            src="/report_icon.png"
+            alt="reportsicon"
+            className="team-member-tasks-user-report-link-image"
+            id={`report-icon-${props.user._id}`}
             style={{
-              fontSize: 18,
-              opacity: canSeeReports ? 1 : 0.7,
-              background: 'none',
-              border: 'none',
-              padding: 0,
+              width: 16,   
+              height: 16,
+              verticalAlign: 'middle',
             }}
-            onClick={(event) => {
-              if (!canSeeReports) {
-                event.preventDefault();
-                return;
-              }
+          />
+        </Link>
 
-              if (event.metaKey || event.ctrlKey || event.button === 1) {
-                window.open(`/peoplereport/${props.user._id}`, '_blank');
-                return;
-              }
+      </span>
 
-              event.preventDefault(); // prevent full reload
-              history.push(`/peoplereport/${props.user._id}`);
-            }}
-          >
-            <img
-              src="/report_icon.png"
-              alt="reportsicon"
-              className="team-member-tasks-user-report-link-image"
-              id={`report-icon-${props.user._id}`}
-              style={{
-                cursor: canSeeReports ? 'pointer' : 'not-allowed', // Change cursor style to indicate the disabled state
-              }}
-            />
-          </button>
-        </span>
 
         <span style={{ position: 'absolute', bottom: 0, right: 0 }}>
           <i

--- a/src/components/UserManagement/__tests__/UserTableData.test.jsx
+++ b/src/components/UserManagement/__tests__/UserTableData.test.jsx
@@ -8,6 +8,8 @@ import { configureStore } from 'redux-mock-store';
 import UserTableData from '../UserTableData';
 import { authMock, themeMock } from '../../../__tests__/mockStates';
 import { renderWithProvider } from '../../../__tests__/utils';
+import { MemoryRouter } from 'react-router-dom';
+
 // Mock Axios requests
 vi.mock('axios');
 const mockStore = configureStore([thunk]);
@@ -79,18 +81,20 @@ describe('User Table Data: Non-Jae related Account', () => {
   let store;
   const renderRow = (user) => {
     renderWithProvider(
-      <table>
-        <tbody>
-          <UserTableData
-            isActive
-            index={0}
-            user={user}
-            onActiveInactiveClick={onActiveInactiveClick}
-            onPauseResumeClick={onPauseResumeClick}
-            onDeleteClick={onDeleteClick}
-          />
-        </tbody>
-      </table>,
+      <MemoryRouter initialEntries={['/usermanagement']}>
+        <table>
+          <tbody>
+            <UserTableData
+              isActive
+              index={0}
+              user={user}
+              onActiveInactiveClick={onActiveInactiveClick}
+              onPauseResumeClick={onPauseResumeClick}
+              onDeleteClick={onDeleteClick}
+            />
+          </tbody>
+        </table>
+      </MemoryRouter>,
       { store },
     );
   }
@@ -229,19 +233,21 @@ describe('User Table Data: Jae protected account record and login as Jae related
   let onActiveInactiveClick;
   let store;
   const renderRow = (user) => {
-     renderWithProvider(
-      <table>
-        <tbody>
-          <UserTableData
-            isActive
-            index={0}
-            user={user}
-            onActiveInactiveClick={onActiveInactiveClick}
-            onPauseResumeClick={onPauseResumeClick}
-            onDeleteClick={onDeleteClick}
-          />
-        </tbody>
-      </table>,
+    renderWithProvider(
+      <MemoryRouter initialEntries={['/usermanagement']}>
+        <table>
+          <tbody>
+            <UserTableData
+              isActive
+              index={0}
+              user={user}
+              onActiveInactiveClick={onActiveInactiveClick}
+              onPauseResumeClick={onPauseResumeClick}
+              onDeleteClick={onDeleteClick}
+            />
+          </tbody>
+        </table>
+      </MemoryRouter>,
       { store },
     );
   }


### PR DESCRIPTION
# Description
This PR fixes the issue with redirecting to People Reports page from User Management page when opening it in a new tab.

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change file UserTableData.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other Links -> User Management.
6. Navigate to People Reports in a new tab.
