### PR TITLE
Venkataramanan 🔥 req time off icon issue in User Management page

### DIFF
--- a/src/components/UserManagement/usermanagement.css
+++ b/src/components/UserManagement/usermanagement.css
@@ -44,8 +44,7 @@ thead {
 
 .usermanagement__tr .edituser_input,
 .usermanagement__tr .btn,
-.usermanagement__tr .copy_icon,
-.usermanagement__tr svg {
+.usermanagement__tr .copy_icon {
   margin: 0;
   padding-top: 15px;
   box-sizing: border-box;


### PR DESCRIPTION
# Description
This is to fix the issue with Req Time off icon in User Management page.

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change file usermanagement.css

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Other links -> User Management

## Screenshots or videos of changes:
<img width="2940" height="1664" alt="image" src="https://github.com/user-attachments/assets/ce571068-2522-4f65-8c24-6a90279ef4da" />
