### PR TITLE
Shashank madan fix tools donut chart

### DIFF
--- a/src/components/BMDashboard/WeeklyProjectSummary/ToolStatusDonutChart/ToolStatusDonutChart.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/ToolStatusDonutChart/ToolStatusDonutChart.css
@@ -2,9 +2,12 @@
   --donut-text-color: #000;
   --legend-text-color: #000;
   width: 100%;
-  max-width: 400px;
+  height: 100%;
   margin: 0 auto;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 .dark-mode.tool-donut-wrapper {
@@ -15,9 +18,10 @@
 .tool-donut-title {
   text-align: center;
   font-weight: 600;
-  margin-bottom: 1.2rem;
+  margin-bottom: 1rem;
   font-size: 1.1rem;
   color: var(--donut-text-color);
+  flex-shrink: 0;
 }
 
 .tool-donut-filters {
@@ -57,6 +61,7 @@
   margin-top: 1rem;
   gap: 0.5rem;
   width: 100%;
+  flex-shrink: 0;
 }
 
 .tool-donut-legend-item {
@@ -69,43 +74,14 @@
   text-align: center;
 }
 
-/* Responsive Donut Layout */
-.tools-tracking-layout {
-  display: flex;
-  flex-direction: row;
-  gap: 1rem;
-  justify-content: space-between;
-  align-items: stretch;
-  padding: 1rem;
-}
-
-.tools-donut-wrap {
-  flex: 0 0 60%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.tools-card-wrap {
-  flex: 0 0 40%;
-  background: #f9f9f9;
-  border-radius: 8px;
-  padding: 1rem;
-  font-size: 1rem;
-  font-weight: 500;
-  color: #333;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.05);
-}
-
+/* Responsive adjustments for donut chart */
 @media (max-width: 768px) {
-  .tools-tracking-layout {
+  .tool-donut-filters {
     flex-direction: column;
-    align-items: center;
+    gap: 1rem;
   }
-
-  .tools-donut-wrap,
-  .tools-card-wrap {
-    flex: 1 1 100%;
-    max-width: 100%;
+  
+  .filter-item {
+    width: 100%;
   }
 }

--- a/src/components/BMDashboard/WeeklyProjectSummary/ToolStatusDonutChart/ToolStatusDonutChart.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/ToolStatusDonutChart/ToolStatusDonutChart.jsx
@@ -87,17 +87,17 @@ export default function ToolStatusDonutChart() {
   let outerRadius;
   let chartHeight;
   if (isXS) {
+    innerRadius = 25;
+    outerRadius = 40;
+    chartHeight = 180;
+  } else if (windowWidth <= 768) {
+    innerRadius = 30;
+    outerRadius = 50;
+    chartHeight = 200;
+  } else {
     innerRadius = 35;
     outerRadius = 60;
-    chartHeight = 240;
-  } else if (windowWidth <= 768) {
-    innerRadius = 45;
-    outerRadius = 75;
-    chartHeight = 260;
-  } else {
-    innerRadius = 70;
-    outerRadius = 100;
-    chartHeight = 320;
+    chartHeight = 220;
   }
 
   return (
@@ -138,42 +138,44 @@ export default function ToolStatusDonutChart() {
         </div>
       </div>
 
-      <ResponsiveContainer width="100%" height={chartHeight}>
-        <PieChart margin={{ top: 30, bottom: 30, left: isXS ? 30 : 40, right: isXS ? 30 : 40 }}>
-          <Pie
-            data={chartData}
-            cx="50%"
-            cy="50%"
-            innerRadius={innerRadius}
-            outerRadius={outerRadius}
-            labelLine={false}
-            label={props => renderCustomizedLabel({ ...props, width: windowWidth })}
-            dataKey="count"
-            isAnimationActive={false}
-          >
-            {chartData.map(entry => (
-              <Cell key={entry.status} fill={COLORS[entry.status.toUpperCase()]} />
-            ))}
-          </Pie>
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
+          <PieChart margin={{ top: 30, bottom: 30, left: isXS ? 30 : 40, right: isXS ? 30 : 40 }}>
+            <Pie
+              data={chartData}
+              cx="50%"
+              cy="50%"
+              innerRadius={innerRadius}
+              outerRadius={outerRadius}
+              labelLine={false}
+              label={props => renderCustomizedLabel({ ...props, width: windowWidth })}
+              dataKey="count"
+              isAnimationActive={false}
+            >
+              {chartData.map(entry => (
+                <Cell key={entry.status} fill={COLORS[entry.status.toUpperCase()]} />
+              ))}
+            </Pie>
 
-          <text
-            x="50%"
-            y="50%"
-            textAnchor="middle"
-            dominantBaseline="middle"
-            fill="var(--donut-text-color)"
-            fontSize={14}
-            fontWeight="bold"
-          >
-            TOTAL: {total}
-          </text>
+            <text
+              x="50%"
+              y="50%"
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fill="var(--donut-text-color)"
+              fontSize={14}
+              fontWeight="bold"
+            >
+              TOTAL: {total}
+            </text>
 
-          <Tooltip
-            formatter={value => `${((value / total) * 100).toFixed(1)}%`}
-            contentStyle={{ fontSize: '14px' }}
-          />
-        </PieChart>
-      </ResponsiveContainer>
+            <Tooltip
+              formatter={value => `${((value / total) * 100).toFixed(1)}%`}
+              contentStyle={{ fontSize: '14px' }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
 
       <div className="tool-donut-legend">
         {chartData.map(entry => (

--- a/src/components/BMDashboard/WeeklyProjectSummary/ToolStatusDonutChart/ToolStatusDonutChart.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/ToolStatusDonutChart/ToolStatusDonutChart.jsx
@@ -33,6 +33,82 @@ const renderCustomizedLabel = ({ cx, cy, midAngle, outerRadius, percent, width }
   );
 };
 
+// Custom tooltip component
+const CustomTooltip = ({ active, payload, total, hasNoData, toolName, projectName, toolId }) => {
+  if (!active || !payload || !payload.length) {
+    return null;
+  }
+
+  // If total is 0, show no tools match message
+  if (total === 0) {
+    return (
+      <div
+        style={{
+          backgroundColor: 'rgba(255, 255, 255, 0.95)',
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          padding: '8px 12px',
+          fontSize: '14px',
+          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+          maxWidth: '200px',
+        }}
+      >
+        <div style={{ fontWeight: '600', color: '#333' }}>📊 No Tools Match</div>
+        <div style={{ color: '#666', fontSize: '12px' }}>
+          No tools match the selected combination
+        </div>
+      </div>
+    );
+  }
+
+  // If specific tool is selected but has no data
+  if (hasNoData && toolId) {
+    return (
+      <div
+        style={{
+          backgroundColor: 'rgba(255, 255, 255, 0.95)',
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          padding: '8px 12px',
+          fontSize: '14px',
+          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+          maxWidth: '200px',
+        }}
+      >
+        <div style={{ fontWeight: '600', color: '#333' }}>{toolName}</div>
+        <div style={{ color: '#666', fontSize: '12px' }}>❌ Not used in this project</div>
+      </div>
+    );
+  }
+
+  const data = payload[0];
+  const percentage = total > 0 ? ((data.value / total) * 100).toFixed(1) : '0.0';
+
+  return (
+    <div
+      style={{
+        backgroundColor: 'rgba(255, 255, 255, 0.95)',
+        border: '1px solid #ccc',
+        borderRadius: '4px',
+        padding: '8px 12px',
+        fontSize: '14px',
+        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+        maxWidth: '200px',
+      }}
+    >
+      <div style={{ fontWeight: '600', color: '#333', marginBottom: '4px' }}>
+        {toolName || 'All Tools'}
+      </div>
+      <div style={{ color: '#666', marginBottom: '2px' }}>
+        Count: <strong>{data.value}</strong>
+      </div>
+      <div style={{ color: '#666' }}>
+        Percentage: <strong>{percentage}%</strong>
+      </div>
+    </div>
+  );
+};
+
 export default function ToolStatusDonutChart() {
   const dispatch = useDispatch();
   const toolslist = useSelector(state => state.tools.toolslist);
@@ -42,10 +118,20 @@ export default function ToolStatusDonutChart() {
   const [toolId, setToolId] = useState('');
   const [projectId, setProjectId] = useState('');
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+  const [allToolsData, setAllToolsData] = useState(null);
 
   useEffect(() => {
     dispatch(fetchTools());
+    // Fetch all tool availability data initially to populate dropdowns
+    dispatch(fetchToolAvailability('', ''));
   }, [dispatch]);
+
+  // Store the initial data for dropdowns when it's available
+  useEffect(() => {
+    if (availabilityData && !toolId && !projectId && !allToolsData) {
+      setAllToolsData(availabilityData);
+    }
+  }, [availabilityData, toolId, projectId, allToolsData]);
 
   useEffect(() => {
     dispatch(fetchToolAvailability(toolId, projectId));
@@ -61,27 +147,39 @@ export default function ToolStatusDonutChart() {
   const chartData = availabilityData?.data || [];
   const total = availabilityData?.total || 0;
 
-  const toolsFromAvailability = availabilityData?.tools;
-  const allTools =
-    Array.isArray(toolsFromAvailability) && toolsFromAvailability.length
-      ? toolsFromAvailability
-      : toolslist;
+  // Check if we have no data for the selected combination
+  const hasNoData = (toolId || projectId) && chartData.length === 0 && total === 0;
+  const hasNoToolsMatch = total === 0;
 
+  // Use the stored initial data for dropdowns, or fall back to current data
+  const dropdownData = allToolsData || availabilityData;
+  const toolsFromDropdown = dropdownData?.tools || [];
+  const allAvailableTools =
+    Array.isArray(toolsFromDropdown) && toolsFromDropdown.length
+      ? toolsFromDropdown
+      : toolslist || [];
+
+  // Get all unique projects from the combined data
   const uniqueProjects = Array.from(
     new Map(
-      allTools
+      allAvailableTools
         .filter(t => t?.projectId)
         .map(t => [t.projectId, { id: t.projectId, name: t.projectName || 'Unnamed Project' }]),
     ).values(),
   );
 
+  // Get all unique tools from the combined data
   const uniqueTools = Array.from(
     new Map(
-      allTools
+      allAvailableTools
         .filter(t => t?.toolId)
         .map(t => [t.toolId, { id: t.toolId, name: t.name || 'Unnamed Tool' }]),
     ).values(),
   );
+
+  // Get the selected tool name
+  const selectedTool = uniqueTools.find(tool => tool.id === toolId);
+  const toolName = selectedTool ? selectedTool.name : null;
 
   let innerRadius;
   let outerRadius;
@@ -138,56 +236,108 @@ export default function ToolStatusDonutChart() {
         </div>
       </div>
 
-      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <ResponsiveContainer width="100%" height={chartHeight}>
-          <PieChart margin={{ top: 30, bottom: 30, left: isXS ? 30 : 40, right: isXS ? 30 : 40 }}>
-            <Pie
-              data={chartData}
-              cx="50%"
-              cy="50%"
-              innerRadius={innerRadius}
-              outerRadius={outerRadius}
-              labelLine={false}
-              label={props => renderCustomizedLabel({ ...props, width: windowWidth })}
-              dataKey="count"
-              isAnimationActive={false}
-            >
-              {chartData.map(entry => (
-                <Cell key={entry.status} fill={COLORS[entry.status.toUpperCase()]} />
-              ))}
-            </Pie>
-
-            <text
-              x="50%"
-              y="50%"
-              textAnchor="middle"
-              dominantBaseline="middle"
-              fill="var(--donut-text-color)"
-              fontSize={14}
-              fontWeight="bold"
-            >
-              TOTAL: {total}
-            </text>
-
-            <Tooltip
-              formatter={value => `${((value / total) * 100).toFixed(1)}%`}
-              contentStyle={{ fontSize: '14px' }}
-            />
-          </PieChart>
-        </ResponsiveContainer>
-      </div>
-
-      <div className="tool-donut-legend">
-        {chartData.map(entry => (
+      {hasNoData || hasNoToolsMatch ? (
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexDirection: 'column',
+            padding: '2rem',
+            textAlign: 'center',
+            position: 'relative',
+          }}
+          title={
+            hasNoToolsMatch
+              ? 'No tools match the selected combination'
+              : 'Tool not used in this project'
+          }
+        >
           <div
-            key={entry.status}
-            className="tool-donut-legend-item"
-            style={{ backgroundColor: COLORS[entry.status.toUpperCase()] }}
+            style={{
+              fontSize: '1.2rem',
+              color: 'var(--donut-text-color)',
+              fontWeight: '500',
+              marginBottom: '0.5rem',
+            }}
           >
-            {entry.status}
+            {hasNoToolsMatch ? '📊 No Tools Match' : '📊 No Data Available'}
           </div>
-        ))}
-      </div>
+          <div
+            style={{
+              fontSize: '0.9rem',
+              color: 'var(--donut-text-color)',
+              opacity: 0.7,
+            }}
+          >
+            {hasNoToolsMatch
+              ? 'No tools match the selected combination'
+              : 'Tool not used in this project'}
+          </div>
+        </div>
+      ) : (
+        <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <ResponsiveContainer width="100%" height={chartHeight}>
+            <PieChart margin={{ top: 30, bottom: 30, left: isXS ? 30 : 40, right: isXS ? 30 : 40 }}>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                innerRadius={innerRadius}
+                outerRadius={outerRadius}
+                labelLine={false}
+                label={props => renderCustomizedLabel({ ...props, width: windowWidth })}
+                dataKey="count"
+                isAnimationActive={false}
+              >
+                {chartData.map(entry => (
+                  <Cell key={entry.status} fill={COLORS[entry.status.toUpperCase()]} />
+                ))}
+              </Pie>
+
+              <text
+                x="50%"
+                y="50%"
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill="var(--donut-text-color)"
+                fontSize={14}
+                fontWeight="bold"
+              >
+                TOTAL: {total}
+              </text>
+
+              <Tooltip
+                content={
+                  <CustomTooltip
+                    total={total}
+                    hasNoData={hasNoData}
+                    toolName={toolName}
+                    toolId={toolId}
+                  />
+                }
+                cursor={false}
+                allowEscapeViewBox={{ x: false, y: false }}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {!hasNoData && !hasNoToolsMatch && (
+        <div className="tool-donut-legend">
+          {chartData.map(entry => (
+            <div
+              key={entry.status}
+              className="tool-donut-legend-item"
+              style={{ backgroundColor: COLORS[entry.status.toUpperCase()] }}
+            >
+              {entry.status}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
@@ -280,16 +280,20 @@ function WeeklyProjectSummary() {
         title: 'Tools and Equipment Tracking',
         key: 'Tools and Equipment Tracking',
         className: 'half',
-        content: (
-          <div className="weekly-project-summary-card normal-card tools-tracking-layout">
-            <div className="tools-donut-wrap">
-              <ToolStatusDonutChart />
-            </div>
-            <div className="weekly-project-summary-card normal-card" style={{ minHeight: '300px' }}>
-              <ToolsHorizontalBarChart darkMode={darkMode} />
-            </div>
-          </div>
-        ),
+        content: [
+          <div
+            key="donut-chart"
+            className={`${styles.weeklyProjectSummaryCard} ${styles.normalCard}`}
+          >
+            <ToolStatusDonutChart />
+          </div>,
+          <div
+            key="bar-chart"
+            className={`${styles.weeklyProjectSummaryCard} ${styles.normalCard}`}
+          >
+            <ToolsHorizontalBarChart darkMode={darkMode} />
+          </div>,
+        ],
       },
       {
         title: 'Lessons Learned',

--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.module.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.module.css
@@ -223,6 +223,15 @@
   background: var(--section-bg);
 }
 
+/* Adjust grid columns based on section size */
+.weeklyProjectSummaryDashboardSection.half .weeklyProjectSummaryDashboardCategoryContent {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.weeklyProjectSummaryDashboardSection.small .weeklyProjectSummaryDashboardCategoryContent {
+  grid-template-columns: 1fr;
+}
+
 /* ---------------- DARK MODE VARIABLES ---------------- */
 :root {
   --bg-color: #ffffff;


### PR DESCRIPTION
# Description
<img width="1016" height="399" alt="image" src="https://github.com/user-attachments/assets/4e097b04-dbec-40f1-b2a4-02b7af4094bd" />


## Related PRS (if any):
This frontend PR is related to the development branch of the backend.

This is a correction of bugs from the PRs #3301 and backend PR [#1331](https://github.com/OneCommunityGlobal/HGNRest/pull/1331)

## Main changes explained:
- Refactored drop downs to be independent of each other.
- Adjusted css and sizing to ensure donut chart fits inside the card.
- Fixed tooltip to display relevant information when hovering over the chart. 

## How to test:
1. check into current branch
2. do `yarn install` and `yarn start` to run this PR locally
3. Clear site data/cache
4. log as an owner/admin user
5. Navigate to: http://localhost:3000/bmdashboard/totalconstructionsummary
6. Click on the tools and equipment tracking section.
7. Verify that the donut chart fits inside the card.
8. Verify that selecting an item from either of the dropdowns do not hide any other item.
9. Verify that for some combinations of tool and project where data does not exist, the relevant message is displayed.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/bc1a3eec-f4ae-47da-b523-df3e84bac6ca



## Note:
The backend API has not been changed from what it was in the previous PRs (#3301 and backend PR [#1331](https://github.com/OneCommunityGlobal/HGNRest/pull/1331))
