### PR TITLE
Venkataramanan fix end date issue in user profile page

### DIFF
--- a/src/components/UserManagement/SetUpFinalDayPopUp.jsx
+++ b/src/components/UserManagement/SetUpFinalDayPopUp.jsx
@@ -8,7 +8,7 @@ import '../Header/DarkMode.css';
  * Modal popup to show the user profile in create mode
  */
 const SetUpFinalDayPopUpComponent = ({ open, onClose, onSave, darkMode }) => {
-  const [finalDayDate, onDateChange] = useState(Date.now());
+  const [finalDayDate, onDateChange] = useState(moment().add(1, 'day').format('YYYY-MM-DD'));
   const [dateError, setDateError] = useState(false);
 
   const closePopup = () => {
@@ -16,11 +16,14 @@ const SetUpFinalDayPopUpComponent = ({ open, onClose, onSave, darkMode }) => {
   };
 
   const deactiveUser = () => {
-    if (moment().isBefore(moment(finalDayDate))) {
-      onSave(finalDayDate); // Pass the selected date to the parent component
-    } else {
+    const picked = moment(finalDayDate, 'YYYY-MM-DD', true);
+    if (!picked.isValid() || picked.isSameOrBefore(moment(), 'day')) {
       setDateError(true);
+      return;
     }
+    // Critical: store end-of-day so it stays the SAME calendar day in all timezones.
+    const finalDayEndOfDayISO = picked.endOf('day').toISOString();
+    onSave(finalDayEndOfDayISO);
   };
   const inputRef = useRef(null);
 
@@ -48,6 +51,7 @@ useEffect(() => {
           name="inactiveDate"
           id="inactiveDate"
           value={finalDayDate}
+          min={moment().add(1, 'day').format('YYYY-MM-DD')}
           onChange={event => {
             setDateError(false);
             onDateChange(event.target.value);

--- a/src/components/UserManagement/__tests__/SetUpFinalDayPopUp.test.jsx
+++ b/src/components/UserManagement/__tests__/SetUpFinalDayPopUp.test.jsx
@@ -70,7 +70,8 @@ describe('SetUpFinalDayPopUp Component', () => {
     fireEvent.change(screen.getByTestId('date-input'), { target: { value: futureDate } });
     fireEvent.click(screen.getByText('Save'));
 
-    expect(onSaveMock).toHaveBeenCalledWith(futureDate);
+    const expectedIso = moment(futureDate, 'YYYY-MM-DD').endOf('day').toISOString();
+    expect(onSaveMock).toHaveBeenCalledWith(expectedIso);
     expect(screen.queryByText('Please choose a future date.')).not.toBeInTheDocument();
   });
 
@@ -142,7 +143,8 @@ describe('SetUpFinalDayPopUp Component', () => {
     fireEvent.change(screen.getByTestId('date-input'), { target: { value: futureDate } });
     fireEvent.click(screen.getByText('Save'));
 
-    expect(onSaveMock).toHaveBeenCalledWith(futureDate);
+    const expectedIso = moment(futureDate, 'YYYY-MM-DD').endOf('day').toISOString();
+    expect(onSaveMock).toHaveBeenCalledWith(expectedIso);
   });
   it('should close the modal without calling onSave when the Close button is clicked', () => {
     renderComponent(store, { open: true, onClose: onCloseMock, onSave: onSaveMock });


### PR DESCRIPTION
# Description
This PR addresses the issue with setting the final day in User Profile Page.

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change SetFinalDayPopup.jsx 

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ User Profile
6. Click on Set Final Day and enter a final day.
7. Check if it is properly reflected in the User profile.
