### PR TITLE
Akshith: fix event date selector

### DIFF
--- a/src/components/CommunityPortal/Reports/Participation/CreateEventModal.jsx
+++ b/src/components/CommunityPortal/Reports/Participation/CreateEventModal.jsx
@@ -91,7 +91,7 @@ function CreateEventModal({ isOpen, toggle }) {
     }
 
     if (formData.date) {
-      const selectedDate = moment(FormDataEvent.date, 'YYYY-MM-DD').startOf('day');
+      const selectedDate = moment(formData.date, 'YYYY-MM-DD').startOf('day');
       const today = moment()
         .tz('America/Los_Angeles')
         .startOf('day');

--- a/src/components/CommunityPortal/Reports/Participation/CreateEventModal.jsx
+++ b/src/components/CommunityPortal/Reports/Participation/CreateEventModal.jsx
@@ -90,6 +90,16 @@ function CreateEventModal({ isOpen, toggle }) {
       newErrors.date = 'Date is required';
     }
 
+    if (formData.date) {
+      const selectedDate = moment(FormDataEvent.date, 'YYYY-MM-DD').startOf('day');
+      const today = moment()
+        .tz('America/Los_Angeles')
+        .startOf('day');
+      if (selectedDate.isBefore(today)) {
+        newErrors.date = 'Event Date Cannot be in the past';
+      }
+    }
+
     if (!formData.startTime) {
       newErrors.startTime = 'Start time is required';
     }
@@ -273,6 +283,9 @@ function CreateEventModal({ isOpen, toggle }) {
               value={formData.date}
               onChange={handleChange}
               disabled={loading}
+              min={moment()
+                .tz('America/Los_Angeles')
+                .format('YYYY-MM-DD')}
               style={darkMode ? { colorScheme: 'dark' } : {}}
             />
             {errors.date && <div className="text-danger small">{errors.date}</div>}


### PR DESCRIPTION
# Description
<img width="443" height="602" alt="image" src="https://github.com/user-attachments/assets/d3fd19b3-51cd-4bf9-9304-a732b4face63" />

 

## Related PRS (if any):
This frontend PR is not related to any other PR.
…

## Main changes explained:
- Disabled Date selector from displaying past dates.
- Added Error message if past date is entered for the event date. 
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. login as admin user
5. go to dashboard→  https://localhost:5173/communityportal/reports/participation
6. Click on Event Date.
7. The Date selector now displays the present dates and future.
8. Try typing a past date for the event date and creating the event.
9. The modal displays error message indicating past date is not allowed.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/f624f28d-25e8-420f-a39b-a932ed773701



## Note:
Include the information the reviewers need to know.
