### PR TITLE
Rithika taking over for Aditya-feat: Add New Bar Chart Card to the Lessons Learned Section on the Total Construction Summary Page

### DIFF
--- a/src/components/BMDashboard/LessonsLearnt/LessonsLearntChart.jsx
+++ b/src/components/BMDashboard/LessonsLearnt/LessonsLearntChart.jsx
@@ -1,10 +1,11 @@
-/* eslint-disable */ /* prettier-ignore */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { Bar } from 'react-chartjs-2';
 import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Title } from 'chart.js';
 import axios from 'axios';
 import Select from 'react-select';
 import DatePicker from 'react-datepicker';
+import PropTypes from 'prop-types';
 
 import { ENDPOINTS } from '../../../utils/URL';
 import styles from './LessonsLearntChart.module.css';
@@ -12,45 +13,55 @@ import 'react-datepicker/dist/react-datepicker.css';
 
 ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Title);
 
-const useLessonsData = (selectedProjects, startDate, endDate) => {
+const toYMD = d =>
+  d instanceof Date && !Number.isNaN(d.getTime())
+    ? `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+        d.getDate(),
+      ).padStart(2, '0')}`
+    : '';
+
+const useLessonsData = (selectedProject, startDate, endDate) => {
   const [allProjects, setAllProjects] = useState([]);
   const [lessonsData, setLessonsData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    let cancelled = false;
     const fetchProjects = async () => {
       try {
         const response = await axios.get(ENDPOINTS.BM_PROJECTS);
-        const projects = Array.isArray(response.data) ? response.data : [];
-        setAllProjects(projects);
-      } catch (err) {
-        console.error('Error fetching projects:', err);
-        setAllProjects([]);
+        if (!cancelled) {
+          setAllProjects(Array.isArray(response.data) ? response.data : []);
+        }
+      } catch {
+        if (!cancelled) setAllProjects([]);
       }
     };
     fetchProjects();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
     const fetchLessons = async () => {
       setIsLoading(true);
       setError(null);
       try {
         const params = {};
 
-        if (selectedProjects && selectedProjects.length > 0) {
-          params.projectId = selectedProjects.length === 1 ? selectedProjects[0].value : 'ALL';
+        if (selectedProject) {
+          params.projectId = selectedProject.value;
         }
 
-        if (startDate) {
-          params.startDate = startDate.toISOString();
-        }
-        if (endDate) {
-          params.endDate = endDate.toISOString();
-        }
+        const formattedStart = toYMD(startDate);
+        const formattedEnd = toYMD(endDate);
+        if (formattedStart) params.startDate = formattedStart;
+        if (formattedEnd) params.endDate = formattedEnd;
 
-        const response = await axios.get(`${ENDPOINTS.BM_LESSONS}-learnt`, { params });
+        const response = await axios.get(ENDPOINTS.BM_LESSONS_LEARNT, { params });
 
         const responseData = response.data?.data || response.data || [];
         const lessonsArray = Array.isArray(responseData) ? responseData : [];
@@ -60,145 +71,220 @@ const useLessonsData = (selectedProjects, startDate, endDate) => {
           projectId: item.projectId,
           lessonsCount: item.lessonsCount || 0,
           percentage:
-            parseFloat((item.changePercentage || '0%').replace('%', '').replace('+', '')) || 0,
+            Number.parseFloat((item.changePercentage || '0%').replace('%', '').replace('+', '')) ||
+            0,
           changePercentage: item.changePercentage || '0%',
         }));
 
-        setLessonsData(transformedData);
+        if (!cancelled) setLessonsData(transformedData);
       } catch (err) {
-        console.error('Error fetching lessons learnt:', err);
-        setError(err.message || 'Failed to fetch lessons data');
-        setLessonsData([]);
+        if (!cancelled) {
+          setError(err.message || 'Failed to fetch lessons data');
+          setLessonsData([]);
+        }
       } finally {
-        setIsLoading(false);
+        if (!cancelled) setIsLoading(false);
       }
     };
     fetchLessons();
-  }, [selectedProjects, startDate, endDate]);
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedProject, startDate, endDate]);
 
   return { allProjects, lessonsData, isLoading, error };
 };
 
-function ChartTitle({ title }) {
-  return <h2 className={styles.chartTitle}>{title}</h2>;
-}
+const BAR_COLOR_LIGHT = '#10b981';
+const BAR_COLOR_DARK = '#34d399';
 
