### PR TITLE
Amaan taking over for Peterson fixed the filter not finding users due to inner spaces.

### DIFF
--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -370,26 +370,22 @@ class UserManagement extends React.PureComponent {
       const trimmedFirstNameSearch = firstNameSearch.trim();
       const trimmedLastNameSearch = lastNameSearch.trim();
 
-      const isFirstNameExactMatch =
-        firstNameSearch.endsWith(' ') && trimmedFirstNameSearch.length > 0;
-      const isLastNameExactMatch = lastNameSearch.endsWith(' ') && trimmedLastNameSearch.length > 0;
+      // Remove whitespace from both stored names and search input so typed spaces do not change name matching.
+      const normalizedFirstName = firstName.replaceAll(/\s+/g, '');
+      const normalizedFirstNameSearch = trimmedFirstNameSearch.toLowerCase().replaceAll(/\s+/g, '');
+      const normalizedLastName = lastName.replaceAll(/\s+/g, '');
+      const normalizedLastNameSearch = trimmedLastNameSearch.toLowerCase().replaceAll(/\s+/g, '');
 
       let firstNameMatches = true;
       if (trimmedFirstNameSearch) {
-        if (isFirstNameExactMatch) {
-          firstNameMatches = firstName === trimmedFirstNameSearch.toLowerCase();
-        } else {
-          firstNameMatches = firstName.includes(trimmedFirstNameSearch.toLowerCase());
-        }
+        // Name column filters intentionally use includes() so whitespace-normalized partial searches still work.
+        firstNameMatches = normalizedFirstName.includes(normalizedFirstNameSearch);
       }
 
       let lastNameMatches = true;
       if (trimmedLastNameSearch) {
-        if (isLastNameExactMatch) {
-          lastNameMatches = lastName === trimmedLastNameSearch.toLowerCase().replaceAll(/\s+/g, '').trim();
-        } else {
-          lastNameMatches = lastName.includes(trimmedLastNameSearch.toLowerCase().replaceAll(/\s+/g, '').trim());
-        }
+        // Name column filters intentionally use includes() so whitespace-normalized partial searches still work.
+        lastNameMatches = normalizedLastName.includes(normalizedLastNameSearch);
       }
 
       let wildcardMatches = true;

--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -386,9 +386,9 @@ class UserManagement extends React.PureComponent {
       let lastNameMatches = true;
       if (trimmedLastNameSearch) {
         if (isLastNameExactMatch) {
-          lastNameMatches = lastName === trimmedLastNameSearch.toLowerCase();
+          lastNameMatches = lastName === trimmedLastNameSearch.toLowerCase().replace(/\s+/g, '').trim();
         } else {
-          lastNameMatches = lastName.includes(trimmedLastNameSearch.toLowerCase());
+          lastNameMatches = lastName.includes(trimmedLastNameSearch.toLowerCase().replace(/\s+/g, '').trim());
         }
       }
 

--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -386,9 +386,9 @@ class UserManagement extends React.PureComponent {
       let lastNameMatches = true;
       if (trimmedLastNameSearch) {
         if (isLastNameExactMatch) {
-          lastNameMatches = lastName === trimmedLastNameSearch.toLowerCase().replace(/\s+/g, '').trim();
+          lastNameMatches = lastName === trimmedLastNameSearch.toLowerCase().replaceAll(/\s+/g, '').trim();
         } else {
-          lastNameMatches = lastName.includes(trimmedLastNameSearch.toLowerCase().replace(/\s+/g, '').trim());
+          lastNameMatches = lastName.includes(trimmedLastNameSearch.toLowerCase().replaceAll(/\s+/g, '').trim());
         }
       }
 


### PR DESCRIPTION
# Description
This PR was opened to fix the bug that prevents the filter input from working when the typed text contains spaces.

## Related PRS (if any):
None.

## Main changes explained:
The UserManagement.jsx component has been modified to fix the bug.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an admin or owner user
5. Go to Other Links → User Management
6. Type in the filter located in the “Last Name” column and insert a space in the middle of the text. Even so, the table should display the users that match the text entered in the input.

## Screenshots or videos of changes:
### Before my fix:
https://github.com/user-attachments/assets/b58df256-cd41-47d5-9fe8-a92cfbfa4c74

### After my fix
https://github.com/user-attachments/assets/e451aae8-a27a-4c16-af33-28a4e0a7acaa

## Note:
None.