### PR TITLE
Kristin Make Non-Month Dates Transparent in Calendar Page

### DIFF
--- a/src/components/CommunityPortal/Calendar/CommunityCalendar.module.css
+++ b/src/components/CommunityPortal/Calendar/CommunityCalendar.module.css
@@ -144,6 +144,20 @@
   padding: 2px;
 }
 
+.reactCalendar :global(.react-calendar__month-view__days__day--neighboringMonth) {
+  background: transparent !important;
+  color: #cbd5e0 !important;
+  opacity: 0.6;
+  pointer-events: auto;
+  border: 1px solid #dee2e6 !important;
+}
+
+.reactCalendarDarkMode :global(.react-calendar__month-view__days__day--neighboringMonth) {
+  background: transparent !important;
+  color: #4a5568 !important;
+  opacity: 0.4;
+}
+
 .reactCalendar :global(.react-calendar__navigation) {
   background-color: #f9f9f9;
   border-bottom: 1px solid #ddd;


### PR DESCRIPTION
# Description
Make the community calendar display the dates that belong to the currently selected month, and make the next month's dates transparent.

## Related PRS (if any):
This frontend PR is related to the #XXX backend PR.
To test this backend PR you need to checkout the #XXX frontend PR.
…

## Main changes explained:
- Update CommunityCalendar.module.css for greying out dates on neighborhood months

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to communityportal/calendar
6. verify dates not from this month are greyed out

## Screenshots or videos of changes:
<img width="1575" height="993" alt="Fed_2026" src="https://github.com/user-attachments/assets/c5df0367-6236-479a-b18a-b6db63b3d826" />
