### PR TITLE
Chirag linked projects filters fix

### DIFF
--- a/src/components/BMDashboard/Issues/issueChart.module.css
+++ b/src/components/BMDashboard/Issues/issueChart.module.css
@@ -1,28 +1,151 @@
-/* issueChart.module.css */
+:global(.loiSelectDark__control) {
+  background-color: #1e293b !important;
+  border: 1px solid #334155 !important;
+  border-radius: 8px !important;
+}
+
+:global(.loiSelectDark__menu) {
+  background-color: #1e293b !important;
+}
+
+:global(.loiSelectDark__multi-value),
+:global(.loiSelectDark__multi-value__label),
+:global(.loiSelectDark__option--is-focused) {
+  background-color: #334155 !important;
+  color: #fff !important;
+}
+
+
+:global(.loiSelect__control) {
+  background-color: #fff !important;
+  border: 1px solid #334155 !important;
+  border-radius: 8px !important;
+}
+
+:global(.loiSelect__menu) {
+  background-color: #fff !important;
+}
+
+:global(.loiSelect__multi-value),
+:global(.loiSelect__option--is-focused) {
+  background-color: #ccd1dc !important;
+}
+
+:global(.react-datepicker__month-container){
+  padding: 10px;
+}
+
+.darkDatePicker :global(.react-datepicker__month-container),
+.darkDatePicker :global(.react-datepicker__header),
+.darkDatePicker :global(.react-datepicker__day-name), 
+.darkDatePicker :global(.react-datepicker__current-month), 
+.darkDatePicker :global(.react-datepicker__day),
+.darkDatePicker :global(.react-datepicker__month-text),
+.darkDatePicker :global(.react-datepicker__year-text){
+  background-color: #1e293b !important;
+  color: #fff !important;
+}
+
+.darkDatePicker :global(.react-datepicker__day:hover),
+.darkDatePicker :global(.react-datepicker__month-text:hover),
+.darkDatePicker :global(.react-datepicker__year-text:hover) {
+  background-color: #334155 !important;
+}
+
+:global(.react-datepicker__month-container),
+:global(.react-datepicker__header),
+:global(.react-datepicker__day-name), 
+:global(.react-datepicker__current-month), 
+:global(.react-datepicker__day),
+:global(.react-datepicker__month-text),
+:global(.react-datepicker__year-text){
+  background-color: #f0f0f0 !important;
+  color: #1e293b !important;
+}
+
+:global(.react-datepicker__day:hover),
+:global(.react-datepicker__month-text:hover),
+:global(.react-datepicker__year-text:hover) {
+  background-color: #ccd1dc !important;
+}
+
+:global(.react-datepicker__day.react-datepicker__day--selected){
+  background-color: #007bff !important;
+}
+
+:global(.react-datepicker__day.react-datepicker__day--today) {
+  text-decoration: underline !important;
+}
 
 .issueChartEventContainer {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 20px;
-  background: #f9f9f9;
+  max-width: 1000px;
+  padding: 32px;
   border-radius: 8px;
-  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 .issueChartEventContainerDark {
-  background: #121212;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.9);
+  background: #2B3E59;
   color: #ccd1dc;
 }
 
 .issueChartEventTitle {
   text-align: center;
   font-size: 24px;
-  color: #333;
+  color: var(--text-color);
 }
 
 .issueChartEventTitleDark {
   color: #fff;
+}
+
+.dateRangePicker {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.rangeSeparator {
+  font-size: 14px;
+  opacity: 0.7;
+  color: #94a3b8;
+}
+
+.filtersContainer{
+  display: flex;
+  padding: 25px 0px;
+  gap: 15px;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.filter {
+    flex: 1;
+    min-width: 280px;
+}
+
+.filter label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 14px;
+  color: var(--text-color);
+}
+
+.filterSelect {
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 14px;
+  color: var(--text-color);
+}
+
+.filterSelectDark{
+  background: #1E293B;
+  border: 1px solid #334155;
+}
+
+.multiSelect{
+  width: 100%;
+  font-size: 14px;
+  color: var(--text-color);
 }
 
 .chartWrapper {
@@ -33,18 +156,58 @@
 }
 
 .chartWrapperDark {
-  background: #1e1e1e;
   box-shadow: 0 0 15px rgba(0,0,0,0.9);
   color: #ccd1dc;
 }
 
+.chartContainer {
+  width: 100%;
+  height: 400px;
+  border-radius: 8px;
+  background-color: var(--card-bg) !important;
+  color: var(--text-color) !important;
+}
+
+.chartContainerDark {
+  background-color: var(--card-bg) !important;
+  color: var(--text-color) !important;
+}
+
+.noDataMessage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  color: #666;
+}
+
+.noDataMessageDark {
+  background: #22272D;
+  color: #999;
+}
+
+.noDataContent {
+  text-align: center;
+  padding: 40px 20px;
+  max-width: 400px;
+}
+
 .issueChartLabel {
   font-size: 16px;
-  color: #555;
+  color: var(--text-color) !important;
 }
 
 .issueChartLabelDark {
-  color: #fff;
+  color: var(--text-color) !important;
+}
+
+.rechartsLabel{
+  color: #232323
+}
+
+.rechartsLabelDark{
+  color: #fff
 }
 
 .issueChartSelect {

--- a/src/components/BMDashboard/Issues/openIssueCharts.jsx
+++ b/src/components/BMDashboard/Issues/openIssueCharts.jsx
@@ -18,15 +18,15 @@ import {
   fetchLongestOpenIssues,
   setProjectFilter,
 } from '../../../actions/bmdashboard/issueChartActions';
-import './issueCharts.css';
+import styles from './issueChart.module.css';
 
 function IssueCharts() {
   const dispatch = useDispatch();
   const { issues, loading, error, selectedProjects } = useSelector(state => state.bmissuechart);
   const projects = useSelector(state => state.bmProjects);
   const darkMode = useSelector(state => state.theme.darkMode);
-  const [startDate, setStartDate] = useState(null);
-  const [endDate, setEndDate] = useState(null);
+  const [startDate, setStartDate] = useState();
+  const [endDate, setEndDate] = useState();
   const chartContainerRef = useRef(null);
   const [containerWidth, setContainerWidth] = useState(window.innerWidth);
 
@@ -58,7 +58,7 @@ function IssueCharts() {
       }
     }
     window.addEventListener('resize', handleResize);
-    handleResize(); // Initial set
+    handleResize();
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
@@ -88,16 +88,63 @@ function IssueCharts() {
   if (error) return <div>Error: {error}</div>;
 
   return (
-    <div className={`issue-chart-container ${darkMode ? 'dark' : ''}`}>
-      <h2>Longest Open Issues</h2>
+    <div
+      className={`${styles.issueChartEventContainer} ${
+        darkMode ? styles.issueChartEventContainerDark : ''
+      }`}
+    >
+      <h2
+        className={`${styles.issueChartEventTitle} ${
+          darkMode ? styles.issueChartEventTitleDark : ''
+        }`}
+      >
+        Longest Open Issues
+      </h2>
 
-      <div className="filters-container">
-        <div className="filter">
-          <label className="issue-chart-label" htmlFor="start-date">
-            Date Range:
-          </label>
-          <div className="date-range-picker">
+      <div className={`${styles.filtersContainer}`}>
+        <div className={`${styles.filter}`}>
+          <label htmlFor="start-date">Date Range:</label>
+
+          <div className={`${styles.dateRangePicker} ${darkMode ? styles.darkDatePicker : ''}`}>
             <DatePicker
+              renderCustomHeader={({ date, decreaseMonth, increaseMonth }) => (
+                <div style={{ display: 'flex', alignItems: 'center', marginBottom: '10px' }}>
+                  <button
+                    onClick={decreaseMonth}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      color: darkMode ? 'white' : 'black',
+                      fontSize: '16px',
+                    }}
+                  >
+                    ◀
+                  </button>
+
+                  <span
+                    style={{ flex: 1, textAlign: 'center', fontWeight: 'bold', fontSize: '16px' }}
+                  >
+                    {date.toLocaleString('default', {
+                      month: 'long',
+                      year: 'numeric',
+                    })}
+                  </span>
+
+                  <button
+                    onClick={increaseMonth}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      color: darkMode ? 'white' : 'black',
+                      fontSize: '16px',
+                    }}
+                  >
+                    ▶
+                  </button>
+                </div>
+              )}
               id="start-date"
               selected={startDate}
               onChange={date => setStartDate(date)}
