### PR TITLE
Diya fix(usp): added counter on ccList button for BS

### DIFF
--- a/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
@@ -421,15 +421,36 @@ const handleCcListUpdate = (newCount) => {
 
       <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
         <div className="d-flex w-100 align-items-center">
-          <Button
-            color="secondary"
-            onClick={openCc}
-            style={boxStyling}
-            className="mr-2"
-          >
-            CC List({ccCount})
-          </Button>
-              <div className="ml-auto d-flex align-items-center" style={{ gap: '0.5rem', flexWrap: 'wrap' }}>
+          <div style={{ position: 'relative', display: 'inline-block' }}>
+            <Button
+              color="secondary"
+              onClick={openCc}
+              style={boxStyling}
+              className="mr-2"
+            >
+              CC List
+            </Button>
+            {ccCount > 0 && (
+              <span
+              style={{
+              position: 'absolute',
+              top: '-10px',
+              right: '-3px',
+              backgroundColor: '#28a745', // green
+              color: 'white',
+              borderRadius: '50%',
+              padding: '2px 6px',
+              fontSize: '12px',
+              fontWeight: 'bold',
+              boxShadow: '0 2px 4px rgba(0, 0, 0, 0.2)',
+            }}
+            >
+              {ccCount}
+              </span>
+            )}
+          </div>
+
+            <div className="ml-auto d-flex align-items-center" style={{ gap: '0.5rem', flexWrap: 'wrap' }}>
             {type === 'addBlueSquare' && (
               <Button
                 color="danger"


### PR DESCRIPTION
# Description
This PR updates the UI to display a badge-style counter showing the current number of CCs for a user.

## Related PRS (if any):
None

## Main changes explained:
- `UserProfileModal.jsx`
-- Replaced plain text CC List(count) button with a badge-style circular counter for a cleaner look and consistent design. Added badge positioning and styling improvements to match other UI elements.

## How to test:
1. Check into the current branch
2. Do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as a user who has access to assign Blue Squares
5. User Profile > Add new BS
6. Verify CCList button updated as per video below

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/021d5151-05f7-4cbd-b02e-38e438e52cb3

