### PR TITLE
Neeraj Add Amount Label and Extend Graph Bars in Resource Usage Chart

### DIFF
--- a/src/components/CommunityPortal/ResourceUsage/ResourceUsage.jsx
+++ b/src/components/CommunityPortal/ResourceUsage/ResourceUsage.jsx
@@ -129,7 +129,7 @@ export default function ResourceUsage() {
   useEffect(() => {
     badgeRefs.current.forEach(badge => {
       if (badge) {
-        badge.style.setProperty('color', darkMode ? '#000' : '#000');
+        badge.style.setProperty('color', '#000');
       }
     });
   }, [insights, darkMode]);

--- a/src/components/CommunityPortal/ResourceUsage/ResourceUsage.jsx
+++ b/src/components/CommunityPortal/ResourceUsage/ResourceUsage.jsx
@@ -287,7 +287,7 @@ export default function ResourceUsage() {
 
                 <div
                   ref={el => (badgeRefs.current[idx] = el)}
-                  className={`${styles.insightBadge} ${darkMode ? 'text-dark' : ''}`}
+                  className={styles.insightBadge}
                   style={{ backgroundColor: insight.color }}
                 >
                   {insight.value}

--- a/src/components/CommunityPortal/ResourceUsage/ResourceUsage.jsx
+++ b/src/components/CommunityPortal/ResourceUsage/ResourceUsage.jsx
@@ -252,33 +252,34 @@ export default function ResourceUsage() {
           <div className={`${styles.insightsSection} ${darkMode ? 'bg-space-cadet text-light' : ''}`}>
             <div className={styles.insightsHeader}>
               <h2>Insights</h2>
-                    <Dropdown>
-                      <Dropdown.Toggle className={styles.customDropdown}>
-                        {insightsTimePeriod}
-                      </Dropdown.Toggle>
-                      <Dropdown.Menu>
-                        <Dropdown.Item onClick={() => setInsightsTimePeriod('This Week')}>
-                          This Week
-                        </Dropdown.Item>
-                        <Dropdown.Item onClick={() => setInsightsTimePeriod('Last Week')}>
-                          Last Week
-                        </Dropdown.Item>
-                        <Dropdown.Item onClick={() => setInsightsTimePeriod('This Month')}>
-                          This Month
-                        </Dropdown.Item>
-                      </Dropdown.Menu>
-                    </Dropdown>
+              <Dropdown>
+                <Dropdown.Toggle className={styles.customDropdown}>
+                  {insightsTimePeriod}
+                </Dropdown.Toggle>
+                <Dropdown.Menu>
+                  <Dropdown.Item onClick={() => setInsightsTimePeriod('This Week')}>
+                    This Week
+                  </Dropdown.Item>
+                  <Dropdown.Item onClick={() => setInsightsTimePeriod('Last Week')}>
+                    Last Week
+                  </Dropdown.Item>
+                  <Dropdown.Item onClick={() => setInsightsTimePeriod('This Month')}>
+                    This Month
+                  </Dropdown.Item>
+                </Dropdown.Menu>
+              </Dropdown>
+            </div>
+
+            <div className={styles.insightsGrid}>
+              {insights.map((insight, idx) => (
+                <div
+                  key={idx}
+                  className={`${styles.insightCard} ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}
+                >
+                  {/* Tooltip description */}
+                  <div className={styles.insightTooltip}>
+                    {insightDefinitions[insight.title]}
                   </div>
-        <div className={styles.insightsGrid}>
-          {insights.map((insight, idx) => (
-            <div
-              key={idx}
-              className={`${styles.insightCard} ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}
-            >
-              {/* Tooltip description */}
-              <div className={styles.insightTooltip}>
-                {insightDefinitions[insight.title]}
-              </div>
 
               <div
                 className={styles.insightTitle}

--- a/src/components/CommunityPortal/ResourceUsage/ResourceUsage.jsx
+++ b/src/components/CommunityPortal/ResourceUsage/ResourceUsage.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef} from 'react';
 import { Dropdown } from 'react-bootstrap';
 import {
   BarChart,
@@ -82,34 +82,38 @@ const insightDefinitions = {
   'Highest cost venues/hr': 'Venue with the highest hourly cost during the selected period.',
 };
 
+function filterDataByDate(data, timePeriod) {
+  return data;
+}
+
 function CustomTooltip({ active, payload, darkMode }) {
   if (!active || !payload || !payload.length) return null;
 
-  const data = payload[0].payload;
+const data = payload[0].payload;
 
-  return (
-    <div
-      className={styles.chartTooltip}
-      style={{
-        backgroundColor: darkMode ? '#1e293b' : '#ffffff',
-        color: darkMode ? '#f8fafc' : '#111827',
-      }}
-    >
-      <div className={styles.tooltipTitle}>{data.name}</div>
+return (
+  <div
+    className={styles.chartTooltip}
+    style={{
+      backgroundColor: darkMode ? '#1e293b' : '#ffffff',
+      color: darkMode ? '#f8fafc' : '#111827',
+    }}
+  >
+    <div className={styles.tooltipTitle}>{data.name}</div>
 
-      <div className={styles.tooltipRow}>
-        <span className={styles.tooltipDot} style={{ background: '#22c55e' }} />
-        <span>Returned</span>
-        <span className={styles.tooltipValue}>{data.returned}</span>
-      </div>
-
-      <div className={styles.tooltipRow}>
-        <span className={styles.tooltipDot} style={{ background: '#fca5a5' }} />
-        <span>Loaned</span>
-        <span className={styles.tooltipValue}>{data.loaned}</span>
-      </div>
+    <div className={styles.tooltipRow}>
+      <span className={styles.tooltipDot} style={{ background: '#22c55e' }} />
+      <span>Returned</span>
+      <span className={styles.tooltipValue}>{data.returned}</span>
     </div>
-  );
+
+    <div className={styles.tooltipRow}>
+      <span className={styles.tooltipDot} style={{ background: '#fca5a5' }} />
+      <span>Loaned</span>
+      <span className={styles.tooltipValue}>{data.loaned}</span>
+    </div>
+  </div>
+);
 }
 
 export default function ResourceUsage() {
@@ -120,10 +124,21 @@ export default function ResourceUsage() {
   const [insights, setInsights] = useState(allInsights['Last Week']);
 
   const darkMode = useSelector(state => state.theme.darkMode);
+  const badgeRefs = useRef([]);
 
   useEffect(() => {
-    setData(allData[resourceType.toLowerCase()]);
-  }, [resourceType]);
+    badgeRefs.current.forEach(badge => {
+      if (badge) {
+        badge.style.setProperty('color', '#000', 'important');
+      }
+    });
+  }, [insights]);
+
+  useEffect(() => {
+    const resourceTypeKey = resourceType.toLowerCase();
+    const filteredData = filterDataByDate(allData[resourceTypeKey], timePeriod);
+    setData(filteredData);
+  }, [resourceType, timePeriod, allData]);
 
   useEffect(() => {
     setInsights(allInsights[insightsTimePeriod]);
@@ -172,85 +187,98 @@ export default function ResourceUsage() {
             Amount
           </div>
 
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={data} margin={{ top: 20, right: 30, left: 30, bottom: 80 }}>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke={darkMode ? '#3A506B' : '#eee'}
-                vertical={false}
-              />
+          {data && data.length > 0 ? (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={data} margin={{ top: 20, right: 30, left: 30, bottom: 80 }}>
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke={darkMode ? '#3A506B' : '#eee'}
+                  vertical={false}
+                />
 
-              <XAxis
-                dataKey="name"
-                axisLine={false}
-                tickLine={false}
-                tick={{
-                  fill: darkMode ? '#ffffff' : '#666',
-                  fontWeight: 700,
-                  fontSize: 12,
-                }}
-              />
+                <XAxis
+                  dataKey="name"
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{
+                    fill: darkMode ? '#ffffff' : '#666',
+                    fontWeight: 700,
+                    fontSize: 12,
+                  }}
+                />
 
-              <YAxis
-                axisLine={false}
-                tickLine={false}
-                tick={{
-                  fill: darkMode ? '#ffffff' : '#666',
-                  fontWeight: 700,
-                  fontSize: 12,
-                }}
-              />
+                <YAxis
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{
+                    fill: darkMode ? '#ffffff' : '#666',
+                    fontWeight: 700,
+                    fontSize: 12,
+                  }}
+                />
 
-              <Tooltip content={<CustomTooltip darkMode={darkMode} />} />
+                <Tooltip content={<CustomTooltip darkMode={darkMode} />} />
 
-              <Legend
-                align="right"
-                verticalAlign="top"
-                iconType="circle"
-                iconSize={8}
-                wrapperStyle={{
-                  color: darkMode ? '#ffffff' : '#666',
-                }}
-              />
+                <Legend
+                  align="right"
+                  verticalAlign="top"
+                  iconType="circle"
+                  iconSize={8}
+                  wrapperStyle={{
+                    color: darkMode ? '#ffffff' : '#666',
+                  }}
+                />
 
-              <Bar dataKey="returned" stackId="a" fill="#22c55e" radius={[4, 4, 0, 0]} />
-              <Bar dataKey="loaned" stackId="a" fill="#fca5a5" radius={[4, 4, 0, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
+                <Bar dataKey="returned" stackId="a" fill="#22c55e" radius={[4, 4, 0, 0]} />
+                <Bar dataKey="loaned" stackId="a" fill="#fca5a5" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          ) : (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                height: '100%',
+              }}
+            >
+              <p>No data available for the selected time period and resource type.</p>
+            </div>
+          )}
+          </div>
+          </div>
 
-      {/* RIGHT SECTION */}
-      <div className={`${styles.insightsSection} ${darkMode ? styles.darkInsightsSection : ''}`}>
-        <div className={styles.insightsHeader}>
-          <h2>Insights</h2>
-
-          <Dropdown>
-            <Dropdown.Toggle className={styles.customDropdown}>
-              {insightsTimePeriod}
-            </Dropdown.Toggle>
-            <Dropdown.Menu>
-              <Dropdown.Item onClick={() => setInsightsTimePeriod('This Week')}>
-                This Week
-              </Dropdown.Item>
-              <Dropdown.Item onClick={() => setInsightsTimePeriod('Last Week')}>
-                Last Week
-              </Dropdown.Item>
-              <Dropdown.Item onClick={() => setInsightsTimePeriod('This Month')}>
-                This Month
-              </Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
-        </div>
-
+          {/* RIGHT SECTION */}
+          <div className={`${styles.insightsSection} ${darkMode ? 'bg-space-cadet text-light' : ''}`}>
+            <div className={styles.insightsHeader}>
+              <h2>Insights</h2>
+                    <Dropdown>
+                      <Dropdown.Toggle className={styles.customDropdown}>
+                        {insightsTimePeriod}
+                      </Dropdown.Toggle>
+                      <Dropdown.Menu>
+                        <Dropdown.Item onClick={() => setInsightsTimePeriod('This Week')}>
+                          This Week
+                        </Dropdown.Item>
+                        <Dropdown.Item onClick={() => setInsightsTimePeriod('Last Week')}>
+                          Last Week
+                        </Dropdown.Item>
+                        <Dropdown.Item onClick={() => setInsightsTimePeriod('This Month')}>
+                          This Month
+                        </Dropdown.Item>
+                      </Dropdown.Menu>
+                    </Dropdown>
+                  </div>
         <div className={styles.insightsGrid}>
           {insights.map((insight, idx) => (
             <div
               key={idx}
               className={`${styles.insightCard} ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}
             >
-              {/* 🔹 ADD THIS LINE RIGHT HERE */}
-              <div className={styles.insightTooltip}>{insightDefinitions[insight.title]}</div>
+              {/* Tooltip description */}
+              <div className={styles.insightTooltip}>
+                {insightDefinitions[insight.title]}
+              </div>
 
               <div
                 className={styles.insightTitle}
@@ -261,17 +289,20 @@ export default function ResourceUsage() {
               </div>
 
               <div
+                ref={el => (badgeRefs.current[idx] = el)}
                 className={`${styles.insightBadge} ${darkMode ? 'text-dark' : ''}`}
                 style={{ backgroundColor: insight.color }}
               >
                 {insight.value}
               </div>
 
-              <div className={styles.insightMeta}>Based on returned vs loaned comparison</div>
+              <div className={styles.insightMeta}>
+                Based on returned vs loaned comparison
+              </div>
             </div>
           ))}
         </div>
+              </div>
       </div>
-    </div>
   );
 }

--- a/src/components/CommunityPortal/ResourceUsage/ResourceUsage.jsx
+++ b/src/components/CommunityPortal/ResourceUsage/ResourceUsage.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef} from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Dropdown } from 'react-bootstrap';
 import {
   BarChart,
@@ -89,31 +89,31 @@ function filterDataByDate(data, timePeriod) {
 function CustomTooltip({ active, payload, darkMode }) {
   if (!active || !payload || !payload.length) return null;
 
-const data = payload[0].payload;
+  const data = payload[0].payload;
 
-return (
-  <div
-    className={styles.chartTooltip}
-    style={{
-      backgroundColor: darkMode ? '#1e293b' : '#ffffff',
-      color: darkMode ? '#f8fafc' : '#111827',
-    }}
-  >
-    <div className={styles.tooltipTitle}>{data.name}</div>
+  return (
+    <div
+      className={styles.chartTooltip}
+      style={{
+        backgroundColor: darkMode ? '#1e293b' : '#ffffff',
+        color: darkMode ? '#f8fafc' : '#111827',
+      }}
+    >
+      <div className={styles.tooltipTitle}>{data.name}</div>
 
-    <div className={styles.tooltipRow}>
-      <span className={styles.tooltipDot} style={{ background: '#22c55e' }} />
-      <span>Returned</span>
-      <span className={styles.tooltipValue}>{data.returned}</span>
+      <div className={styles.tooltipRow}>
+        <span className={styles.tooltipDot} style={{ background: '#22c55e' }} />
+        <span>Returned</span>
+        <span className={styles.tooltipValue}>{data.returned}</span>
+      </div>
+
+      <div className={styles.tooltipRow}>
+        <span className={styles.tooltipDot} style={{ background: '#fca5a5' }} />
+        <span>Loaned</span>
+        <span className={styles.tooltipValue}>{data.loaned}</span>
+      </div>
     </div>
-
-    <div className={styles.tooltipRow}>
-      <span className={styles.tooltipDot} style={{ background: '#fca5a5' }} />
-      <span>Loaned</span>
-      <span className={styles.tooltipValue}>{data.loaned}</span>
-    </div>
-  </div>
-);
+  );
 }
 
 export default function ResourceUsage() {
@@ -129,10 +129,10 @@ export default function ResourceUsage() {
   useEffect(() => {
     badgeRefs.current.forEach(badge => {
       if (badge) {
-        badge.style.setProperty('color', '#000', 'important');
+        badge.style.setProperty('color', darkMode ? '#000' : '#000');
       }
     });
-  }, [insights]);
+  }, [insights, darkMode]);
 
   useEffect(() => {
     const resourceTypeKey = resourceType.toLowerCase();
@@ -245,65 +245,63 @@ export default function ResourceUsage() {
               <p>No data available for the selected time period and resource type.</p>
             </div>
           )}
-          </div>
-          </div>
+        </div>
+      </div>
 
-          {/* RIGHT SECTION */}
-          <div className={`${styles.insightsSection} ${darkMode ? 'bg-space-cadet text-light' : ''}`}>
-            <div className={styles.insightsHeader}>
-              <h2>Insights</h2>
-              <Dropdown>
-                <Dropdown.Toggle className={styles.customDropdown}>
-                  {insightsTimePeriod}
-                </Dropdown.Toggle>
-                <Dropdown.Menu>
-                  <Dropdown.Item onClick={() => setInsightsTimePeriod('This Week')}>
-                    This Week
-                  </Dropdown.Item>
-                  <Dropdown.Item onClick={() => setInsightsTimePeriod('Last Week')}>
-                    Last Week
-                  </Dropdown.Item>
-                  <Dropdown.Item onClick={() => setInsightsTimePeriod('This Month')}>
-                    This Month
-                  </Dropdown.Item>
-                </Dropdown.Menu>
-              </Dropdown>
-            </div>
+      {/* RIGHT SECTION */}
+      <div className={`${styles.insightsSection} ${darkMode ? styles.darkInsightsSection : ''}`}>
+        <div className={styles.insightsHeader}>
+          <h2>Insights</h2>
+          <Dropdown>
+            <Dropdown.Toggle className={styles.customDropdown}>
+              {insightsTimePeriod}
+            </Dropdown.Toggle>
+            <Dropdown.Menu>
+              <Dropdown.Item onClick={() => setInsightsTimePeriod('This Week')}>
+                This Week
+              </Dropdown.Item>
+              <Dropdown.Item onClick={() => setInsightsTimePeriod('Last Week')}>
+                Last Week
+              </Dropdown.Item>
+              <Dropdown.Item onClick={() => setInsightsTimePeriod('This Month')}>
+                This Month
+              </Dropdown.Item>
+            </Dropdown.Menu>
+          </Dropdown>
+        </div>
 
-            <div className={styles.insightsGrid}>
-              {insights.map((insight, idx) => (
+        <div className={styles.insightsGrid}>
+          {insights.map((insight, idx) => (
+            <div
+              key={idx}
+              className={`${styles.insightCard} ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}
+            >
+              <div className={styles.insightContent}>
                 <div
-                  key={idx}
-                  className={`${styles.insightCard} ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}
+                  className={styles.insightTitle}
+                  title={insightDefinitions[insight.title]}
+                  style={{ color: darkMode ? '#e5e7eb' : '#6b7280', fontWeight: 600 }}
                 >
-                  {/* Tooltip description */}
-                  <div className={styles.insightTooltip}>
-                    {insightDefinitions[insight.title]}
-                  </div>
+                  {insight.title}
+                </div>
 
-              <div
-                className={styles.insightTitle}
-                title={insightDefinitions[insight.title]}
-                style={{ color: darkMode ? '#342d2dff' : '#6b7280', fontWeight: 600 }}
-              >
-                {insight.title}
+                <div
+                  ref={el => (badgeRefs.current[idx] = el)}
+                  className={`${styles.insightBadge} ${darkMode ? 'text-dark' : ''}`}
+                  style={{ backgroundColor: insight.color }}
+                >
+                  {insight.value}
+                </div>
+
+                <div className={styles.insightMeta}>Based on returned vs loaned comparison</div>
               </div>
 
-              <div
-                ref={el => (badgeRefs.current[idx] = el)}
-                className={`${styles.insightBadge} ${darkMode ? 'text-dark' : ''}`}
-                style={{ backgroundColor: insight.color }}
-              >
-                {insight.value}
-              </div>
-
-              <div className={styles.insightMeta}>
-                Based on returned vs loaned comparison
-              </div>
+              {/* Tooltip */}
+              <div className={styles.insightTooltip}>{insightDefinitions[insight.title]}</div>
             </div>
           ))}
         </div>
-              </div>
       </div>
+    </div>
   );
 }

--- a/src/components/CommunityPortal/ResourceUsage/ResourceUsage.module.css
+++ b/src/components/CommunityPortal/ResourceUsage/ResourceUsage.module.css
@@ -62,25 +62,12 @@
   z-index: 5;
 }
 
-.yAxisLabel {
-  position: absolute;
-  top: -8px;
-  left: 35px;
-  font-size: 13px;
-  font-weight: 700;
-  z-index: 5;
-}
-
 /* ---------------- INSIGHTS ---------------- */
 
 .insightsSection {
   width: 400px;
   padding: 1.5rem;
   border-left: 1px solid #e5e7eb;
-}
-
-.darkInsightsSection {
-  background: #1b2a41;
 }
 
 .insightCard {
@@ -111,27 +98,22 @@
 /* Tooltip */
 .insightTooltip {
   position: absolute;
-  bottom: 3.25rem;
+  bottom: 100%;
   left: 50%;
-  transform: translateX(-50%) translateY(6px);
-  max-width: 140px;
-  width: max-content;
-  padding: 0.6rem 0.75rem;
-  background-color: #374151;
-  color: #fff;
-  font-size: 0.75rem;
-  line-height: 1.35;
-  border-radius: 0.5rem;
-  white-space: normal;
-  text-align: left;
-  box-shadow: 0 8px 20px rgb(0 0 0 / 18%);
+  transform: translateX(-50%);
+  background: #374151;
+  color: white;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-size: 12px;
   opacity: 0;
+  visibility: hidden;
+  transition: all 0.2s ease;
   pointer-events: none;
-  transition: opacity 0.15s ease, transform 0.15s ease;
-  z-index: 5;
+  z-index: 10;
 }
 
-/* 🔥 FIX: Apply dark styles INSIDE insights section */
+/* FIX: Apply dark styles INSIDE insights section */
 .darkInsightsSection .insightCard {
   background-color: #1e293b;
   border: 1px solid #334155;
@@ -176,20 +158,6 @@
 }
 
 /* BADGE */
-
-.insightCard {
-  padding: 1rem;
-  border-radius: 0.75rem;
-}
-
-.darkInsightCard {
-  background: #2b3e59;
-}
-
-.insightTitle {
-  margin-bottom: 0.75rem;
-  font-size: 0.875rem;
-}
 
 .insightBadge {
   padding: 0.25rem 0.75rem;
@@ -256,7 +224,7 @@
 .dark-mode .customDropdown,
 .dark-mode .dropdown-toggle.customDropdown {
   background-color: #1C2541 !important;
-  color: #ffffff !important;
+  color: #fff !important;
   border-color: #3A506B !important;
 }
 
@@ -271,16 +239,11 @@
 }
 
 .dark-mode .dropdown-item {
-  color: #ffffff !important;
+  color: #fff !important;
 }
 
 .dark-mode .dropdown-item:hover {
   background-color: #3A506B !important;
-}
-
-/* Badge visibility in dark mode */
-.dark-mode .insightBadge {
-  color: #111827 !important;
 }
 
 /* Chart ticks */
@@ -288,5 +251,4 @@
   font-size: 12px;
   font-weight: 700;
   fill: #666;
-  font-weight: 700;
 }

--- a/src/components/CommunityPortal/ResourceUsage/ResourceUsage.module.css
+++ b/src/components/CommunityPortal/ResourceUsage/ResourceUsage.module.css
@@ -1,7 +1,6 @@
 .resourceUsageContainer {
   display: flex;
   min-height: 100vh;
-  background-color: #fff;
 }
 
 .darkContainer {
@@ -11,6 +10,10 @@
 .chartSection {
   flex: 1;
   padding: 1.5rem;
+}
+
+.darkChartSection {
+  background: #2b3e59;
 }
 
 .headerSection {
@@ -27,11 +30,36 @@
   padding: 0.5rem 1rem !important;
   border-radius: 0.375rem !important;
   font-size: 0.875rem !important;
+
+  /* Your enhancements */
+  box-shadow: none !important;
+  display: flex !important;
+  align-items: center !important;
+  gap: 0.5rem !important;
+}
+
+.customDropdown:hover,
+.customDropdown:focus {
+  background-color: #b7b7b8 !important;
+  border-color: #e5e7eb !important;
+}
+
+.customDropdown::after {
+  margin-left: 0.5rem !important;
 }
 
 .chartContainer {
   height: calc(100vh - 200px);
   position: relative;
+}
+
+.yAxisLabel {
+  position: absolute;
+  top: -8px;
+  left: 35px;
+  font-size: 13px;
+  font-weight: 700;
+  z-index: 5;
 }
 
 .yAxisLabel {
@@ -134,6 +162,7 @@
   font-weight: 600;
   margin: 0;
   color: #111827;
+  border-left: 1px solid #e5e7eb;
 }
 
 .darkInsightsSection .insightsHeader h2 {
@@ -147,6 +176,21 @@
 }
 
 /* BADGE */
+
+.insightCard {
+  padding: 1rem;
+  border-radius: 0.75rem;
+}
+
+.darkInsightCard {
+  background: #2b3e59;
+}
+
+.insightTitle {
+  margin-bottom: 0.75rem;
+  font-size: 0.875rem;
+}
+
 .insightBadge {
   padding: 0.25rem 0.75rem;
   border-radius: 1rem;
@@ -155,9 +199,15 @@
   color: #111827;
 }
 
-
 .insightCard .insightBadge {
   color: #111827 !important;
+}
+
+/* Tooltip */
+.customTooltip {
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid #e5e7eb;
 }
 
 .insightCard:hover .insightTooltip {
@@ -176,6 +226,7 @@
   line-height: 1.3;
 }
 
+/* Tooltip styles */
 .tooltipTitle {
   font-weight: 600;
   font-size: 0.8rem;
@@ -201,31 +252,35 @@
   font-weight: 600;
 }
 
-/* ---------------- DARK MODE DROPDOWNS ---------------- */
-
+/* DARK MODE DROPDOWN */
 .dark-mode .customDropdown,
 .dark-mode .dropdown-toggle.customDropdown {
-  background-color: #1c2541 !important;
-  color: #fff !important;
-  border-color: #3a506b !important;
+  background-color: #1C2541 !important;
+  color: #ffffff !important;
+  border-color: #3A506B !important;
 }
 
 .dark-mode .dropdown-toggle.customDropdown.show,
 .dark-mode .show > .customDropdown.dropdown-toggle {
-  background-color: #243b5a !important;
+  background-color: #243B5A !important;
 }
 
 .dark-mode .dropdown-menu {
-  background-color: #1c2541 !important;
-  border-color: #3a506b !important;
+  background-color: #1C2541 !important;
+  border-color: #3A506B !important;
 }
 
 .dark-mode .dropdown-item {
-  color: #fff !important;
+  color: #ffffff !important;
 }
 
 .dark-mode .dropdown-item:hover {
-  background-color: #3a506b !important;
+  background-color: #3A506B !important;
+}
+
+/* Badge visibility in dark mode */
+.dark-mode .insightBadge {
+  color: #111827 !important;
 }
 
 /* Chart ticks */
@@ -233,4 +288,5 @@
   font-size: 12px;
   font-weight: 700;
   fill: #666;
+  font-weight: 700;
 }

--- a/src/components/CommunityPortal/ResourceUsage/__tests__/ResourceUsage.test.jsx
+++ b/src/components/CommunityPortal/ResourceUsage/__tests__/ResourceUsage.test.jsx
@@ -39,6 +39,7 @@ describe('ResourceUsage Component', () => {
     // Find ALL "Venue" buttons
     const venueButtons = screen.getAllByRole('button', { name: 'Venue' });
 
+    // The LAST one is the dropdown menu option
     const menuOption = venueButtons[venueButtons.length - 1];
 
     fireEvent.click(menuOption);


### PR DESCRIPTION
# Description
<img width="767" height="528" alt="image" src="https://github.com/user-attachments/assets/a9b34729-82ba-4b01-9ba1-5a7156ddc7a5" />
<img width="743" height="665" alt="image" src="https://github.com/user-attachments/assets/36dc42ee-abeb-48c7-9e37-ce58577128af" />

## Related PRS (if any):
To test this frontend PR you need to checkout the development backend PR.
…

## Main changes explained:
- Updated ResourceUsage.jsx
    - Added Amount Y-axis label above the chart as requested in task description.
    - Improved dark mode styling for chart labels, dropdowns, insight cards, and tooltip for proper visibility.
    - Extended Material bars to match updated UI requirement.
- Added unit test file
    - ResourceUsage.test.jsx
    - Added test coverage for:
        - Rendering of component title.
        - Changing resource type via dropdown.
        - Rendering insights grid.
        - Validating dark-mode class application.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Navigate to : http://localhost:5173/communityportal/reports/resourceusage
6. Verify the following: 
    - The label "Amount" appears over Y axis.
    - The chart should show all material bars (A–G) as in the Figma design for complete data representation.

## Screenshots or videos of changes:

<img width="1467" height="863" alt="image" src="https://github.com/user-attachments/assets/8e636c4e-45e9-4d84-8fe7-ea2c8e916b8b" />

## Note:
The component is mock-data driven and does not affect backend API calls.