### PR TITLE
Maithili - fix: resolve the issue that interactive map is not seen

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -714,6 +714,7 @@ export default (
         <BMProtectedRoute path="/bmdashboard/issuechart" component={IssueChart} />
         <BMProtectedRoute path="/bmdashboard/timelog/" component={BMTimeLogger} />
         <BMProtectedRoute path="/bmdashboard/issues/" component={IssueDashboard} />
+        <BMProtectedRoute path="/bmdashboard/InteractiveMap" component={InteractiveMap} />
         <BMProtectedRoute
           path="/bmdashboard/timelog/:projectId"
           fallback


### PR DESCRIPTION
# Description
This is a new PR covering the feedback and solving conflicts on https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3432

## Related PRS (if any):
This frontend PR is related to the [2064 ](https://github.com/OneCommunityGlobal/HGNRest/pull/2064) backend PR.
…

## Main changes explained:
modified routes.jsx file
…

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4.l og as admin user
5. go to http://localhost:3000/bmdashboard/interactivemap
6. Verify that the map is interactive and the dots are clickable
7. Verify that the date filters work.
8. go to http://localhost:3000/bmdashboard/totalconstructionsummary
9. verify that the map is displayed under "Global Distribution and Project Status Overview"
10. verify it in dark and light mode

## Screenshots or videos of changes:

<img width="1374" height="628" alt="Screenshot 2026-03-20 at 10 27 17 AM" src="https://github.com/user-attachments/assets/ac2169a9-aab8-486a-b21f-534163ab7a4a" />
<img width="1400" height="631" alt="Screenshot 2026-03-20 at 10 27 04 AM" src="https://github.com/user-attachments/assets/bc5742e0-29e5-4d10-98b1-64e84d6eda9a" />
<img width="1412" height="756" alt="Screenshot 2026-03-20 at 10 25 02 AM" src="https://github.com/user-attachments/assets/8a950408-af6a-4405-9ca0-ce578794cd50" />

## Note:
Include the information the reviewers need to know.
