### PR TITLE
Venkataramanan fix: actual password required for admin and owner role…

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -92,7 +92,7 @@ class UserProfileAdd extends Component {
         lastName: 'Last Name is required',
         email: 'Email is required',
         phoneNumber: 'Phone Number is required',
-        actualEmail: 'Actual Email is required',
+        actualEmail: 'Use your production sign-in email.',
         actualPassword: 'Actual Password is required',
         actualConfirmedPassword: 'Actual Confirmed Password is required',
         defaultPassword: 'Default Password is required',
@@ -744,6 +744,9 @@ class UserProfileAdd extends Component {
       return false;
     } else if (this.state.teamCode && !this.state.codeValid) {
       toast.error('Team Code is invalid');
+      return false;
+    } else if ((role === 'Administrator' || role === 'Owner') && !this.state.userProfile.actualPassword) {
+      toast.error('Actual Password is required for this role');
       return false;
     } else if (role !== 'Administrator' && role !== 'Owner' && !defaultPassword) {
       toast.error('Default Password is required for non-admin users');


### PR DESCRIPTION
# Description
This PR adds a new error message indicating the Actual Password is required for admin and owner roles while creating a new user in user management page. 

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change UserProfileAdd.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ User Management
6. Try creating a new user with admin or owner roles and check if actual password is required.
