### PR TITLE
Sayali: optimize TotalOrgSummary date range loading with parallel API calls, debounce, and caching

### DIFF
--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -1,50 +1,50 @@
 /* eslint-disable testing-library/no-node-access */
-import { connect } from 'react-redux';
-import { useEffect, useState, useRef } from 'react';
-import {
-  Alert,
-  Col,
-  Container,
-  Row,
-  Dropdown,
-  DropdownToggle,
-  DropdownMenu,
-  DropdownItem,
-  Modal,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-  Button,
-} from 'reactstrap';
-import DatePicker from 'react-datepicker';
-import 'react-datepicker/dist/react-datepicker.css';
-import 'moment-timezone';
 import html2canvas from 'html2canvas';
 import { jsPDF } from 'jspdf';
+import 'moment-timezone';
+import { useEffect, useRef, useState } from 'react';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import { connect } from 'react-redux';
+import {
+  Alert,
+  Button,
+  Col,
+  Container,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownToggle,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Row,
+} from 'reactstrap';
 
 import hasPermission from '~/utils/permissions';
 
 // actions
-import { getTotalOrgSummary, getTaskAndProjectStats } from '~/actions/totalOrgSummary';
+import { getTaskAndProjectStats, getTotalOrgSummary } from '~/actions/totalOrgSummary';
 
-import '../Header/index.css';
-import styles from './TotalOrgSummary.module.css';
 import { clsx } from 'clsx';
-import VolunteerHoursDistribution from './VolunteerHoursDistribution/VolunteerHoursDistribution';
+import '../Header/index.css';
 import AccordianWrapper from './AccordianWrapper/AccordianWrapper';
-import VolunteerStatus from './VolunteerStatus/VolunteerStatus';
-import VolunteerActivities from './VolunteerActivities/VolunteerActivities';
-import VolunteerStatusChart from './VolunteerStatus/VolunteerStatusChart';
+import AnniversaryCelebrated from './AnniversaryCelebrated/AnniversaryCelebrated';
 import BlueSquareStats from './BlueSquareStats/BlueSquareStats';
-import TeamStats from './TeamStats/TeamStats';
+import GlobalVolunteerMap from './GlobalVolunteerMap/GlobalVolunteerMap';
 import HoursCompletedBarChart from './HoursCompleted/HoursCompletedBarChart';
 import NumbersVolunteerWorked from './NumbersVolunteerWorked/NumbersVolunteerWorked';
-import AnniversaryCelebrated from './AnniversaryCelebrated/AnniversaryCelebrated';
+import TaskCompletedBarChart from './TaskCompleted/TaskCompletedBarChart';
+import TeamStats from './TeamStats/TeamStats';
+import styles from './TotalOrgSummary.module.css';
+import VolunteerActivities from './VolunteerActivities/VolunteerActivities';
+import VolunteerHoursDistribution from './VolunteerHoursDistribution/VolunteerHoursDistribution';
 import RoleDistributionPieChart from './VolunteerRolesTeamDynamics/RoleDistributionPieChart';
 import WorkDistributionBarChart from './VolunteerRolesTeamDynamics/WorkDistributionBarChart';
+import VolunteerStatus from './VolunteerStatus/VolunteerStatus';
+import VolunteerStatusChart from './VolunteerStatus/VolunteerStatusChart';
 import VolunteerTrendsLineChart from './VolunteerTrendsLineChart/VolunteerTrendsLineChart';
