### PR TITLE
Akshith - Add Missing Year Information in Event Date Display

### DIFF
--- a/src/components/CommunityPortal/CPDashboard.jsx
+++ b/src/components/CommunityPortal/CPDashboard.jsx
@@ -94,6 +94,7 @@ export function CPDashboard() {
       weekday: 'long',
       month: 'long',
       day: 'numeric',
+      year: 'numeric',
       hour: 'numeric',
       minute: '2-digit',
     });


### PR DESCRIPTION
# Description
<img width="642" height="456" alt="image" src="https://github.com/user-attachments/assets/34600354-a35a-43a5-a274-c8386804aa02" />
 

## Related PRS (if any):
This frontend PR is not related to any PR.
…

## Main changes explained:
- Added Missing Year Information the Event Card Display
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. login as any user user
5. go to dashboard→ https://localhost:5173/communityportal
6. Verify if the Event Cards display the complete date of the event that includes the year.
7. Check in both light and dark modes

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/32885fc5-2410-4f49-9f93-8ca463085170



## Note:
Include the information the reviewers need to know.
