### PR TITLE
Sai Teja fix forbidden 403 error toast when admin owner views another user dashboard

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -251,11 +251,12 @@ export function Header(props) {
     if (roles.length === 0 && isAuthenticated) {
       props.getAllRoles();
     }
-    // Fetch unread notification
-    if (isAuthenticated && displayUserId) {
-      dispatch(getUnreadUserNotifications(displayUserId));
+    // Fetch unread notification - always use the logged-in user's ID,
+    // not displayUserId, which may be a viewed user (causing a 403 error)
+    if (isAuthenticated && user.userid) {
+      dispatch(getUnreadUserNotifications(user.userid));
     }
-  }, [isAuthenticated, displayUserId, roles.length]);
+  }, [isAuthenticated, user.userid, roles.length]);
 
   useEffect(() => {
     if (props.notification?.error) {


### PR DESCRIPTION
# Description
<img width="1490" height="1156" alt="image" src="https://github.com/user-attachments/assets/03ac9279-dc00-4e86-9c67-14d2bd41ea6c" />

When an Admin/Owner navigated to the Leaderboard and clicked the dot next to 
a user's name (or viewed another user's Dashboard > Tasks tab), a red toast 
error - "You are forbidden to access the resource" - appeared immediately after 
confirming the "Jump to personal Dashboard" modal.

## Related PRS (if any):
N/A
…

## Main changes explained:
- Update `src/components/Header/Header.jsx` - changed `getUnreadUserNotifications` 
  to always use `user.userid` (the logged-in user's own ID) instead of `displayUserId`, 
  which was being updated to the viewed user's ID when an Admin/Owner switched 
  dashboards, causing a 403 forbidden error from the backend.
…

## How to test:
1. Check into current branch
2. Run `npm install` and `npm start` to run locally
3. Clear site data/cache
4. Log in as Admin or Owner
5. Go to Leaderboard → click the colored dot next to any user's name
6. Click "Ok" on the "Jump to personal Dashboard" confirmation modal
7. Verify the red "You are forbidden to access the resource" toast does NOT appear
8. Also verify: while viewing another user's dashboard, click the Tasks tab — 
   same result, no error toast
9. Verify dark mode works as expected

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/8f0ebbc0-51bc-4f79-bae7-49f88c3a3223

## Note:
Root cause: The Header's `useEffect` for fetching unread notifications had 
`displayUserId` as a dependency. When viewingUser was set in sessionStorage 
(on leaderboard dot click), `displayUserId` updated to the viewed user's ID 
and triggered a notification fetch for that user — which the backend correctly 
rejects with 403. Fix ensures notifications are always fetched for the 
authenticated user only.
