### PR TITLE
Sourabh implementation slashdot autoposter

### DIFF
--- a/src/components/Announcements/index.jsx
+++ b/src/components/Announcements/index.jsx
@@ -10,6 +10,7 @@ import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
 import { faFacebook, faLinkedin, faMedium } from '@fortawesome/free-brands-svg-icons';
 import ReactTooltip from 'react-tooltip';
 import EmailPanel from './platforms/email'; // ← new
+import SlashdotAutoPoster from './platforms/slashdot';
 
 function Announcements({ title, email: initialEmail }) {
   const [activeTab, setActiveTab] = useState('email');
@@ -129,11 +130,15 @@ function Announcements({ title, email: initialEmail }) {
             'slashdot',
             'blogger',
             'truthsocial',
-          ].map(platform => (
-            <TabPane tabId={platform} key={platform}>
-              <SocialMediaComposer platform={platform} />
-            </TabPane>
-          ))}
+          ].map(platform => {
+            const PlatformComposer =
+              platform === 'slashdot' ? SlashdotAutoPoster : SocialMediaComposer;
+            return (
+              <TabPane tabId={platform} key={platform}>
+                <PlatformComposer platform={platform} />
+              </TabPane>
+            );
+          })}
         </TabContent>
       </div>
     </div>

--- a/src/components/Announcements/platforms/slashdot/Helper.jsx
+++ b/src/components/Announcements/platforms/slashdot/Helper.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useParams } from 'react-router-dom';
+
+export default function SlashdotHelper() {
+  const { id } = useParams();
+  const [draft, setDraft] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await axios.get(`/api/slashdot/drafts/${id}`);
+      setDraft(data);
+    })();
+  }, [id]);
+
+  const copy = t => navigator.clipboard.writeText(t || '');
+
+  if (!draft) return <div style={{ padding: 24 }}>Loading…</div>;
+
+  return (
+    <div style={{ maxWidth: 760, margin: '24px auto', padding: 12 }}>
+      <h2>Slashdot Submit Helper</h2>
+      <ol>
+        <li>
+          Open{' '}
+          <a href="https://slashdot.org/submit" target="_blank" rel="noreferrer">
+            slashdot.org/submit
+          </a>{' '}
+          and ensure you’re logged in.
+        </li>
+        <li>Copy each field below and paste into the form; then Preview/Submit.</li>
+      </ol>
+      <Field title="Headline" value={draft.headline} copy={copy} />
+      <Field title="Source URL" value={draft.url} copy={copy} />
+      <Field title="Dept" value={draft.dept} copy={copy} />
+      <Field title="Tags" value={draft.tags} copy={copy} />
+      <Field title="Intro / Summary" value={draft.intro} copy={copy} />
+    </div>
+  );
+}
+
+function Field({ title, value, copy }) {
+  return (
+    <div style={{ margin: '12px 0' }}>
+      <h4 style={{ margin: '0 0 6px' }}>{title}</h4>
+      <pre
+        style={{
+          whiteSpace: 'pre-wrap',
+          background: '#fafafa',
+          padding: 8,
+          border: '1px solid #eee',
+        }}
+      >
+        {value || '—'}
+      </pre>
+      <button onClick={() => copy(value)}>Copy</button>
+    </div>
+  );
+}

--- a/src/components/Announcements/platforms/slashdot/Slashdot.module.css
+++ b/src/components/Announcements/platforms/slashdot/Slashdot.module.css
@@ -268,6 +268,20 @@
   width: 100%;
 }
 
