### PR TITLE
Peterson implement wrap long text inside modal delete team

### DIFF
--- a/src/components/Teams/DeleteTeamPopup.jsx
+++ b/src/components/Teams/DeleteTeamPopup.jsx
@@ -14,6 +14,9 @@ export const DeleteTeamPopup = React.memo(props => {
   const canDeleteTeam = props.hasPermission('deleteTeam');
   const canPutTeam = props.hasPermission('putTeam');
 
+  const wrapLongTeamName = teamName =>
+    teamName.length >= 60 ? teamName.slice(0, 50) + '...' : teamName;
+
   return (
     <Modal
       isOpen={props.open}
@@ -25,7 +28,9 @@ export const DeleteTeamPopup = React.memo(props => {
       </ModalHeader>
       <ModalBody style={{ textAlign: 'center' }} className={darkMode ? 'bg-yinmn-blue' : ''}>
         <span>
-          {`Are you sure you want to delete the team with name "${props.selectedTeamName}"?
+          {`Are you sure you want to delete the team with name "${wrapLongTeamName(
+            props.selectedTeamName,
+          )}"?
           This action cannot be undone. Switch this team to "Inactive" if you'd like to keep it in the system.`}
         </span>
       </ModalBody>

--- a/src/components/Teams/DeleteTeamPopup.jsx
+++ b/src/components/Teams/DeleteTeamPopup.jsx
@@ -15,7 +15,7 @@ export const DeleteTeamPopup = React.memo(props => {
   const canPutTeam = props.hasPermission('putTeam');
 
   const wrapLongTeamName = teamName =>
-    teamName.length >= 60 ? teamName.slice(0, 50) + '...' : teamName;
+    teamName && teamName.length >= 60 ? teamName.slice(0, 50) + '...' : teamName;
 
   return (
     <Modal


### PR DESCRIPTION
# Description
This PR was opened to implement text wrapping for long content in the modal to prevent the text from exceeding the modal’s width.

## Related PRS (if any):
None.

## Main changes explained:
The TeamMembersPopup.jsx component has been modified to fix the bug.

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to other links → teams
6. Create a team with a very long name that does not exceed the modal’s width.

## Screenshots or videos of changes:
### Before my fix:
https://github.com/user-attachments/assets/c2f406c5-1e9e-49a8-b34a-d00e1b759956

### After my fix:
https://github.com/user-attachments/assets/1c505389-f030-44c2-8383-bf5dc294c6b4

## Note:
None.