### PR TITLE
Add Slashdot Auto-Poster Tab

### DIFF
--- a/src/components/Announcements/Announcements.css
+++ b/src/components/Announcements/Announcements.css
@@ -158,6 +158,204 @@ summary::-webkit-details-marker {
   display: none;
 }
 
+.slashdot-autoposter {
+  max-width: 980px;
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+}
+
+.slashdot-autoposter.dark {
+  color: #dbe6ff;
+}
+
+.slashdot-autoposter.dark label {
+  color: #dbe6ff;
+}
+
+.slashdot-autoposter.dark p {
+  color: #dbe6ff;
+}
+
+.slashdot-card {
+  background: #fff;
+  border: 1px solid #d6dde7;
+  border-radius: 12px;
+  padding: 20px 22px;
+  box-shadow: 0 10px 24px rgba(15, 37, 80, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.slashdot-autoposter.dark .slashdot-card {
+  background: #14233a;
+  border-color: #25354d;
+  box-shadow: none;
+}
+
+.slashdot-card.invalid {
+  border-color: #d9534f;
+  box-shadow: 0 0 0 1px rgba(217, 83, 79, 0.18);
+}
+
+.slashdot-autoposter.dark .slashdot-card.invalid {
+  border-color: #ff7b72;
+  box-shadow: none;
+}
+
+.slashdot-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.slashdot-field__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.slashdot-field__meta {
+  font-size: 0.85rem;
+  color: #6c757d;
+}
+
+.slashdot-field__meta.invalid {
+  color: #d9534f;
+}
+
+.slashdot-autoposter.dark .slashdot-field__meta {
+  color: #9aa9c6;
+}
+
+.slashdot-field__input {
+  width: 100%;
+  border: 1px solid #c7d1e5;
+  border-radius: 8px;
+  padding: 12px 14px;
+  font-size: 0.95rem;
+  background: #fff;
+  color: #1b1f29;
+}
+
+.slashdot-autoposter.dark .slashdot-field__input {
+  background: #0f1c2d;
+  border-color: #2b3b55;
+  color: #e4edff;
+}
+
+.slashdot-field__textarea {
+  resize: vertical;
+  min-height: 110px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.slashdot-field__error {
+  color: #d9534f;
+  font-size: 0.85rem;
+  margin-top: 8px;
+}
+
+.slashdot-autoposter.dark .slashdot-field__error {
+  color: #ff9384;
+}
+
+.slashdot-field__hint {
+  color: #6c757d;
+  font-size: 0.85rem;
+  margin-top: 8px;
+}
+
+.slashdot-autoposter.dark .slashdot-field__hint {
+  color: #9aa9c6;
+}
+
+.slashdot-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.slashdot-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #e9efff;
+  color: #1c3f82;
+  font-size: 0.8rem;
+  font-weight: 600;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.slashdot-autoposter.dark .slashdot-chip {
+  background: rgba(13, 110, 253, 0.22);
+  color: #cfe0ff;
+}
+
+.slashdot-preview__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.slashdot-preview__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.slashdot-preview__body {
+  white-space: pre-wrap;
+  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  background: #f8f9fb;
+  border: 1px solid #d6dde7;
+  border-radius: 8px;
+  padding: 16px;
+  color: #27324b;
+  max-height: 240px;
+  overflow: auto;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.slashdot-autoposter.dark .slashdot-preview__body {
+  background: #0f1c2d;
+  border-color: #2b3b55;
+  color: #e4edff;
+}
+
+.slashdot-preview__hint {
+  font-size: 0.85rem;
+  color: #6c757d;
+  margin-top: 12px;
+}
+
+.slashdot-autoposter.dark .slashdot-preview__hint {
+  color: #9aa9c6;
+}
+
+@media (max-width: 640px) {
+  .slashdot-autoposter {
+    gap: 18px;
+  }
+
+  .slashdot-card {
+    padding: 18px;
+  }
+}
+
 .tab-nav-container {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/Announcements/index.jsx
+++ b/src/components/Announcements/index.jsx
@@ -10,6 +10,7 @@ import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
 import { faFacebook, faLinkedin, faMedium } from '@fortawesome/free-brands-svg-icons';
 import ReactTooltip from 'react-tooltip';
 import EmailPanel from './platforms/email'; // ← new
+import SlashdotAutoPoster from './platforms/slashdot';
 
 function Announcements({ title, email: initialEmail }) {
   const [activeTab, setActiveTab] = useState('email');
@@ -129,11 +130,15 @@ function Announcements({ title, email: initialEmail }) {
             'slashdot',
             'blogger',
             'truthsocial',
-          ].map(platform => (
-            <TabPane tabId={platform} key={platform}>
-              <SocialMediaComposer platform={platform} />
-            </TabPane>
-          ))}
+          ].map(platform => {
+            const PlatformComposer =
+              platform === 'slashdot' ? SlashdotAutoPoster : SocialMediaComposer;
+            return (
+              <TabPane tabId={platform} key={platform}>
+                <PlatformComposer platform={platform} />
+              </TabPane>
+            );
+          })}
         </TabContent>
       </div>
     </div>

--- a/src/components/Announcements/platforms/slashdot/Helper.jsx
+++ b/src/components/Announcements/platforms/slashdot/Helper.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useParams } from 'react-router-dom';
+
+export default function SlashdotHelper() {
+  const { id } = useParams();
+  const [draft, setDraft] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await axios.get(`/api/slashdot/drafts/${id}`);
+      setDraft(data);
+    })();
+  }, [id]);
+
+  const copy = t => navigator.clipboard.writeText(t || '');
+
+  if (!draft) return <div style={{ padding: 24 }}>Loading…</div>;
+
+  return (
+    <div style={{ maxWidth: 760, margin: '24px auto', padding: 12 }}>
+      <h2>Slashdot Submit Helper</h2>
+      <ol>
+        <li>
+          Open{' '}
+          <a href="https://slashdot.org/submit" target="_blank" rel="noreferrer">
+            slashdot.org/submit
+          </a>{' '}
+          and ensure you’re logged in.
+        </li>
+        <li>Copy each field below and paste into the form; then Preview/Submit.</li>
+      </ol>
+      <Field title="Headline" value={draft.headline} copy={copy} />
+      <Field title="Source URL" value={draft.url} copy={copy} />
+      <Field title="Dept" value={draft.dept} copy={copy} />
+      <Field title="Tags" value={draft.tags} copy={copy} />
+      <Field title="Intro / Summary" value={draft.intro} copy={copy} />
+    </div>
+  );
+}
+
+function Field({ title, value, copy }) {
+  return (
+    <div style={{ margin: '12px 0' }}>
+      <h4 style={{ margin: '0 0 6px' }}>{title}</h4>
+      <pre
+        style={{
+          whiteSpace: 'pre-wrap',
+          background: '#fafafa',
+          padding: 8,
+          border: '1px solid #eee',
+        }}
+      >
+        {value || '—'}
+      </pre>
+      <button onClick={() => copy(value)}>Copy</button>
+    </div>
+  );
+}

