### PR TITLE
Venkataramanan 🔥 fix: tasks and timelogs alignment

### DIFF
--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -823,8 +823,8 @@ return (
                   <Row className="d-flex flex-nowrap align-items-center w-100 gx-0">
                   {/* LEFT: title/subtitle takes remaining space */}
                   <Col className="px-0 flex-grow-1" style={{ minWidth: 0 }}>
-                    <CardTitle tag="h4">
-                      <div className="d-flex align-items-center flex-wrap">
+                  <CardTitle tag="h4" className="mb-0 d-flex align-items-center h-100">
+                      <div className="d-flex align-items-center flex-wrap mb-0">
                         <span className={`${timeLog.taskboardHeaderTitle} mb-1 mr-2`}>
                           Tasks and Timelogs
                         </span>
@@ -870,15 +870,6 @@ return (
                         />
                       </div>
                     </CardTitle>
-
-                    <CardSubtitle
-                      tag="h6"
-                      className={`${
-                        darkMode ? 'text-azure' : `text-muted ${timeLog['text-muted']} text-muted`
-                      } ${timeLog['responsive-font-size']}`}
-                    >
-                      Viewing time entries logged in the last 3 weeks
-                    </CardSubtitle>
                   </Col>
 
                   {/* RIGHT: button stays compact and right-aligned (never becomes a big centered block) */}
@@ -889,15 +880,15 @@ return (
                         style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}
                       >
                         <div className={timeLog.followupTooltipButton}>
-                          <Button
-                            className="btn btn-success"
-                            onClick={toggle}
-                            style={{
-                              ...(darkMode ? boxStyleDark : boxStyle),
-                              whiteSpace: 'nowrap',
-                              alignSelf: 'flex-start',
-                            }}
-                          >
+                        <Button
+                          className="btn btn-success"
+                          onClick={toggle}
+                          style={{
+                            ...(darkMode ? boxStyleDark : boxStyle),
+                            whiteSpace: 'nowrap',
+                            alignSelf: 'center',
+                          }}
+                        >
                             Add Intangible Time Entry
                             <TooltipPortal
                               darkMode={darkMode}

--- a/src/components/Timelog/Timelog.module.css
+++ b/src/components/Timelog/Timelog.module.css
@@ -306,16 +306,23 @@
 
 .tasksAndTimelogHeaderRow {
   display: flex;
-  grid-template-columns: auto auto;
   align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .tasksAndTimelogHeaderAddTimeDiv {
-  float: left;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 
 .taskboardHeaderTitle {
   font-size: 1.8rem;
+  margin: 0;
+  line-height: 1;
+  display: flex;
+  align-items: center;
 }
 
 @media screen and (width <= 1240px) {


### PR DESCRIPTION
# Description
This PR fixes the issue with Tasks and Timelogs alignment and removes the "Viewing time entries logged in the last 3 weeks" text.

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change file Timelog.jsx and Timelog.module.css

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard.
6. Check if the text is removed and "Tasks and Timelogs" is aligned properly with the "Add Intagible time" button.