-const LessonsLearntChart = () => {
-  const [selectedProjects, setSelectedProjects] = useState([]);
+function LessonsLearntChart({ darkMode: propDarkMode }) {
+  const reduxDarkMode = useSelector(state => state.theme.darkMode);
+  const darkMode = propDarkMode === undefined ? reduxDarkMode : propDarkMode;
+
+  const [selectedProject, setSelectedProject] = useState(null);
   const [startDate, setStartDate] = useState(null);
   const [endDate, setEndDate] = useState(null);
 
   const { allProjects, lessonsData, isLoading, error } = useLessonsData(
-    selectedProjects,
+    selectedProject,
     startDate,
     endDate,
   );
 
-  const handleProjectChange = selected => {
-    setSelectedProjects(selected || []);
-  };
+  const today = useMemo(() => {
+    const d = new Date();
+    d.setHours(23, 59, 59, 999);
+    return d;
+  }, []);
 
-  const projectOptions = Array.isArray(allProjects)
-    ? allProjects
-        .filter(proj => proj && (proj._id || proj.id))
-        .map(proj => ({
-          value: proj._id || proj.id,
-          label: proj.name || 'Unnamed Project',
-        }))
-    : [];
+  const projectOptions = useMemo(() => {
+    const opts = Array.isArray(allProjects)
+      ? allProjects
+          .filter(proj => proj && (proj._id || proj.id))
+          .map(proj => ({
+            value: proj._id || proj.id,
+            label: proj.name || 'Unnamed Project',
+          }))
+      : [];
+    return [{ value: 'ALL', label: 'All Projects' }, ...opts];
+  }, [allProjects]);
 
-  const safeLabels = Array.isArray(lessonsData)
-    ? lessonsData.map(d => d?.projectName || 'Unknown')
-    : [];
+  const barColor = darkMode ? BAR_COLOR_DARK : BAR_COLOR_LIGHT;
 
-  const safeData = Array.isArray(lessonsData) ? lessonsData.map(d => d?.lessonsCount || 0) : [];
+  const chartData = useMemo(() => {
+    const safeLabels = Array.isArray(lessonsData)
+      ? lessonsData.map(d => d?.projectName || 'Unknown')
+      : [];
+    const safeData = Array.isArray(lessonsData) ? lessonsData.map(d => d?.lessonsCount || 0) : [];
 
-  const chartData = {
-    labels: safeLabels,
-    datasets: [
-      {
-        label: 'Lessons Count',
-        data: safeData,
-        backgroundColor: '#10b981',
-      },
-    ],
-  };
+    return {
+      labels: safeLabels,
+      datasets: [
+        {
+          label: 'Lessons Count',
+          data: safeData,
+          backgroundColor: barColor,
+        },
+      ],
+    };
+  }, [lessonsData, barColor]);
 
-  const chartOptions = {
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      title: {
-        display: false,
-      },
-      tooltip: {
-        callbacks: {
-          afterLabel: context => {
-            const dataIndex = context.dataIndex;
-            if (Array.isArray(lessonsData) && lessonsData[dataIndex]) {
-              return `Change: ${lessonsData[dataIndex].changePercentage || '0%'}`;
-            }
-            return '';
+  const chartOptions = useMemo(() => {
+    const tickColor = darkMode ? '#cbd5e1' : '#374151';
+    const gridColor = darkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
+
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        title: { display: false },
+        tooltip: {
+          callbacks: {
+            afterLabel: context => {
+              const { dataIndex } = context;
+              if (Array.isArray(lessonsData) && lessonsData[dataIndex]) {
+                return `MoM Change: ${lessonsData[dataIndex].changePercentage || '0%'}`;
+              }
+              return '';
+            },
           },
         },
       },
-    },
-    scales: {
-      y: {
-        beginAtZero: true,
-        ticks: {
-          stepSize: 1,
+      scales: {
+        y: {
+          beginAtZero: true,
+          ticks: { stepSize: 1, color: tickColor },
+          grid: { color: gridColor },
+        },
+        x: {
+          ticks: { color: tickColor },
+          grid: { color: gridColor },
         },
       },
-    },
-  };
+    };
+  }, [lessonsData, darkMode]);
+
+  const selectStyles = useMemo(
+    () => ({
+      control: base => ({
+        ...base,
+        backgroundColor: darkMode ? '#334155' : '#fff',
+        borderColor: darkMode ? '#475569' : '#d1d5db',
+        minHeight: '32px',
+        fontSize: '13px',
+        color: darkMode ? '#f1f5f9' : '#000',
+      }),
+      singleValue: base => ({
+        ...base,
+        color: darkMode ? '#f1f5f9' : '#000',
+      }),
+      menu: base => ({
+        ...base,
+        backgroundColor: darkMode ? '#1e293b' : '#fff',
+      }),
+      option: (base, state) => {
+        const focusedBg = darkMode ? '#475569' : '#e2e8f0';
+        const defaultBg = darkMode ? '#1e293b' : '#fff';
+        return {
+          ...base,
+          backgroundColor: state.isFocused ? focusedBg : defaultBg,
+          color: darkMode ? '#f1f5f9' : '#000',
+          fontSize: '12px',
+          padding: '6px 10px',
+        };
+      },
+      input: base => ({
+        ...base,
+        color: darkMode ? '#f1f5f9' : '#000',
+      }),
+      placeholder: base => ({
+        ...base,
+        color: darkMode ? '#94a3b8' : '#9ca3af',
+      }),
+    }),
+    [darkMode],
+  );
 
   return (
-    <div className={styles.chartContainer}>
-      <ChartTitle title="Lessons Learnt" />
+    <div className={`${styles.chartContainer} ${darkMode ? styles.darkMode : ''}`}>
+      <h3 className={styles.chartTitle}>Lessons Learnt</h3>
 
       <div className={styles.filterRow}>
         <div className={styles.filter}>
-          <label>Select Projects</label>
+          <label htmlFor="lessons-project-select" className={styles.filterLabel}>
+            Project
+          </label>
           <Select
-            isMulti
+            inputId="lessons-project-select"
             options={projectOptions}
-            value={selectedProjects}
-            onChange={handleProjectChange}
-            placeholder="Select projects..."
+            value={selectedProject}
+            onChange={setSelectedProject}
+            placeholder="All projects"
             isClearable
+            styles={selectStyles}
           />
         </div>
         <div className={styles.filter}>
-          <label>From</label>
+          <label htmlFor="lessons-start-date" className={styles.filterLabel}>
+            From
+          </label>
           <DatePicker
+            id="lessons-start-date"
             selected={startDate}
             onChange={date => setStartDate(date)}
             placeholderText="Start date"
+            dateFormat="MM/dd/yyyy"
             isClearable
+            maxDate={endDate || today}
           />
         </div>
         <div className={styles.filter}>
-          <label>To</label>
+          <label htmlFor="lessons-end-date" className={styles.filterLabel}>
+            To
+          </label>
           <DatePicker
+            id="lessons-end-date"
             selected={endDate}
             onChange={date => setEndDate(date)}
             placeholderText="End date"
+            dateFormat="MM/dd/yyyy"
             isClearable
+            minDate={startDate}
+            maxDate={today}
           />
         </div>
       </div>
 
       <div className={styles.chartWrapper}>
-        {isLoading ? (
-          <p>Loading...</p>
-        ) : error ? (
-          <p>Error loading data: {error}</p>
-        ) : !Array.isArray(lessonsData) || lessonsData.length === 0 ? (
-          <p>No lessons data available for the selected criteria</p>
-        ) : (
+        {isLoading && <p className={styles.statusText}>Loading...</p>}
+        {!isLoading && error && <p className={styles.statusText}>Error loading data: {error}</p>}
+        {!isLoading && !error && (!Array.isArray(lessonsData) || lessonsData.length === 0) && (
+          <p className={styles.statusText}>No lessons data available for the selected criteria</p>
+        )}
+        {!isLoading && !error && Array.isArray(lessonsData) && lessonsData.length > 0 && (
           <>
-            <div style={{ height: '400px', width: '100%' }}>
+            <div className={styles.barContainer}>
               <Bar data={chartData} options={chartOptions} />
             </div>
             <div className={styles.percentageLabels}>
@@ -219,6 +305,14 @@ const LessonsLearntChart = () => {
       </div>
     </div>
   );
+}
+
+LessonsLearntChart.propTypes = {
+  darkMode: PropTypes.bool,
+};
+
+LessonsLearntChart.defaultProps = {
+  darkMode: undefined,
 };
 
 export default LessonsLearntChart;

--- a/src/components/BMDashboard/LessonsLearnt/LessonsLearntChart.jsx
+++ b/src/components/BMDashboard/LessonsLearnt/LessonsLearntChart.jsx
@@ -20,7 +20,7 @@ const toYMD = d =>
       ).padStart(2, '0')}`
     : '';
 
-const useLessonsData = (selectedProject, startDate, endDate) => {
+const useLessonsData = (selectedProjects, startDate, endDate) => {
   const [allProjects, setAllProjects] = useState([]);
   const [lessonsData, setLessonsData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -52,8 +52,14 @@ const useLessonsData = (selectedProject, startDate, endDate) => {
       try {
         const params = {};
 
-        if (selectedProject) {
-          params.projectId = selectedProject.value;
+        // Backend supports single projectId or 'ALL'.
+        // For one selection send that ID; for 0 or 2+ send ALL and filter client-side.
+        const hasSelection = Array.isArray(selectedProjects) && selectedProjects.length > 0;
+        const singleProject = hasSelection && selectedProjects.length === 1;
+        if (singleProject) {
+          params.projectId = selectedProjects[0].value;
+        } else if (hasSelection) {
+          params.projectId = 'ALL';
         }
 
         const formattedStart = toYMD(startDate);
@@ -76,7 +82,15 @@ const useLessonsData = (selectedProject, startDate, endDate) => {
           changePercentage: item.changePercentage || '0%',
         }));
 
-        if (!cancelled) setLessonsData(transformedData);
+        // When multiple projects selected, filter to only the chosen ones
+        const needsClientFilter = hasSelection && !singleProject;
+        let filtered = transformedData;
+        if (needsClientFilter) {
+          const selectedIds = new Set(selectedProjects.map(p => p.value));
+          filtered = transformedData.filter(d => selectedIds.has(d.projectId));
+        }
+
+        if (!cancelled) setLessonsData(filtered);
       } catch (err) {
         if (!cancelled) {
           setError(err.message || 'Failed to fetch lessons data');
@@ -90,7 +104,7 @@ const useLessonsData = (selectedProject, startDate, endDate) => {
     return () => {
       cancelled = true;
     };
-  }, [selectedProject, startDate, endDate]);
+  }, [selectedProjects, startDate, endDate]);
 
   return { allProjects, lessonsData, isLoading, error };
 };
@@ -102,12 +116,12 @@ function LessonsLearntChart({ darkMode: propDarkMode }) {
   const reduxDarkMode = useSelector(state => state.theme.darkMode);
   const darkMode = propDarkMode === undefined ? reduxDarkMode : propDarkMode;
 
-  const [selectedProject, setSelectedProject] = useState(null);
+  const [selectedProjects, setSelectedProjects] = useState([]);
   const [startDate, setStartDate] = useState(null);
   const [endDate, setEndDate] = useState(null);
 
   const { allProjects, lessonsData, isLoading, error } = useLessonsData(
-    selectedProject,
+    selectedProjects,
     startDate,
     endDate,
   );
@@ -118,17 +132,18 @@ function LessonsLearntChart({ darkMode: propDarkMode }) {
     return d;
   }, []);
 
-  const projectOptions = useMemo(() => {
-    const opts = Array.isArray(allProjects)
-      ? allProjects
-          .filter(proj => proj && (proj._id || proj.id))
-          .map(proj => ({
-            value: proj._id || proj.id,
-            label: proj.name || 'Unnamed Project',
-          }))
-      : [];
-    return [{ value: 'ALL', label: 'All Projects' }, ...opts];
-  }, [allProjects]);
+  const projectOptions = useMemo(
+    () =>
+      Array.isArray(allProjects)
+        ? allProjects
+            .filter(proj => proj && (proj._id || proj.id))
+            .map(proj => ({
+              value: proj._id || proj.id,
+              label: proj.name || 'Unnamed Project',
+            }))
+        : [],
+    [allProjects],
+  );
 
   const barColor = darkMode ? BAR_COLOR_DARK : BAR_COLOR_LIGHT;
 
@@ -195,9 +210,19 @@ function LessonsLearntChart({ darkMode: propDarkMode }) {
         fontSize: '13px',
         color: darkMode ? '#f1f5f9' : '#000',
       }),
-      singleValue: base => ({
+      multiValue: base => ({
+        ...base,
+        backgroundColor: darkMode ? '#475569' : '#e2e8f0',
+      }),
+      multiValueLabel: base => ({
         ...base,
         color: darkMode ? '#f1f5f9' : '#000',
+        fontSize: '11px',
+      }),
+      multiValueRemove: base => ({
+        ...base,
+        color: darkMode ? '#94a3b8' : '#6b7280',
+        ':hover': { backgroundColor: darkMode ? '#64748b' : '#cbd5e1', color: '#fff' },
       }),
       menu: base => ({
         ...base,
@@ -237,9 +262,10 @@ function LessonsLearntChart({ darkMode: propDarkMode }) {
           </label>
           <Select
             inputId="lessons-project-select"
+            isMulti
             options={projectOptions}
-            value={selectedProject}
-            onChange={setSelectedProject}
+            value={selectedProjects}
+            onChange={selected => setSelectedProjects(selected || [])}
             placeholder="All projects"
             isClearable
             styles={selectStyles}

--- a/src/components/BMDashboard/LessonsLearnt/LessonsLearntChart.module.css
+++ b/src/components/BMDashboard/LessonsLearnt/LessonsLearntChart.module.css
@@ -79,6 +79,7 @@
   position: relative;
   flex: 1;
   min-height: 0;
+  margin-top: 1.5rem;
 }
 
 .barContainer {

--- a/src/components/BMDashboard/LessonsLearnt/LessonsLearntChart.module.css
+++ b/src/components/BMDashboard/LessonsLearnt/LessonsLearntChart.module.css
@@ -1,37 +1,101 @@
 /* stylelint-disable  */
 .chartContainer {
-  padding: 1.5rem;
-  background: #f9fafb;
-  border: 1px solid #e5e7eb;
+  padding: 1rem;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border-color, #e5e7eb);
   border-radius: 0.75rem;
   max-width: 100%;
+  color: var(--text-color, #000);
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+}
+
+.darkMode {
+  --card-bg: #2b3e59;
+  --text-color: #fff;
+  --border-color: #4a5a77;
+  --label-color: #94a3b8;
+  --accent-color: #34d399;
+  --status-text-color: #cbd5e1;
 }
 
 .chartTitle {
-  font-size: 1.5rem;
-  margin-bottom: 1rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: var(--text-color, #000);
+  transition: color 0.3s ease;
+  flex-shrink: 0;
 }
 
 .filterRow {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  align-items: flex-end;
+  flex-shrink: 0;
 }
 
 .filter {
   display: flex;
   flex-direction: column;
-  min-width: 200px;
+  flex: 1 1 140px;
+  min-width: 120px;
+}
+
+.filterLabel {
+  font-size: 0.75rem;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+  color: var(--label-color, #6b7280);
+  transition: color 0.3s ease;
+}
+
+.darkMode .filterLabel {
+  color: #94a3b8;
+}
+
+.filter input {
+  background: var(--card-bg, #fff);
+  color: var(--text-color, #000);
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 13px;
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+.darkMode .filter input {
+  background: #334155;
+  color: #f1f5f9;
+  border-color: #475569;
 }
 
 .chartWrapper {
   position: relative;
+  flex: 1;
+  min-height: 0;
+}
+
+.barContainer {
+  height: 300px;
+  width: 100%;
+}
+
+.statusText {
+  color: var(--text-color, #6b7280);
+  font-size: 0.875rem;
+  text-align: center;
+  padding: 2rem 0;
 }
 
 .percentageLabels {
   position: absolute;
-  top: -1.5rem;
+  top: -1.25rem;
   width: 100%;
   display: flex;
   justify-content: space-around;
@@ -41,6 +105,42 @@
 .percentageLabel {
   position: absolute;
   transform: translateX(-50%);
-  font-size: 0.875rem;
-  color: #10b981;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent-color, #10b981);
+  transition: color 0.3s ease;
+}
+
+.darkMode .percentageLabel {
+  color: #34d399;
+}
+
+/* Responsive */
+@media (width <= 768px) {
+  .chartContainer {
+    padding: 0.75rem;
+  }
+
+  .filterRow {
+    gap: 0.5rem;
+  }
+
+  .filter {
+    min-width: 100px;
+    flex: 1 1 100%;
+  }
+
+  .barContainer {
+    height: 250px;
+  }
+
+  .chartTitle {
+    font-size: 1rem;
+  }
+}
+
+@media (width <= 480px) {
+  .barContainer {
+    height: 220px;
+  }
 }

--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
@@ -27,6 +27,7 @@ import IssueCharts from '../Issues/openIssueCharts';
 import LossTrackingLineChart from './Financials/LossTrackingLineCharts/LossTrackingLineChart';
 import SupplierPerformanceGraph from './SupplierPerformanceGraph.jsx';
 import MostFrequentKeywords from './MostFrequentKeywords/MostFrequentKeywords';
+import LessonsLearntChart from '../LessonsLearnt/LessonsLearntChart';
 import DistributionLaborHours from './DistributionLaborHours/DistributionLaborHours';
 
 const projectStatusButtons = [
@@ -327,6 +328,12 @@ function WeeklyProjectSummary() {
             className={`${styles.weeklyProjectSummaryCard} ${styles.normalCard}`}
           >
             <InjuryCategoryBarChart />
+          </div>,
+          <div
+            key="lessons-learnt-chart"
+            className={`${styles.weeklyProjectSummaryCard} ${styles.normalCard}`}
+          >
+            <LessonsLearntChart darkMode={darkMode} />
           </div>,
         ],
       },

--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.module.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.module.css
@@ -464,19 +464,6 @@
   --card-elev-hover: rgb(0 0 0 / 18%);
 }
 
-/* ---------------- DARK MODE VARIABLES ---------------- */
-:root {
-  --bg-color: #ffffff;
-  --text-color: #000000;
-  --card-bg: #fafafa;
-  --card-shadow: rgba(0, 0, 0, 0.1);
-  --section-bg: white;
-  --section-title-bg: white;
-  --section-title-hover: #e0e0e0;
-  --button-bg: black;
-  --button-hover: #333;
-}
-
 /* ---------------- DARK MODE STYLES ---------------- */
 .darkMode {
   --bg-color: #1b2a41;
@@ -500,7 +487,6 @@
 
 /* MERGED: keep background + FORCE all title text visible in dark mode */
 .darkMode .weeklyProjectSummaryDashboardCategoryTitle {
-  color: #fff;
   background: #2d4059;
   color: #ffffff;
 }

--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.module.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.module.css
@@ -42,7 +42,7 @@
   max-width: 1280px;
   padding: 12px 16px;
   background: var(--section-bg);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
   border-radius: 8px;
   gap: 12px;
 }
@@ -93,9 +93,19 @@
   font-size: 14px;
   background: var(--section-bg);
   color: var(--text-color);
-  box-sizing: border-box;
-  line-height: 1.25;
-  vertical-align: middle;
+  transition: all 0.3s ease;
+  appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23333' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 16px;
+}
+
+.darkMode .weeklySummaryHeaderControls select {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+  background-color: var(--card-bg) !important;
+  color: var(--text-color) !important;
+  border-color: var(--card-shadow) !important;
 }
 
 .weeklySummaryHeaderControls select:focus {
@@ -143,6 +153,11 @@
 
 .weeklySummaryShareBtn:hover:not(:disabled) {
   background-color: var(--button-hover) !important;
+}
+
+.weeklySummaryShareBtn:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(59 130 246 / 50%);
 }
 
 .weeklySummaryShareBtn:disabled {
@@ -210,7 +225,47 @@
 
 .darkMode .weeklyProjectSummaryCard {
   background: var(--card-bg);
-  box-shadow: 0 2px 5px rgba(255, 255, 255, 0.1);
+  box-shadow: 0 2px 5px rgb(255 255 255 / 10%);
+}
+
+.weeklyProjectSummaryCard :global(.container) {
+  background: #fff !important;
+  width: 100% !important;
+  height: 100% !important;
+  padding: 0 !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+.darkMode .weeklyProjectSummaryCard :global(.container) {
+  background: #1e293b !important;
+}
+
+.weeklyProjectSummaryCard :global(.recharts-wrapper) {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.weeklyProjectSummaryCard :global(.recharts-surface) {
+  overflow: visible !important;
+}
+
+.weeklyProjectSummaryCard :global(.chartContainer) {
+  flex: 1;
+  min-height: 280px;
+  position: relative;
+}
+
+.weeklyProjectSummaryCard :global(.recharts-bar-rectangle) {
+  shape-rendering: geometricprecision !important;
+}
+
+.weeklyProjectSummaryCard :global(.recharts-cartesian-axis-tick-value) {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+}
+
+.weeklyProjectSummaryCard :global(.recharts-cartesian-grid-horizontal line) {
+  stroke-dasharray: 3 3 !important;
 }
 
 .financialSmall {
@@ -227,8 +282,8 @@
   padding: 0;
   background: white;
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  overflow: visible;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
+  overflow: hidden;
   margin-bottom: 20px;
 }
 
@@ -301,27 +356,112 @@
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 20px;
   border-top: 1px solid var(--card-shadow);
-  animation: fadeIn 0.3s ease-in-out;
+  animation: fade-in 0.3s ease-in-out;
   background: var(--section-bg);
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
 }
 
-/* Adjust grid columns based on section size */
+.darkMode .weeklyProjectSummaryDashboardCategoryContent {
+  background-color: var(--section-bg);
+  border-top: 1px solid rgb(255 255 255 / 20%);
+}
+
 .weeklyProjectSummaryDashboardSection.half .weeklyProjectSummaryDashboardCategoryContent {
+  display: grid;
   grid-template-columns: repeat(2, 1fr);
+  gap: 15px;
 }
 
 .weeklyProjectSummaryDashboardSection.small .weeklyProjectSummaryDashboardCategoryContent {
+  display: grid;
   grid-template-columns: 1fr;
+  gap: 15px;
 }
 
-/* Stack cards vertically on tablet and mobile screens */
-@media (max-width: 1024px) {
-  .weeklyProjectSummaryDashboardSection.half .weeklyProjectSummaryDashboardCategoryContent {
-    grid-template-columns: 1fr;
-  }
+/* ---------------- LESSONS LEARNED SECTION ---------------- */
+.lessonsLearnedGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  width: 100%;
+  align-items: stretch;
+  min-height: 600px;
+}
+
+.lessonsCard {
+  min-height: 600px;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px var(--card-shadow);
+  transition: all 0.3s ease;
+}
+
+/* ---------------- TOOLS TRACKING LAYOUT ---------------- */
+.toolsTrackingLayout {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  width: 100%;
+}
+
+.toolsDonutWrap {
+  grid-column: span 1;
+  min-height: 300px;
+}
+
+/* ---------------- FINANCIALS GRID ---------------- */
+.financialsGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 15px;
+  width: 100%;
+}
+
+.financialsGrid .financialBig {
+  grid-column: span 4;
+  min-height: 400px;
+}
+
+/* ---------------- LABOR TIME GRID ---------------- */
+.laborTimeGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+  width: 100%;
+}
+
+/* ---------------- FINANCIALS TRACKING GRID ---------------- */
+.financialsTrackingGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 15px;
+  width: 100%;
+}
+
+/* ---------------- LIGHT MODE VARIABLES ---------------- */
+:root {
+  --bg-color: #fff;
+  --text-color: #000;
+  --text-secondary: #666;
+  --card-bg: #fff;
+  --card-shadow: rgb(0 0 0 / 10%);
+  --section-bg: #fff;
+  --section-title-bg: #f8fafc;
+  --section-title-hover: #f1f5f9;
+  --button-bg: black;
+  --button-hover: #333;
+  --border-color: #e5e7eb;
+  --pos-color: #15803d;
+  --neg-color: #b91c1c;
+  --neutral-change: rgb(0 0 0 / 65%);
+  --card-elev: rgb(0 0 0 / 15%);
+  --card-elev-hover: rgb(0 0 0 / 18%);
 }
 
 /* ---------------- DARK MODE VARIABLES ---------------- */
@@ -340,9 +480,10 @@
 /* ---------------- DARK MODE STYLES ---------------- */
 .darkMode {
   --bg-color: #1b2a41;
-  --text-color: #ffffff;
+  --text-color: #fff;
+  --text-secondary: #94a3b8;
   --card-bg: #2b3e59;
-  --card-shadow: rgba(255, 255, 255, 0.1);
+  --card-shadow: rgb(255 255 255 / 10%);
   --section-bg: #253342;
   --section-title-bg: #2d4059;
   --section-title-hover: #3a506b;
@@ -350,10 +491,16 @@
   --button-hover: #f5b13a;
   --border-color: #4a5a77;
   --focus-border-color: #e8a71c;
+  --pos-color: #22c55e;
+  --neg-color: #ef4444;
+  --neutral-change: rgb(255 255 255 / 75%);
+  --card-elev: rgb(0 0 0 / 45%);
+  --card-elev-hover: rgb(0 0 0 / 60%);
 }
 
 /* MERGED: keep background + FORCE all title text visible in dark mode */
 .darkMode .weeklyProjectSummaryDashboardCategoryTitle {
+  color: #fff;
   background: #2d4059;
   color: #ffffff;
 }
@@ -362,120 +509,20 @@
   background: #3a506b;
 }
 
-.darkMode .weeklyProjectSummaryDashboardCategoryTitle span {
-  color: #ffffff;
-}
-
-.darkMode .weeklyProjectSummaryDashboardCategoryTitle * {
-  color: #ffffff;
-}
-
-.darkMode .weeklyProjectSummaryDashboardCategoryContent {
-  background-color: var(--section-bg);
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
-}
-
 .darkMode .weeklySummaryHeaderContainer {
   background: var(--section-bg);
   color: var(--text-color);
 }
 
-/* ---------------- TOOLTIP SCROLL FIX ---------------- */
-.quantityOfMaterialsUsedChartTooltip {
-  max-height: 80vh !important;
-  overflow-y: auto !important;
-  padding-right: 15px !important;
-
-  /* Firefox */
-  scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0.1);
+.darkMode .weeklySummaryShareBtn {
+  background-color: var(--button-bg) !important;
 }
 
-/* Chrome/Safari scrollbar */
-.quantityOfMaterialsUsedChartTooltip::-webkit-scrollbar {
-  width: 8px;
+.darkMode .weeklySummaryShareBtn:hover {
+  background-color: var(--button-hover) !important;
 }
 
-.quantityOfMaterialsUsedChartTooltip::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.1);
-  border-radius: 4px;
-}
-
-.quantityOfMaterialsUsedChartTooltip::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 4px;
-}
-
-/* Additional adjustments for dark mode if needed */
-.darkMode .quantityOfMaterialsUsedChartTooltip::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.darkMode .quantityOfMaterialsUsedChartTooltip::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.3);
-}
-
-.darkMode .quantityOfMaterialsUsedChartTooltip {
-  scrollbar-color: rgba(255, 255, 255, 0.3) rgba(255, 255, 255, 0.1);
-}
-
-/* ---------------- RESPONSIVE DESIGN ---------------- */
-@media (max-width: 1024px) {
-  .weeklySummaryHeaderContainer {
-    flex-direction: column;
-    align-items: stretch;
-    width: 95%;
-  }
-
-  .weeklySummaryHeaderControls {
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    width: 100%;
-  }
-
-  .weeklyProjectSummaryDashboardGrid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (max-width: 768px) {
-  .weeklySummaryHeaderContainer {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .weeklySummaryHeaderControls {
-    flex-direction: column;
-    gap: 10px;
-    width: 100%;
-  }
-
-  .weeklySummaryHeaderControls select {
-    width: 100%;
-    max-width: none;
-  }
-
-  .weeklySummaryHeaderControls :global(.form-control) {
-    max-width: none;
-  }
-
-  .weeklySummaryShareBtn {
-    width: 100%;
-  }
-
-  .weeklyProjectSummaryDashboardGrid {
-    grid-template-columns: 1fr;
-  }
-
-  .weeklyProjectSummaryDashboardSection.full,
-  .weeklyProjectSummaryDashboardSection.large,
-  .weeklyProjectSummaryDashboardSection.half,
-  .weeklyProjectSummaryDashboardSection.small {
-    grid-column: span 1;
-  }
-}
-
-/* ---------------- STATUS CARD ---------------- */
+/* ---------------- STATUS CARD (base) ---------------- */
 .statusCard {
   display: flex;
   flex-direction: column;
@@ -486,10 +533,91 @@
   max-width: 284px;
   height: 190px;
   text-align: center;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 8px rgb(0 0 0 / 15%);
   padding: 20px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  border: 1px solid rgb(0 0 0 / 10%);
   position: relative;
+  transition: all 0.3s ease;
+}
+
+.weeklyCardTitle {
+  color: #000;
+  font-size: clamp(14px, 1.4vw, 18px);
+  font-weight: 600;
+  transition: color 0.3s ease;
+}
+
+.weeklyStatusValue {
+  color: #000;
+  font-size: 40px;
+  font-weight: 600;
+  transition: color 0.3s ease;
+}
+
+.weekly-status-change {
+  transition: color 0.3s ease;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.darkMode .statusCard {
+  background: var(--card-bg) !important;
+  color: var(--text-color) !important;
+  border-color: rgb(255 255 255 / 10%) !important;
+}
+
+.darkMode .weeklyCardTitle,
+.darkMode .weeklyStatusValue,
+.darkMode .weekly-status-change {
+  color: var(--text-color) !important;
+}
+
+/* Tooltip styles */
+.quantityOfMaterialsUsedChartTooltip {
+  max-height: 80vh !important;
+  overflow-y: auto !important;
+  padding-right: 15px !important;
+
+  /* Firefox */
+  scrollbar-width: thin;
+  scrollbar-color: rgb(0 0 0 / 30%) rgb(0 0 0 / 10%);
+}
+
+/* Chrome/Safari scrollbar */
+.quantityOfMaterialsUsedChartTooltip::-webkit-scrollbar {
+  width: 8px;
+}
+
+.quantityOfMaterialsUsedChartTooltip::-webkit-scrollbar-track {
+  background: rgb(0 0 0 / 10%);
+  border-radius: 4px;
+}
+
+.quantityOfMaterialsUsedChartTooltip::-webkit-scrollbar-thumb {
+  background: rgb(0 0 0 / 30%);
+  border-radius: 4px;
+}
+
+/* Additional adjustments for dark mode if needed */
+.darkMode .quantityOfMaterialsUsedChartTooltip::-webkit-scrollbar-track {
+  background: rgb(255 255 255 / 10%);
+}
+
+.darkMode .quantityOfMaterialsUsedChartTooltip::-webkit-scrollbar-thumb {
+  background: rgb(255 255 255 / 30%);
+}
+
+/* Animation */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ---------------- RESPONSIVE GRID LAYOUT ---------------- */
@@ -519,49 +647,253 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 2px 5px rgb(0 0 0 / 15%);
   margin: 12px 0;
 }
 
-.weeklyCardTitle {
-  color: #000;
-  font-size: clamp(14px, 1.4vw, 18px);
-  font-weight: 600;
-}
-
-.weeklyStatusValue {
-  color: #000;
-  font-size: 40px;
-  font-weight: 600;
-}
-
 /* ---------------- RESPONSIVE BREAKPOINTS ---------------- */
-@media (min-width: 1600px) {
+
+/* Large Screens */
+@media (width >= 1400px) {
+  .lessonsLearnedGrid {
+    min-height: 650px;
+  }
+  
+  .lessonsCard {
+    min-height: 650px;
+  }
+}
+
+@media (width <= 1399px) and (width >= 1200px) {
+  .lessonsLearnedGrid {
+    min-height: 600px;
+  }
+  
+  .lessonsCard {
+    min-height: 600px;
+  }
+}
+
+@media (width <= 1199px) and (width >= 992px) {
+  .lessonsLearnedGrid {
+    min-height: 550px;
+    gap: 20px;
+  }
+  
+  .lessonsCard {
+    min-height: 550px;
+  }
+}
+
+@media (width <= 991px) and (width >= 769px) {
+  .lessonsLearnedGrid {
+    min-height: 500px;
+    gap: 16px;
+  }
+  
+  .lessonsCard {
+    min-height: 500px;
+  }
+}
+
+/* Medium Screens */
+@media (width <= 1024px) {
+  .weeklySummaryHeaderContainer {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .weeklySummaryHeaderControls {
+    flex-wrap: wrap;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .weeklyProjectSummaryDashboardGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Small Screens */
+@media (width <= 768px) {
+  .weeklySummaryHeaderContainer {
+    flex-direction: column;
+    align-items: center;
+    width: 95%;
+  }
+
+  .weeklySummaryHeaderControls {
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+  }
+
+  .weeklySummaryHeaderControls select {
+    width: 100%;
+  }
+
+  .weeklySummaryShareBtn {
+    width: 100%;
+    margin-top: 5px;
+  }
+
+  .weeklyProjectSummaryDashboardGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .weeklyProjectSummaryDashboardSection.full,
+  .weeklyProjectSummaryDashboardSection.large,
+  .weeklyProjectSummaryDashboardSection.half,
+  .weeklyProjectSummaryDashboardSection.small {
+    grid-column: span 1;
+  }
+
+  .projectStatusGrid {
+    grid-template-columns: 1fr;
+  }
+  
+  .weeklyProjectSummaryDashboardSection.half .weeklyProjectSummaryDashboardCategoryContent {
+    grid-template-columns: 1fr;
+  }
+  
+  .weeklyProjectSummaryCard :global(.chartContainer) {
+    min-height: 240px;
+  }
+  
+  .normalCard {
+    min-height: 280px;
+  }
+
+  .lessonsLearnedGrid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    min-height: auto;
+  }
+  
+  .lessonsCard {
+    min-height: 500px;
+  }
+  
+  .toolsTrackingLayout {
+    grid-template-columns: 1fr;
+  }
+  
+  .toolsDonutWrap {
+    grid-column: span 1;
+  }
+  
+  .financialsGrid {
+    grid-template-columns: 1fr;
+  }
+  
+  .financialsGrid .financialBig {
+    grid-column: span 1;
+  }
+  
+  .laborTimeGrid {
+    grid-template-columns: 1fr;
+  }
+  
+  .financialsTrackingGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Extra Small Screens */
+@media (width <= 480px) {
+  .lessonsCard {
+    min-height: 450px;
+  }
+  
+  .weeklyProjectSummaryCard :global(.chartContainer) {
+    min-height: 220px;
+  }
+  
+  .normalCard {
+    min-height: 260px;
+  }
+  
+  .weeklySummaryHeaderTitle {
+    font-size: large;
+    flex-direction: column;
+    gap: 5px;
+  }
+}
+
+/* Status Grid Responsive */
+@media (width >= 1600px) {
   .projectStatusGrid {
     grid-template-columns: repeat(6, 1fr);
   }
 }
 
-@media (max-width: 1400px) {
+@media (width <= 1400px) {
   .projectStatusGrid {
     grid-template-columns: repeat(4, 1fr);
   }
 }
 
-@media (max-width: 1024px) {
+@media (width <= 1024px) {
   .projectStatusGrid {
     grid-template-columns: repeat(3, 1fr);
   }
 }
 
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .projectStatusGrid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
-@media (max-width: 576px) {
+@media (width <= 576px) {
   .projectStatusGrid {
     grid-template-columns: repeat(1, 1fr);
+  }
+}
+
+/* Dark mode fixes */
+.darkMode .weeklyProjectSummaryContainer {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.darkMode .weeklyProjectSummaryDashboardContainer {
+  background-color: var(--bg-color);
+}
+
+.darkMode .weeklyProjectSummaryDashboardSection {
+  background: var(--section-bg);
+}
+
+.darkMode * {
+  color: inherit;
+}
+
+.darkMode .lessonsCard {
+  box-shadow: 0 4px 6px rgb(0 0 0 / 30%);
+}
+
+/* Print styles */
+@media print {
+  .weeklyProjectSummaryCard {
+    break-inside: avoid;
+  }
+  
+  .weeklyProjectSummaryCard :global(.container) {
+    box-shadow: none;
+    border: 1px solid #ddd;
+  }
+  
+  .lessonsLearnedGrid,
+  .toolsTrackingLayout,
+  .financialsGrid,
+  .laborTimeGrid,
+  .financialsTrackingGrid {
+    break-inside: avoid;
+  }
+  
+  .weeklySummaryShareBtn,
+  .weeklySummaryHeaderControls select {
+    display: none;
   }
 }

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -716,7 +716,11 @@ export default (
         {/* ----- BEGIN BM Dashboard Routing ----- */}
         <BMProtectedRoute path="/bmdashboard" exact component={BMDashboard} />
         <Route path="/bmdashboard/login" component={BMLogin} />
-        <Route path="/LessonsLearntChart" component={LessonsLearntChart} />
+        <BMProtectedRoute
+          path="/bmdashboard/lessons-learnt-chart"
+          fallback
+          component={LessonsLearntChart}
+        />
         <Route path="/UtilizationChart" component={UtilizationChart} />
         <BMProtectedRoute path="/mostsusceptibletoolschart" component={SimpleToolChart} />
         <Route path="/projectglobaldistribution" component={ProjectsGlobalDistribution} />

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -380,6 +380,7 @@ export const ENDPOINTS = {
   BM_TOOLS_PURCHASE: `${APIEndpoint}/bm/tools/purchase`,
   POST_LESSON: `${APIEndpoint}/bm/lessons/new`,
   BM_LESSONS: `${APIEndpoint}/bm/lessons`,
+  BM_LESSONS_LEARNT: `${APIEndpoint}/bm/lessons-learnt`,
   BM_LESSON: `${APIEndpoint}/bm/lesson/`,
   BM_LESSON_LIKES: lessonId => `${APIEndpoint}/bm/lesson/${lessonId}/like`,
   BM_EXTERNAL_TEAM: `${APIEndpoint}/bm/externalTeam`,


### PR DESCRIPTION
# Description

This PR adds the chart as a fully functional card within that section, alongside the existing "Most Frequent Keywords" and "Injury Severity by Category" cards, and fixes multiple issues in the original implementation including missing dark mode support, broken grid layout, inaccessible markup, no date validation, a fragile API URL, unprotected routing, and non-functional CSS class names on the injury chart card.
<img width="614" height="481" alt="IssueDescription" src="https://github.com/user-attachments/assets/b980513b-b50c-40b4-96b2-61fb39fdeba6" />

Fixes [Add New Bar Chart Card to the Lessons Learned Section on the Total Construction Summary Page](https://docs.google.com/document/d/1WONWQW_56pXlyZpdQFibddFuT3iMxFjho-wfGwbHFV8/edit?tab=t.0#bookmark=id.57736nx29vwh).
## Related PRs (if any):

- Previous Frontend [PR #3584](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3584)(merged)
- Backend PR: [PR #2093](https://github.com/OneCommunityGlobal/HGNRest/pull/2093)
## Main changes explained:
### Created/Updated Files:

- **`src/utils/URL.js`**
	- Added dedicated `BM_LESSONS_LEARNT` endpoint constant (`/api/bm/lessons-learnt`) so the component no longer builds the URL via fragile string concatenation on `BM_LESSONS`.
- **`src/components/BMDashboard/LessonsLearnt/LessonsLearntChart.jsx`**
	- **Integration-ready rewrite** of the component introduced in PR #3584:
		- Removed blanket `/* eslint-disable */ /* prettier-ignore */` that was suppressing 3 accessibility errors and 2 warnings.
		- Added `htmlFor` / `id` associations on all `<label>` + control pairs to fix `jsx-a11y/label-has-associated-control` errors.
		- Added full **dark mode support**: reads `darkMode` from Redux (`state.theme.darkMode`), also accepts an optional `darkMode` prop (same pattern as `MostFrequentKeywords`). Chart.js tick/grid colors, bar color, and `react-select` dropdown all adapt to dark mode.
		- Changed project filter to **multi-select** (`isMulti`). When one project is selected, its ID is sent directly; when 2+ are selected, `ALL` is sent, and the response is filtered client-side to the chosen projects. An empty selection shows all projects.
		- Added **date validation** via `minDate` / `maxDate` on `DatePicker` components (start date capped to end date, end date capped to today) — addresses PR #3584 review feedback.
		- Changed date format sent to API from full ISO string to **`YYYY-MM-DD`** using a `toYMD` helper (consistent with `InjuryCategoryBarChart`).
		- Uses `ENDPOINTS.BM_LESSONS_LEARNT` instead of `${ENDPOINTS.BM_LESSONS}-learnt`.
		- Added cleanup flags (`cancelled`) to both `useEffect` hooks to prevent state updates after unmount.
		- Used `useMemo` for chart data, options, and select styles. Added `PropTypes`.
- **`src/components/BMDashboard/LessonsLearnt/LessonsLearntChart.module.css`**
	- Replaced all hardcoded light-theme colors (`#f9fafb`, `#e5e7eb`, `#10b981`) with CSS variables (`var(--card-bg)`, `var(--border-color)`, `var(--text-color)`) that inherit from the page theme.
	- Added `.darkMode` class with dark variable overrides.
	- Added dark mode rules for filter labels, inputs, and percentage labels.
	- Added `.barContainer` (fixed height), `.statusText`, `.filterLabel` classes.
	- Added `margin-top: 1.5rem` on `.chartWrapper` to prevent percentage labels from overlapping the filter row.
	- Added responsive breakpoints for mobile (768px, 480px).
- **`src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx`**
	- **Imported `LessonsLearntChart`** and added it as a third card in the Lessons Learned section content array, wrapped in a card div with `styles.weeklyProjectSummaryCard` and `styles.normalCard`, passing `darkMode` as a prop.
	- Fixed the existing injury chart card from broken string class names (`"weekly-project-summary-card normal-card"` — matches no CSS) to proper CSS module references (`styles.weeklyProjectSummaryCard`, `styles.normalCard`).
- **`src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.module.css`**
	- Added `display: grid` and `gap: 15px` to `.weeklyProjectSummaryDashboardSection.half .weeklyProjectSummaryDashboardCategoryContent` — the existing `grid-template-columns: repeat(2, 1fr)` had no effect without `display: grid`, causing all `half` section cards (Tools, Lessons Learned) to stack vertically instead of side-by-side.
	- Applied the same fix to the `.small` section content for consistency.
- **`src/routes.jsx`**
	- Changed standalone route from unprotected `<Route path="/LessonsLearntChart">` to `<BMProtectedRoute path="/bmdashboard/lessons-learnt-chart" fallback>` — consistent with all other BM dashboard routes (protected, kebab-case, under `/bmdashboard/`).
### Key Implementation Details:

- **Multi-select with single-projectId backend**: The backend `GET /api/bm/lessons-learnt` only accepts a single `projectId` (or `ALL`). When the user selects multiple projects, the frontend sends `projectId=ALL` and then filters the response client-side to only include the selected project IDs. This avoids needing backend changes while providing the expected UX.
- **Dark mode cascade**: The `LessonsLearntChart` card sits inside the `WeeklyProjectSummary` container, which sets CSS variables via `.darkMode`. The chart's CSS uses those same variables, so colors automatically adapt. For Chart.js internals (ticks, grid, bar color) and `react-select` styles, JS-side dark mode branching is used.
- **Grid layout fix**: The `half` section content container had `grid-template-columns` but no `display: grid`, meaning the rule was silently ignored. Adding `display: grid` fixes the 2-column layout for all `half` sections (Tools and Equipment Tracking, Lessons Learned).
## How to test:

1. Check into current branch: `Aditya-feat/Add-New-Bar-Chart-Card-to-the-Lessons-Learned-Section-on-the-Total-Construction-Summary-Page`
2. Reinstall dependencies and clear cache: `rm -rf node_modules && yarn cache clean`
3. Run `yarn install` and start the app: `yarn start:local`
4. **Test the Lessons Learned section on Total Construction Summary**:
	- Navigate to `/bmdashboard/totalconstructionsummary`
	- Click the "Lessons Learned" section header to expand it
	- Verify **three cards** appear: "Most Frequent Keywords", "Injury Severity by Category", and "Lessons Learnt"
	- Verify the cards display in a **2-column grid** layout (third card wraps to next row)
5. **Test the Lessons Learnt chart card**:
	- Verify the bar chart loads and displays project names on the X-axis and lesson counts on the Y-axis
	- Test the **multi-select project filter**: select multiple projects and verify only those projects' bars appear
	- Test **date filters**: select a start date, verify end date picker disallows dates before start; select an end date, verify start date picker disallows dates after end
	- Clear filters and verify all projects reappear
6. **Test dark mode**:
	- Toggle dark mode on the page
	- Verify the Lessons Learnt card background, text, borders, chart axis labels, grid lines, bar color, percentage labels, filter labels, date picker inputs, and select dropdown all adapt to dark theme
7. **Test responsive behavior**:
	- Resize browser to < 768px and verify cards stack to a single column
	- Verify the chart resizes without overflow
8. **Test standalone route**:
	- Navigate to `/bmdashboard/lessons-learnt-chart`
	- Verify it loads (requires auth — redirects to login if not authenticated)
	- Verify the old route `/LessonsLearntChart` no longer works
9. **Verify**:
	- No console errors on load or interaction
	- Empty state ("No lessons data available") displays correctly when no data matches the filters
	- Percentage labels (MoM change) appear above bars without overlapping the filter row
## Screenshots or videos of changes:

- Light Mode:
	
<img width="307" height="404" alt="LightModeChart" src="https://github.com/user-attachments/assets/4f0337dc-8a8f-407e-a360-4000809ab0ce" />

- Dark Mode:
	
<img width="325" height="427" alt="DarkModeChart" src="https://github.com/user-attachments/assets/add14e85-60df-4671-8591-b52ead5a3db5" />

- Test Video:
	
https://github.com/user-attachments/assets/234b4c6d-cc3a-441f-b8ca-be79c4d1a7e0

## Note:

- The standalone route path changed from `/LessonsLearntChart` to `/bmdashboard/lessons-learnt-chart` and now requires authentication. Any bookmarks or links to the old URL will need updating.
- **Database Changes**: None
- Date pickers constrain selectable ranges via `minDate`/`maxDate`. The backend also validates date params and returns 400 for unparseable values.
- The `LessonsLearntChart` component now accepts an optional `darkMode` prop but defaults to reading from Redux, so it works both as a standalone page and embedded in the summary page.