### PR TITLE
Aayush changed color of cooking workshop

### DIFF
--- a/src/components/CommunityPortal/Reports/Participation/MyCases.module.css
+++ b/src/components/CommunityPortal/Reports/Participation/MyCases.module.css
@@ -236,8 +236,8 @@
 }
 
 .eventBadge[data-type='Cooking Workshop'] {
-  background-color: #fdecea;
-  color: #e74c3c;
+  background-color: #eaeafd;
+  color: #3c3ce7;
 }
 
 .eventBadge[data-type='Dance Class'] {
@@ -262,8 +262,8 @@
 }
 
 .caseCardDark .eventBadge[data-type='Cooking Workshop'] {
-  background-color: rgba(231, 76, 60, 0.2);
-  color: #f1948a;
+  background-color: rgba(4, 0, 255, 0.2);
+  color: #8a8af1;
 }
 
 .caseCardDark .eventBadge[data-type='Dance Class'] {


### PR DESCRIPTION
# Description
<img width="1049" height="495" alt="Screenshot 2026-03-08 212109" src="https://github.com/user-attachments/assets/910ed358-4b14-4382-8d57-6d3fb7db9f01" />

## Related PRS (if any):

…

## Main changes explained:
- Updated MyCases.module.css to change the color of the eventBadge

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to /communityportal/reports/participation
6. verify if the color of the 'Cooking Workshop' event is not red
7. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:
<img width="1908" height="925" alt="Screenshot 2026-03-08 212852" src="https://github.com/user-attachments/assets/007e95ce-e2c2-46a8-948e-346a3197b904" />

