### PR TITLE
Peterson implemented an error toast for invalid links in the user profile.

### DIFF
--- a/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/EditLinkModal.jsx
@@ -15,6 +15,7 @@ import styles from './EditLinkModal.module.css';
 import { boxStyle, boxStyleDark } from '~/styles';
 import { connect, useSelector } from 'react-redux';
 import { isValidGoogleDocsUrl, isValidMediaUrl } from '~/utils/checkValidURL';
+import { toast } from 'react-toastify';
 
 const EditLinkModal = props => {
   const darkMode = useSelector(state => state.theme.darkMode)
@@ -95,6 +96,7 @@ const EditLinkModal = props => {
       !isValidUrl(newLink.Link)
     ) {
       setIsValidLink(false);
+      toast.error('Please enter valid URLs for each link.');
     } else {
       const newLinks = [...links, { Name: newLink.Name, Link: newLink.Link }];
       setLinks(newLinks);
@@ -160,6 +162,7 @@ const EditLinkModal = props => {
       closeModal();
     } else {
       setIsValidLink(false);
+      toast.error('Please enter valid URLs for each link.');
     }
   };
 
@@ -383,11 +386,6 @@ const EditLinkModal = props => {
                   </div>
                 </div>
               </Card>
-              {!isValidLink && (
-                <p className={`${styles['invalid-help-context']}`} data-testid='invalid-url-warning' >
-                  Please enter valid URLs for each link.
-                </p>
-              )}
             </CardBody>
           </div>
         </ModalBody>


### PR DESCRIPTION
# Description
This PR has been opened to replace the existing error message with a toast notification when a user attempts to add an invalid link to their profile.

## Related PRS (if any):
None

## Main changes explained:
The EditLinkModal.jsx component has been modified to fix the bug.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an admin or owner user.
5. Go to welcome → view profile.
6. On the user profile page, click on Edit Link, add an invalid link, and attempt to submit it. A red toast notification should appear indicating the error.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/f6790acb-9e61-4d2f-ad8c-95da797816f7

## Note:
None.