### PR TITLE
Rithika taking over for Aditya-feat: Add Network Failure Handling & Upload Status Feedback on Update Tool/Equipment Status Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 /public/tinymce/Community/
 Community/
 public/tinymce/
+.claude/

--- a/src/actions/bmdashboard/equipmentActions.js
+++ b/src/actions/bmdashboard/equipmentActions.js
@@ -97,7 +97,7 @@ export const updateMultipleEquipmentLogs = (projectId, bulkArr) => dispatch => {
     });
 }
 
-export const updateEquipment = (equipmentId, updateData) => async (dispatch, getState) => {
+export const updateEquipment = (equipmentId, updateData, imageFile = null) => async (dispatch, getState) => {
   const url = `${ENDPOINTS.BM_EQUIPMENT_STATUS_UPDATE(equipmentId)}`;
 
   try {
@@ -126,15 +126,30 @@ export const updateEquipment = (equipmentId, updateData) => async (dispatch, get
 
     const statusUpdateData = {
       condition: updateData.condition,
-      lastUsedBy: updateData.lastUsedBy,
-      lastUsedFor: updateData.lastUsedFor,
-      replacementRequired: updateData.replacementRequired,
+      lastUsedBy: updateData.lastUsedBy || '',
+      lastUsedFor: updateData.lastUsedFor || '',
+      replacementRequired: updateData.replacementRequired || '',
       description: updateData.description || '',
       notes: updateData.notes || '',
       createdBy: currentUserId,
     };
 
-    const res = await axios.put(url, statusUpdateData);
+    let res;
+    if (imageFile) {
+      const formData = new FormData();
+      formData.append('condition', statusUpdateData.condition);
+      formData.append('createdBy', statusUpdateData.createdBy);
+      formData.append('lastUsedBy', statusUpdateData.lastUsedBy);
+      formData.append('lastUsedFor', statusUpdateData.lastUsedFor);
+      formData.append('replacementRequired', statusUpdateData.replacementRequired);
+      formData.append('description', statusUpdateData.description);
+      formData.append('notes', statusUpdateData.notes);
+      formData.append('image', imageFile);
+      // Do NOT set Content-Type — axios sets multipart/form-data with the correct boundary
+      res = await axios.put(url, formData);
+    } else {
+      res = await axios.put(url, statusUpdateData);
+    }
 
     dispatch(setEquipment(res.data));
     toast.success('Equipment status updated successfully!');
@@ -142,7 +157,6 @@ export const updateEquipment = (equipmentId, updateData) => async (dispatch, get
 
     return res.data;
   } catch (err) {
-
     let errorMessage = 'Failed to update equipment status.';
 
     if (err.response) {

--- a/src/actions/bmdashboard/equipmentActions.js
+++ b/src/actions/bmdashboard/equipmentActions.js
@@ -98,7 +98,7 @@ export const updateMultipleEquipmentLogs = (projectId, bulkArr) => dispatch => {
     });
 }
 
-export const updateEquipment = (equipmentId, updateData) => async (dispatch, getState) => {
+export const updateEquipment = (equipmentId, updateData, imageFile = null) => async (dispatch, getState) => {
   const url = `${ENDPOINTS.BM_EQUIPMENT_STATUS_UPDATE(equipmentId)}`;
 
   try {
@@ -127,15 +127,30 @@ export const updateEquipment = (equipmentId, updateData) => async (dispatch, get
 
     const statusUpdateData = {
       condition: updateData.condition,
-      lastUsedBy: updateData.lastUsedBy,
-      lastUsedFor: updateData.lastUsedFor,
-      replacementRequired: updateData.replacementRequired,
+      lastUsedBy: updateData.lastUsedBy || '',
+      lastUsedFor: updateData.lastUsedFor || '',
+      replacementRequired: updateData.replacementRequired || '',
       description: updateData.description || '',
       notes: updateData.notes || '',
       createdBy: currentUserId,
     };
 
-    const res = await axios.put(url, statusUpdateData);
+    let res;
+    if (imageFile) {
+      const formData = new FormData();
+      formData.append('condition', statusUpdateData.condition);
+      formData.append('createdBy', statusUpdateData.createdBy);
+      formData.append('lastUsedBy', statusUpdateData.lastUsedBy);
+      formData.append('lastUsedFor', statusUpdateData.lastUsedFor);
+      formData.append('replacementRequired', statusUpdateData.replacementRequired);
+      formData.append('description', statusUpdateData.description);
+      formData.append('notes', statusUpdateData.notes);
+      formData.append('image', imageFile);
+      // Do NOT set Content-Type — axios sets multipart/form-data with the correct boundary
+      res = await axios.put(url, formData);
+    } else {
+      res = await axios.put(url, statusUpdateData);
+    }
 
     dispatch(setEquipment(res.data));
     toast.success('Equipment status updated successfully!');
@@ -143,7 +158,6 @@ export const updateEquipment = (equipmentId, updateData) => async (dispatch, get
 
     return res.data;
   } catch (err) {
-
     let errorMessage = 'Failed to update equipment status.';
 
     if (err.response) {

--- a/src/components/BMDashboard/Equipment/List/EquipmentsTable.jsx
+++ b/src/components/BMDashboard/Equipment/List/EquipmentsTable.jsx
@@ -220,13 +220,13 @@ function EquipmentsTable({ equipment, project }) {
                     <td>{new Date(rec.rentalDueDate).toLocaleDateString()}</td>
 
                     <td className="materials_cell">
-                      <button
-                        type="button"
-                        onClick={() => handleOpenModal(rec, 'UpdatesEdit')}
-                        aria-label="Edit updates"
+                      <Link
+                        to={`/bmdashboard/tools/${rec._id}/update`}
+                        aria-label="Update equipment status"
+                        style={{ display: 'inline-flex', color: 'inherit', textDecoration: 'none' }}
                       >
                         <BiPencil />
-                      </button>
+                      </Link>
                       <Button
                         color="primary"
                         outline

--- a/src/components/BMDashboard/Equipment/List/EquipmentsTable.jsx
+++ b/src/components/BMDashboard/Equipment/List/EquipmentsTable.jsx
@@ -162,51 +162,54 @@ function EquipmentsTable({ equipment, project }) {
           </thead>
           <tbody>
             {equipmentsViewData && equipmentsViewData.length > 0 ? (
-              equipmentsViewData.map(rec => (
-                <tr key={rec._id}>
-                  <td>{rec.project?.name}</td>
-                  <td>
-                    <Link
-                      to={`/bmdashboard/equipment/${rec._id}`}
-                      className={styles.linkButton}
-                      data-tip="Open equipment details"
-                    >
-                      {rec.itemType?.name || rec.name || 'View Details'}
-                    </Link>
-                  </td>
-                  <td>{rec.purchaseStatus === 'Purchased' ? 'Yes' : 'No'}</td>
-                  <td>{rec.purchaseStatus === 'Rental' ? 'Yes' : 'No'}</td>
-                  <td>{new Date(rec.rentedOnDate).toLocaleDateString()}</td>
-                  <td>{new Date(rec.rentalDueDate).toLocaleDateString()}</td>
-                  <td className="materials_cell">
-                    <button
-                      type="button"
-                      onClick={() => handleOpenModal(rec, 'UpdatesEdit')}
-                      aria-label="Edit updates"
-                    >
-                      <BiPencil />
-                    </button>
-                    <Button
-                      color="primary"
-                      outline
-                      size="sm"
-                      onClick={() => handleOpenModal(rec, 'UpdatesView')}
-                    >
-                      View
-                    </Button>
-                  </td>
-                  <td>
-                    <Button
-                      color="primary"
-                      outline
-                      size="sm"
-                      onClick={() => handleOpenModal(rec, 'PurchasesView')}
-                    >
-                      View
-                    </Button>
-                  </td>
-                </tr>
-              ))
+              equipmentsViewData.map(rec => {
+                return (
+                  <tr key={rec._id}>
+                    <td>{rec.project?.name}</td>
+                    <td>
+                      <Link
+                        to={`/bmdashboard/equipment/${rec._id}`}
+                        className={styles.linkButton}
+                        data-tip="Open equipment details"
+                      >
+                        {rec.itemType?.name || rec.name || 'View Details'}
+                      </Link>
+                    </td>
+                    <td>{rec.purchaseStatus === 'Purchased' ? 'Yes' : 'No'}</td>
+                    <td>{rec.purchaseStatus === 'Rental' ? 'Yes' : 'No'}</td>
+                    <td>{new Date(rec.rentedOnDate).toLocaleDateString()}</td>
+                    <td>{new Date(rec.rentalDueDate).toLocaleDateString()}</td>
+
+                    <td className="materials_cell">
+                      <Link
+                        to={`/bmdashboard/tools/${rec._id}/update`}
+                        aria-label="Update equipment status"
+                        style={{ display: 'inline-flex', color: 'inherit', textDecoration: 'none' }}
+                      >
+                        <BiPencil />
+                      </Link>
+                      <Button
+                        color="primary"
+                        outline
+                        size="sm"
+                        onClick={() => handleOpenModal(rec, 'UpdatesView')}
+                      >
+                        View
+                      </Button>
+                    </td>
+                    <td>
+                      <Button
+                        color="primary"
+                        outline
+                        size="sm"
+                        onClick={() => handleOpenModal(rec, 'PurchasesView')}
+                      >
+                        View
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })
             ) : (
               <tr>
                 <td colSpan={8} style={{ textAlign: 'center' }}>

--- a/src/components/BMDashboard/Equipment/Update/UpdateEquipment.jsx
+++ b/src/components/BMDashboard/Equipment/Update/UpdateEquipment.jsx
@@ -11,6 +11,10 @@ import FilePreview from '~/components/common/FilePreview/FilePreview'; // Import
 import styles from './UpdateEquipment.module.css';
 import styles1 from '../../BMDashboard.module.css';
 
+const ALLOWED_MIME_TYPES = ['image/png', 'image/jpeg'];
+const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
+const INVALID_IMAGE_MSG = 'Invalid image. Use PNG, JPG, or JPEG under 5MB.';
+
 export default function UpdateEquipment() {
   const history = useHistory();
   const { equipmentId } = useParams();
@@ -136,13 +140,14 @@ export default function UpdateEquipment() {
       const validFiles = files.filter(file => {
         const fileType = file.type || '';
         const fileName = file.name || '';
-        const isValidType = fileType.startsWith('image/');
-        const isValidExtension = fileName.match(/\.(jpg|jpeg|png|gif|webp)$/i);
-        return isValidType || isValidExtension;
+        const isValidType = ALLOWED_MIME_TYPES.includes(fileType);
+        const isValidExtension = /\.(jpg|jpeg|png)$/i.test(fileName);
+        const isValidSize = file.size <= MAX_IMAGE_SIZE_BYTES;
+        return (isValidType || isValidExtension) && isValidSize;
       });
 
       if (validFiles.length === 0) {
-        console.warn('No valid image files found');
+        setSubmitError(INVALID_IMAGE_MSG);
         return;
       }
 
@@ -172,6 +177,18 @@ export default function UpdateEquipment() {
         return;
       }
 
+      const imageFile = uploadedFiles.length > 0 ? uploadedFiles[0] : null;
+
+      if (imageFile) {
+        const isValidType = ALLOWED_MIME_TYPES.includes(imageFile.type);
+        const isValidSize = imageFile.size <= MAX_IMAGE_SIZE_BYTES;
+        if (!isValidType || !isValidSize) {
+          setSubmitError(INVALID_IMAGE_MSG);
+          setIsSubmitting(false);
+          return;
+        }
+      }
+
       setIsSubmitting(true);
       setSubmitError('');
       setSubmitSuccess('');
@@ -186,36 +203,35 @@ export default function UpdateEquipment() {
           notes: sendNote === 'yes' ? notes : '',
         };
 
-        await dispatch(updateEquipment(equipmentId, updateData));
+        await dispatch(updateEquipment(equipmentId, updateData, imageFile));
         dispatch(fetchEquipmentById(equipmentId));
         setIsUpdated(true);
 
-        let successMessage = 'Equipment status updated successfully!';
+        const successMessage = imageFile
+          ? 'Equipment status updated successfully! Image saved.'
+          : 'Equipment status updated successfully!';
 
-        if (uploadedFiles.length > 0) {
-          successMessage += ' The form has been updated.';
-          cleanupFilePreviews(uploadedFilesPreview);
-          setUploadedFiles([]);
-          setUploadedFilesPreview([]);
-        }
-
+        cleanupFilePreviews(uploadedFilesPreview);
+        setUploadedFiles([]);
+        setUploadedFilesPreview([]);
         setSubmitSuccess(successMessage);
 
         if (lastUsedBy === 'other') setLastUsedByOther('');
         if (lastUsedFor === 'other') setLastUsedForOther('');
       } catch (error) {
-        console.error('Update failed:', error);
+        const baseError =
+          error.response?.data?.error ||
+          error.response?.data?.message ||
+          (error.request ? 'No response from server. Please check your connection.' : null) ||
+          error.message ||
+          'Failed to update equipment. Please try again.';
 
-        let errorMessage = 'Failed to update equipment. Please try again.';
-
-        if (error.message?.includes('User not authenticated')) {
-          errorMessage = 'Authentication error. Please check if you are logged in.';
-        } else if (error.response?.data?.error?.includes('Invalid user ID format')) {
-          errorMessage = 'User ID format error. Please contact support.';
-        }
+        const errorMessage =
+          uploadedFiles.length > 0
+            ? `${baseError} Note: Images were selected and previewed but not saved to database.`
+            : baseError;
 
         if (uploadedFiles.length > 0) {
-          errorMessage += ' Note: Images were selected and previewed but not saved to database.';
           setUploadedFilesPreview(prev =>
             prev.map(file => ({
               ...file,
@@ -662,7 +678,7 @@ export default function UpdateEquipment() {
           <Label for="file-upload-input" style={formLabelStyle}>
             Upload latest picture of this tool or equipment. (optional)
             <small className="text-muted ms-2" style={{ color: darkMode ? '#b0b7c0' : '#6c757d' }}>
-              Accepted: PNG, JPG, JPEG, GIF, WEBP
+              Accepted: PNG, JPG, JPEG (max 5MB)
             </small>
           </Label>
 
@@ -720,7 +736,7 @@ export default function UpdateEquipment() {
                     <i className="fas fa-info-circle me-1" />
                     {hasNotSavedFiles
                       ? 'Images are shown for preview purposes only and are not saved to the database.'
-                      : 'Images are uploaded for preview. Form data will be saved to database.'}
+                      : 'Images will be submitted with the form and saved to the database.'}
                   </small>
                 </Alert>
               </div>

--- a/src/components/BMDashboard/Equipment/Update/UpdateEquipment.jsx
+++ b/src/components/BMDashboard/Equipment/Update/UpdateEquipment.jsx
@@ -232,19 +232,10 @@ export default function UpdateEquipment() {
         if (lastUsedBy === 'other') setLastUsedByOther('');
         if (lastUsedFor === 'other') setLastUsedForOther('');
       } catch (error) {
-        const baseError =
-          error.response?.data?.error ||
-          error.response?.data?.message ||
-          (error.request ? 'No response from server. Please check your connection.' : null) ||
-          error.message ||
-          'Failed to update equipment. Please try again.';
+        const hasUploadedFiles = uploadedFiles.length > 0;
+        const errorMessage = buildErrorMessage(error, hasUploadedFiles);
 
-        const errorMessage =
-          uploadedFiles.length > 0
-            ? `${baseError} Note: Images were selected and previewed but not saved to database.`
-            : baseError;
-
-        if (uploadedFiles.length > 0) {
+        if (hasUploadedFiles) {
           setUploadedFilesPreview(prev =>
             prev.map(file => ({
               ...file,

--- a/src/components/BMDashboard/Equipment/Update/UpdateEquipment.jsx
+++ b/src/components/BMDashboard/Equipment/Update/UpdateEquipment.jsx
@@ -11,7 +11,7 @@ import FilePreview from '~/components/common/FilePreview/FilePreview'; // Import
 import styles from './UpdateEquipment.module.css';
 import styles1 from '../../BMDashboard.module.css';
 
-const ALLOWED_MIME_TYPES = ['image/png', 'image/jpeg'];
+const ALLOWED_MIME_TYPES = new Set(['image/png', 'image/jpeg']);
 const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
 const INVALID_IMAGE_MSG = 'Invalid image. Use PNG, JPG, or JPEG under 5MB.';
 
@@ -140,7 +140,7 @@ export default function UpdateEquipment() {
       const validFiles = files.filter(file => {
         const fileType = file.type || '';
         const fileName = file.name || '';
-        const isValidType = ALLOWED_MIME_TYPES.includes(fileType);
+        const isValidType = ALLOWED_MIME_TYPES.has(fileType);
         const isValidExtension = /\.(jpg|jpeg|png)$/i.test(fileName);
         const isValidSize = file.size <= MAX_IMAGE_SIZE_BYTES;
         return (isValidType || isValidExtension) && isValidSize;
@@ -167,6 +167,19 @@ export default function UpdateEquipment() {
     [uploadedFilesPreview, cleanupFilePreviews],
   );
 
+  const buildErrorMessage = (error, hasUploadedFiles) => {
+    const baseError =
+      error.response?.data?.error ||
+      error.response?.data?.message ||
+      (error.request ? 'No response from server. Please check your connection.' : null) ||
+      error.message ||
+      'Failed to update equipment. Please try again.';
+
+    return hasUploadedFiles
+      ? `${baseError} Note: Images were selected and previewed but not saved to database.`
+      : baseError;
+  };
+
   const handleSubmit = useCallback(
     async e => {
       e.preventDefault();
@@ -180,7 +193,7 @@ export default function UpdateEquipment() {
       const imageFile = uploadedFiles.length > 0 ? uploadedFiles[0] : null;
 
       if (imageFile) {
-        const isValidType = ALLOWED_MIME_TYPES.includes(imageFile.type);
+        const isValidType = ALLOWED_MIME_TYPES.has(imageFile.type);
         const isValidSize = imageFile.size <= MAX_IMAGE_SIZE_BYTES;
         if (!isValidType || !isValidSize) {
           setSubmitError(INVALID_IMAGE_MSG);

--- a/src/components/BMDashboard/ToolItemList/ToolItemsTable.jsx
+++ b/src/components/BMDashboard/ToolItemList/ToolItemsTable.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import { Table, Button } from 'reactstrap';
 import { BiPencil } from 'react-icons/bi';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -14,12 +13,15 @@ export default function ToolItemsTable({
   selectedProject,
   selectedItem,
   filteredItems,
+  UpdateItemModal,
   dynamicColumns,
 }) {
   const [sortedData, setData] = useState(filteredItems);
   const [modal, setModal] = useState(false);
   const [record, setRecord] = useState(null);
   const [recordType, setRecordType] = useState('');
+  const [updateModal, setUpdateModal] = useState(false);
+  const [updateRecord, setUpdateRecord] = useState(null);
 
   const [projectNameCol, setProjectNameCol] = useState({
     iconsToDisplay: faSort,
@@ -48,6 +50,13 @@ export default function ToolItemsTable({
     setConditionCol({ iconsToDisplay: faSort, sortOrder: 'default' });
     setToolStatusCol({ iconsToDisplay: faSort, sortOrder: 'default' });
   }, [selectedProject, selectedItem]);
+
+  const handleEditRecordsClick = (selectedEl, type) => {
+    if (type === 'Update') {
+      setUpdateModal(true);
+      setUpdateRecord(selectedEl);
+    }
+  };
 
   const handleViewRecordsClick = (data, type) => {
     setModal(true);
@@ -132,6 +141,7 @@ export default function ToolItemsTable({
         setRecord={setRecord}
         recordType={recordType}
       />
+      <UpdateItemModal modal={updateModal} setModal={setUpdateModal} record={updateRecord} />
       <div className={`${styles.itemsTableContainer}`}>
         <Table className={`${styles.itemsTable}`}>
           <thead>
@@ -235,13 +245,13 @@ export default function ToolItemsTable({
 
                     <td>{el.code}</td>
                     <td className={`${styles.itemsCell}`}>
-                      <Link
-                        to={`/bmdashboard/tools/${el._id}/update`}
-                        aria-label="Update tool status"
-                        style={{ display: 'inline-flex', color: 'inherit', textDecoration: 'none' }}
+                      <button
+                        type="button"
+                        onClick={() => handleEditRecordsClick(el, 'Update')}
+                        aria-label="Edit Record"
                       >
                         <BiPencil />
-                      </Link>
+                      </button>
                       <Button
                         color="primary"
                         outline

--- a/src/components/BMDashboard/ToolItemList/ToolItemsTable.jsx
+++ b/src/components/BMDashboard/ToolItemList/ToolItemsTable.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Table, Button } from 'reactstrap';
 import { BiPencil } from 'react-icons/bi';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,15 +14,12 @@ export default function ToolItemsTable({
   selectedProject,
   selectedItem,
   filteredItems,
-  UpdateItemModal,
   dynamicColumns,
 }) {
   const [sortedData, setData] = useState(filteredItems);
   const [modal, setModal] = useState(false);
   const [record, setRecord] = useState(null);
   const [recordType, setRecordType] = useState('');
-  const [updateModal, setUpdateModal] = useState(false);
-  const [updateRecord, setUpdateRecord] = useState(null);
 
   const [projectNameCol, setProjectNameCol] = useState({
     iconsToDisplay: faSort,
@@ -50,13 +48,6 @@ export default function ToolItemsTable({
     setConditionCol({ iconsToDisplay: faSort, sortOrder: 'default' });
     setToolStatusCol({ iconsToDisplay: faSort, sortOrder: 'default' });
   }, [selectedProject, selectedItem]);
-
-  const handleEditRecordsClick = (selectedEl, type) => {
-    if (type === 'Update') {
-      setUpdateModal(true);
-      setUpdateRecord(selectedEl);
-    }
-  };
 
   const handleViewRecordsClick = (data, type) => {
     setModal(true);
@@ -141,7 +132,6 @@ export default function ToolItemsTable({
         setRecord={setRecord}
         recordType={recordType}
       />
-      <UpdateItemModal modal={updateModal} setModal={setUpdateModal} record={updateRecord} />
       <div className={`${styles.itemsTableContainer}`}>
         <Table className={`${styles.itemsTable}`}>
           <thead>
@@ -245,13 +235,13 @@ export default function ToolItemsTable({
 
                     <td>{el.code}</td>
                     <td className={`${styles.itemsCell}`}>
-                      <button
-                        type="button"
-                        onClick={() => handleEditRecordsClick(el, 'Update')}
-                        aria-label="Edit Record"
+                      <Link
+                        to={`/bmdashboard/tools/${el._id}/update`}
+                        aria-label="Update tool status"
+                        style={{ display: 'inline-flex', color: 'inherit', textDecoration: 'none' }}
                       >
                         <BiPencil />
-                      </button>
+                      </Link>
                       <Button
                         color="primary"
                         outline

--- a/src/components/BMDashboard/ToolItemList/ToolItemsTable.jsx
+++ b/src/components/BMDashboard/ToolItemList/ToolItemsTable.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Table, Button } from 'reactstrap';
 import { BiPencil } from 'react-icons/bi';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -11,7 +12,6 @@ export default function ToolItemsTable({
   selectedProject,
   selectedItem,
   filteredItems,
-  UpdateItemModal,
   dynamicColumns,
 }) {
   const darkMode = useSelector(state => state.theme?.darkMode || false);
@@ -20,8 +20,6 @@ export default function ToolItemsTable({
   const [modal, setModal] = useState(false);
   const [record, setRecord] = useState(null);
   const [recordType, setRecordType] = useState('');
-  const [updateModal, setUpdateModal] = useState(false);
-  const [updateRecord, setUpdateRecord] = useState(null);
 
   const [projectNameCol, setProjectNameCol] = useState({
     iconsToDisplay: faSort,
@@ -50,13 +48,6 @@ export default function ToolItemsTable({
     setConditionCol({ iconsToDisplay: faSort, sortOrder: 'default' });
     setToolStatusCol({ iconsToDisplay: faSort, sortOrder: 'default' });
   }, [selectedProject, selectedItem]);
-
-  const handleEditRecordsClick = (selectedEl, type) => {
-    if (type === 'Update') {
-      setUpdateModal(true);
-      setUpdateRecord(selectedEl);
-    }
-  };
 
   const handleViewRecordsClick = (data, type) => {
     setModal(true);
@@ -146,11 +137,9 @@ export default function ToolItemsTable({
         setRecord={setRecord}
         recordType={recordType}
       />
-      <UpdateItemModal modal={updateModal} setModal={setUpdateModal} record={updateRecord} />
-
-      <div className={`${styles.itemsTableContainer} ${darkMode ? styles.darkModeTable : ''}`}>
-        <Table>
-          <thead className={styles.tableHeader}>
+      <div className={`${styles.itemsTableContainer}`}>
+        <Table className={`${styles.itemsTable}`}>
+          <thead>
             <tr>
               {noProjectFilter ? (
                 <th onClick={() => sortData('ProjectName')}>
@@ -256,13 +245,13 @@ export default function ToolItemsTable({
                     <td>{el.code}</td>
 
                     <td className={`${styles.itemsCell}`}>
-                      <button
-                        type="button"
-                        onClick={() => handleEditRecordsClick(el, 'Update')}
-                        aria-label="Edit Record"
+                      <Link
+                        to={`/bmdashboard/tools/${el._id}/update`}
+                        aria-label="Update tool status"
+                        style={{ display: 'inline-flex', color: 'inherit', textDecoration: 'none' }}
                       >
                         <BiPencil />
-                      </button>
+                      </Link>
                       <Button
                         color="primary"
                         outline

--- a/src/components/BMDashboard/ToolItemList/ToolItemsTable.jsx
+++ b/src/components/BMDashboard/ToolItemList/ToolItemsTable.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import { Table, Button } from 'reactstrap';
 import { BiPencil } from 'react-icons/bi';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -12,6 +11,7 @@ export default function ToolItemsTable({
   selectedProject,
   selectedItem,
   filteredItems,
+  UpdateItemModal,
   dynamicColumns,
 }) {
   const darkMode = useSelector(state => state.theme?.darkMode || false);
@@ -20,6 +20,8 @@ export default function ToolItemsTable({
   const [modal, setModal] = useState(false);
   const [record, setRecord] = useState(null);
   const [recordType, setRecordType] = useState('');
+  const [updateModal, setUpdateModal] = useState(false);
+  const [updateRecord, setUpdateRecord] = useState(null);
 
   const [projectNameCol, setProjectNameCol] = useState({
     iconsToDisplay: faSort,
@@ -48,6 +50,13 @@ export default function ToolItemsTable({
     setConditionCol({ iconsToDisplay: faSort, sortOrder: 'default' });
     setToolStatusCol({ iconsToDisplay: faSort, sortOrder: 'default' });
   }, [selectedProject, selectedItem]);
+
+  const handleEditRecordsClick = (selectedEl, type) => {
+    if (type === 'Update') {
+      setUpdateModal(true);
+      setUpdateRecord(selectedEl);
+    }
+  };
 
   const handleViewRecordsClick = (data, type) => {
     setModal(true);
@@ -137,6 +146,7 @@ export default function ToolItemsTable({
         setRecord={setRecord}
         recordType={recordType}
       />
+      <UpdateItemModal modal={updateModal} setModal={setUpdateModal} record={updateRecord} />
       <div className={`${styles.itemsTableContainer}`}>
         <Table className={`${styles.itemsTable}`}>
           <thead>
@@ -245,13 +255,13 @@ export default function ToolItemsTable({
                     <td>{el.code}</td>
 
                     <td className={`${styles.itemsCell}`}>
-                      <Link
-                        to={`/bmdashboard/tools/${el._id}/update`}
-                        aria-label="Update tool status"
-                        style={{ display: 'inline-flex', color: 'inherit', textDecoration: 'none' }}
+                      <button
+                        type="button"
+                        onClick={() => handleEditRecordsClick(el, 'Update')}
+                        aria-label="Edit Record"
                       >
                         <BiPencil />
-                      </Link>
+                      </button>
                       <Button
                         color="primary"
                         outline

--- a/src/components/common/DragAndDrop/DragAndDrop.jsx
+++ b/src/components/common/DragAndDrop/DragAndDrop.jsx
@@ -86,7 +86,7 @@ const DragAndDrop = ({ updateUploadedFiles }) => {
         type="file"
         name="file-upload-input"
         multiple={true}
-        accept="image/jpeg, image/jpg, image/png, image/gif, image/webp"
+        accept="image/png, image/jpeg, image/jpg"
         onChange={handleChange}
         aria-label="Upload image files"
       />
@@ -173,7 +173,7 @@ const DragAndDrop = ({ updateUploadedFiles }) => {
               id="file-upload-description"
               style={{ margin: '4px 0' }}
             >
-              Accepted: PNG, JPG, JPEG, GIF, WEBP
+              Accepted: PNG, JPG, JPEG (max 5MB)
             </p>
             <div
               className={styles.uploadIndicator}


### PR DESCRIPTION
# Description

Adds **image upload and upload-status feedback** on the BM Dashboard **Update Tool/Equipment Status** page (`/bmdashboard/tools/:equipmentId/update`). The page previously only previewed images locally; this PR submits the selected image to the backend via the existing status-update API (multipart when an image is present), validates format (PNG/JPG/JPEG) and size (max 5 MB) before submit, and ensures every submission attempt results in clear success or failure feedback—including a user-friendly message when offline or when the image could not be saved (e.g. "No response from server. Please check your connection." and "Image selected but not saved."). The tools table is updated so the pencil icon links to the full update page instead of opening an update modal.
<img width="614" height="586" alt="IssueDescription" src="https://github.com/user-attachments/assets/11c777e9-925c-480d-abe7-7211c86a81e4" />

## Related PRs (if any):

- **Previous Frontend (merged):** [PR #4656](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4656)
- **Backend status API (merged):** [PR #1984](https://github.com/OneCommunityGlobal/HGNRest/pull/1984)
- **Backend image upload:** [PR #2103](https://github.com/OneCommunityGlobal/HGNRest/pull/2103): Same endpoint now accepts an optional image via `multipart/form-data` (field `image`), validates PNG/JPEG/5 MB, stores in Azure, and persists `imageUrl` on equipment and update record.
## Main changes explained:
### Created/Updated Files:

- **`src/actions/bmdashboard/equipmentActions.js`** (+26 / −3)
	- **`updateEquipment(equipmentId, updateData, imageFile = null)`** — Added optional third argument `imageFile`. When `imageFile` is provided, it builds a `FormData` with the same status fields (`condition`, `createdBy`, `lastUsedBy`, `lastUsedFor`, `replacementRequired`, `description`, `notes`) as form strings and appends the file under the field name **`image`**; it sends `PUT` with the FormData **without** setting `Content-Type` so axios sets `multipart/form-data` with the correct boundary. When `imageFile` is null/undefined, it keeps the existing behavior: sends JSON body via `axios.put(url, statusUpdateData)`.
	- Optional fields in `statusUpdateData` are normalized with `|| ''` for consistency when sent as form fields.
	- Error handling unchanged: uses `err.response.data?.error` then `err.response.data?.message`; for no response (`err.request` without `err.response`) uses **"No response from server. Please check your connection."**; toasts error and rethrows.
- **`src/components/BMDashboard/Equipment/Update/UpdateEquipment.jsx`** (+66 / −33)
	- **Constants:** `ALLOWED_MIME_TYPES = ['image/png', 'image/jpeg']`, `MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024`, `INVALID_IMAGE_MSG = 'Invalid image. Use PNG, JPG, or JPEG under 5MB.'` (aligned with backend message).
	- **`handleFileUpload`:** Restricts accepted files to PNG/JPEG (by MIME and extension `\.(jpg|jpeg|png)$/i`) and max 5 MB. When no valid files remain after filter, sets `setSubmitError(INVALID_IMAGE_MSG)` instead of `console.warn`.
	- **`handleSubmit`:** Before calling the action, when the user has selected files, validates the **first** file (type and size); if invalid, sets `setSubmitError(INVALID_IMAGE_MSG)` and returns without submitting. Passes `uploadedFiles[0] ?? null` as the third argument to `updateEquipment`. On success, shows "Equipment status updated successfully! Image saved." when an image was sent, otherwise "Equipment status updated successfully!"; always clears file preview state. On failure, builds error message from `error.response?.data?.error` (or `message`, or network message "No response from server. Please check your connection."); when images were selected, appends " Note: Images were selected and previewed but not saved to database." and marks previews as `status: 'not-saved'`. Ensures `setIsSubmitting(false)` in `finally` so no silent failures.
	- **Labels/copy:** "Accepted: PNG, JPG, JPEG (max 5MB)" and "Images will be submitted with the form and saved to the database." (replacing GIF/WEBP and "preview only" wording).
- **`src/components/common/DragAndDrop/DragAndDrop.jsx`** (+2 / −2)
	- **`accept`** attribute changed from `image/jpeg, image/jpg, image/png, image/gif, image/webp` to **`image/png, image/jpeg, image/jpg`** to match backend.
	- Helper text updated from "Accepted: PNG, JPG, JPEG, GIF, WEBP" to **"Accepted: PNG, JPG, JPEG (max 5MB)"**.
- **`src/components/BMDashboard/ToolItemList/ToolItemsTable.jsx`** (+6 / −16)
	- Replaced the pencil **button** that opened **UpdateItemModal** with a **`Link`** to `/bmdashboard/tools/${el._id}/update` so users go to the full Update Tool/Equipment Status page. Removed `UpdateItemModal` prop and related state (`updateModal`, `updateRecord`) and handler `handleEditRecordsClick`. Added `Link` import from `react-router-dom`. The "View" button for updating records remains and still opens the records modal.
### Key Implementation Details:

- **API contract:** Endpoint remains `PUT /api/bm/equipment/:equipmentId/status` (see `ENDPOINTS.BM_EQUIPMENT_STATUS_UPDATE(equipmentId)` in `src/utils/URL.js`). With image: request is `multipart/form-data` with form fields plus one file under field name **`image`**; without image: request is `application/json` as before. Backend (PR #2103) validates image type (PNG/JPEG) and size (5 MB) and returns `response.data.error` for validation/upload failures.
- **No Content-Type for FormData:** When sending FormData, the code does **not** set `Content-Type` so the browser/axios can set `multipart/form-data` with the correct boundary, per backend contract.
- **Single image:** Only the first selected file is sent (`uploadedFiles[0]`); backend accepts one file per request.
- **Error surface:** User-facing messages come from `err.response.data.error` (then `message`); network/offline case uses the fixed string "No response from server. Please check your connection." so offline submission always shows a clear toast and in-page error.
- **Backward compatibility:** When no image is selected, behavior is unchanged (JSON PUT). Parent of `ToolItemsTable` (`ToolItemListView`) still passes `UpdateItemModal`; the prop is simply no longer used by `ToolItemsTable`, so no parent change is required.
## How to test:

1. Check into current branch: `Aditya-feat/Add-Network–Failure-Handling-Upload-Status-Feedback-on-Update-Tool-Equipment-Status-Page`
2. Ensure backend with image upload is running (e.g., HGNRest with PR #2103 or equivalent) and Azure credentials are set in the backend `.env` file.
3. Reinstall dependencies and clear cache: `rm -rf node_modules && yarn cache clean`
4. Run `yarn install` and start the app: `yarn start:local`
5. Login using Admin/Owner Login.
6. **Test Update Tool/Equipment Status with image:**
	- Navigate directly to `/bmdashboard/tools/:equipmentId/update` with a valid equipment ID from `GET /api/bm/equipments`. I used these two for testing: `6680a2ec7e038e1028825dde`, `6869da54b653924ff05eb471`
	- Fill required fields (Status/Condition, Who used last, What used for, Replacement required). Optionally add an image via drag-and-drop or file picker (PNG or JPEG, &lt; 5 MB).
	- Submit. Expect success toast and in-page message "Equipment status updated successfully! Image saved." when an image was included; the equipment detail/update page should show the new image (e.g., `equipmentDetails.imageUrl`).
7. **Test without image:** Submit with no image selected. Expect "Equipment status updated successfully!" and no image in the request (JSON path).
8. **Test validation:** Select a file that is not PNG/JPEG (e.g., GIF) or &gt; 5 MB. Expect an inline error "Invalid image. Use PNG, JPG, or JPEG under 5MB." before or on submit.
9. **Test offline/failure:** With an image selected, disconnect the network (or stop the backend) and submit. Expect toast and in-page error, including "No response from server. Please check your connection," and, when images were selected, "Note: Images were selected and previewed but not saved to database."
10. **Test tools table link:** From the BM Dashboard → Tools list, click the pencil icon on a tool/equipment row. Expect navigation to `/bmdashboard/tools/:id/update` (full update page) instead of opening a modal.
11. **Verify:** No silent failures—every submit shows either success or failure feedback (toast and in-page Alert). Backend 400/404/500/503 messages (e.g., "Image selected but not saved.", "Invalid image. Use PNG, JPG, or JPEG under 5MB.") appear as provided in `response.data.error`.
## Screenshots or videos of changes:

- Screenshot of Update Tool/Equipment Status page with image selected:
<img width="1512" height="910" alt="ImageSelectedLightMode" src="https://github.com/user-attachments/assets/1f480506-726e-40e6-8aca-576cf78fa097" />
<img width="1509" height="909" alt="ImageSelectedDarkMode" src="https://github.com/user-attachments/assets/f2af1c29-4015-4696-83fa-c72df2ad9ef3" />

- Test Video:

https://github.com/user-attachments/assets/09aa7f53-676d-4bc2-8a85-e4f8db702e4f

## Note:

- **Validation:** Client-side: PNG/JPEG/JPG only, max 5 MB (aligned with backend). Backend re-validates and returns 400 with `Invalid image. Use PNG, JPG, or JPEG under 5MB.` when invalid.
- Ensure backend is running with the image-upload implementation (e.g., PR #2103) for full image save and `imageUrl` in response.
- In my testing video, uploading the image throws an error. That is because I don't have the Azure environment variables for the backend. The rest of the functionality works, and once I get the variables, I will update the test videos.