+.slashdot-scheduler__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 18px 0;
+}
+
+.slashdot-scheduler__field {
+  flex: 1 1 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .slashdot-scheduler__textarea {
   min-height: 220px;
 }

--- a/src/components/Announcements/platforms/slashdot/Slashdot.module.css
+++ b/src/components/Announcements/platforms/slashdot/Slashdot.module.css
@@ -114,7 +114,14 @@
 .slashdot-autoposter.dark .slashdot-field__meta {
   color: #9aa9c6;
 }
+.slashdot-field__required {
+  color: #d9534f;
+  margin-left: 4px;
+}
 
+.slashdot-autoposter.dark .slashdot-field__required {
+  color: #ff9384;
+}
 .slashdot-field__input {
   width: 100%;
   border: 1px solid #c7d1e5;
@@ -131,6 +138,16 @@
   color: #e4edff;
 }
 
+
+.slashdot-field__input--invalid {
+  border-color: #d9534f;
+  box-shadow: 0 0 0 1px rgba(217, 83, 79, 0.2);
+}
+
+.slashdot-autoposter.dark .slashdot-field__input--invalid {
+  border-color: #ff9384;
+  box-shadow: 0 0 0 1px rgba(255, 147, 132, 0.3);
+}
 .slashdot-field__textarea {
   resize: vertical;
   min-height: 110px;

--- a/src/components/Announcements/platforms/slashdot/Slashdot.module.css
+++ b/src/components/Announcements/platforms/slashdot/Slashdot.module.css
@@ -268,6 +268,27 @@
   width: 100%;
 }
 
+.slashdot-scheduler__grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+  align-items: start;
+}
+
+.slashdot-card--saved {
+  max-width: 100%;
+}
+
+.slashdot-scheduler__note {
+  font-size: 0.85rem;
+  color: #6c757d;
+  margin-top: 12px;
+}
+
+.slashdot-autoposter.dark .slashdot-scheduler__note {
+  color: #9aa9c6;
+}
+
 .slashdot-scheduler__controls {
   display: flex;
   flex-wrap: wrap;
@@ -291,6 +312,97 @@
   flex-wrap: wrap;
   gap: 12px;
   margin-top: 18px;
+}
+
+.slashdot-scheduler__empty {
+  font-size: 0.9rem;
+  color: #6c757d;
+  margin: 8px 0 0;
+}
+
+.slashdot-autoposter.dark .slashdot-scheduler__empty {
+  color: #9aa9c6;
+}
+
+.slashdot-saved__list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.slashdot-saved__item {
+  border: 1px solid #d6dde7;
+  border-radius: 10px;
+  background: #f4f7fd;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.slashdot-autoposter.dark .slashdot-saved__item {
+  border-color: #2b3b55;
+  background: #0f1c2d;
+}
+
+.slashdot-saved__item--active {
+  border-color: #0d6efd;
+  box-shadow: 0 0 0 1px rgba(13, 110, 253, 0.24);
+}
+
+.slashdot-autoposter.dark .slashdot-saved__item--active {
+  border-color: #4785ff;
+  box-shadow: 0 0 0 1px rgba(71, 133, 255, 0.32);
+}
+
+.slashdot-saved__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.slashdot-saved__title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  color: #1b1f29;
+}
+
+.slashdot-autoposter.dark .slashdot-saved__title {
+  color: #dbe6ff;
+}
+
+.slashdot-saved__meta {
+  font-size: 0.85rem;
+  color: #6c757d;
+}
+
+.slashdot-autoposter.dark .slashdot-saved__meta {
+  color: #9aa9c6;
+}
+
+.slashdot-saved__excerpt {
+  font-size: 0.9rem;
+  color: #4f5a73;
+  margin: 0;
+}
+
+.slashdot-autoposter.dark .slashdot-saved__excerpt {
+  color: #cfd9f8;
+}
+
+.slashdot-saved__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+@media (max-width: 960px) {
+  .slashdot-scheduler__grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 640px) {

--- a/src/components/Announcements/platforms/slashdot/Slashdot.module.css
+++ b/src/components/Announcements/platforms/slashdot/Slashdot.module.css
@@ -1,0 +1,289 @@
+
+
+.slashdot-autoposter {
+  /* max-width: 980px; */
+  width: 100%;
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+}
+
+.slashdot-autoposter.dark {
+  color: #dbe6ff;
+}
+
+.slashdot-autoposter.dark label {
+  color: #dbe6ff;
+}
+
+.slashdot-autoposter.dark p {
+  color: #dbe6ff;
+}
+
+.slashdot-subtabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 18px;
+  border-bottom: 1px solid #ccd4e0;
+}
+
+.slashdot-subtab {
+  padding: 9px 16px;
+  border-radius: 6px 6px 0 0;
+  border: 1px solid transparent;
+  border-bottom: none;
+  background: #d9d9d9;
+  color: #333;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.slashdot-subtab:hover {
+  background: #cfcfcf;
+}
+
+.slashdot-subtab.active {
+  background: #d7ecff;
+  color: #0d6efd;
+  border-color: #99c8ff;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.slashdot-autoposter.dark .slashdot-subtab {
+  border-color: transparent;
+  background: #2d3c53;
+  color: #cdd8f6;
+}
+
+.slashdot-autoposter.dark .slashdot-subtab.active {
+  background: #1f4a80;
+  border-color: #1f4a80;
+  color: #fff;
+}
+
+.slashdot-card {
+  background: #fff;
+  border: 1px solid #d6dde7;
+  border-radius: 12px;
+  padding: 20px 22px;
+  box-shadow: 0 10px 24px rgba(15, 37, 80, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.slashdot-autoposter.dark .slashdot-card {
+  background: #14233a;
+  border-color: #25354d;
+  box-shadow: none;
+}
+
+.slashdot-card.invalid {
+  border-color: #d9534f;
+  box-shadow: 0 0 0 1px rgba(217, 83, 79, 0.18);
+}
+
+.slashdot-autoposter.dark .slashdot-card.invalid {
+  border-color: #ff7b72;
+  box-shadow: none;
+}
+
+.slashdot-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.slashdot-field__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.slashdot-field__meta {
+  font-size: 0.85rem;
+  color: #6c757d;
+}
+
+.slashdot-field__meta.invalid {
+  color: #d9534f;
+}
+
+.slashdot-autoposter.dark .slashdot-field__meta {
+  color: #9aa9c6;
+}
+
+.slashdot-field__input {
+  width: 100%;
+  border: 1px solid #c7d1e5;
+  border-radius: 8px;
+  padding: 12px 14px;
+  font-size: 0.95rem;
+  background: #fff;
+  color: #1b1f29;
+}
+
+.slashdot-autoposter.dark .slashdot-field__input {
+  background: #0f1c2d;
+  border-color: #2b3b55;
+  color: #e4edff;
+}
+
+.slashdot-field__textarea {
+  resize: vertical;
+  min-height: 110px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.slashdot-field__error {
+  color: #d9534f;
+  font-size: 0.85rem;
+  margin-top: 8px;
+}
+
+.slashdot-autoposter.dark .slashdot-field__error {
+  color: #ff9384;
+}
+
+.slashdot-field__hint {
+  color: #6c757d;
+  font-size: 0.85rem;
+  margin-top: 8px;
+}
+
+.slashdot-autoposter.dark .slashdot-field__hint {
+  color: #9aa9c6;
+}
+
+.slashdot-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.slashdot-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #e9efff;
+  color: #1c3f82;
+  font-size: 0.8rem;
+  font-weight: 600;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  gap: 6px;
+}
+
+.slashdot-autoposter.dark .slashdot-chip {
+  background: rgba(13, 110, 253, 0.22);
+  color: #cfe0ff;
+}
+
+.slashdot-chip__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.slashdot-chip__clear {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #d9534f;
+  font-size: 0.9rem;
+  padding: 0 4px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s ease;
+}
+
+.slashdot-chip__clear:hover,
+.slashdot-chip__clear:focus {
+  color: #b7322d;
+  background: transparent;
+}
+
+.slashdot-autoposter.dark .slashdot-chip__clear {
+  color: #ff9384;
+}
+
+.slashdot-preview__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.slashdot-preview__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.slashdot-preview__body {
+  white-space: pre-wrap;
+  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  background: #f8f9fb;
+  border: 1px solid #d6dde7;
+  border-radius: 8px;
+  padding: 16px;
+  color: #27324b;
+  max-height: 240px;
+  overflow: auto;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.slashdot-autoposter.dark .slashdot-preview__body {
+  background: #0f1c2d;
+  border-color: #2b3b55;
+  color: #e4edff;
+}
+
+.slashdot-preview__hint {
+  font-size: 0.85rem;
+  color: #6c757d;
+  margin-top: 12px;
+}
+
+.slashdot-autoposter.dark .slashdot-preview__hint {
+  color: #9aa9c6;
+}
+
+.slashdot-card--scheduler {
+  max-width: 720px;
+}
+
+.slashdot-scheduler__textarea {
+  min-height: 220px;
+}
+
+.slashdot-scheduler__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+@media (max-width: 640px) {
+  .slashdot-autoposter {
+    gap: 18px;
+  }
+
+  .slashdot-card {
+    padding: 18px;
+  }
+}

--- a/src/components/Announcements/platforms/slashdot/Slashdot.module.css
+++ b/src/components/Announcements/platforms/slashdot/Slashdot.module.css
@@ -264,7 +264,8 @@
 }
 
 .slashdot-card--scheduler {
-  max-width: 720px;
+  /* max-width: 720px; */
+  width: 100%;
 }
 
 .slashdot-scheduler__textarea {

--- a/src/components/Announcements/platforms/slashdot/index.jsx
+++ b/src/components/Announcements/platforms/slashdot/index.jsx
@@ -262,6 +262,7 @@ function SlashdotAutoPoster({ platform }) {
     setScheduledTime(formatLocalTime(now));
     setScheduledDraft(preview);
     setActiveSubTab('schedule');
+    setEditingScheduleId(null);
     setIsScheduleDraftDirty(false);
     toast.success('Draft moved to Schedule tab.');
   };
@@ -321,8 +322,10 @@ function SlashdotAutoPoster({ platform }) {
       toast.warn('Add content to the schedule before saving.');
       return;
     }
+    const isEditing = Boolean(editingScheduleId);
+    const recordId = isEditing ? editingScheduleId : createScheduleId();
     const record = {
-      id: editingScheduleId || createScheduleId(),
+      id: recordId,
       headline,
       sourceUrl,
       dept,
@@ -339,10 +342,15 @@ function SlashdotAutoPoster({ platform }) {
       const remaining = prev.filter(item => item.id !== record.id);
       return [record, ...remaining];
     });
-    setScheduledDraft(record.scheduledDraft);
-    setIsScheduleDraftDirty(record.isCustomDraft);
-    setEditingScheduleId(record.id);
-    toast.success(editingScheduleId ? 'Scheduled post updated.' : 'Scheduled post saved.');
+    const toastMessage = isEditing ? 'Scheduled post updated.' : 'Scheduled post saved.';
+    toast.success(toastMessage);
+    handleReset();
+    setScheduledDraft('');
+    setScheduledDate('');
+    setScheduledTime('');
+    setIsScheduleDraftDirty(true);
+    setEditingScheduleId(null);
+    setActiveSubTab('make');
   };
 
   const handleEditSchedule = scheduleId => {
@@ -701,10 +709,7 @@ function SlashdotAutoPoster({ platform }) {
             className={classNames(styles['slashdot-card'], styles['slashdot-card--scheduler'])}
           >
             <h3>Schedule Slashdot Post</h3>
-            <p>
-              Draft content captured from the composer. Scheduling controls will live here—edit the
-              copy below or switch back to Make Post for more changes.
-            </p>
+            <p>Scheduling controls, copy below or switch back to Make Post changes.</p>
             {editingSchedule && (
               <p className={styles['slashdot-scheduler__note']}>
                 Editing saved schedule “{editingSchedule.headline || 'Untitled draft'}”. Saving will
@@ -744,7 +749,7 @@ function SlashdotAutoPoster({ platform }) {
                 styles['slashdot-field__input'],
                 styles['slashdot-scheduler__textarea'],
               )}
-              placeholder="Click “Schedule this post” in the composer to load content here."
+              placeholder="Click “Schedule this post” in the Make Post tab to load content here."
               rows={8}
             />
             <div className={styles['slashdot-scheduler__actions']}>

--- a/src/components/Announcements/platforms/slashdot/index.jsx
+++ b/src/components/Announcements/platforms/slashdot/index.jsx
@@ -276,8 +276,8 @@ function SlashdotAutoPoster({ platform }) {
     setScheduledDate(formatLocalDate(now));
     setScheduledTime(formatLocalTime(now));
     setScheduledDraft(preview);
-    setActiveSubTab('schedule');
     setScheduleAttemptedSave(false);
+    setActiveSubTab('schedule');
     toast.success('Draft moved to Schedule tab.');
   };
 
@@ -735,6 +735,7 @@ function SlashdotAutoPoster({ platform }) {
                   type="date"
                   value={scheduledDate}
                   min={today}
+                  onChange={handleScheduleDateChange}
                   className={classNames(styles['slashdot-field__input'], {
                     [styles['slashdot-field__input--invalid']]:
                       scheduleAttemptedSave && !scheduledDate,
@@ -754,6 +755,7 @@ function SlashdotAutoPoster({ platform }) {
                   type="time"
                   value={scheduledTime}
                   min={scheduleTimeMin}
+                  onChange={handleScheduleTimeChange}
                   className={classNames(styles['slashdot-field__input'], {
                     [styles['slashdot-field__input--invalid']]:
                       scheduleAttemptedSave && !scheduledTime,

--- a/src/components/Announcements/platforms/slashdot/index.jsx
+++ b/src/components/Announcements/platforms/slashdot/index.jsx
@@ -215,13 +215,14 @@ function SlashdotAutoPoster({ platform }) {
   const highlightDept = trimmedDept.length > 0 && !deptValid;
   const highlightSummary = trimmedIntro.length > 0 && !summaryValid;
 
-  const preview = useMemo(() => buildPreview({ headline, sourceUrl, dept, tags, intro }), [
-    headline,
-    sourceUrl,
-    dept,
-    tags,
-    intro,
-  ]);
+  const hasAnyInput = Boolean(
+    trimmedHeadline || trimmedUrl || trimmedDept || trimmedIntro || tagsText.trim(),
+  );
+
+  const preview = useMemo(() => {
+    if (!hasAnyInput) return '';
+    return buildPreview({ headline, sourceUrl, dept, tags, intro });
+  }, [dept, headline, hasAnyInput, intro, sourceUrl, tags]);
   const scheduleHasDraft = scheduledDraft.trim().length > 0;
   const editingSchedule = useMemo(
     () => savedSchedules.find(schedule => schedule.id === editingScheduleId) || null,
@@ -257,6 +258,20 @@ function SlashdotAutoPoster({ platform }) {
   };
 
   const handleScheduleClick = () => {
+    if (!hasAnyInput) {
+      toast.error('Nothing to schedule yet. Add details in Make Post first.');
+      return;
+    }
+    const missingFields = [];
+    if (!trimmedHeadline) missingFields.push('Headline');
+    if (!trimmedUrl) missingFields.push('Source URL');
+    if (!trimmedDept) missingFields.push('Dept');
+    if (tags.length === 0) missingFields.push('Tags');
+    if (!trimmedIntro) missingFields.push('Intro / Summary');
+    if (missingFields.length > 0) {
+      toast.error(`Add ${missingFields.join(', ')} before scheduling.`);
+      return;
+    }
     const now = new Date();
     setScheduledDate(formatLocalDate(now));
     setScheduledTime(formatLocalTime(now));

--- a/src/components/Announcements/platforms/slashdot/index.jsx
+++ b/src/components/Announcements/platforms/slashdot/index.jsx
@@ -1,0 +1,559 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { useSelector } from 'react-redux';
+import { toast } from 'react-toastify';
+
+const HEADLINE_MIN = 12;
+const HEADLINE_MAX = 95;
+const SUMMARY_MIN = 80;
+const STOP_WORDS = new Set([
+  'about',
+  'after',
+  'also',
+  'another',
+  'because',
+  'been',
+  'being',
+  'between',
+  'can',
+  'could',
+  'during',
+  'each',
+  'from',
+  'have',
+  'into',
+  'more',
+  'other',
+  'over',
+  'since',
+  'some',
+  'than',
+  'that',
+  'their',
+  'there',
+  'these',
+  'they',
+  'this',
+  'through',
+  'under',
+  'until',
+  'where',
+  'which',
+  'while',
+  'with',
+  'within',
+]);
+
+const sanitizeTags = text =>
+  text
+    .split(',')
+    .map(tag =>
+      tag
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9-]/g, ''),
+    )
+    .filter(Boolean);
+
+const slugify = text =>
+  text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .trim();
+
+const extractTagCandidates = (headline, summary, existing) => {
+  if (Array.isArray(existing) && existing.length) return existing.slice(0, 6);
+  const corpus = `${headline} ${summary}`.toLowerCase();
+  const words = corpus.match(/[a-z0-9']+/g) || [];
+  const candidates = [];
+  for (const raw of words) {
+    const cleaned = raw.replace(/'/g, '');
+    if (cleaned.length < 4) continue;
+    if (STOP_WORDS.has(cleaned)) continue;
+    if (!candidates.includes(cleaned)) candidates.push(cleaned);
+    if (candidates.length === 6) break;
+  }
+  return candidates;
+};
+
+const buildPreview = ({ headline, sourceUrl, dept, tags, intro }) =>
+  `Headline\n${headline?.trim() || '—'}\n\nSource URL\n${sourceUrl?.trim() ||
+    '—'}\n\nDept\n${dept?.trim() || '—'}\n\nTags\n${
+    tags.length ? tags.join(', ') : '—'
+  }\n\nIntro / Summary\n${intro?.trim() || '—'}\n`;
+
+const topCardActions = () => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '12px',
+  marginTop: '16px',
+});
+
+const buttonStyle = (variant, darkMode) => {
+  const base = {
+    borderRadius: '999px',
+    border: 'none',
+    cursor: 'pointer',
+    fontWeight: 600,
+    padding: '10px 18px',
+    transition: 'filter 0.2s ease',
+  };
+  if (variant === 'primary') {
+    return {
+      ...base,
+      backgroundColor: '#0d6efd',
+      color: '#fff',
+    };
+  }
+  if (variant === 'outline') {
+    return {
+      ...base,
+      backgroundColor: 'transparent',
+      color: darkMode ? '#9bb5ff' : '#0d6efd',
+      border: `1px solid ${darkMode ? '#3d4d6d' : '#0d6efd'}`,
+    };
+  }
+  return {
+    ...base,
+    backgroundColor: darkMode ? '#1c2b44' : '#e9efff',
+    color: darkMode ? '#cfd9f8' : '#1c3f82',
+  };
+};
+
+const fieldActionRow = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '10px',
+  marginTop: '12px',
+};
+
+function SlashdotAutoPoster({ platform }) {
+  const darkMode = useSelector(state => state.theme.darkMode);
+
+  const [headline, setHeadline] = useState('');
+  const [sourceUrl, setSourceUrl] = useState('');
+  const [dept, setDept] = useState('');
+  const [tagsText, setTagsText] = useState('');
+  const [intro, setIntro] = useState('');
+  const [activeSubTab, setActiveSubTab] = useState('make');
+  const [scheduledDraft, setScheduledDraft] = useState('');
+
+  const subTabs = useMemo(
+    () => [
+      { id: 'make', label: '📝 Make Post' },
+      { id: 'schedule', label: '⏰ Scheduled Post' },
+    ],
+    [],
+  );
+
+  const tags = useMemo(() => sanitizeTags(tagsText), [tagsText]);
+
+  const trimmedHeadline = headline.trim();
+  const trimmedUrl = sourceUrl.trim();
+  const trimmedDept = dept.trim();
+  const trimmedIntro = intro.trim();
+
+  const headlineInRange =
+    trimmedHeadline.length >= HEADLINE_MIN && trimmedHeadline.length <= HEADLINE_MAX;
+  const urlValid = /^https?:\/\//i.test(trimmedUrl);
+  const deptValid = trimmedDept.length >= 3;
+  const summaryValid = trimmedIntro.length >= SUMMARY_MIN;
+  const tagsValid = tags.length > 0;
+
+  const readyToCopy = headlineInRange && urlValid && deptValid && summaryValid && tagsValid;
+
+  const highlightHeadline = trimmedHeadline.length > 0 && !headlineInRange;
+  const highlightUrl = trimmedUrl.length > 0 && !urlValid;
+  const highlightDept = trimmedDept.length > 0 && !deptValid;
+  const highlightSummary = trimmedIntro.length > 0 && !summaryValid;
+
+  const preview = useMemo(() => buildPreview({ headline, sourceUrl, dept, tags, intro }), [
+    headline,
+    sourceUrl,
+    dept,
+    tags,
+    intro,
+  ]);
+
+  const copyText = async (text, label) => {
+    const value = text?.trim();
+    if (!value) {
+      toast.warn(`Nothing to copy for ${label}.`);
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success(`${label} copied to clipboard`);
+    } catch (error) {
+      toast.error(`Could not copy ${label.toLowerCase()}.`);
+    }
+  };
+
+  const handleReset = () => {
+    setHeadline('');
+    setSourceUrl('');
+    setDept('');
+    setTagsText('');
+    setIntro('');
+  };
+
+  const openSlashdotSubmit = () => {
+    if (typeof window !== 'undefined') {
+      window.open('https://slashdot.org/submit', '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  const handleScheduleClick = () => {
+    setScheduledDraft(preview);
+    setActiveSubTab('schedule');
+    toast.success('Draft moved to Schedule tab.');
+  };
+
+  const removeTag = tagToRemove => {
+    const remaining = tags.filter(tag => tag !== tagToRemove);
+    setTagsText(remaining.join(', '));
+  };
+
+  return (
+    <div className={classNames('slashdot-autoposter', { dark: darkMode })}>
+      <div className={classNames('slashdot-subtabs', { dark: darkMode })}>
+        {subTabs.map(({ id, label }) => (
+          <button
+            key={id}
+            type="button"
+            className={classNames('slashdot-subtab', { active: activeSubTab === id })}
+            onClick={() => setActiveSubTab(id)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {activeSubTab === 'make' ? (
+        <>
+          <section className="slashdot-card">
+            <h3>Slashdot Auto-Poster</h3>
+            <p>
+              Slashdot submissions require five pieces: a strong headline, the source URL, a short
+              department slug, relevant tags, and an 80+ character summary. Use the tools below to
+              build a ready-to-submit draft, then copy it (or open slashdot.org/submit) to finish
+              the manual submission.
+            </p>
+            <div style={topCardActions()}>
+              <button type="button" style={buttonStyle('outline', darkMode)} onClick={handleReset}>
+                Clear fields
+              </button>
+            </div>
+          </section>
+
+          <div className="slashdot-grid">
+            <div className={classNames('slashdot-card', { invalid: highlightHeadline })}>
+              <div className="slashdot-field__header">
+                <label htmlFor="slashdot-headline">Headline *</label>
+                <span
+                  className={classNames('slashdot-field__meta', {
+                    invalid: highlightHeadline || (!trimmedHeadline && readyToCopy),
+                  })}
+                >
+                  {headline.trim().length}/{HEADLINE_MAX}
+                </span>
+              </div>
+              <input
+                id="slashdot-headline"
+                type="text"
+                value={headline}
+                onChange={e => setHeadline(e.target.value)}
+                className="slashdot-field__input"
+                placeholder="e.g. Open Source Volunteers Deliver Weekly Progress Platform"
+              />
+              {!trimmedHeadline && (
+                <p className="slashdot-field__hint">
+                  Add a headline with at least {HEADLINE_MIN} characters and keep it below{' '}
+                  {HEADLINE_MAX}.
+                </p>
+              )}
+              {highlightHeadline && (
+                <p className="slashdot-field__error">
+                  Aim for {HEADLINE_MIN}-{HEADLINE_MAX} characters so the headline fits Slashdot’s
+                  front page.
+                </p>
+              )}
+              <div style={fieldActionRow}>
+                <button
+                  type="button"
+                  style={buttonStyle('ghost', darkMode)}
+                  onClick={() => copyText(headline, 'Headline')}
+                >
+                  Copy headline
+                </button>
+                <button
+                  type="button"
+                  style={buttonStyle('ghost', darkMode)}
+                  onClick={() => setHeadline('')}
+                >
+                  Clear headline
+                </button>
+              </div>
+            </div>
+
+            <div className={classNames('slashdot-card', { invalid: highlightUrl })}>
+              <div className="slashdot-field__header">
+                <label htmlFor="slashdot-url">Source URL *</label>
+              </div>
+              <input
+                id="slashdot-url"
+                type="url"
+                value={sourceUrl}
+                onChange={e => setSourceUrl(e.target.value)}
+                className="slashdot-field__input"
+                placeholder="https://"
+              />
+              {!trimmedUrl && (
+                <p className="slashdot-field__hint">Paste the canonical article or project URL.</p>
+              )}
+              {highlightUrl && (
+                <p className="slashdot-field__error">
+                  Slashdot only accepts fully qualified HTTP(S) links.
+                </p>
+              )}
+              <div style={fieldActionRow}>
+                <button
+                  type="button"
+                  style={buttonStyle('ghost', darkMode)}
+                  onClick={() => copyText(sourceUrl, 'Source URL')}
+                >
+                  Copy URL
+                </button>
+              </div>
+            </div>
+
+            <div className={classNames('slashdot-card', { invalid: highlightDept })}>
+              <div className="slashdot-field__header">
+                <label htmlFor="slashdot-dept">Dept *</label>
+                <span className="slashdot-field__meta">short slug</span>
+              </div>
+              <input
+                id="slashdot-dept"
+                type="text"
+                value={dept}
+                onChange={e => setDept(e.target.value.toLowerCase())}
+                className="slashdot-field__input"
+                placeholder="e.g. volunteer-tech"
+              />
+              {!trimmedDept && (
+                <p className="slashdot-field__hint">
+                  Set the playful department label Slashdot shows under the headline.
+                </p>
+              )}
+              {highlightDept && (
+                <p className="slashdot-field__error">
+                  Use a short slug-style phrase with lowercase letters and dashes.
+                </p>
+              )}
+              <div style={fieldActionRow}>
+                <button
+                  type="button"
+                  style={buttonStyle('ghost', darkMode)}
+                  onClick={() => setDept(slugify(dept || headline || platform || 'one-community'))}
+                >
+                  Suggest dept
+                </button>
+                <button
+                  type="button"
+                  style={buttonStyle('ghost', darkMode)}
+                  onClick={() => copyText(dept, 'Dept')}
+                >
+                  Copy dept
+                </button>
+              </div>
+            </div>
+
+            <div
+              className={classNames('slashdot-card', { invalid: !tagsValid && !!tagsText.trim() })}
+            >
+              <div className="slashdot-field__header">
+                <label htmlFor="slashdot-tags">Tags *</label>
+                <span className="slashdot-field__meta">comma separated</span>
+              </div>
+              <textarea
+                id="slashdot-tags"
+                value={tagsText}
+                onChange={e => setTagsText(e.target.value)}
+                className="slashdot-field__input slashdot-field__textarea"
+                rows={2}
+                placeholder="open-source, volunteering, sustainability"
+              />
+              <div className="slashdot-chips">
+                {tags.map(tag => (
+                  <span key={tag} className="slashdot-chip">
+                    <span className="slashdot-chip__label">{tag}</span>
+                    <button
+                      type="button"
+                      className="slashdot-chip__clear"
+                      onClick={() => removeTag(tag)}
+                      aria-label={`Remove tag ${tag}`}
+                    >
+                      ✖
+                    </button>
+                  </span>
+                ))}
+              </div>
+              {!tagsValid && (
+                <p className="slashdot-field__hint">
+                  Provide at least one descriptive tag separated by commas.
+                </p>
+              )}
+              <div style={fieldActionRow}>
+                <button
+                  type="button"
+                  style={buttonStyle('ghost', darkMode)}
+                  onClick={() => setTagsText(extractTagCandidates(headline, intro).join(', '))}
+                >
+                  Suggest tags
+                </button>
+                <button
+                  type="button"
+                  style={buttonStyle('ghost', darkMode)}
+                  onClick={() => copyText(tags.join(', '), 'Tags')}
+                >
+                  Copy tags
+                </button>
+              </div>
+            </div>
+
+            <div className={classNames('slashdot-card', { invalid: highlightSummary })}>
+              <div className="slashdot-field__header">
+                <label htmlFor="slashdot-summary">Intro / Summary *</label>
+                <span
+                  className={classNames('slashdot-field__meta', {
+                    invalid: highlightSummary || (!trimmedIntro && readyToCopy),
+                  })}
+                >
+                  {intro.trim().length} characters
+                </span>
+              </div>
+              <textarea
+                id="slashdot-summary"
+                value={intro}
+                onChange={e => setIntro(e.target.value)}
+                className="slashdot-field__input slashdot-field__textarea"
+                rows={5}
+                placeholder="Craft a 3-4 sentence summary that highlights why the story matters to Slashdot readers."
+              />
+              {!trimmedIntro && (
+                <p className="slashdot-field__hint">
+                  Write a 2–3 sentence overview tailored for Slashdot readers.
+                </p>
+              )}
+              {highlightSummary && (
+                <p className="slashdot-field__error">
+                  Slashdot requires at least {SUMMARY_MIN} characters of summary text.
+                </p>
+              )}
+              <div style={fieldActionRow}>
+                <button
+                  type="button"
+                  style={buttonStyle('ghost', darkMode)}
+                  onClick={() => copyText(intro, 'Intro / Summary')}
+                >
+                  Copy summary
+                </button>
+                <button
+                  type="button"
+                  style={buttonStyle('ghost', darkMode)}
+                  onClick={() => setIntro('')}
+                >
+                  Clear summary
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <section className="slashdot-card">
+            <div className="slashdot-preview__header">
+              <h4>Submission preview</h4>
+              <div className="slashdot-preview__actions">
+                <button
+                  type="button"
+                  style={buttonStyle('ghost', darkMode)}
+                  onClick={handleScheduleClick}
+                >
+                  Schedule this post
+                </button>
+                <button
+                  type="button"
+                  style={buttonStyle('outline', darkMode)}
+                  onClick={openSlashdotSubmit}
+                >
+                  Open slashdot.org/submit
+                </button>
+                <button
+                  type="button"
+                  style={{ ...buttonStyle('primary', darkMode), opacity: readyToCopy ? 1 : 0.5 }}
+                  onClick={() => copyText(preview, 'Slashdot draft')}
+                  disabled={!readyToCopy}
+                >
+                  Copy full draft
+                </button>
+              </div>
+            </div>
+            <pre className="slashdot-preview__body">{preview}</pre>
+            {!readyToCopy && (
+              <p className="slashdot-preview__hint">
+                Fill every required field to enable copying the complete draft. Slashdot’s form
+                mirrors this layout.
+              </p>
+            )}
+          </section>
+        </>
+      ) : (
+        <section className="slashdot-card slashdot-card--scheduler">
+          <h3>Schedule Slashdot Post</h3>
+          <p>
+            Draft content captured from the composer. Scheduling controls will live here—edit the
+            copy below or switch back to Make Post for more changes.
+          </p>
+          <label htmlFor="slashdot-schedule-content">Scheduled draft</label>
+          <textarea
+            id="slashdot-schedule-content"
+            value={scheduledDraft}
+            onChange={e => setScheduledDraft(e.target.value)}
+            className="slashdot-field__input slashdot-scheduler__textarea"
+            placeholder="Click “Schedule this post” in the composer to load content here."
+            rows={8}
+          />
+          <div className="slashdot-scheduler__actions">
+            <button
+              type="button"
+              style={buttonStyle('ghost', darkMode)}
+              onClick={() => copyText(scheduledDraft, 'Scheduled draft')}
+            >
+              Copy scheduled draft
+            </button>
+            <button
+              type="button"
+              style={buttonStyle('outline', darkMode)}
+              onClick={() => setActiveSubTab('make')}
+            >
+              Back to Make Post
+            </button>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+SlashdotAutoPoster.propTypes = {
+  platform: PropTypes.string,
+};
+
+SlashdotAutoPoster.defaultProps = {
+  platform: 'slashdot',
+};
+
+export default SlashdotAutoPoster;

--- a/src/components/Announcements/platforms/slashdot/index.jsx
+++ b/src/components/Announcements/platforms/slashdot/index.jsx
@@ -4,6 +4,8 @@ import classNames from 'classnames';
 import { useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
 
+import styles from './Slashdot.module.css';
+
 const HEADLINE_MIN = 12;
 const HEADLINE_MAX = 95;
 const SUMMARY_MIN = 80;
@@ -219,13 +221,15 @@ function SlashdotAutoPoster({ platform }) {
   };
 
   return (
-    <div className={classNames('slashdot-autoposter', { dark: darkMode })}>
-      <div className={classNames('slashdot-subtabs', { dark: darkMode })}>
+    <div className={classNames(styles['slashdot-autoposter'], { [styles.dark]: darkMode })}>
+      <div className={classNames(styles['slashdot-subtabs'], { [styles.dark]: darkMode })}>
         {subTabs.map(({ id, label }) => (
           <button
             key={id}
             type="button"
-            className={classNames('slashdot-subtab', { active: activeSubTab === id })}
+            className={classNames(styles['slashdot-subtab'], {
+              [styles.active]: activeSubTab === id,
+            })}
             onClick={() => setActiveSubTab(id)}
           >
             {label}
@@ -235,7 +239,7 @@ function SlashdotAutoPoster({ platform }) {
 
       {activeSubTab === 'make' ? (
         <>
-          <section className="slashdot-card">
+          <section className={styles['slashdot-card']}>
             <h3>Slashdot Auto-Poster</h3>
             <p>
               Slashdot submissions require five pieces: a strong headline, the source URL, a short
@@ -250,13 +254,17 @@ function SlashdotAutoPoster({ platform }) {
             </div>
           </section>
 
-          <div className="slashdot-grid">
-            <div className={classNames('slashdot-card', { invalid: highlightHeadline })}>
-              <div className="slashdot-field__header">
+          <div className={styles['slashdot-grid']}>
+            <div
+              className={classNames(styles['slashdot-card'], {
+                [styles.invalid]: highlightHeadline,
+              })}
+            >
+              <div className={styles['slashdot-field__header']}>
                 <label htmlFor="slashdot-headline">Headline *</label>
                 <span
-                  className={classNames('slashdot-field__meta', {
-                    invalid: highlightHeadline || (!trimmedHeadline && readyToCopy),
+                  className={classNames(styles['slashdot-field__meta'], {
+                    [styles.invalid]: highlightHeadline || (!trimmedHeadline && readyToCopy),
                   })}
                 >
                   {headline.trim().length}/{HEADLINE_MAX}
@@ -267,17 +275,17 @@ function SlashdotAutoPoster({ platform }) {
                 type="text"
                 value={headline}
                 onChange={e => setHeadline(e.target.value)}
-                className="slashdot-field__input"
+                className={styles['slashdot-field__input']}
                 placeholder="e.g. Open Source Volunteers Deliver Weekly Progress Platform"
               />
               {!trimmedHeadline && (
-                <p className="slashdot-field__hint">
+                <p className={styles['slashdot-field__hint']}>
                   Add a headline with at least {HEADLINE_MIN} characters and keep it below{' '}
                   {HEADLINE_MAX}.
                 </p>
               )}
               {highlightHeadline && (
-                <p className="slashdot-field__error">
+                <p className={styles['slashdot-field__error']}>
                   Aim for {HEADLINE_MIN}-{HEADLINE_MAX} characters so the headline fits Slashdot’s
                   front page.
                 </p>
@@ -300,8 +308,12 @@ function SlashdotAutoPoster({ platform }) {
               </div>
             </div>
 
-            <div className={classNames('slashdot-card', { invalid: highlightUrl })}>
-              <div className="slashdot-field__header">
+            <div
+              className={classNames(styles['slashdot-card'], {
+                [styles.invalid]: highlightUrl,
+              })}
+            >
+              <div className={styles['slashdot-field__header']}>
                 <label htmlFor="slashdot-url">Source URL *</label>
               </div>
               <input
@@ -309,14 +321,16 @@ function SlashdotAutoPoster({ platform }) {
                 type="url"
                 value={sourceUrl}
                 onChange={e => setSourceUrl(e.target.value)}
-                className="slashdot-field__input"
+                className={styles['slashdot-field__input']}
                 placeholder="https://"
               />
               {!trimmedUrl && (
-                <p className="slashdot-field__hint">Paste an article or project URL.</p>
+                <p className={styles['slashdot-field__hint']}>
+                  Paste the canonical article or project URL.
+                </p>
               )}
               {highlightUrl && (
-                <p className="slashdot-field__error">
+                <p className={styles['slashdot-field__error']}>
                   Slashdot only accepts fully qualified HTTP(S) links.
                 </p>
               )}
@@ -331,22 +345,30 @@ function SlashdotAutoPoster({ platform }) {
               </div>
             </div>
 
-            <div className={classNames('slashdot-card', { invalid: highlightDept })}>
-              <div className="slashdot-field__header">
+            <div
+              className={classNames(styles['slashdot-card'], {
+                [styles.invalid]: highlightDept,
+              })}
+            >
+              <div className={styles['slashdot-field__header']}>
                 <label htmlFor="slashdot-dept">Dept *</label>
-                <span className="slashdot-field__meta">short slug</span>
+                <span className={styles['slashdot-field__meta']}>short slug</span>
               </div>
               <input
                 id="slashdot-dept"
                 type="text"
                 value={dept}
                 onChange={e => setDept(e.target.value.toLowerCase())}
-                className="slashdot-field__input"
+                className={styles['slashdot-field__input']}
                 placeholder="e.g. volunteer-tech"
               />
-              {!trimmedDept && <p className="slashdot-field__hint"> Department label. </p>}
+              {!trimmedDept && (
+                <p className={styles['slashdot-field__hint']}>
+                  Set the playful department label Slashdot shows under the headline.
+                </p>
+              )}
               {highlightDept && (
-                <p className="slashdot-field__error">
+                <p className={styles['slashdot-field__error']}>
                   Use a short slug-style phrase with lowercase letters and dashes.
                 </p>
               )}
@@ -369,27 +391,32 @@ function SlashdotAutoPoster({ platform }) {
             </div>
 
             <div
-              className={classNames('slashdot-card', { invalid: !tagsValid && !!tagsText.trim() })}
+              className={classNames(styles['slashdot-card'], {
+                [styles.invalid]: !tagsValid && !!tagsText.trim(),
+              })}
             >
-              <div className="slashdot-field__header">
+              <div className={styles['slashdot-field__header']}>
                 <label htmlFor="slashdot-tags">Tags *</label>
-                <span className="slashdot-field__meta">comma separated</span>
+                <span className={styles['slashdot-field__meta']}>comma separated</span>
               </div>
               <textarea
                 id="slashdot-tags"
                 value={tagsText}
                 onChange={e => setTagsText(e.target.value)}
-                className="slashdot-field__input slashdot-field__textarea"
+                className={classNames(
+                  styles['slashdot-field__input'],
+                  styles['slashdot-field__textarea'],
+                )}
                 rows={2}
                 placeholder="open-source, volunteering, sustainability"
               />
-              <div className="slashdot-chips">
+              <div className={styles['slashdot-chips']}>
                 {tags.map(tag => (
-                  <span key={tag} className="slashdot-chip">
-                    <span className="slashdot-chip__label">{tag}</span>
+                  <span key={tag} className={styles['slashdot-chip']}>
+                    <span className={styles['slashdot-chip__label']}>{tag}</span>
                     <button
                       type="button"
-                      className="slashdot-chip__clear"
+                      className={styles['slashdot-chip__clear']}
                       onClick={() => removeTag(tag)}
                       aria-label={`Remove tag ${tag}`}
                     >
@@ -399,7 +426,7 @@ function SlashdotAutoPoster({ platform }) {
                 ))}
               </div>
               {!tagsValid && (
-                <p className="slashdot-field__hint">
+                <p className={styles['slashdot-field__hint']}>
                   Provide at least one descriptive tag separated by commas.
                 </p>
               )}
@@ -421,12 +448,16 @@ function SlashdotAutoPoster({ platform }) {
               </div>
             </div>
 
-            <div className={classNames('slashdot-card', { invalid: highlightSummary })}>
-              <div className="slashdot-field__header">
+            <div
+              className={classNames(styles['slashdot-card'], {
+                [styles.invalid]: highlightSummary,
+              })}
+            >
+              <div className={styles['slashdot-field__header']}>
                 <label htmlFor="slashdot-summary">Intro / Summary *</label>
                 <span
-                  className={classNames('slashdot-field__meta', {
-                    invalid: highlightSummary || (!trimmedIntro && readyToCopy),
+                  className={classNames(styles['slashdot-field__meta'], {
+                    [styles.invalid]: highlightSummary || (!trimmedIntro && readyToCopy),
                   })}
                 >
                   {intro.trim().length} characters
@@ -436,17 +467,20 @@ function SlashdotAutoPoster({ platform }) {
                 id="slashdot-summary"
                 value={intro}
                 onChange={e => setIntro(e.target.value)}
-                className="slashdot-field__input slashdot-field__textarea"
+                className={classNames(
+                  styles['slashdot-field__input'],
+                  styles['slashdot-field__textarea'],
+                )}
                 rows={5}
                 placeholder="Craft a 3-4 sentence summary that highlights why the story matters to Slashdot readers."
               />
               {!trimmedIntro && (
-                <p className="slashdot-field__hint">
+                <p className={styles['slashdot-field__hint']}>
                   Write a 2–3 sentence overview tailored for Slashdot readers.
                 </p>
               )}
               {highlightSummary && (
-                <p className="slashdot-field__error">
+                <p className={styles['slashdot-field__error']}>
                   Slashdot requires at least {SUMMARY_MIN} characters of summary text.
                 </p>
               )}
@@ -469,10 +503,10 @@ function SlashdotAutoPoster({ platform }) {
             </div>
           </div>
 
-          <section className="slashdot-card">
-            <div className="slashdot-preview__header">
+          <section className={styles['slashdot-card']}>
+            <div className={styles['slashdot-preview__header']}>
               <h4>Submission preview</h4>
-              <div className="slashdot-preview__actions">
+              <div className={styles['slashdot-preview__actions']}>
                 <button
                   type="button"
                   style={buttonStyle('ghost', darkMode)}
@@ -497,9 +531,9 @@ function SlashdotAutoPoster({ platform }) {
                 </button>
               </div>
             </div>
-            <pre className="slashdot-preview__body">{preview}</pre>
+            <pre className={styles['slashdot-preview__body']}>{preview}</pre>
             {!readyToCopy && (
-              <p className="slashdot-preview__hint">
+              <p className={styles['slashdot-preview__hint']}>
                 Fill every required field to enable copying the complete draft. Slashdot’s form
                 mirrors this layout.
               </p>
@@ -507,19 +541,27 @@ function SlashdotAutoPoster({ platform }) {
           </section>
         </>
       ) : (
-        <section className="slashdot-card slashdot-card--scheduler">
+        <section
+          className={classNames(styles['slashdot-card'], styles['slashdot-card--scheduler'])}
+        >
           <h3>Schedule Slashdot Post</h3>
-          <p>Scheduled posts.</p>
+          <p>
+            Draft content captured from the composer. Scheduling controls will live here—edit the
+            copy below or switch back to Make Post for more changes.
+          </p>
           <label htmlFor="slashdot-schedule-content">Scheduled draft</label>
           <textarea
             id="slashdot-schedule-content"
             value={scheduledDraft}
             onChange={e => setScheduledDraft(e.target.value)}
-            className="slashdot-field__input slashdot-scheduler__textarea"
+            className={classNames(
+              styles['slashdot-field__input'],
+              styles['slashdot-scheduler__textarea'],
+            )}
             placeholder="Click “Schedule this post” in the composer to load content here."
             rows={8}
           />
-          <div className="slashdot-scheduler__actions">
+          <div className={styles['slashdot-scheduler__actions']}>
             <button
               type="button"
               style={buttonStyle('ghost', darkMode)}

--- a/src/components/Announcements/platforms/slashdot/index.jsx
+++ b/src/components/Announcements/platforms/slashdot/index.jsx
@@ -313,7 +313,7 @@ function SlashdotAutoPoster({ platform }) {
                 placeholder="https://"
               />
               {!trimmedUrl && (
-                <p className="slashdot-field__hint">Paste the canonical article or project URL.</p>
+                <p className="slashdot-field__hint">Paste an article or project URL.</p>
               )}
               {highlightUrl && (
                 <p className="slashdot-field__error">
@@ -344,11 +344,7 @@ function SlashdotAutoPoster({ platform }) {
                 className="slashdot-field__input"
                 placeholder="e.g. volunteer-tech"
               />
-              {!trimmedDept && (
-                <p className="slashdot-field__hint">
-                  Set the playful department label Slashdot shows under the headline.
-                </p>
-              )}
+              {!trimmedDept && <p className="slashdot-field__hint"> Department label. </p>}
               {highlightDept && (
                 <p className="slashdot-field__error">
                   Use a short slug-style phrase with lowercase letters and dashes.
@@ -513,10 +509,7 @@ function SlashdotAutoPoster({ platform }) {
       ) : (
         <section className="slashdot-card slashdot-card--scheduler">
           <h3>Schedule Slashdot Post</h3>
-          <p>
-            Draft content captured from the composer. Scheduling controls will live here—edit the
-            copy below or switch back to Make Post for more changes.
-          </p>
+          <p>Scheduled posts.</p>
           <label htmlFor="slashdot-schedule-content">Scheduled draft</label>
           <textarea
             id="slashdot-schedule-content"


### PR DESCRIPTION
# Description
Implements the Slashdot auto-poster workflow.
Adds a dedicated Slashdot tab in the Announcements section where volunteers can compose Slashdot submissions, copy the prepared content, and follow the correct posting steps.
Validates required fields, provides clipboard copy buttons, and updates dark-mode styling so the new UI stays readable.
Suggest tags suggests for first 6 keywords from the headline and summary fields for the words that has added as stop words. Later can be added manually to the tags section on additional tags separated with comma.
## Related PRS (if any):
None.
…

## Main changes explained:
* Create src/components/Announcements/platforms/slashdot/index.jsx for the Slashdot auto-poster form (headline/source URL/dept/tags/summary, copy buttons, preview, submit shortcut, tag suggestions).
* Update src/components/Announcements/index.jsx to route the Slashdot tab to the new component instead of the generic SocialMediaComposer.
* Extend src/components/Announcements/Announcements.css with Slashdot-specific card styling, dark-mode overrides, long-text wrapping, and chip truncation.
…

## How to test:
1. Checkout this branch.
2. yarn install then npm run start:local
3. Sign in as an admin and navigate to /announcements. (From Dashboard > Other Links > Send Emails > Slashdot)
4. Select the “Slashdot” tab.
5. Fill each field (headline 12–95 chars, valid URL, dept slug, at least one tag, 80+ char summary).
6. Click the copy buttons to ensure clipboard feedback appears; hit “Copy full draft” once inputs are valid.
7. Click “Open slashdot.org/submit” and confirm it opens in a new tab.
8. Toggle dark mode and check if UI works same for dark mode.
9. Enter very long URLs/tags/summary to verify the layout wraps without breaking cards.
10. Check if success message upon copy fields and context is copied.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/81b1d5b0-7cf4-4dc5-aec1-c4142db6141a

## Note:
Slashdot still lacks a public submission API, this UI prepares content for manual submission.
Currently scheduled post tab is just a textarea.
Dark Mode still needs to be modified for friendly and Intro / Summary width will be adjusted with extra space and moved down to other fields in next PR along with schedule post tab.