### PR TITLE
Xinyi - fix: add raw data export function to Task Completed Bar Chart

### DIFF
--- a/src/components/TotalOrgSummary/TaskCompleted/TaskCompletedBarChart.jsx
+++ b/src/components/TotalOrgSummary/TaskCompleted/TaskCompletedBarChart.jsx
@@ -4,6 +4,7 @@ import Loading from '../../common/Loading';
 export default function TaskCompletedBarChart({ isLoading, data, darkMode }) {
   const active = data?.active || {};
   const complete = data?.complete || {};
+  const raw = data?.raw || {};
 
   const stats = [
     {
@@ -68,6 +69,39 @@ export default function TaskCompletedBarChart({ isLoading, data, darkMode }) {
     );
   };
 
+  // --- Export CSV helper ---
+  const exportCSV = () => {
+    if (!raw?.current?.length && !raw?.comparison?.length) {
+      alert('No raw data available to export.');
+      return;
+    }
+
+    let csv = 'Range,Status,Count\n';
+
+    if (raw.current) {
+      raw.current.forEach(item => {
+        csv += `Current,${item._id},${item.count}\n`;
+      });
+    }
+
+    if (raw.comparison) {
+      raw.comparison.forEach(item => {
+        csv += `Comparison,${item._id},${item.count}\n`;
+      });
+    }
+
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'task-stats.csv';
+    // eslint-disable-next-line testing-library/no-node-access
+    a.click();
+
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div
       style={{
@@ -78,7 +112,24 @@ export default function TaskCompletedBarChart({ isLoading, data, darkMode }) {
         flexDirection: 'column',
       }}
     >
-      <div style={{ textAlign: 'center', marginBottom: 0 }} />
+      {/* Export button */}
+      <div style={{ textAlign: 'right', marginBottom: '8px' }}>
+        <button
+          onClick={exportCSV}
+          style={{
+            padding: '6px 12px',
+            borderRadius: '6px',
+            border: '1px solid',
+            borderColor: darkMode ? '#555' : '#ccc',
+            background: darkMode ? '#333' : '#f9f9f9',
+            color: darkMode ? 'white' : 'black',
+            cursor: 'pointer',
+          }}
+        >
+          Export CSV
+        </button>
+      </div>
+
       <div style={{ flex: 1, minHeight: 0 }}>
         {isLoading ? (
           <div className="d-flex justify-content-center align-items-center">


### PR DESCRIPTION
# Description
<img width="1118" height="976" alt="image" src="https://github.com/user-attachments/assets/40806a56-229c-43da-adbe-507d7bfdc04d" />

## Related PRS (if any):
This frontend PR is related to the [#1775](https://github.com/OneCommunityGlobal/HGNRest/pull/1775) backend PR.

## Main changes explained:
- Update file TaskCompletedBarChart.jsx for adding an export button to access underlying data.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard → Reports → Total Org Summary
6. verify the export button work
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/bbc44611-d69b-40b0-b79a-f72ab205f18c

