### PR TITLE
Namitha: Replace emoji with PDF icon in Save as PDF button

### DIFF
--- a/src/components/CommunityPortal/Reports/Participation/EventParticipation.jsx
+++ b/src/components/CommunityPortal/Reports/Participation/EventParticipation.jsx
@@ -1,6 +1,8 @@
 /* eslint-disable testing-library/no-node-access */
 import { useSelector } from 'react-redux';
 import { useRef, useState, useCallback } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFilePdf } from '@fortawesome/free-solid-svg-icons';
 import MyCases from './MyCases';
 import DropOffTracking from './DropOffTracking';
 import NoShowInsights from './NoShowInsights';
@@ -63,7 +65,14 @@ function EventParticipation() {
           disabled={exporting}
           aria-busy={exporting}
         >
-          {exporting ? 'Preparing…' : '📄 Save as PDF'}
+          {exporting ? (
+            'Preparing…'
+          ) : (
+            <>
+              <FontAwesomeIcon icon={faFilePdf} style={{ marginRight: '6px' }} />
+              Save as PDF
+            </>
+          )}
         </button>
       </header>
 


### PR DESCRIPTION
# Description
<img width="723" height="755" alt="image" src="https://github.com/user-attachments/assets/e74995f4-310d-46df-9a46-900aae834f3e" />

## Related PRS (if any):

## Main changes explained:
1. Replaced emoji with a proper PDF icon — Swapped the 📄 emoji in the "Save as PDF" button with a FontAwesome icon, which is already a project dependency — no new packages added.
2. Improved visual clarity and UX consistency — The PDF icon is a universally recognized symbol for PDF exports, aligning the button with standard UI conventions and making the action immediately clear to users.
3. No functional changes — The export/print logic is untouched; only the button's visual icon was updated, making this a safe, low-risk UI enhancement.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ /communityportal/reports/participation
(https://dev.highestgood.com/communityportal/reports/participation)
7. verify the new PDF icon in the "Save as PDF" button

## Screenshots or videos of changes:
<img width="1919" height="954" alt="Screenshot 2026-03-26 133352" src="https://github.com/user-attachments/assets/ed709b58-0637-486c-bd0e-4341d57f4ad8" />

https://github.com/user-attachments/assets/495bc7db-bae0-45a1-9276-7af5b2a263a2
