### PR TITLE
Aditya - Add mentor count to volunteer status dashboard

### DIFF
--- a/src/constants/totalOrgSummary.js
+++ b/src/constants/totalOrgSummary.js
@@ -27,6 +27,12 @@ export const VOLUNTEER_STATUS_TAB = {
     tabBackgroundColor: '#ffe9fa',
     shapeBackgroundColor: '#fecff3',
   },
+  mentors: {
+    title: 'Mentors',
+    type: 'mentors',
+    tabBackgroundColor: '#fdf5e5',
+    shapeBackgroundColor: '#F0E6D2',
+  },
   totalHoursWorked: {
     title: 'Total Hours Worked',
     type: 'total-hours-worked',

--- a/src/utils/totalOrgSummary.js
+++ b/src/utils/totalOrgSummary.js
@@ -14,6 +14,7 @@ export const normalizeVolunteerStats = (volunteerNumberStats, totalHoursWorked) 
     normalizeStats(volunteerNumberStats.activeVolunteers, 'activeVolunteers'),
     normalizeStats(volunteerNumberStats.newVolunteers, 'newVolunteers'),
     normalizeStats(volunteerNumberStats.deactivatedVolunteers, 'deactivatedVolunteers'),
+    normalizeStats(volunteerNumberStats.mentors, 'mentors'),
     {
       ...VOLUNTEER_STATUS_TAB.totalHoursWorked,
       number: Math.round(totalHoursWorked.current),


### PR DESCRIPTION
# Description

Implements - Add mentor count to volunteer status dashboard

![[HGN/Features-Bugs/Features/Frontend/New PR/Images/IssueDescription.png]]

This PR adds mentor count functionality to the volunteer status section of the organization summary dashboard. The changes include adding a new "Mentors" tab alongside existing volunteer status tabs (Active Volunteers, New Volunteers, Deactivated Volunteers) to provide better visibility into mentor statistics.

  

## Related PRS (if any):
This frontend PR is related to the [PR #1760](https://github.com/OneCommunityGlobal/HGNRest/pull/1760) backend PR.
## Main changes explained:
- **Update file `src/constants/totalOrgSummary.js`**: Added new `mentors` configuration object to `VOLUNTEER_STATUS_TAB` with appropriate styling (warm beige color scheme) and metadata for the mentors tab
- **Update file `src/utils/totalOrgSummary.js`**: Added mentor data normalization in `normalizeVolunteerStats` function to include mentor count statistics in the volunteer status dashboard
## How to test:
1. Check into current branch: `Aditya-feature/add-mentor-count-volunteer-status`
2. clear cache, node_modules and package-lock.json.
3. Point the frontend to `http://localhost:4500/api`.
4. Run `yarn install` to install dependencies, then run the app locally `yarn start`
5. Clear site data/cache
6. Log as owner user
7. Go to the Dashboard → Reports → Total Org Summary → Volunteer Status section
8. Verify that a new "Mentors" tab appears alongside the existing volunteer status tabs
9. Verify that the mentors tab displays the correct count and percentage change data
10. Verify that the mentors tab has the appropriate styling (warm beige background colors)
## Screenshots or videos of changes:

![[HGN/Features-Bugs/Features/Frontend/New PR/Images/Test Video.mov|Test Video]]
## Note:

- This change enhances the organization summary dashboard by providing visibility into mentor statistics. 
- The mentors tab follows the same pattern as other volunteer status tabs and will display real-time data from the backend when the corresponding API endpoints are available. 
- The mentor count will behave same as the active volunteers count, i.e. all the mentors created till the end date of the filter.
- The styling uses a warm beige color scheme to distinguish mentors from other volunteer categories.