### PR TITLE
Xinyi - fix: add export data button, search filter, and users' join dates

### DIFF
--- a/src/components/TotalOrgSummary/AnniversaryCelebrated/AnniversaryCelebrated.jsx
+++ b/src/components/TotalOrgSummary/AnniversaryCelebrated/AnniversaryCelebrated.jsx
@@ -42,7 +42,6 @@ export default function AnniversaryCelebrated({ isLoading, data, darkMode }) {
 
   const getAnniversaryListItem = (userData = {}, anniversaryMonths = 6) => {
     const { _id, profilePic, email, firstName, lastName, createdDate } = userData;
-    console.log(createdDate);
     return (
       <li key={_id} className="d-flex flex-column">
         <div
@@ -103,6 +102,7 @@ export default function AnniversaryCelebrated({ isLoading, data, darkMode }) {
     const link = document.createElement('a');
     link.href = url;
     link.download = 'anniversaries.json';
+    // eslint-disable-next-line testing-library/no-node-access
     link.click();
   };
 


### PR DESCRIPTION
# Description
<img width="1096" height="886" alt="image" src="https://github.com/user-attachments/assets/3ebeea1f-5129-4683-a3f9-d871fc1e4e32" />

## Related PRS (if any):
This frontend PR is related to the [#1770](https://github.com/OneCommunityGlobal/HGNRest/pull/1770) backend PR.

## Main changes explained:
- Update file AnniversaryCelebrated.jsx for including export data button, search filter, and users' join dates

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ reports→ Total Org Symmary → Anniversary Celebrated
6. verify that the search function filters users correctly and the export button generates the expected data file
7. verify that each user’s start date aligns correctly with the displayed anniversary award (e.g., 6-month or 1-year)
8. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
before: 
<img width="564" height="555" alt="image" src="https://github.com/user-attachments/assets/c1f90487-06c6-42d8-97c5-1ec5af7243aa" />
after:
<img width="588" height="628" alt="image" src="https://github.com/user-attachments/assets/1d2801fb-b0cf-4737-afcb-3f217968eb7d" />