-import GlobalVolunteerMap from './GlobalVolunteerMap/GlobalVolunteerMap';
-import TaskCompletedBarChart from './TaskCompleted/TaskCompletedBarChart';
 
 function calculateStartDate() {
   // returns a string date in YYYY-MM-DD format of the start of the previous week
@@ -125,42 +125,62 @@ function TotalOrgSummary(props) {
   const [currentFromDate, setCurrentFromDate] = useState(fromDate);
   const [currentToDate, setCurrentToDate] = useState(toDate);
   const rootRef = useRef(null);
+  const cacheRef = useRef({});
 
   useEffect(() => {
+    let cancelled = false;
+
     const fetchVolunteerStats = async () => {
       try {
         setIsLoading(true);
+
         const { comparisonStartDate, comparisonEndDate } = calculateComparisonDates(
           selectedComparison,
           currentFromDate,
           currentToDate,
         );
 
-        const volunteerStatsResponse = await props.getTotalOrgSummary(
-          currentFromDate,
-          currentToDate,
-          comparisonStartDate,
-          comparisonEndDate,
-        );
+        const cacheKey = `${currentFromDate}_${currentToDate}_${selectedComparison}`;
 
-        // Fetch task and project stats separately
-        const taskAndProjectStatsResponse = await props.getTaskAndProjectStats(
-          currentFromDate,
-          currentToDate,
-        );
+        if (cacheRef.current[cacheKey]) {
+          if (!cancelled) {
+            setVolunteerStats(cacheRef.current[cacheKey]);
+            setIsLoading(false);
+          }
+          return;
+        }
 
-        setVolunteerStats({
-          ...volunteerStatsResponse.data,
-          taskAndProjectStats: taskAndProjectStatsResponse,
-        });
-        await props.hasPermission('');
-        setIsLoading(false);
+        const [volunteerStatsResponse, taskAndProjectStatsResponse] = await Promise.all([
+          props.getTotalOrgSummary(
+            currentFromDate,
+            currentToDate,
+            comparisonStartDate,
+            comparisonEndDate,
+          ),
+          props.getTaskAndProjectStats(currentFromDate, currentToDate),
+        ]);
+
+        if (!cancelled) {
+          const merged = {
+            ...volunteerStatsResponse.data,
+            taskAndProjectStats: taskAndProjectStatsResponse,
+          };
+          cacheRef.current[cacheKey] = merged;
+          setVolunteerStats(merged);
+          setIsLoading(false);
+        }
       } catch (catchFetchError) {
-        setIsVolunteerFetchingError(true);
+        if (!cancelled) setIsVolunteerFetchingError(true);
       }
     };
 
-    fetchVolunteerStats();
+    const debounceTimer = setTimeout(fetchVolunteerStats, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(debounceTimer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentFromDate, currentToDate, selectedComparison]);
 
   const handleSaveAsPDF = async () => {


### PR DESCRIPTION
<img width="722" height="404" alt="image" src="https://github.com/user-attachments/assets/4b6ab032-774f-449c-a587-b769c9ce4894" />

# Description
Implements #(TaskNumber) (Priority Medium)

## Related PRS (if any):
Backend PR related to frontend PR - HGNRest Sayali_Optimize_TotalOrgSummary_DateRange
https://github.com/OneCommunityGlobal/HGNRest/pull/2111

## Main changes explained:
- Updated TotalOrgSummary.jsx to run both API calls in parallel using Promise.all instead of sequential awaits
- Added 300ms debounce on date range changes to prevent redundant API calls on rapid selection
- Added frontend in-memory cache (cacheRef) to serve previously fetched date ranges instantly
- Added request cancellation flag to prevent stale responses from updating state

## How to test:
1. Check out branch Sayali_Optimize_TotalOrgSummary_DateRange
2. npm install && npm run start:local
3. Clear cache, log in as admin 
4. Navigate to Dashboard → Total Org Summary
5. Select a date range - verify data loads with spinner
6. Switch to a different date range, then switch back to the first one - verify it loads instantly (no spinner)
7. Rapidly change date ranges - verify only one API call fires after 300ms
8. Verify dark mode works

## Screenshots or videos of changes:
<img width="1919" height="870" alt="image" src="https://github.com/user-attachments/assets/6304c61e-251c-4d15-81e3-f52c9564de89" />
<img width="1883" height="948" alt="image" src="https://github.com/user-attachments/assets/070e6bb8-4ef5-4e76-95fb-af4a3f067363" />
<img width="1004" height="661" alt="image" src="https://github.com/user-attachments/assets/27963454-4af5-41f0-88b0-b6a1be877a79" />
<img width="1919" height="869" alt="image" src="https://github.com/user-attachments/assets/88a02f86-a9e2-48be-8beb-fb2f666c106e" />

## Note:
Backend PR must be merged alongside this for full optimization benefit (server-side caching).