### PR TITLE
Mani shashank UI responsiveness and dark mode implementation 

### DIFF
--- a/src/components/Collaboration/JobFormBuilder.module.css
+++ b/src/components/Collaboration/JobFormBuilder.module.css
@@ -15,6 +15,15 @@
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
+.darkContainer {
+  background-color: #1a2332;
+  color: #e8e8e8;
+  max-width: 100%;
+  margin: 0;
+  box-shadow: none;
+  border-radius: 0;
+}
+
 .customForm {
   background-color: #d9d9d9;
   padding: 10px;
@@ -23,30 +32,63 @@
   border: 1px solid #d9d9d9;
 }
 
+.darkContainer .customForm {
+  background-color: #1e2a3a;
+  border-color: #3a4a5c;
+}
+
 .jobformNavbar {
-  display: flex;
-  flex-wrap: wrap;
-  padding: 0 10px;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  padding: 20px;
+  gap: 20px;
   background-color: #97ca02;
   border-radius: 5px;
   border: 1px solid #97ca02;
   margin-bottom: 3%;
-  align-items: center;
+  align-items: start;
+}
+
+.darkNavbar {
+  background-color: #243447;
+  border-color: #243447;
+}
+
+.navbarSection {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background-color: rgba(255, 255, 255, 0.1);
+  padding: 15px;
+  border-radius: 5px;
+}
+
+.navbarSectionTitle {
+  font-weight: bold;
+  font-size: 14px;
+  color: #333;
+  margin-bottom: 5px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.darkContainer .navbarSection {
+  background-color: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.darkContainer .navbarSectionTitle {
+  color: #e8e8e8;
 }
 
 .jobformNavbar input {
-  margin: 8px 0;
+  margin: 4px 0;
+  max-width: 100%;
 }
 
 .jobformNavbar select {
-  margin: 8px 0;
+  margin: 4px 0;
   width: 100%;
-}
-
-.jobformNavbar div {
-  display: flex;
-  padding: 2px;
 }
 
 .jobformNavbar button {
@@ -61,7 +103,73 @@
   transition: background-color 0.3s;
 }
 
+.darkContainer input,
+.darkContainer select,
+.darkContainer textarea {
+  background-color: #1e2a3a;
+  color: #e8e8e8;
+  border-color: #3a4a5c;
+}
+
+.darkContainer .goButton,
+.darkContainer .jobformNavbar button {
+  background-color: #3d4f62;
+  color: #e8e8e8;
+}
+
+.darkContainer .goButton:hover,
+.darkContainer .jobformNavbar button:hover {
+  background-color: #4a5f75;
+}
+
+.darkContainer .addFieldButton,
+.darkContainer .addOptionButton {
+  background-color: #3d7a40;
+}
+
+.darkContainer .addFieldButton:hover,
+.darkContainer .addOptionButton:hover {
+  background-color: #2f5f33;
+}
+
+.darkContainer .jobSubmitButton {
+  background-color: #3d7a40;
+}
+
+.darkContainer .jobSubmitButton:hover {
+  background-color: #2f5f33;
+}
+
 .jobformNavbar button:hover {
+  background-color: grey;
+}
+
+.buttonRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.inputGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.goButton {
+  padding: 11px 20px;
+  border: none;
+  background-color: #cccccc;
+  color: white;
+  font-size: 16px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  white-space: nowrap;
+}
+
+.goButton:hover {
   background-color: grey;
 }
 
@@ -73,6 +181,14 @@
   text-align: center;
   color: black;
   font-weight: bold;
+}
+
+.darkContainer .jobformTitle,
+.darkContainer .jobformDesc,
+.darkContainer .jbformLabel,
+.darkContainer label,
+.darkContainer .fieldLabel {
+  color: #f5f5f5;
 }
 
 .jbformLabel {
@@ -93,6 +209,14 @@
   background-color: white;
 }
 
+.darkContainer .jobformInput,
+.darkContainer .jobformTextarea,
+.darkContainer .jobformSelect {
+  background-color: #1e2a3a;
+  color: #e8e8e8;
+  border-color: #3a4a5c;
+}
+
 .jobformTextarea {
   height: 80px;
   resize: vertical;
@@ -101,6 +225,10 @@
 .newFieldSection {
   background-color: #d9d9d9;
   padding: 20px;
+}
+
+.darkContainer .newFieldSection {
+  background-color: #1e2a3a;
 }
 
 /* General Container for Each Question */
@@ -224,26 +352,38 @@
   .formBuilderContainer {
     width: 98%;
     max-width: 100%;
+    margin: 1% 1% 0;
     padding: 10px;
   }
+  
   .jobformNavbar {
+    grid-template-columns: 1fr;
+    padding: 15px;
+    gap: 15px;
+  }
+
+  .navbarSection {
+    padding: 12px;
+  }
+
+  .buttonRow {
     flex-direction: column;
-    padding: 8px;
     align-items: stretch;
   }
 
-  .jobformNavbar > div {
-    flex-direction: column;
-    align-items: stretch;
-    min-width: 0;
-    width: 100%;
+  .jobformNavbar input[type="text"] {
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 4px 0 !important;
   }
 
   .jobformInput,
   .jobformTextarea,
   .jobformSelect,
   .goButton {
-    width: 100%;
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 4px 0 !important;
   }
 
   .formDiv {

--- a/src/components/Collaboration/JobFormbuilder.jsx
+++ b/src/components/Collaboration/JobFormbuilder.jsx
@@ -332,69 +332,24 @@ function JobFormBuilder() {
     }
   };
 
+  const darkMode = useSelector(state => state.theme?.darkMode);
+
   return (
-    <div className={styles.formBuilderContainer}>
+    <div
+      className={`${styles.formBuilderContainer} ${darkMode ? 'bg-oxford-blue' : ''} ${
+        darkMode ? styles.darkContainer : ''
+      }`}
+    >
       <img
         src={OneCommunityImage}
         alt="One Community Logo"
         id="onecommunity-image"
         className={styles.oneCommunityGlobalImg}
       />
-      <div className={styles.jobformNavbar}>
-        {/* Referral Link Generator UI */}
-        <div style={{ marginTop: 10 }}>
-          <div style={{ marginTop: 10 }}>
-            <label htmlFor="referralSource" className={styles.jbformLabel}>
-              Source Identifier (e.g., LN, FB):
-            </label>
-            <input
-              id="referralSource"
-              type="text"
-              value={referralSource}
-              onChange={e => setReferralSource(e.target.value)}
-              className={styles.jobformInput}
-              placeholder="Enter source"
-              style={{ width: 120, marginLeft: 8 }}
-              maxLength={10}
-            />
-          </div>
-
-          {referralLink && (
-            <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 8 }}>
-              <input
-                type="text"
-                value={referralLink}
-                readOnly
-                ref={referralInputRef}
-                className={styles.jobformInput}
-                style={{
-                  width: 250,
-                  marginRight: 8,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  background: '#fff',
-                  cursor: 'pointer',
-                }}
-                title={referralLink} // Tooltip for full link
-              />
-              <button type="button" onClick={handleCopyReferralLink} className={styles.goButton}>
-                Copy Link
-              </button>
-            </div>
-          )}
-        </div>
-        <div>
-          <input
-            placeholder="Enter Job Title"
-            className={styles.jobformInput}
-            style={{ width: '120px', minWidth: '0', padding: '8px' }}
-          />
-          <button type="button" className={styles.goButton}>
-            Go
-          </button>
-        </div>
-        <div>
+      <div className={`${styles.jobformNavbar} ${darkMode ? styles.darkNavbar : ''}`}>
+        {/* Job Position Selection Section */}
+        <div className={styles.navbarSection}>
+          <div className={styles.navbarSectionTitle}>Select Job Position</div>
           <select
             value={jobTitle}
             onChange={q => setJobTitle(q.target.value)}
@@ -407,6 +362,66 @@ function JobFormBuilder() {
               </option>
             ))}
           </select>