@@ -107,10 +154,37 @@ function IssueCharts() {
               maxDate={endDate}
               placeholderText="Start Date"
               isClearable
-              className="filter-select"
+              className={`${styles.filterSelect} ${darkMode ? styles.filterSelectDark : ''}`}
             />
+
             <span>to</span>
+
             <DatePicker
+              renderCustomHeader={({ date, decreaseMonth, increaseMonth }) => (
+                <div style={{ display: 'flex', alignItems: 'center', marginBottom: '10px' }}>
+                  <button
+                    onClick={decreaseMonth}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      color: darkMode ? 'white' : 'black',
+                      fontSize: '16px',
+                    }}
+                  >
+                    ◀
+                  </button>
+
+                  <span
+                    style={{ flex: 1, textAlign: 'center', fontWeight: 'bold', fontSize: '16px' }}
+                  >
+                    {date.toLocaleString('default', {
+                      month: 'long',
+                      year: 'numeric',
+                    })}
+                  </span>
+                </div>
+              )}
               selected={endDate}
               onChange={date => setEndDate(date)}
               selectsEnd
@@ -120,31 +194,33 @@ function IssueCharts() {
               maxDate={new Date()}
               placeholderText="End Date"
               isClearable
-              className="filter-select"
+              className={`${styles.filterSelect} ${darkMode ? styles.filterSelectDark : ''}`}
             />
           </div>
         </div>
 
-        <div className="filter">
-          <label className="issue-chart-label" htmlFor="start-date">
-            Projects:
-          </label>
+        <div className={`${styles.filter}`}>
+          <label htmlFor="selectProjectsDropdown">Projects:</label>
+
           <Select
-            id="start-date"
             isMulti
+            id="selectProjectsDropdown"
             options={projectOptions}
             onChange={handleProjectChange}
             value={projectOptions.filter(option => (selectedProjects ?? []).includes(option.value))}
-            className="filter-select"
-            classNamePrefix="select"
+            classNamePrefix={darkMode ? 'loiSelectDark' : 'loiSelect'}
+            className={`${styles.multiSelect} ${darkMode ? styles.multiSelectDark : ''}`}
           />
         </div>
       </div>
 
-      <div className="chart-container" ref={chartContainerRef}>
+      <div
+        className={`${styles.chartContainer} ${darkMode ? styles.chartContainerDark : ''}`}
+        ref={chartContainerRef}
+      >
         {!issues || issues.length === 0 ? (
-          <div className="no-data-message">
-            <div className="no-data-content">
+          <div className={`${styles.noDataMessage} ${darkMode ? styles.noDataMessageDark : ''}`}>
+            <div className={`${styles.noDataContent} ${darkMode ? styles.noDataContentDark : ''}`}>
               <h3>No Open Issues Found</h3>
               <p>There are currently no open issues matching your selected criteria.</p>
               <p>Try adjusting your date range or project filters to see more results.</p>
@@ -173,7 +249,7 @@ function IssueCharts() {
                   dataKey="durationOpen"
                   position="right"
                   formatter={v => `${v} mo`}
-                  className="recharts-label"
+                  className={`${darkMode ? styles.rechartsLabelDark : styles.rechartsLabel}`}
                 />
               </Bar>
             </BarChart>

--- a/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
@@ -20,6 +20,7 @@ import { useSelector } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
 import { Info, Repeat } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
+import { setProjectFilter } from '../../../../actions/bmdashboard/issueChartActions';
 import styles from './QuantityOfMaterialsUsed.module.css';
 
 ChartJS.register(
@@ -69,7 +70,10 @@ function getRandomColor() {
 
 function QuantityOfMaterialsUsed({ data }) {
   const [chartData, setChartData] = useState(null);
+  const projects = useSelector(state => state.bmProjects);
   const [selectedMaterials, setSelectedMaterials] = useState([]);
+  const [selectedProjects, setSelectedProjects] = useState(projects);
+
   const [selectedDate, setSelectedDate] = useState('Last Week');
   const [dateRangeOne, setDateRangeOne] = useState([null, null]);
   const [dateRangeTwo, setDateRangeTwo] = useState([null, null]);
@@ -80,7 +84,6 @@ function QuantityOfMaterialsUsed({ data }) {
   const [visibleRange, setVisibleRange] = useState([0, 30]);
   const [selectedMaterialName, setSelectedMaterialName] = useState(null);
   const [showModal, setShowModal] = useState(false);
-
   const [isSmallScreen, setIsSmallScreen] = useState(false);
 
   const selectStyles = useMemo(
@@ -164,6 +167,9 @@ function QuantityOfMaterialsUsed({ data }) {
     [darkMode],
   );
 
+  const handleProjectChange = selected => {
+    setProjectFilter(selected ? selected.map(option => option.value) : []);
+  };
   useEffect(() => {
     const handleResize = () => {
       setIsSmallScreen(window.innerWidth <= 1200);
@@ -191,6 +197,11 @@ function QuantityOfMaterialsUsed({ data }) {
   }, [data]);
 
   const orgOptions = useMemo(() => [{ value: selectedOrg, label: selectedOrg }], [selectedOrg]);
+
+  const projectOptions = selectedProjects.map(project => ({
+    value: project._id,
+    label: project.name,
+  }));
 
   const dateOptions = useMemo(
     () => [
@@ -735,13 +746,19 @@ function QuantityOfMaterialsUsed({ data }) {
         />
 
         <Select
-          options={orgOptions}
-          value={orgOptions.find(option => option.value === selectedOrg)}
-          placeholder="Organization"
+          isMulti
+          isSearchable
+          options={projectOptions}
+          value={projectOptions.filter(option => selectedProjects.includes(option.value))}
+          onChange={selectedOptions =>
+            setSelectedProjects(selectedOptions.map(({ value }) => value))
+          }
+          placeholder="Projects"
           menuPlacement={isSmallScreen ? 'top' : 'auto'}
           classNamePrefix="custom-select"
           className={`quantity-of-materials-used-dropdown-item ${styles.dropdownItem}`}
-          // isDisabled
+          closeMenuOnSelect={false}
+          hideSelectedOptions={false}
           styles={selectStyles}
         />
         <Select

--- a/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/QuantityOfMaterialsUsed/QuantityOfMaterialsUsed.jsx
@@ -72,7 +72,8 @@ function QuantityOfMaterialsUsed({ data }) {
   const [chartData, setChartData] = useState(null);
   const projects = useSelector(state => state.bmProjects);
   const [selectedMaterials, setSelectedMaterials] = useState([]);
-  const [selectedProjects, setSelectedProjects] = useState(projects);
+  // const [selectedProjects, setSelectedProjects] = useState(projects);
+  const [selectedProjects, setSelectedProjects] = useState([]);
 
   const [selectedDate, setSelectedDate] = useState('Last Week');
   const [dateRangeOne, setDateRangeOne] = useState([null, null]);
@@ -167,9 +168,6 @@ function QuantityOfMaterialsUsed({ data }) {
     [darkMode],
   );
 
-  const handleProjectChange = selected => {
-    setProjectFilter(selected ? selected.map(option => option.value) : []);
-  };
   useEffect(() => {
     const handleResize = () => {
       setIsSmallScreen(window.innerWidth <= 1200);
@@ -198,7 +196,7 @@ function QuantityOfMaterialsUsed({ data }) {
 
   const orgOptions = useMemo(() => [{ value: selectedOrg, label: selectedOrg }], [selectedOrg]);
 
-  const projectOptions = selectedProjects.map(project => ({
+  const projectOptions = projects.map(project => ({
     value: project._id,
     label: project.name,
   }));
@@ -504,7 +502,7 @@ function QuantityOfMaterialsUsed({ data }) {
           : []),
       ],
     });
-  }, [data, selectedMaterials, selectedOrg, selectedDate, dateRangeOne, dateRangeTwo]);
+  }, [data, selectedMaterials, selectedProjects, selectedDate, dateRangeOne, dateRangeTwo]);
 
   const barWidth = 12;
   // Subtract the 40-px y-axis offset
@@ -738,7 +736,6 @@ function QuantityOfMaterialsUsed({ data }) {
           placeholder="All Materials testing"
           classNamePrefix="custom-select"
           className={`quantity-of-materials-used-dropdown-item ${styles.dropdownItem} custom-scrollbar ${styles.multiSelect}`}
-          menuPosition="fixed"
           menuPlacement={isSmallScreen ? 'top' : 'auto'}
           closeMenuOnSelect={false}
           hideSelectedOptions={false}
@@ -756,7 +753,7 @@ function QuantityOfMaterialsUsed({ data }) {
           placeholder="Projects"
           menuPlacement={isSmallScreen ? 'top' : 'auto'}
           classNamePrefix="custom-select"
-          className={`quantity-of-materials-used-dropdown-item ${styles.dropdownItem}`}
+          className={`quantity-of-materials-used-dropdown-item ${styles.dropdownItem} custom-scrollbar ${styles.multiSelect}`}
           closeMenuOnSelect={false}
           hideSelectedOptions={false}
           styles={selectStyles}


### PR DESCRIPTION
# Description
<img width="696" height="328" alt="Screenshot 2025-11-28 at 7 05 32 PM" src="https://github.com/user-attachments/assets/78f798f4-1d5d-4104-afb6-874b8c1bb11d" />


## Related PRS (if any):
This change is NOT related to any other PRs.

## Main changes explained:
- Fixed the link between the graphs.
- Added new state fixes to ensure that the drop-downs of one graph do no affect the values of the other.

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. navigate to `/bmdashboard/totalconstructionsummary`
6. verify that when selecting any value in the project dropdown under **Longest Open Issues** graph in the Issue Tracking section does not change the Projects dropdown under **Quantity of Materials Used** dropdown in Material Consumption section.

## Screenshots or videos of changes:
Here's what the original issue without the fix was.

https://github.com/user-attachments/assets/4bbbe61d-8e7f-41d9-9e81-32c7afbff5f9


Here's how it should work now.

https://github.com/user-attachments/assets/9ff16a99-9810-4079-8e0a-0f15b371933c

## Note:
Currently the screen is using Mock Data and hence selection of values may not have any visible impact on the graphs. But please verify that the Project drop-downs in  **Longest Open Issues** graph in the Issue Tracking section and the Projects dropdown under the **Quantity of Materials Used** graph in Material Consumption section are working independent of each other.