### PR TITLE
Venkataramanan 🔥 fix: create new filter order in weekly summaries reports page

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -2180,12 +2180,19 @@ const WeeklySummariesReport = props => {
 
   const applyFilter = selectedFilter => {
     const filter = selectedFilter.filterData;
-    const selectedCodesChoice = state.teamCodes.filter(code =>
-      filter.selectedCodes.has(code.value),
-    );
+
+    const savedCodeValues = Array.isArray(filter.selectedCodes)
+      ? filter.selectedCodes
+      : Array.from(filter.selectedCodes || []);
+
+    const selectedCodesChoice = savedCodeValues
+      .map(savedCodeValue => state.teamCodes.find(code => code.value === savedCodeValue))
+      .filter(Boolean);
+
     const selectedColorsChoice = state.colorOptions.filter(color =>
       filter.selectedColors.has(color.value),
     );
+
     const selectedExtraMembersChoice = state.summaries
       .filter(summary => filter.selectedExtraMembers.has(summary._id))
       .map(summary => ({


### PR DESCRIPTION
# Description
This PR fixes the issue with create new filter in weekly summaries report page.

## Related PRS (if any):
This is not related to any other PRs.

## Main changes explained:
- Change file WeeklySummariesReport.jsx

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Weekly Summaries Report -> Manage Filters
6. Create new filters and add team codes
7. Check if selecting the newly created filters displays the team code in the selected order.
