### PR TITLE
Durga Venkata Praveen Fix: Header Scroll Bar Issue

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -3,12 +3,12 @@
   height: fit-content;
   width: clamp(100vw, 0.1rem + 1vw, 100%);
 }
-.close-button {
+/*
   position: absolute;
   top: 0;
   left: 0;
   padding: 12px;
-}
+} */
 /* Timer Message Section */
 .timer-message-section {
   display: flex;
@@ -20,22 +20,43 @@
 }
 
 .card-content {
-  padding: 5px;
+  padding: 15px;
   padding-left: 40px;
-  padding-right: 30px;
+  padding-right: 40px; /* Match left padding for balance */
   white-space: pre-line;
   color: white;
   font-size: medium;
+  line-height: 1.4;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  box-sizing: border-box;
+  width: 100%;
+  margin: 0; /* Remove all margins */
 }
 
 .headerCard {
-  margin-left: 35px;
-  margin-right: 50px;
+  margin-left: 0; /* Remove left margin */
+  margin-right: 0; /* Remove right margin */
+  /* Use full viewport width */
+  width: 100vw;
+  max-width: 100vw;
+  box-sizing: border-box;
+  overflow: hidden;
+  position: relative;
+  /* Ensure card extends to full width */
+  left: 0;
+  right: 0;
 }
 
 .card-wrapper {
   padding-top: 1rem;
   padding-bottom: 1rem;
+  /* Ensure wrapper uses full width */
+  width: 100%;
+  margin: 0;
+  padding-left: 0;
+  padding-right: 0;
+  box-sizing: border-box;
 }
 
 .navbar {


### PR DESCRIPTION
# Description
<img width="1276" height="572" alt="image" src="https://github.com/user-attachments/assets/904fcf04-44f2-44b5-a096-9f5d80113f4e" />


## Related PRS (if any):

…

## Main changes explained:
After login, the notice previously showed a scrollbar that overlapped the content. This has been fixed by resizing the scroll area, and the content is now clearly visible.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ task→…
6. verify function “A” (feel free to include screenshot here)
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
### Before
<img width="1202" height="688" alt="image" src="https://github.com/user-attachments/assets/b3485d95-1641-43e5-95e5-4dbde7aba823" />

### After
<img width="2560" height="1010" alt="Screenshot 2025-09-26 222248" src="https://github.com/user-attachments/assets/472ba321-cefa-49ca-b098-54aa94e87614" />

## Note:
Include the information the reviewers need to know.
The modal will appear immediately upon page load, regardless of user role, date, or team membership. You can test the close functionality and visual appearance to ensure everything works as expected.
So for testing purpose make setModalVisible(true);
<img width="1332" height="1150" alt="image" src="https://github.com/user-attachments/assets/e3efcc2a-8db2-4420-9186-91fdb0e33445" />
<img width="1342" height="456" alt="image" src="https://github.com/user-attachments/assets/190222db-a699-4ba5-bcba-ae2752222236" />



