### PR TITLE
Xinyi - Fix hours completed bar chart

### DIFF
--- a/src/components/TotalOrgSummary/HoursCompleted/HoursCompletedBarChart.jsx
+++ b/src/components/TotalOrgSummary/HoursCompleted/HoursCompletedBarChart.jsx
@@ -80,6 +80,7 @@ export default function HoursCompletedBarChart({ isLoading, data, darkMode }) {
     color: ['rgba(76,75,245,255)', 'rgba(0,175,244,255)'],
   }));
   const projectBarInfo = {
+    ifcompare: projectChangePercentage !== undefined && projectChangePercentage !== null,
     amount: projectHours.count,
     percentage: `${(projectPercentage * 100).toFixed(2)}%`,
     change:
@@ -158,7 +159,13 @@ export default function HoursCompletedBarChart({ isLoading, data, darkMode }) {
               100}% of Total Tangible Hours Submitted to Tasks`}
           </span>
           {(() => {
-            const isPositive = data.hoursSubmittedToTasksComparisonPercentage >= 0;
+            const percentage = data.hoursSubmittedToTasksComparisonPercentage;
+
+            if (percentage === undefined || percentage === null) {
+              // No comparison → hide metrics
+              return null;
+            }
+            const isPositive = percentage >= 0;
             let color;
             if (isPositive) {
               color = darkMode ? 'lightgreen' : 'green';
@@ -166,8 +173,8 @@ export default function HoursCompletedBarChart({ isLoading, data, darkMode }) {
               color = 'red';
             }
             const value = isPositive
-              ? `+${(data.hoursSubmittedToTasksComparisonPercentage * 100).toFixed(0)}%`
-              : `${(data.hoursSubmittedToTasksComparisonPercentage * 100).toFixed(0)}%`;
+              ? `+${(percentage * 100).toFixed(0)}%`
+              : `${(percentage * 100).toFixed(0)}%`;
             return <span style={{ color, marginLeft: 8, fontSize: '12px' }}>{value}</span>;
           })()}
         </div>
@@ -177,7 +184,7 @@ export default function HoursCompletedBarChart({ isLoading, data, darkMode }) {
           chartData={chartData.filter(item => item.name === 'Tasks')}
           maxY={maxY}
           tickInterval={tickInterval}
-          renderCustomizedLabel={renderCustomizedLabel}
+          // renderCustomizedLabel={renderCustomizedLabel}
           darkMode={darkMode}
           projectBarInfo={projectBarInfo}
           yAxisLabel="Hours"

--- a/src/components/TotalOrgSummary/TinyBarChart.jsx
+++ b/src/components/TotalOrgSummary/TinyBarChart.jsx
@@ -41,7 +41,11 @@ function ProjectLabel({ viewBox, info }) {
         <div style={{ color: '#444', fontWeight: 'bold', fontSize: 15 }}>Projects</div>
         <div style={{ color: '#222', fontWeight: 'bold', fontSize: 14 }}>{info.amount}</div>
         <div style={{ color: '#666', fontSize: 10 }}>({info.percentage})</div>
-        <div style={{ color: info.fontcolor, fontSize: 10, fontWeight: 'bold' }}>{info.change}</div>
+        {info.ifcompare && (
+          <div style={{ color: info.fontcolor, fontSize: 10, fontWeight: 'bold' }}>
+            {info.change}
+          </div>
+        )}
       </div>
     </foreignObject>
   );


### PR DESCRIPTION
# Description
Problem: Backend returns undefined for comparison fields when no comparison range is chosen, and the frontend formats them into NaN%.
Suggestion: Hide comparison metrics in the UI when comparison mode = No comparison.

## Related PRS (if any):
This frontend PR is not related to any PRs.

## Main changes explained:
- Update file HoursCompletedBarChart.jsx for hiding comparison metrics when comparison data is undefined or null.
- Update file TinyBarChart.jsx for hiding comparison metrics when comparison data is undefined or null.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ Total Organization Summary → Hours Completed Bar Chart
6. verify when no comparison range is chosen, the frontend won't show comparison metrics
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
Before: 
<img width="345" height="534" alt="image" src="https://github.com/user-attachments/assets/41066196-1613-44e0-9f94-364dba49cf28" />

After:
<img width="356" height="527" alt="image" src="https://github.com/user-attachments/assets/18dc6ab6-6310-46a7-b3b8-05d52ab6cb02" />
