### PR TITLE
Abhishek - Fix - Role Distribution Pie Chart - Set loader when filters are changed

### DIFF
--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -129,6 +129,7 @@ function TotalOrgSummary(props) {
   useEffect(() => {
     const fetchVolunteerStats = async () => {
       try {
+        setIsLoading(true);
         const { comparisonStartDate, comparisonEndDate } = calculateComparisonDates(
           selectedComparison,
           currentFromDate,


### PR DESCRIPTION
# Description
Added changes to set the loader when the filters are changed and the data is being fetched from the backend.

<img width="643" height="175" alt="image" src="https://github.com/user-attachments/assets/31618b51-a444-487d-9582-d3669ee84b3c" />

## Related PRS (if any):
This frontend PR is related to the #XXX backend PR.
…

## Main changes explained:
- Set the loader to true before fetching the date from the backend in `fetchVolunteerStats`.

## How to test:
1. Check into `abhishek-fix-role-dist-pie-chart` branch 
2. Do `npm install`, `npm run start:local` to run this PR locally
3. Clear site data/cache.
4. Log in as Admin user.
5. Navigate to dashboard→ Reports→ Total Org SUmmary
6. Verify if the loader gets displayed when the date range is changed.
7. Verify if the date filter works for the Role Distribution Pie Chart.

## Screenshots or videos of changes:

### Before

https://github.com/user-attachments/assets/43add8cd-d9e1-4ffb-bfc5-65208b2bc4bd

### After

https://github.com/user-attachments/assets/35c238e0-215d-4ac2-b2e2-f964693ab618
