### PR TITLE
Venkataramanan fix copy icon issue in user management page

### DIFF
--- a/src/components/UserManagement/usermanagement.css
+++ b/src/components/UserManagement/usermanagement.css
@@ -46,9 +46,8 @@ thead {
 .usermanagement__tr .btn,
 .usermanagement__tr .copy_icon,
 .usermanagement__tr svg {
-  height: 100%;
   margin: 0;
-  padding: 0;
+  padding-top: 15px;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
# Description
This PR is to fix the issue in User Management page with the copy icon misalignment.

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change file usermanagement.css

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other links -> User management
6. Check if all alignments are correct.