--- a/src/components/Announcements/platforms/slashdot/index.jsx
+++ b/src/components/Announcements/platforms/slashdot/index.jsx
@@ -1,0 +1,500 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { useSelector } from 'react-redux';
+import { toast } from 'react-toastify';
+
+const HEADLINE_MIN = 12;
+const HEADLINE_MAX = 95;
+const SUMMARY_MIN = 80;
+const STOP_WORDS = new Set([
+  'about',
+  'after',
+  'also',
+  'another',
+  'because',
+  'been',
+  'being',
+  'between',
+  'can',
+  'could',
+  'during',
+  'each',
+  'from',
+  'have',
+  'into',
+  'more',
+  'other',
+  'over',
+  'since',
+  'some',
+  'than',
+  'that',
+  'their',
+  'there',
+  'these',
+  'they',
+  'this',
+  'through',
+  'under',
+  'until',
+  'where',
+  'which',
+  'while',
+  'with',
+  'within',
+]);
+
+const sanitizeTags = text =>
+  text
+    .split(',')
+    .map(tag =>
+      tag
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9-]/g, ''),
+    )
+    .filter(Boolean);
+
+const slugify = text =>
+  text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .trim();
+
+const extractTagCandidates = (headline, summary, existing) => {
+  if (Array.isArray(existing) && existing.length) return existing.slice(0, 6);
+  const corpus = `${headline} ${summary}`.toLowerCase();
+  const words = corpus.match(/[a-z0-9']+/g) || [];
+  const candidates = [];
+  for (const raw of words) {
+    const cleaned = raw.replace(/'/g, '');
+    if (cleaned.length < 4) continue;
+    if (STOP_WORDS.has(cleaned)) continue;
+    if (!candidates.includes(cleaned)) candidates.push(cleaned);
+    if (candidates.length === 6) break;
+  }
+  return candidates;
+};
+
+const buildPreview = ({ headline, sourceUrl, dept, tags, intro }) =>
+  `Headline\n${headline?.trim() || '—'}\n\nSource URL\n${sourceUrl?.trim() ||
+    '—'}\n\nDept\n${dept?.trim() || '—'}\n\nTags\n${
+    tags.length ? tags.join(', ') : '—'
+  }\n\nIntro / Summary\n${intro?.trim() || '—'}\n`;
+const initialFromAnnouncement = announcement => ({
+  headline: announcement?.title?.trim() || '',
+  sourceUrl: announcement?.url || announcement?.link || '',
+  dept: announcement?.dept || announcement?.category || '',
+  tags: Array.isArray(announcement?.tags) ? announcement.tags.join(', ') : '',
+  intro:
+    announcement?.summary ||
+    announcement?.intro ||
+    announcement?.body ||
+    announcement?.content ||
+    '',
+});
+
+const topCardActions = () => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '12px',
+  marginTop: '16px',
+});
+
+const buttonStyle = (variant, darkMode) => {
+  const base = {
+    borderRadius: '999px',
+    border: 'none',
+    cursor: 'pointer',
+    fontWeight: 600,
+    padding: '10px 18px',
+    transition: 'filter 0.2s ease',
+  };
+  if (variant === 'primary') {
+    return {
+      ...base,
+      backgroundColor: '#0d6efd',
+      color: '#fff',
+    };
+  }
+  if (variant === 'outline') {
+    return {
+      ...base,
+      backgroundColor: 'transparent',
+      color: darkMode ? '#9bb5ff' : '#0d6efd',
+      border: `1px solid ${darkMode ? '#3d4d6d' : '#0d6efd'}`,
+    };
+  }
+  return {
+    ...base,
+    backgroundColor: darkMode ? '#1c2b44' : '#e9efff',
+    color: darkMode ? '#cfd9f8' : '#1c3f82',
+  };
+};
+
+const fieldActionRow = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '10px',
+  marginTop: '12px',
+};
+
+function SlashdotAutoPoster({ announcement, platform }) {
+  const darkMode = useSelector(state => state.theme.darkMode);
+  const base = useMemo(() => initialFromAnnouncement(announcement), [announcement]);
+
+  const [headline, setHeadline] = useState(base.headline);
+  const [sourceUrl, setSourceUrl] = useState(base.sourceUrl);
+  const [dept, setDept] = useState(base.dept);
+  const [tagsText, setTagsText] = useState(base.tags);
+  const [intro, setIntro] = useState(base.intro);
+
+  useEffect(() => {
+    setHeadline(base.headline);
+    setSourceUrl(base.sourceUrl);
+    setDept(base.dept);
+    setTagsText(base.tags);
+    setIntro(base.intro);
+  }, [base.headline, base.sourceUrl, base.dept, base.tags, base.intro]);
+
+  const tags = useMemo(() => sanitizeTags(tagsText), [tagsText]);
+
+  const trimmedHeadline = headline.trim();
+  const trimmedUrl = sourceUrl.trim();
+  const trimmedDept = dept.trim();
+  const trimmedIntro = intro.trim();
+
+  const headlineInRange =
+    trimmedHeadline.length >= HEADLINE_MIN && trimmedHeadline.length <= HEADLINE_MAX;
+  const urlValid = /^https?:\/\//i.test(trimmedUrl);
+  const deptValid = trimmedDept.length >= 3;
+  const summaryValid = trimmedIntro.length >= SUMMARY_MIN;
+  const tagsValid = tags.length > 0;
+
+  const readyToCopy = headlineInRange && urlValid && deptValid && summaryValid && tagsValid;
+
+  const highlightHeadline = trimmedHeadline.length > 0 && !headlineInRange;
+  const highlightUrl = trimmedUrl.length > 0 && !urlValid;
+  const highlightDept = trimmedDept.length > 0 && !deptValid;
+  const highlightSummary = trimmedIntro.length > 0 && !summaryValid;
+
+  const preview = useMemo(() => buildPreview({ headline, sourceUrl, dept, tags, intro }), [
+    headline,
+    sourceUrl,
+    dept,
+    tags,
+    intro,
+  ]);
+
+  const copyText = async (text, label) => {
+    const value = text?.trim();
+    if (!value) {
+      toast.warn(`Nothing to copy for ${label}.`);
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success(`${label} copied to clipboard`);
+    } catch (error) {
+      toast.error(`Could not copy ${label.toLowerCase()}.`);
+    }
+  };
+
+  const handleReset = () => {
+    setHeadline('');
+    setSourceUrl('');
+    setDept('');
+    setTagsText('');
+    setIntro('');
+  };
+
+  const openSlashdotSubmit = () => {
+    if (typeof window !== 'undefined') {
+      window.open('https://slashdot.org/submit', '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  return (
+    <div className={classNames('slashdot-autoposter', { dark: darkMode })}>
+      <section className="slashdot-card">
+        <h3>Slashdot Auto-Poster</h3>
+        <p>
+          Slashdot submissions require five pieces: a strong headline, the source URL, a short
+          department slug, relevant tags, and an 80+ character summary. Use the tools below to build
+          a ready-to-submit draft, then copy it (or open slashdot.org/submit) to finish the manual
+          submission.
+        </p>
+        <div style={topCardActions()}>
+          <button type="button" style={buttonStyle('outline', darkMode)} onClick={handleReset}>
+            Clear fields
+          </button>
+        </div>
+      </section>
+
+      <div className="slashdot-grid">
+        <div className={classNames('slashdot-card', { invalid: highlightHeadline })}>
+          <div className="slashdot-field__header">
+            <label htmlFor="slashdot-headline">Headline *</label>
+            <span
+              className={classNames('slashdot-field__meta', {
+                invalid: highlightHeadline || (!trimmedHeadline && readyToCopy),
+              })}
+            >
+              {headline.trim().length}/{HEADLINE_MAX}
+            </span>
+          </div>
+          <input
+            id="slashdot-headline"
+            type="text"
+            value={headline}
+            onChange={e => setHeadline(e.target.value)}
+            className="slashdot-field__input"
+            placeholder="e.g. Open Source Volunteers Deliver Weekly Progress Platform"
+          />
+          {!trimmedHeadline && (
+            <p className="slashdot-field__hint">
+              Add a headline with at least {HEADLINE_MIN} characters and keep it below{' '}
+              {HEADLINE_MAX}.
+            </p>
+          )}
+          {highlightHeadline && (
+            <p className="slashdot-field__error">
+              Aim for {HEADLINE_MIN}-{HEADLINE_MAX} characters so the headline fits Slashdot’s front
+              page.
+            </p>
+          )}
+          <div style={fieldActionRow}>
+            <button
+              type="button"
+              style={buttonStyle('ghost', darkMode)}
+              onClick={() => setDept(slugify(headline))}
+            >
+              Use headline as dept slug
+            </button>
+            <button
+              type="button"
+              style={buttonStyle('ghost', darkMode)}
+              onClick={() => copyText(headline, 'Headline')}
+            >
+              Copy headline
+            </button>
+          </div>
+        </div>
+
+        <div className={classNames('slashdot-card', { invalid: highlightUrl })}>
+          <div className="slashdot-field__header">
+            <label htmlFor="slashdot-url">Source URL *</label>
+          </div>
+          <input
+            id="slashdot-url"
+            type="url"
+            value={sourceUrl}
+            onChange={e => setSourceUrl(e.target.value)}
+            className="slashdot-field__input"
+            placeholder="https://"
+          />
+          {!trimmedUrl && (
+            <p className="slashdot-field__hint">Paste the canonical article or project URL.</p>
+          )}
+          {highlightUrl && (
+            <p className="slashdot-field__error">
+              Slashdot only accepts fully qualified HTTP(S) links.
+            </p>
+          )}
+          <div style={fieldActionRow}>
+            <button
+              type="button"
+              style={buttonStyle('ghost', darkMode)}
+              onClick={() => copyText(sourceUrl, 'Source URL')}
+            >
+              Copy URL
+            </button>
+          </div>
+        </div>
+
+        <div className={classNames('slashdot-card', { invalid: highlightDept })}>
+          <div className="slashdot-field__header">
+            <label htmlFor="slashdot-dept">Dept *</label>
+            <span className="slashdot-field__meta">short slug</span>
+          </div>
+          <input
+            id="slashdot-dept"
+            type="text"
+            value={dept}
+            onChange={e => setDept(e.target.value.toLowerCase())}
+            className="slashdot-field__input"
+            placeholder="e.g. volunteer-tech"
+          />
+          {!trimmedDept && (
+            <p className="slashdot-field__hint">
+              Set the playful department label Slashdot shows under the headline.
+            </p>
+          )}
+          {highlightDept && (
+            <p className="slashdot-field__error">
+              Use a short slug-style phrase with lowercase letters and dashes.
+            </p>
+          )}
+          <div style={fieldActionRow}>
+            <button
+              type="button"
+              style={buttonStyle('ghost', darkMode)}
+              onClick={() => setDept(slugify(dept || headline || platform || 'one-community'))}
+            >
+              Suggest dept
+            </button>
+            <button
+              type="button"
+              style={buttonStyle('ghost', darkMode)}
+              onClick={() => copyText(dept, 'Dept')}
+            >
+              Copy dept
+            </button>
+          </div>
+        </div>
+
+        <div className={classNames('slashdot-card', { invalid: !tagsValid && !!tagsText.trim() })}>
+          <div className="slashdot-field__header">
+            <label htmlFor="slashdot-tags">Tags *</label>
+            <span className="slashdot-field__meta">comma separated</span>
+          </div>
+          <textarea
+            id="slashdot-tags"
+            value={tagsText}
+            onChange={e => setTagsText(e.target.value)}
+            className="slashdot-field__input slashdot-field__textarea"
+            rows={2}
+            placeholder="open-source, volunteering, sustainability"
+          />
+          <div className="slashdot-chips">
+            {tags.map(tag => (
+              <span key={tag} className="slashdot-chip">
+                {tag}
+              </span>
+            ))}
+          </div>
+          {!tagsValid && (
+            <p className="slashdot-field__hint">
+              Provide at least one descriptive tag separated by commas.
+            </p>
+          )}
+          <div style={fieldActionRow}>
+            <button
+              type="button"
+              style={buttonStyle('ghost', darkMode)}
+              onClick={() =>
+                setTagsText(extractTagCandidates(headline, intro, announcement?.tags).join(', '))
+              }
+            >
+              Suggest tags
+            </button>
+            <button
+              type="button"
+              style={buttonStyle('ghost', darkMode)}
+              onClick={() => copyText(tags.join(', '), 'Tags')}
+            >
+              Copy tags
+            </button>
+          </div>
+        </div>
+
+        <div className={classNames('slashdot-card', { invalid: highlightSummary })}>
+          <div className="slashdot-field__header">
+            <label htmlFor="slashdot-summary">Intro / Summary *</label>
+            <span
+              className={classNames('slashdot-field__meta', {
+                invalid: highlightSummary || (!trimmedIntro && readyToCopy),
+              })}
+            >
+              {intro.trim().length} characters
+            </span>
+          </div>
+          <textarea
+            id="slashdot-summary"
+            value={intro}
+            onChange={e => setIntro(e.target.value)}
+            className="slashdot-field__input slashdot-field__textarea"
+            rows={5}
+            placeholder="Craft a 3-4 sentence summary that highlights why the story matters to Slashdot readers."
+          />
+          {!trimmedIntro && (
+            <p className="slashdot-field__hint">
+              Write a 2–3 sentence overview tailored for Slashdot readers.
+            </p>
+          )}
+          {highlightSummary && (
+            <p className="slashdot-field__error">
+              Slashdot requires at least {SUMMARY_MIN} characters of summary text.
+            </p>
+          )}
+          <div style={fieldActionRow}>
+            <button
+              type="button"
+              style={buttonStyle('ghost', darkMode)}
+              onClick={() => copyText(intro, 'Intro / Summary')}
+            >
+              Copy summary
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <section className="slashdot-card">
+        <div className="slashdot-preview__header">
+          <h4>Submission preview</h4>
+          <div className="slashdot-preview__actions">
+            <button
+              type="button"
+              style={buttonStyle('outline', darkMode)}
+              onClick={openSlashdotSubmit}
+            >
+              Open slashdot.org/submit
+            </button>
+            <button
+              type="button"
+              style={{ ...buttonStyle('primary', darkMode), opacity: readyToCopy ? 1 : 0.5 }}
+              onClick={() => copyText(preview, 'Slashdot draft')}
+              disabled={!readyToCopy}
+            >
+              Copy full draft
+            </button>
+          </div>
+        </div>
+        <pre className="slashdot-preview__body">{preview}</pre>
+        {!readyToCopy && (
+          <p className="slashdot-preview__hint">
+            Fill every required field to enable copying the complete draft. Slashdot’s form mirrors
+            this layout.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}
+
+SlashdotAutoPoster.propTypes = {
+  announcement: PropTypes.shape({
+    title: PropTypes.string,
+    url: PropTypes.string,
+    link: PropTypes.string,
+    dept: PropTypes.string,
+    category: PropTypes.string,
+    summary: PropTypes.string,
+    intro: PropTypes.string,
+    body: PropTypes.string,
+    content: PropTypes.string,
+    tags: PropTypes.arrayOf(PropTypes.string),
+  }),
+  platform: PropTypes.string,
+};
+
+SlashdotAutoPoster.defaultProps = {
+  announcement: null,
+  platform: 'slashdot',
+};
+
+export default SlashdotAutoPoster;


### PR DESCRIPTION
# Description
Implements the Slashdot auto-poster workflow.
Adds a dedicated Slashdot tab in the Announcements section where volunteers can compose Slashdot submissions, copy the prepared content, and follow the correct posting steps.
Validates required fields, provides clipboard copy buttons, and updates dark-mode styling so the new UI stays readable.
Suggest tags suggests for first 6 keywords from the headline and summary fields for the words that has more than 4 characters. Later can be added manually to the tags section on additional tags separated with comma.
## Related PRS (if any):
None.
…

## Main changes explained:
* Create src/components/Announcements/platforms/slashdot/index.jsx for the Slashdot auto-poster form (headline/source URL/dept/tags/summary, copy buttons, preview, submit shortcut, tag suggestions).
* Update src/components/Announcements/index.jsx to route the Slashdot tab to the new component instead of the generic SocialMediaComposer.
* Extend src/components/Announcements/Announcements.css with Slashdot-specific card styling, dark-mode overrides, long-text wrapping, and chip truncation.
…

## How to test:
1. Checkout this branch.
2. yarn install then npm run start:local
3. Sign in as an admin and navigate to /announcements. (From Dashboard > Other Links > Send Emails > Slashdot)
4. Select the “Slashdot” tab.
5. Fill each field (headline 12–95 chars, valid URL, dept slug, at least one tag, 80+ char summary).
6. Click the copy buttons to ensure clipboard feedback appears; hit “Copy full draft” once inputs are valid.
7. Click “Open slashdot.org/submit” and confirm it opens in a new tab.
8. Toggle dark mode and check if UI works same for dark mode.
9. Enter very long URLs/tags/summary to verify the layout wraps without breaking cards.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/7e3871ba-edb2-41d4-8752-4a3c63561254

<img width="1440" height="900" alt="slashdot dark" src="https://github.com/user-attachments/assets/9005d181-4671-44a7-ae69-f04e0b905ae8" />


## Note:
Slashdot still lacks a public submission API, this UI prepares content for manual submission.