### PR TITLE
Abhishek - Fix - Role Distribution Pie Chart in Total Org Summary - Set Loader State

### DIFF
--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -129,6 +129,7 @@ function TotalOrgSummary(props) {
   useEffect(() => {
     const fetchVolunteerStats = async () => {
       try {
+        setIsLoading(true);
         const { comparisonStartDate, comparisonEndDate } = calculateComparisonDates(
           selectedComparison,
           currentFromDate,


### PR DESCRIPTION
# Description
Added changes to set the loader when data is being fetched after changing the date filter.

<img width="643" height="175" alt="image" src="https://github.com/user-attachments/assets/8e02b517-5798-471d-91c8-8b58261898ad" />

## Related PRS (if any):
This frontend PR is related to the [#1757](https://github.com/OneCommunityGlobal/HGNRest/pull/1757) backend PR.

## Main changes explained:
- Set loader to `true`  before fetching data from the backend after date filters are changed.

## How to test:
1. Check into `abhishek-fix-role-dist-pie-chart` branch.
2. Check into the backend branch `abhishek-fix-role-dist-pie-chart` and run the backend branch.
3. Do `npm install` and `npm run start:local` to run this PR locally.
4. Clear site data/cache
5. log as admin user
6. Go to dashboard→ Reports→ Total Org Summary
7. Verify if the loader gets displayed when the date range is changed.
8. Verify if the date filter works for the Role Distribution Pie Chart.

## Screenshots or videos of changes:

### Before

https://github.com/user-attachments/assets/43add8cd-d9e1-4ffb-bfc5-65208b2bc4bd

### After

https://github.com/user-attachments/assets/35c238e0-215d-4ac2-b2e2-f964693ab618