### PR TITLE
Diya Fix(bccBS): changed default for BCC and fix on the top of the list

### DIFF
--- a/src/components/UserProfile/BluequareEmailBBCPopUp.jsx
+++ b/src/components/UserProfile/BluequareEmailBBCPopUp.jsx
@@ -58,29 +58,43 @@ const BluequareEmailAssignmentPopUp = React.memo(props => {
 
   const DEFAULT_RECIPIENT = {
     _id: '63feae337186de1898fa8f51',
-    email: 'jae@onecommunityglobal.org',
+    email: 'onecommunityhospitality@gmail.com',
     assignedTo: {
-      firstName: 'Jae',
+      firstName: 'Sara',
       lastName: 'Sabol',
-      role: 'Owner',
+      role: 'Administrator',
       isActive: true,
     },
     locked: true,
   };
 
   const assignmentsWithDefault = useMemo(() => {
-    const list = blueSquareEmailAssignments || [];
-    const hasDefault = list.some(
-    a => (a.email || '').toLowerCase() === DEFAULT_RECIPIENT.email.toLowerCase()
-  );
+  const list = blueSquareEmailAssignments || [];
+
   const withLockFlag = list.map(a => ({
     ...a,
     locked:
       a.locked ||
       (a.email || '').toLowerCase() === DEFAULT_RECIPIENT.email.toLowerCase(),
   }));
-  return hasDefault ? withLockFlag : [DEFAULT_RECIPIENT, ...withLockFlag];
-  }, [blueSquareEmailAssignments]);
+
+  const hasDefault = withLockFlag.some(
+    a => (a.email || '').toLowerCase() === DEFAULT_RECIPIENT.email.toLowerCase()
+  );
+
+  const combined = hasDefault
+    ? withLockFlag
+    : [DEFAULT_RECIPIENT, ...withLockFlag];
+
+  return combined.sort((a, b) =>
+    (a.email || '').toLowerCase() === DEFAULT_RECIPIENT.email.toLowerCase()
+      ? -1
+      : (b.email || '').toLowerCase() === DEFAULT_RECIPIENT.email.toLowerCase()
+      ? 1
+      : 0
+  );
+}, [blueSquareEmailAssignments]);
+
   
   
   const handleAddBCC = (e) =>{


### PR DESCRIPTION
# Description
This PR updates the Blue Square email assignment pop-up to change the default recipient and ensure the default recipient is always displayed at the top of the list.

## Related PRS (if any):
None

## Main changes explained:
- **Changed default recipient:** updated the default recipient email to the new address.
- **Ensured ordering:** modified list logic so the default recipient always appears at the top.

## How to test:
1. Check into the current branch
2. Do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Login as admin user
5. User Profile > Blue Square Email BCCs
6. Verify that the user is 'Sara Sabol' with email 'onecommunityhospitality@gmail.com'
7. Verify that adding new users to the BCC list always keeps the default at the top!

## Screenshots or videos of changes:
<img width="826" height="742" alt="Screenshot 2025-09-30 at 6 46 14 PM" src="https://github.com/user-attachments/assets/8af90291-c1e1-4ce9-8cc2-cba81701e05d" />
