### PR TITLE
Mani shashank fix stacked horizontal bar graph for tools stoppage reason

### DIFF
--- a/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.jsx
+++ b/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.jsx
@@ -116,16 +116,18 @@ const handleFirstProjectSelection = async (
 };
 
 // Helper function to handle data fetching logic
-const handleDataFetching = async (
-  selectedProject,
-  projects,
-  startDate,
-  endDate,
-  setSelectedProject,
-  setData,
-  setError,
-  emptyData,
-) => {
+const handleDataFetching = async params => {
+  const {
+    selectedProject,
+    projects,
+    startDate,
+    endDate,
+    setSelectedProject,
+    setData,
+    setError,
+    emptyData,
+  } = params;
+
   if (selectedProject) {
     await handleSelectedProjectData(
       selectedProject,
@@ -286,7 +288,7 @@ export default function ToolsStoppageHorizontalBarChart() {
       setError(null);
 
       try {
-        await handleDataFetching(
+        await handleDataFetching({
           selectedProject,
           projects,
           startDate,
@@ -295,7 +297,7 @@ export default function ToolsStoppageHorizontalBarChart() {
           setData,
           setError,
           emptyData,
-        );
+        });
       } catch (err) {
         setData(emptyData);
         setError('Failed to load tools stoppage reason data. Please try again.');

--- a/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.jsx
+++ b/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.jsx
@@ -15,8 +15,8 @@ import {
 } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { Bar } from 'react-chartjs-2';
-import axios from 'axios';
 import { ENDPOINTS } from '../../../utils/URL';
+import httpService from '../../../services/httpService';
 import styles from './ToolsStoppageHorizontalBarChart.module.css';
 
 // Register Chart.js components
@@ -67,7 +67,7 @@ const processResponseData = responseData => {
 // Helper function to fetch stoppage data for a project
 const fetchStoppageDataForProject = async (projectId, startDate, endDate) => {
   const url = ENDPOINTS.BM_TOOLS_STOPPAGE_BY_PROJECT(projectId, startDate, endDate);
-  const response = await axios.get(url);
+  const response = await httpService.get(url);
   return processResponseData(response.data);
 };
 
@@ -270,7 +270,7 @@ export default function ToolsStoppageHorizontalBarChart() {
       setLoading(true);
       setError(null);
       try {
-        const response = await axios.get(ENDPOINTS.BM_TOOL_PROJECTS);
+        const response = await httpService.get(ENDPOINTS.BM_TOOL_PROJECTS);
         setProjects(response.data);
       } catch (err) {
         setError('Failed to load projects. Please try again.');

--- a/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.jsx
+++ b/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.jsx
@@ -329,6 +329,10 @@ export default function ToolsStoppageHorizontalBarChart() {
       ...base,
       backgroundColor: '#2c3344',
     }),
+    menuList: base => ({
+      ...base,
+      backgroundColor: '#2c3344',
+    }),
     option: (base, state) => ({
       ...base,
       backgroundColor: state.isFocused ? '#364156' : '#2c3344',
@@ -342,6 +346,19 @@ export default function ToolsStoppageHorizontalBarChart() {
       ...base,
       color: '#aaaaaa',
     }),
+    input: base => ({
+      ...base,
+      color: '#e0e0e0',
+    }),
+    dropdownIndicator: base => ({
+      ...base,
+      color: '#aaaaaa',
+      ':hover': { color: '#e0e0e0' },
+    }),
+    indicatorSeparator: base => ({
+      ...base,
+      backgroundColor: '#364156',
+    }),
   };
 
   // ✅ Prepare Chart.js data
@@ -351,7 +368,7 @@ export default function ToolsStoppageHorizontalBarChart() {
   const chartOptions = getChartOptions(darkMode);
 
   return (
-    <div className={`tools-availability-page ${darkMode ? 'dark-mode' : ''}`}>
+    <div className={`tools-availability-page ${darkMode ? 'dark-mode darkTheme' : ''}`}>
       <h3 className={`tools-chart-title ${darkMode ? 'dark-mode' : ''}`}>
         Reason of Stoppage of Tools
       </h3>
@@ -366,7 +383,7 @@ export default function ToolsStoppageHorizontalBarChart() {
                 setDateRange(update);
               }}
               placeholderText={dateRangeLabel || 'Filter by Date Range'}
-              className={`${styles.datePickerInput} form-control ${darkMode ? 'darkTheme' : ''}`}
+              className={`${styles.datePickerInput} form-control`}
               calendarClassName={darkMode ? 'darkThemeCalendar' : 'customCalendar'}
             />
             <Button

--- a/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.module.css
+++ b/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.module.css
@@ -11,13 +11,19 @@
   color: #000 !important;
 }
 
-:global(.datePickerInput) {
+.datepickerWrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.datePickerInput {
   font-size: 10px !important;
   padding: 6px 8px;
   border-radius: 4px;
 }
 
-:global(.darkTheme .form-control .datePickerInput) {
+:global(.darkTheme) .datePickerInput {
   background-color: #2b3e59 !important;
   color: #fff !important;
   border: 1px solid #666 !important;
@@ -95,15 +101,27 @@
   background-color: #007bff!important;
 }
 
+/* Title styling */
+:global(.tools-chart-title) {
+  font-size: 1.5rem !important;
+  color: #333 !important;
+  font-weight: 600 !important;
+  margin-bottom: 1rem !important;
+}
+
+:global(.dark-mode .tools-chart-title) {
+  color: #e0e0e0 !important;
+}
+
 /* Filter controls layout for small screens */
 @media (max-width: 768px) {
-  :global(.datepickerWrapper) {
+  .datepickerWrapper {
     display: flex;
     flex-direction: column;
     align-items: stretch;
   }
 
-  :global(.datepickerWrapper .btn) {
+  .datepickerWrapper .btn {
     margin-top: 8px;
     width: 100%;
   }

--- a/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.module.css
+++ b/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.module.css
@@ -100,10 +100,18 @@
 
 /* Dark mode for multi select*/
 :global(.darkTheme .customSelect__control) {
-  background-color: #fff!important;
-  color: #000!important;
-  border-color: #ccc!important;
+  background-color: #2b3e59!important;
+  color: #e0e0e0!important;
+  border-color: #666!important;
   font-size: 10px!important;
+}
+
+:global(.darkTheme .customSelect__single-value) {
+  color: #e0e0e0!important;
+}
+
+:global(.darkTheme .customSelect__placeholder) {
+  color: #aaaaaa!important;
 }
 
 :global(.darkTheme .customSelect__menu) {

--- a/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.module.css
+++ b/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.module.css
@@ -1,3 +1,27 @@
+/* Light mode calendar override (counters dark globals from RentalChart.css) */
+:global(.customCalendar) {
+  background-color: #fff !important;
+  color: #000 !important;
+  border: 1px solid #aeaeae !important;
+}
+
+:global(.customCalendar .react-datepicker__header) {
+  background-color: #f0f0f0 !important;
+  border-bottom: 1px solid #aeaeae !important;
+}
+
+:global(.customCalendar .react-datepicker__current-month),
+:global(.customCalendar .react-datepicker__day-name),
+:global(.customCalendar .react-datepicker__day),
+:global(.customCalendar .react-datepicker__month-text),
+:global(.customCalendar .react-datepicker__year-text) {
+  color: #000 !important;
+}
+
+:global(.customCalendar .react-datepicker__navigation-icon::before) {
+  border-color: #000 !important;
+}
+
 /* Light mode for multi select*/
 :global(.customSelect__control) {
   background-color: #fff !important;
@@ -34,10 +58,10 @@
   background-color: #7d7e7f !important;
 }
 
-/* Hover day styling in dark theme */
+/* Hover day styling in light mode */
 :global(.customCalendar .react-datepicker__day:hover) {
-  background-color: #3b5a81 !important;
-  color: #fff !important;
+  background-color: #f0f0f0 !important;
+  color: #000 !important;
   border-radius: 50%;
 }
 

--- a/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.module.css
+++ b/src/components/BMDashboard/Tools/ToolsStoppageHorizontalBarChart.module.css
@@ -133,6 +133,21 @@
   background-color: #007bff!important;
 }
 
+/* Empty state */
+:global(.tools-chart-empty) {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 2rem 0;
+  color: #333;
+}
+
+:global(.darkTheme .tools-chart-empty),
+:global(.dark-mode .tools-chart-empty) {
+  color: #e0e0e0;
+}
+
 /* Title styling */
 :global(.tools-chart-title) {
   font-size: 1.5rem !important;


### PR DESCRIPTION
# Description
(PRIORITY HIGH) JAE/JAIWANTH/VARSHA: Phase 2 Summary Dashboard: Create a stacked horizontal bar graph titled reason of stoppage of tools
- X-axis should be the percentage of tools. Y-axis is the tool name.
- Turn on stacking so that all data for a tool is in one row.
- Have different colours for each of 3 categories: Used for its lifetime, Damaged and Lost
- Include two filters: A Project filter to view data for a specific project. A Date filter to select a custom date range.
- Turn data labels on so that values for all 3 categories are visible for all tools.


## Related PRS (if any):
This frontend PR is related to the [#1896 ](https://github.com/OneCommunityGlobal/HGNRest/pull/1896)backend PR.

## Main changes explained:
- Add backend API controller for tools stoppage data aggregation
- Implement MongoDB aggregation pipeline for percentage calculations
- Create React component with Chart.js for horizontal stacked bars
- Add project and date range filtering functionality
- Include proper color coding and data labels
- Support dark mode and responsive design

## How to test:
1. check into current branch
2. do npm install and npm run start:local to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ Total Construction Summary→ Tools and Equipment Tracking Card
6. verify the Reason of Stoppage of Tools graph is visible and the values are in %.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/2b3bfd04-76bc-4187-b533-8bc195877168

