### PR TITLE
Yu Yan taking over for Ujjwal create injury chart

### DIFF
--- a/src/actions/bmdashboard/injuryActions.js
+++ b/src/actions/bmdashboard/injuryActions.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
-import { 
-  FETCH_INJURIES_REQUEST, 
-  FETCH_INJURIES_SUCCESS, 
-  FETCH_INJURIES_FAILURE 
+import {
+  FETCH_INJURIES_REQUEST,
+  FETCH_INJURIES_SUCCESS,
+  FETCH_INJURIES_FAILURE
 } from './types';
 import { ENDPOINTS } from '../../utils/URL';
 
@@ -30,6 +30,7 @@ const cleanParams = (obj = {}) => {
   }
   return out;
 };
+
 const paramsSerializer = params => {
   const usp = new URLSearchParams();
   for (const [k, v] of Object.entries(params)) {
@@ -37,6 +38,7 @@ const paramsSerializer = params => {
   }
   return usp.toString();
 };
+
 const safeData = res => (Array.isArray(res?.data) ? res.data : res?.data?.data ?? []);
 
 // Action creators
@@ -64,7 +66,10 @@ export const fetchInjuryData = (filters) => async dispatch => {
   dispatch(setInjuryDataLoading());
   try {
     const params = cleanParams(filters);
-    const res = await axios.get(ENDPOINTS.BM_INJURY_CATEGORY_BREAKDOWN, { params, paramsSerializer });
+    const res = await axios.get(ENDPOINTS.BM_INJURY_PROJECTS, {
+      params,
+      paramsSerializer,
+    });
     dispatch(setInjuryDataSuccess(safeData(res)));
   } catch (error) {
     const msg = error?.response?.data?.error || error?.message || 'Failed to fetch injury data';
@@ -93,7 +98,10 @@ export const fetchInjuryTypes = () => async dispatch => {
 export const fetchInjuryProjects = (filters) => async dispatch => {
   try {
     const params = cleanParams(filters);
-    const res = await axios.get(ENDPOINTS.BM_INJURY_PROJECTS, { params, paramsSerializer });
+    const res = await axios.get(ENDPOINTS.BM_INJURY_PROJECTS, {
+      params,
+      paramsSerializer,
+    });
     dispatch(setInjuryProjects(Array.isArray(res.data) ? res.data : []));
   } catch {
     dispatch(setInjuryProjects([]));
@@ -128,7 +136,7 @@ export const fetchInjurySeverity = (filters = {}) => {
   };
 };
 
-// Action creator for fetching injury data
+// Action creator for fetching injury data (simple list-style; not used by chart)
 export const fetchInjuries = (projectId, startDate, endDate) => async dispatch => {
   dispatch({ type: FETCH_INJURIES_REQUEST });
 
@@ -136,17 +144,20 @@ export const fetchInjuries = (projectId, startDate, endDate) => async dispatch =
     // Build query parameters
     const params = {};
     if (projectId && projectId !== 'all') {
-      params.projectId = projectId;
+      params.projectIds = projectId; // plural
     }
     if (startDate) params.startDate = startDate;
     if (endDate) params.endDate = endDate;
 
     // API call
-    const response = await axios.get(ENDPOINTS.INJURIES, { params });
+    const response = await axios.get(ENDPOINTS.BM_INJURY_PROJECTS, {
+      params,
+      paramsSerializer,
+    });
 
     dispatch({
       type: FETCH_INJURIES_SUCCESS,
-      payload: response.data
+      payload: response.data,
     });
 
     return response;
@@ -155,8 +166,8 @@ export const fetchInjuries = (projectId, startDate, endDate) => async dispatch =
       type: FETCH_INJURIES_FAILURE,
       payload: {
         message: error.response?.data?.message || 'Failed to fetch injury data',
-        status: error.response?.status
-      }
+        status: error.response?.status,
+      },
     });
 
     throw error;
@@ -168,13 +179,13 @@ export const getInjuryData = async (projectId, startDate, endDate) => {
   // Build query parameters
   const params = {};
   if (projectId && projectId !== 'all') {
-    params.projectId = projectId;
+    params.projectIds = projectId; // plural
   }
   if (startDate) params.startDate = startDate;
   if (endDate) params.endDate = endDate;
 
   // API call
-  const response = await axios.get(ENDPOINTS.INJURIES, { params });
+  const response = await axios.get(ENDPOINTS.BM_INJURY_PROJECTS, { params, paramsSerializer });
 
   // Return the data directly
   return response.data;

--- a/src/actions/bmdashboard/projectActions.js
+++ b/src/actions/bmdashboard/projectActions.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { ENDPOINTS } from '~/utils/URL';
+import { ENDPOINTS } from '../../utils/URL';
 import GET_BM_PROJECTS from '../../constants/bmdashboard/projectConstants';
 import { GET_ERRORS } from '../../constants/errors';
 

--- a/src/components/BMDashboard/InjuryChart/InjuryChartForm.jsx
+++ b/src/components/BMDashboard/InjuryChart/InjuryChartForm.jsx
@@ -89,9 +89,15 @@ function InjuryChartForm({ dark = false }) {
   }, [bmSeverities]);
 
   const departments = useMemo(() => {
-    const set = new Set();
-    for (const r of raw) if (r?.department) set.add(r.department);
-    return ['all', ...Array.from(set).sort()];
+    const seen = new Set();
+    const ordered = [];
+    for (const r of raw) {
+      if (r?.department && !seen.has(r.department)) {
+        seen.add(r.department);
+        ordered.push(r.department);
+      }
+    }
+    return ['all', ...ordered];
   }, [raw]);
 
   const chartData = useMemo(() => {

--- a/src/components/BMDashboard/InjuryChart/InjuryChartForm.jsx
+++ b/src/components/BMDashboard/InjuryChart/InjuryChartForm.jsx
@@ -1,283 +1,262 @@
-// InjuryChartForm.jsx - Form and chart display component
-import { useState, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+// InjuryChartForm.jsx — dynamic severities + severity-by-project chart
+import { useEffect, useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import axios from 'axios';
 import { FormGroup, Label, Input } from 'reactstrap';
-import DatePicker from 'react-datepicker';
-import moment from 'moment';
 import {
   BarChart,
   Bar,
-  LineChart,
-  Line,
   XAxis,
   YAxis,
-  CartesianGrid,
   Tooltip,
   Legend,
+  CartesianGrid,
   ResponsiveContainer,
 } from 'recharts';
 import { toast } from 'react-toastify';
-import { getInjuryData } from '../../../actions/bmdashboard/injuryActions';
+
+// Your app utilities
+import { ENDPOINTS } from '../../../utils/URL';
+
+// Redux thunks
 import { fetchBMProjects } from '../../../actions/bmdashboard/projectActions';
+import { fetchSeverities } from '../../../actions/bmdashboard/injuryActions';
 
-import 'react-datepicker/dist/react-datepicker.css';
-import styles from './InjuryChartForm.module.css';
+// A small color palette (cycled if there are more series than colors)
+const PALETTE = [
+  '#1f77b4',
+  '#ff7f0e',
+  '#2ca02c',
+  '#d62728',
+  '#9467bd',
+  '#8c564b',
+  '#e377c2',
+  '#7f7f7f',
+  '#bcbd22',
+  '#17becf',
+];
 
-function InjuryChartForm({ dark }) {
-  // Chart type toggle state
-  const [chartType, setChartType] = useState('line'); // 'bar' or 'line'
+function InjuryChartForm({ dark = false }) {
   const dispatch = useDispatch();
-  const bmProjects = useSelector(state => state.bmProjects || []);
-  // Form state
-  const [projectId, setProjectId] = useState('all');
-  const [startDate, setStartDate] = useState(
-    moment()
-      .subtract(6, 'months')
-      .toDate(),
-  );
-  const [endDate, setEndDate] = useState(new Date());
 
-  // Chart state
-  const [chartData, setChartData] = useState([]);
+  // Redux state
+  const bmProjects = useSelector(s => s.bmProjects || []); // [{ _id, name }]
+  const bmSeverities = useSelector(s => s.bmInjurySeverities || []); // ['Critical','Low',...]
+
+  // Local state
+  const [raw, setRaw] = useState([]); // rows from /bm/injuries/severity-by-project
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  // Load projects on mount
+  // Filters
+  const [projectId, setProjectId] = useState('all');
+  const [department, setDepartment] = useState('all');
+
+  // Chart mode
+  const [stacked, setStacked] = useState(true);
+
+  // 1) Load projects + severities (from API via Redux)
   useEffect(() => {
-    dispatch(fetchBMProjects()).catch(err => {
-      toast.error(`Failed to load projects: ${err.message}`);
-    });
+    dispatch(fetchBMProjects());
+    dispatch(fetchSeverities());
   }, [dispatch]);
 
-  // Transform API data to chart format
-  const transformData = data => {
-    if (!data || !data.months || !Array.isArray(data.months)) {
-      return [];
-    }
-
-    const transformed = data.months.map((month, index) => ({
-      month,
-      Serious: Number(data.serious?.[index]) || 0,
-      Medium: Number(data.medium?.[index]) || 0,
-      Low: Number(data.low?.[index]) || 0,
-    }));
-
-    return transformed;
-  };
-
-  // Fetch injury data
-  const fetchData = async () => {
-    setLoading(true);
-    setError('');
-
-    try {
-      const formattedStartDate = moment(startDate).format('YYYY-MM-DD');
-      const formattedEndDate = moment(endDate).format('YYYY-MM-DD');
-
-      const response = await getInjuryData(projectId, formattedStartDate, formattedEndDate);
-      const transformedData = transformData(response);
-      setChartData(transformedData);
-    } catch (err) {
-      setError(err.message);
-      toast.error(`Error: ${err.message}`);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Fetch data when filters change
+  // 2) Fetch severity-by-project (directly here)
   useEffect(() => {
-    fetchData();
-  }, [projectId, startDate, endDate]);
+    const run = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const res = await axios.get(ENDPOINTS.BM_INJURY_SEVERITY);
+        const data = Array.isArray(res.data) ? res.data : [];
+        // Debug: inspect the API rows
+        console.log('Raw severity-by-project:', data);
+        setRaw(data);
+      } catch (e) {
+        const msg = e?.response?.data?.error || e?.message || 'Failed to fetch chart data';
+        setError(msg);
+        toast.error(msg);
+      } finally {
+        setLoading(false);
+      }
+    };
+    run();
+  }, []);
 
-  // Handle project change
-  const handleProjectChange = e => {
-    setProjectId(e.target.value);
-  };
+  // 3) Map of projectId -> display name (prefer Redux list)
+  const projectNameById = useMemo(() => {
+    const m = new Map();
+    for (const p of bmProjects) {
+      if (p?._id) m.set(p._id, p?.name ?? '');
+    }
+    return m;
+  }, [bmProjects]);
 
-  // Handle date changes
-  const handleStartDateChange = date => {
-    setStartDate(date);
-  };
+  // 4) Dynamic severities list (no hardcoding). Fallback if API empty.
+  const SEVERITIES = useMemo(() => {
+    if (!bmSeverities?.length) {
+      return ['Critical', 'Major', 'Medium', 'Minor', 'Serious', 'Low']; // graceful fallback
+    }
+    // API may return strings or objects. Normalize to strings.
+    return bmSeverities.map(s => (typeof s === 'string' ? s : s?.name)).filter(Boolean);
+  }, [bmSeverities]);
 
-  const handleEndDateChange = date => {
-    setEndDate(date);
-  };
+  // 5) Departments list for filter
+  const departments = useMemo(() => {
+    const set = new Set();
+    for (const r of raw) if (r?.department) set.add(r.department);
+    return ['all', ...Array.from(set).sort()];
+  }, [raw]);
 
-  // Render loading state
+  // 6) Transform rows -> Recharts data [{project, <severity1>, <severity2>, ..., total}]
+  const chartData = useMemo(() => {
+    if (!raw.length) return [];
+
+    // Apply filters
+    const filtered = raw.filter(r => {
+      const okProject = projectId === 'all' ? true : r.projectId === projectId;
+      const okDept = department === 'all' ? true : r.department === department;
+      return okProject && okDept;
+    });
+
+    // Group by project (using Redux name if available)
+    const byProject = new Map();
+    for (const row of filtered) {
+      const label =
+        projectNameById.get(row.projectId) || row.projectName || row.projectId || 'Unknown Project';
+
+      if (!byProject.has(label)) {
+        const base = { project: label, total: 0 };
+        for (const s of SEVERITIES) base[s] = 0;
+        byProject.set(label, base);
+      }
+
+      const bucket = byProject.get(label);
+      const sev = SEVERITIES.includes(row.severity)
+        ? row.severity
+        : SEVERITIES[SEVERITIES.length - 1];
+      const val = Number(row.totalInjuries) || 0;
+      bucket[sev] += val;
+      bucket.total += val;
+    }
+
+    // Sort alphabetically by project (or change to total desc if desired)
+    return Array.from(byProject.values()).sort((a, b) => a.project.localeCompare(b.project));
+  }, [raw, projectId, department, projectNameById, SEVERITIES]);
+
+  // 7) Rendering
+  const containerClass = `p-4 rounded shadow-sm ${dark ? 'bg-dark text-light' : 'bg-white'}`;
+
   if (loading) {
     return (
       <div className="text-center p-5">
-        <div className="spinner-border text-primary" role="status">
-          <span className="visually-hidden" />
-        </div>
+        <div className="spinner-border" role="status" />
       </div>
     );
   }
 
   return (
-    <div className={`${styles.injuryChartContainer} p-4`}>
-      {/* Filter Form */}
+    <div className="p-3">
+      {/* Filters */}
       <div
-        className={`${styles.filterForm} mb-4 p-3  ${
-          dark ? styles.wrapperDark : 'bg-white'
-        } rounded shadow-sm`}
+        className={`mb-4 p-3 rounded shadow-sm ${dark ? 'bg-secondary text-light' : 'bg-white'}`}
       >
-        <div className="row g-3">
-          <div className="col-md-4">
+        <div className="row g-3 align-items-end">
+          <div className="col-md-5">
             <FormGroup>
-              <Label for="project" className={dark ? styles.wrapperDark : ''}>
-                Project
-              </Label>
-              <Input id="project" type="select" value={projectId} onChange={handleProjectChange}>
+              <Label htmlFor="projectSel">Project</Label>
+              <Input
+                id="projectSel"
+                type="select"
+                value={projectId}
+                onChange={e => setProjectId(e.target.value)}
+              >
                 <option value="all">All Projects</option>
-                {bmProjects.map(project => (
-                  <option key={project._id} value={project._id}>
-                    {project.name}
+                {bmProjects.map(p => (
+                  <option key={p._id} value={p._id}>
+                    {p.name}
                   </option>
                 ))}
               </Input>
             </FormGroup>
           </div>
 
-          <div className="ol-md-4">
+          <div className="col-md-5">
             <FormGroup>
-              <Label className={dark ? styles.wrapperDark : ''}>Start Date</Label>
-              <DatePicker
-                selected={startDate}
-                onChange={handleStartDateChange}
-                selectsStart
-                startDate={startDate}
-                endDate={endDate}
-                className="form-control"
-                dateFormat="yyyy-MM-dd"
-              />
+              <Label htmlFor="deptSel">Department</Label>
+              <Input
+                id="deptSel"
+                type="select"
+                value={department}
+                onChange={e => setDepartment(e.target.value)}
+              >
+                {departments.map(d => (
+                  <option key={d} value={d}>
+                    {d === 'all' ? 'All Departments' : d}
+                  </option>
+                ))}
+              </Input>
             </FormGroup>
           </div>
 
-          <div className="col-md-4">
-            <FormGroup>
-              <Label className={dark ? styles.wrapperDark : ''}>End Date</Label>
-              <DatePicker
-                selected={endDate}
-                onChange={handleEndDateChange}
-                selectsEnd
-                startDate={startDate}
-                endDate={endDate}
-                minDate={startDate}
-                className="form-control"
-                dateFormat="yyyy-MM-dd"
+          <div className="col-md-2 d-flex align-items-center">
+            <div className="form-check">
+              <Input
+                id="stackedBars"
+                className="form-check-input"
+                type="checkbox"
+                checked={stacked}
+                onChange={e => setStacked(e.target.checked)}
               />
-            </FormGroup>
+              <Label className="form-check-label" htmlFor="stackedBars">
+                Stacked
+              </Label>
+            </div>
           </div>
         </div>
       </div>
 
-      {/* Error Display */}
+      {/* Error */}
       {error && (
         <div className="alert alert-danger" role="alert">
           {error}
         </div>
       )}
 
-      {/* Chart Display with Toggle */}
-      {!error && chartData && chartData.length > 0 && (
-        <div
-          className={`${styles.injuryChartContainer} ${
-            dark ? styles.wrapperDark : 'bg-white'
-          } p-4 rounded shadow-sm`}
-        >
-          <div className="d-flex justify-content-end mb-2">
-            <button
-              className={`btn btn-sm ${
-                chartType === 'line'
-                  ? `btn-primary ${styles.toggleBtnSpace}`
-                  : 'btn-outline-primary'
-              }`}
-              onClick={() => setChartType('line')}
-              aria-pressed={chartType === 'line'}
-            >
-              Line Chart
-            </button>
-            <button
-              className={`btn btn-sm ${
-                chartType === 'bar' ? `btn-primary ${styles.toggleBtnSpace}` : 'btn-outline-primary'
-              }`}
-              onClick={() => setChartType('bar')}
-              aria-pressed={chartType === 'bar'}
-            >
-              Bar Chart
-            </button>
-          </div>
+      {/* Chart */}
+      {!error && chartData.length > 0 && (
+        <div className={containerClass}>
+          <h5 className="text-center mb-3">Injuries by Severity per Project</h5>
+          <ResponsiveContainer width="100%" height={420}>
+            <BarChart data={chartData} margin={{ top: 10, right: 24, left: 0, bottom: 32 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="project" interval={0} angle={-20} textAnchor="end" height={60} />
+              <YAxis allowDecimals={false} />
+              <Tooltip />
+              <Legend verticalAlign="top" height={36} />
 
-          <h3 className="text-center mb-4">Injury Trends Over Time</h3>
-          <ResponsiveContainer width="100%" height={400}>
-            {chartType === 'bar' ? (
-              <BarChart data={chartData} margin={{ top: 10, right: 30, left: 10, bottom: 30 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#eee" />
-                <XAxis
-                  dataKey="month"
-                  padding={{ left: 20, right: 20 }}
-                  label={{ value: 'Month', position: 'insideBottom', offset: -10 }}
+              {SEVERITIES.map((sev, idx) => (
+                <Bar
+                  key={sev}
+                  dataKey={sev}
+                  name={sev}
+                  fill={PALETTE[idx % PALETTE.length]}
+                  stackId={stacked ? 'stack' : undefined}
                 />
-                <YAxis
-                  allowDecimals={false}
-                  label={{ value: 'Number of Injuries', angle: -90, position: 'insideLeft' }}
-                />
-                <Tooltip />
-                <Legend verticalAlign="top" align="center" />
-                <Bar dataKey="Serious" fill="#dc3545" name="Serious" barSize={20} />
-                <Bar dataKey="Medium" fill="#fd7e14" name="Medium" barSize={20} />
-                <Bar dataKey="Low" fill="#198754" name="Low" barSize={20} />
-              </BarChart>
-            ) : (
-              <LineChart data={chartData} margin={{ top: 10, right: 30, left: 10, bottom: 30 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#eee" />
-                <XAxis
-                  dataKey="month"
-                  padding={{ left: 20, right: 20 }}
-                  label={{ value: 'Month', position: 'insideBottom', offset: -10 }}
-                />
-                <YAxis
-                  allowDecimals={false}
-                  label={{ value: 'Number of Injuries', angle: -90, position: 'insideLeft' }}
-                />
-                <Tooltip />
-                <Legend verticalAlign="top" align="center" />
-                <Line
-                  type="monotone"
-                  dataKey="Serious"
-                  stroke="#dc3545"
-                  strokeWidth={2}
-                  dot={{ r: 4 }}
-                  activeDot={{ r: 6 }}
-                />
-                <Line
-                  type="monotone"
-                  dataKey="Medium"
-                  stroke="#fd7e14"
-                  strokeWidth={2}
-                  dot={{ r: 4 }}
-                  activeDot={{ r: 6 }}
-                />
-                <Line
-                  type="monotone"
-                  dataKey="Low"
-                  stroke="#198754"
-                  strokeWidth={2}
-                  dot={{ r: 4 }}
-                  activeDot={{ r: 6 }}
-                />
-              </LineChart>
-            )}
+              ))}
+            </BarChart>
           </ResponsiveContainer>
         </div>
       )}
 
-      {/* No Data Display */}
-      {!error && !loading && (!chartData || chartData.length === 0) && (
-        <div className="text-center p-5 bg-white rounded shadow-sm">
-          <p className="text-muted">No injury data available for the selected criteria.</p>
+      {/* No data */}
+      {!error && chartData.length === 0 && (
+        <div
+          className={`text-center p-5 rounded shadow-sm ${
+            dark ? 'bg-secondary text-light' : 'bg-white'
+          }`}
+        >
+          <p className="mb-0">No injury data available for the selected criteria.</p>
         </div>
       )}
     </div>

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -185,17 +185,6 @@ const TeamMemberTask = React.memo(
       setSelectedTaskForChangeLog(null);
     };
 
-    /** 
-    const handleReportClick = (event, to) => {
-      if (event.metaKey || event.ctrlKey || event.button === 1) {
-        return;
-      }
-
-      event.preventDefault(); // prevent full reload
-      history.push(`/peoplereport/${to}`);
-    };
-    */
-
     const openDetailModal = request => {
       dispatch(showTimeOffRequestModal(request));
     };

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -295,12 +295,14 @@ POPULARITY_ROLES: `${APIEndpoint}/popularity/roles`,
   BM_ISSUE_CHART: `${APIEndpoint}/bm/issue/issue-chart`,
 
   BM_ISSUE_FORM: `${APIEndpoint}/bm/issue/add`,
+
   BM_INJURY_CATEGORY_BREAKDOWN: `${APIEndpoint}/bm/injuries/category-breakdown`,
   BM_INJURY_SEVERITIES: `${APIEndpoint}/bm/injuries/injury-severities`,
   BM_INJURY_TYPES: `${APIEndpoint}/bm/injuries/injury-types`,
   BM_INJURY_PROJECTS: `${APIEndpoint}/bm/injuries/project-injury`,
   BM_INJURY_ISSUE: `${APIEndpoint}/bm/issues`,
   BM_INJURY_SEVERITY: `${APIEndpoint}/bm/injuries/severity-by-project`,
+  
   BM_RENTAL_CHART: `${APIEndpoint}/bm/rentalChart`,
   TOOLS_AVAILABILITY_PROJECTS: `${APIEndpoint}/bm/tools-availability/projects`,
   TOOLS_AVAILABILITY_BY_PROJECT: (projectId, startDate, endDate) => {


### PR DESCRIPTION
# Description

The InjuryChart graph wasn’t viewable because the frontend wasn’t correctly reading or structuring the injury data from the backend. I recreated the component to properly fetch and transform the API responses, dynamically load severity levels from the /injuries/ endpoints, and render the data as a grouped or stacked bar chart with project and department filters.

Priority Medium

## Related PRS (if any):
Reference Previous PRs - FE-#4082 + BE-[#1468](https://github.com/OneCommunityGlobal/HGNRest/pull/1468) (closed) --> New Merged BE PR is this one: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2347

## Main changes explained:
- Recreated the InjuryChartForm.jsx to accurately show the backend data.
- Added functional project and department filters, a grouped/stacked view toggle
- Fixed smaller issues in InjuryActions, URL.js and projectActions.js

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to http://localhost:5173/bmdashboard/injurychart
6. verify if the chart is visible and works 
7. crosscheck with postman
<img width="461" height="547" alt="image" src="https://github.com/user-attachments/assets/57450bf3-3209-4970-a874-c4ad23dbe482" />
<img width="648" height="131" alt="image" src="https://github.com/user-attachments/assets/34e9adac-7526-498e-9ac2-d6cbffb83bc1" />


## Screenshots or videos of changes:

<img width="1292" height="727" alt="image" src="https://github.com/user-attachments/assets/048c082b-2599-4a82-aa41-471b19c4878d" />

