### PR TITLE
Akshith - Fix: Create Event Form Displays Previously Entered Event Name

### DIFF
--- a/src/components/CommunityPortal/Reports/Participation/CreateEventModal.jsx
+++ b/src/components/CommunityPortal/Reports/Participation/CreateEventModal.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
 import { useDispatch, useSelector } from 'react-redux';
 import moment from 'moment-timezone';
@@ -30,6 +30,12 @@ function CreateEventModal({ isOpen, toggle }) {
     coverImage: '',
   });
 
+  useEffect(() => {
+    if (isOpen && !loading) {
+      resetForm();
+    }
+  }, [isOpen]);
+
   const resetForm = () => {
     setFormData({
       title: '',
@@ -55,9 +61,11 @@ function CreateEventModal({ isOpen, toggle }) {
 
   const handleToggle = () => {
     if (!loading) {
-      toggle();
-      if (!isOpen) {
+      if (isOpen) {
+        toggle();
+      } else {
         resetForm();
+        toggle();
       }
     }
   };


### PR DESCRIPTION
# Description
<img width="440" height="446" alt="image" src="https://github.com/user-attachments/assets/03257d17-f441-4bac-8d44-7e2c91fc08ad" />
 

## Related PRS (if any):
This frontend PR is not related to any other PR.
…

## Main changes explained:
- Fixed the issue of Pre Populated fields after creating an event when create new event is clicked.
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. login as admin user
5. go to dashboard→ https://localhost:5173/communityportal/reports/participation
6. Create an event.
7. Click on Create new event again.
8. When Modal loads check if the modal fields are empty. 

## Screenshots or videos of changes:
Before Changes:

https://github.com/user-attachments/assets/a2aca71f-3db7-41a4-b3c0-0f21e2050656



After Changes:

https://github.com/user-attachments/assets/8486f4e9-3161-4cf3-918d-7f58b697c2e5



## Note:
Include the information the reviewers need to know.
