### PR TITLE
Peterson implemented text wrapping for long text inside the modal.

### DIFF
--- a/src/components/Teams/TeamMembersPopup.jsx
+++ b/src/components/Teams/TeamMembersPopup.jsx
@@ -317,6 +317,9 @@ export const TeamMembersPopup = React.memo(props => {
     return visibleList.map((u, i) => renderRow(u, i));
   };
 
+  const wrapLongTeamName = teamName =>
+    teamName.length >= 60 ? teamName.slice(0, 50) + '...' : teamName;
+
   return (
     <Container fluid>
       <InfoModal isOpen={infoModal} toggle={toggleInfoModal} />
@@ -329,8 +332,8 @@ export const TeamMembersPopup = React.memo(props => {
           props.open ? ' open-team-members-popup-modal' : ''
         }`}
       >
-        <ModalHeader className={darkMode ? 'bg-space-cadet' : ''} toggle={closePopup}>
-          {`Members of ${props.selectedTeamName}`}
+        <ModalHeader className={`${darkMode ? 'bg-space-cadet' : ''} `} toggle={closePopup}>
+          {wrapLongTeamName(`Members of ${props.selectedTeamName}`)}
         </ModalHeader>
 
         <div className={darkMode ? 'bg-space-cadet' : ''}>


### PR DESCRIPTION
# Description
This PR was opened to implement text wrapping for long content in the modal to prevent the text from exceeding the modal’s width.

## Related PRS (if any):
None.

## Main changes explained:
The TeamMembersPopup.jsx component has been modified to fix the bug.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to other links → teams
6. Create a team with a very long name that does not exceed the modal’s width.

## Screenshots or videos of changes:
### Before my fix:
https://github.com/user-attachments/assets/df7a2bad-bb01-4982-a2ce-0a87952c4ef2

### After my fix
https://github.com/user-attachments/assets/25d5c706-281a-48a6-9136-7057eee2cf91

## Note:
None.
