### PR TITLE
Amalesh - Fix inability to delete a team from the Team list

### DIFF
--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -383,6 +383,16 @@ class Teams extends React.PureComponent {
     toast.success('Member removed successfully!');
   };
 
+  onDeleteTeamPopupShow = (teamName, teamId, isActive, teamCode) => {
+    this.setState({
+      deleteTeamPopupOpen: true,
+      selectedTeam: teamName,
+      selectedTeamId: teamId,
+      selectedTeamCode: teamCode,
+      isActive,
+    });
+  };
+
   onDeleteTeamPopupClose = () => {
     this.setState({
       selectedTeamId: undefined,


### PR DESCRIPTION
# Description
<img width="611" height="164" alt="image" src="https://github.com/user-attachments/assets/d9148d13-5cec-4f72-9aeb-c813407bb6d2" />

Before: https://drive.google.com/file/d/1JHvGUVvphQ1y3N840zUoU-9MTpiv-Vp1/view?usp=sharing

## Related PRS (if any):
This frontend PR is related to the development branch of the backend.

## Main changes explained:
- Update Teams.jsx to add the missing onDeleteTeamPopupShow handler that opens the delete confirmation popup and stores the selected team details. This fixes the broken delete flow from the team list.

## How to test:
1. Check out the current branch.
2. Run the frontend and backend locally using the project’s normal startup commands.
3. Clear site data/cache and refresh the app.
4. Log in as an Admin or Owner user.
5. Go to Other Links → Teams or open http://localhost:3000/teams.
6. Click the Delete button for any team and verify that the delete confirmation popup opens.
7. Confirm deletion in the popup and verify that the delete request is triggered and the team is removed from the list.
8. Verify that the updated behavior works in dark mode as well.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/8df34a24-a97f-480f-b895-948ca6ade32f