+        </div>
+
+        {/* Job Search Section */}
+        <div className={styles.navbarSection}>
+          <div className={styles.navbarSectionTitle}>Search Job Title</div>
+          <div className={styles.buttonRow}>
+            <input
+              placeholder="Enter Job Title"
+              className={styles.jobformInput}
+              style={{ flex: 1, minWidth: '150px', padding: '8px' }}
+            />
+            <button type="button" className={styles.goButton}>
+              Go
+            </button>
+          </div>
+        </div>
+
+        {/* Referral Link Generator Section */}
+        <div className={styles.navbarSection}>
+          <div className={styles.navbarSectionTitle}>Referral Link Generator</div>
+          <div className={styles.inputGroup}>
+            <div>
+              <label htmlFor="referralSource" style={{ fontSize: '14px', fontWeight: 'normal' }}>
+                Source Identifier (e.g., LN, FB):
+              </label>
+              <input
+                id="referralSource"
+                type="text"
+                value={referralSource}
+                onChange={e => setReferralSource(e.target.value)}
+                className={styles.jobformInput}
+                placeholder="Enter source"
+                maxLength={10}
+              />
+            </div>
+
+            {referralLink && (
+              <div className={styles.buttonRow}>
+                <input
+                  type="text"
+                  value={referralLink}
+                  readOnly
+                  ref={referralInputRef}
+                  className={styles.jobformInput}
+                  style={{
+                    flex: '1',
+                    minWidth: '150px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    cursor: 'pointer',
+                  }}
+                  title={referralLink}
+                />
+                <button type="button" onClick={handleCopyReferralLink} className={styles.goButton}>
+                  Copy Link
+                </button>
+              </div>
+            )}
+          </div>
         </div>
       </div>
       <h1 className={styles.jobformTitle}>FORM CREATION</h1>
@@ -422,6 +437,7 @@ function JobFormBuilder() {
             formFields={formFields}
             setFormFields={setFormFields}
             onImportQuestions={importQuestions}
+            darkMode={darkMode}
           />
           <form>
             {formFields.map((field, index) => (
@@ -561,6 +577,7 @@ function JobFormBuilder() {
               question={editingQuestion}
               onSave={handleSaveEditedQuestion}
               onCancel={handleCancelEdit}
+              darkMode={darkMode}
             />
           )}
         </div>


### PR DESCRIPTION
# Description
(PRIORITY LATER) Jae/Mrinalini: Application/Job Posting: Finish 4012 Special Action Item for the Referral Link Requirement
<img width="791" height="373" alt="image" src="https://github.com/user-attachments/assets/e3739181-a60c-4b45-b754-4a86f1ce4113" />
<img width="807" height="103" alt="image" src="https://github.com/user-attachments/assets/5444368c-c8bf-4635-8c6f-41f9f86cb28e" />


## Related PRS (if any):
…

## Main changes explained:
-Implemented mobile responsiveness - Fixed layout issues on smaller screens by converting fixed pixel widths to flexible units (maxWidth instead of width), adding flexbox wrapping, and ensuring all inputs stack properly on mobile devices.
-Implemented dark mode to this page
## How to test:

1. check into current branch
2. do npm install and (if needed: npm install slugigy) to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to [http://localhost:3000/jobformbuilder](http://localhost:3000/jobformbuilder)
6. verify the Referral Link Generator feature is working in smaller screens without any problems
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/52b1ffeb-045a-4bd9-b3b8-04e774fb75ec
