### PR TITLE
Diya 🔥 feat: Enhanced existing User State Feature

### DIFF
--- a/src/components/PermissionsManagement/__tests__/RolePermissions.test.jsx
+++ b/src/components/PermissionsManagement/__tests__/RolePermissions.test.jsx
@@ -206,7 +206,8 @@ describe('RolePermissions component', () => {
     const history = createMemoryHistory();
     renderComponent(store, history, roleName, roleId);
 
-    fireEvent.click(screen.getByTestId('edit-role-icon'));
+    const editIcon = await screen.findByTestId('edit-role-icon');
+    fireEvent.click(editIcon);
 
     const dialog = screen.getByRole('dialog');
 

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -8,7 +8,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { Modal, ModalBody, ModalFooter, ModalHeader, Progress, Table } from 'reactstrap';
 import CopyToClipboard from '~/components/common/Clipboard/CopyToClipboard';
 import UserStateDisplay from '../UserState/UserStateDisplay';
@@ -65,6 +65,9 @@ const TeamMemberTask = React.memo(
     const manager = 'Manager';
     const adm = 'Administrator';
     const owner = 'Owner';
+    const isOwnerOrAdmin = ['Owner', 'Administrator'].includes(userRole);
+
+    useEffect(() => {}, [userStateSelection]);
 
     const handleDashboardAccess = () => {
       // null checks
@@ -528,7 +531,9 @@ const TeamMemberTask = React.memo(
                               </div>
                               <UserStateDisplay
                                 userId={user.personId}
+                                userName={user.name}
                                 canEdit={displayUser?.email === 'jae@onecommunityglobal.org'}
+                                canManage={isOwnerOrAdmin}
                                 catalog={userStateCatalog}
                                 onCatalogChange={onCatalogChange}
                                 initialSelected={userStateSelection}

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -67,6 +67,7 @@ const TeamMemberTasks = React.memo(props => {
 
   const [userStateCatalog, setUserStateCatalog] = useState([]);
   const [userStateSelections, setUserStateSelections] = useState({});
+  const [selectionsLoaded, setSelectionsLoaded] = useState(false);
 
   useEffect(() => {
     axios
@@ -77,15 +78,19 @@ const TeamMemberTasks = React.memo(props => {
 
   // Fetch all selections in ONE call once teamList is ready
   useEffect(() => {
-    if (teamList.length === 0) return;
-    const userIds = teamList.map(u => u.personId);
-    const result = axios.post(ENDPOINTS.USER_STATE_SELECTIONS_BATCH, { userIds });
-    if (result && typeof result.then === 'function') {
-      result
-        .then(res => setUserStateSelections(res.data.selections || {}))
-        .catch(() => setUserStateSelections({}));
-    }
-  }, [teamList]);
+    if (usersWithTasks.length === 0) return;
+    const userIds = usersWithTasks.map(u => u.personId);
+    axios
+      .post(ENDPOINTS.USER_STATE_SELECTIONS_BATCH, { userIds })
+      .then(res => {
+        setUserStateSelections(res.data.selections || {});
+        setSelectionsLoaded(true);
+      })
+      .catch(() => {
+        setUserStateSelections({});
+        setSelectionsLoaded(true);
+      });
+  }, [usersWithTasks]);
 
   // Keep width reactive without putting window.innerWidth in deps (which never triggers)
   useEffect(() => {
@@ -718,7 +723,7 @@ const TeamMemberTasks = React.memo(props => {
           </thead>
 
           <tbody className={darkMode ? styles.darkTbody : ''}>
-            {teamList.length === 0 ? (
+            {teamList.length === 0 || !selectionsLoaded ? (
               <SkeletonLoading
                 template="TeamMemberTasks"
                 data-testid="skeleton-loading-team-member-tasks-row"

--- a/src/components/TeamMemberTasks/__tests__/TeamMemberTasks.test.jsx
+++ b/src/components/TeamMemberTasks/__tests__/TeamMemberTasks.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import thunk from 'redux-thunk';
 import { configureStore } from 'redux-mock-store';
@@ -237,7 +237,7 @@ describe('TeamMemberTasks component', () => {
 
     expect(screen.getAllByTestId('team-member-tasks-row')).not.toHaveLength(0);
   });
-  it('check if the skeleton loading html elements are not shown when isLoading is false', () => {
+  it('check if the skeleton loading html elements are not shown when isLoading is false', async () => {
     axios.get.mockResolvedValue({
       status: 200,
       data: '',
@@ -250,7 +250,9 @@ describe('TeamMemberTasks component', () => {
         </MemoryRouter>
       </Provider>,
     );
-    expect(screen.queryAllByTestId('team-member-tasks-row')).toHaveLength(0);
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('team-member-tasks-row')).toHaveLength(0);
+    });
   });
   it('check if class names does not include color when dark mode is false', () => {
     axios.get.mockResolvedValue({

--- a/src/components/TeamMemberTasks/__tests__/TeamMemberTasks.test.jsx
+++ b/src/components/TeamMemberTasks/__tests__/TeamMemberTasks.test.jsx
@@ -88,12 +88,24 @@ const store = mockStore({
 
 vi.mock('axios');
 
+beforeEach(() => {
+  axios.get.mockResolvedValue({
+    status: 200,
+    data: { items: [] },
+  });
+  axios.post.mockResolvedValue({
+    status: 200,
+    data: { selections: {} },
+  });
+});
+
 describe('TeamMemberTasks component', () => {
   it('renders without crashing', () => {
     axios.get.mockResolvedValue({
       status: 200,
       data: '',
     });
+    axios.post.mockResolvedValue({ status: 200, data: { selections: {} } });
     render(
       <Provider store={store}>
         <MemoryRouter>

--- a/src/components/TeamMemberTasks/__tests__/TeamMemberTasks.test.jsx
+++ b/src/components/TeamMemberTasks/__tests__/TeamMemberTasks.test.jsx
@@ -250,7 +250,7 @@ describe('TeamMemberTasks component', () => {
         </MemoryRouter>
       </Provider>,
     );
-    expect(screen.queryByTestId('team-member-tasks-row')).not.toBeInTheDocument();
+    expect(screen.queryAllByTestId('team-member-tasks-row')).toHaveLength(0);
   });
   it('check if class names does not include color when dark mode is false', () => {
     axios.get.mockResolvedValue({

--- a/src/components/UserProfile/UserProfileEdit/__tests__/UserProfileEdit.test.jsx
+++ b/src/components/UserProfile/UserProfileEdit/__tests__/UserProfileEdit.test.jsx
@@ -47,7 +47,12 @@ describe("<UserProfileEdit />", () => {
       allProjects: mockProps.allProjects,
       theme: mockProps.theme,
     });
+    const axios = require('axios');
+    axios.get = vi.fn().mockResolvedValue({ status: 200, data: '' });
+    axios.post = vi.fn().mockResolvedValue({ status: 200, data: {} });
   });
+
+
 
   it("renders the UserProfileEdit component", async () => {
     render(
@@ -62,7 +67,7 @@ describe("<UserProfileEdit />", () => {
       expect(mockProps.getUserProfile).toHaveBeenCalledWith("12345")
     );
     expect(screen.getByText(/Save Changes/i)).toBeInTheDocument();
-  });
+  }, 10000);
 
   it("displays loading spinner initially", () => {
     render(

--- a/src/components/UserState/ColorPicker.jsx
+++ b/src/components/UserState/ColorPicker.jsx
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import { COLOR_SWATCHES } from './constants';
+import styles from './UserState.module.css';
+
+function ColorPicker({ selectedColor, onSelect }) {
+  return (
+    <div className={styles.colorPickerWrapper}>
+      <span className={styles.colorPickerLabel}>Color:</span>
+      {COLOR_SWATCHES.map(swatch => (
+        <button
+          key={swatch.hex}
+          type="button"
+          title={swatch.label}
+          onClick={() => onSelect(swatch.hex)}
+          className={styles.colorSwatch}
+          style={{
+            background: swatch.hex,
+            border: selectedColor === swatch.hex ? '3px solid #000' : '2px solid transparent',
+            outline: selectedColor === swatch.hex ? '2px solid #fff' : 'none',
+            outlineOffset: '-4px',
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+ColorPicker.propTypes = {
+  selectedColor: PropTypes.string.isRequired,
+  onSelect: PropTypes.func.isRequired,
+};
+
+export default ColorPicker;

--- a/src/components/UserState/EmojiPicker.jsx
+++ b/src/components/UserState/EmojiPicker.jsx
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import { EMOJI_OPTIONS } from './constants';
+import styles from './UserState.module.css';
+
+function EmojiPicker({ darkMode, onSelect }) {
+  return (
+    <div className={`${styles.emojiPickerGrid} ${darkMode ? styles.dark : styles.light}`}>
+      {EMOJI_OPTIONS.map(emoji => (
+        <button
+          key={emoji}
+          type="button"
+          onClick={() => onSelect(emoji)}
+          className={styles.emojiBtn}
+        >
+          {emoji}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+EmojiPicker.propTypes = {
+  darkMode: PropTypes.bool.isRequired,
+  onSelect: PropTypes.func.isRequired,
+};
+
+export default EmojiPicker;

--- a/src/components/UserState/ManageStatesModal.jsx
+++ b/src/components/UserState/ManageStatesModal.jsx
@@ -1,0 +1,508 @@
+import axios from 'axios';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Input,
+  FormGroup,
+  Label,
+} from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faPlus,
+  faArrowsUpDown,
+  faCheck,
+  faChevronUp,
+  faChevronDown,
+} from '@fortawesome/free-solid-svg-icons';
+import { ENDPOINTS } from '~/utils/URL';
+import { boxStyle, boxStyleDark } from '~/styles';
+import { DEFAULT_COLOR, DEFAULT_EMOJI, getStateColor } from './constants';
+import ColorPicker from './ColorPicker';
+import EmojiPicker from './EmojiPicker';
+import styles from './UserState.module.css';
+
+function logError(context, error) {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.error(`[ManageStatesModal] ${context}:`, error?.message || error);
+  }
+}
+
+function ManageStatesModal({ isOpen, onClose, catalog, onCatalogChange, darkMode }) {
+  const [isAdding, setIsAdding] = useState(false);
+  const [isReordering, setIsReordering] = useState(false);
+  const [newLabel, setNewLabel] = useState('');
+  const [selectedColor, setSelectedColor] = useState(DEFAULT_COLOR);
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+  const [newEmoji, setNewEmoji] = useState(DEFAULT_EMOJI);
+  const [editEmoji, setEditEmoji] = useState(DEFAULT_EMOJI);
+
+  const [editingKey, setEditingKey] = useState(null);
+  const [editLabel, setEditLabel] = useState('');
+  const [editColor, setEditColor] = useState(DEFAULT_COLOR);
+  const [showEditEmojiPicker, setShowEditEmojiPicker] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState(null);
+
+  const boxStyling = darkMode ? boxStyleDark : boxStyle;
+  const fontColor = darkMode ? 'text-light' : '';
+  const themeClass = darkMode ? styles.dark : styles.light;
+
+  const handleEmojiSelect = emoji => {
+    setNewEmoji(emoji);
+    setShowEmojiPicker(false);
+  };
+  const handleEditEmojiSelect = emoji => {
+    setEditEmoji(emoji);
+    setShowEditEmojiPicker(false);
+  };
+
+  const handleStartEdit = item => {
+    setEditEmoji(item.emoji || DEFAULT_EMOJI);
+    setEditLabel(item.label);
+    setEditColor(item.color || DEFAULT_COLOR);
+    setEditingKey(item.key);
+    setShowEditEmojiPicker(false);
+    setIsAdding(false);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingKey(null);
+    setEditLabel('');
+    setEditColor(DEFAULT_COLOR);
+    setEditEmoji(DEFAULT_EMOJI);
+    setShowEditEmojiPicker(false);
+  };
+
+  const handleAddNew = async () => {
+    const trimmed = newLabel.trim();
+    if (!trimmed) return;
+    try {
+      const res = await axios.post(ENDPOINTS.USER_STATE_CATALOG, {
+        label: trimmed,
+        emoji: newEmoji,
+        color: selectedColor,
+        requestor: { role: 'Owner' },
+      });
+      onCatalogChange(prev => [...prev, res.data.item]);
+      setNewLabel('');
+      setNewEmoji(DEFAULT_EMOJI);
+      setSelectedColor(DEFAULT_COLOR);
+      setIsAdding(false);
+      setShowEmojiPicker(false);
+      toast.success(`State "${trimmed}" created successfully!`);
+    } catch (addError) {
+      // eslint-disable-next-line no-alert
+      toast.error(addError?.response?.data?.error || 'Failed to add new state');
+    }
+  };
+
+  const handleSaveEdit = async key => {
+    const trimmed = editLabel.trim();
+    if (!trimmed) return;
+    try {
+      await axios.patch(ENDPOINTS.USER_STATE_CATALOG_ITEM(key), {
+        label: trimmed,
+        emoji: editEmoji,
+        color: editColor,
+        requestor: { role: 'Owner' },
+      });
+      onCatalogChange(prev =>
+        prev.map(c =>
+          c.key === key ? { ...c, label: trimmed, emoji: editEmoji, color: editColor } : c,
+        ),
+      );
+      handleCancelEdit();
+      toast.success(`State "${trimmed}" updated successfully!`);
+    } catch (editError) {
+      logError('handleSaveEdit', editError);
+      // eslint-disable-next-line no-alert
+      toast.error(editError?.response?.data?.error || 'Failed to update state');
+    }
+  };
+
+  const handleDelete = async key => {
+    const item = catalog.find(c => c.key === key);
+    try {
+      const res = await axios.get(ENDPOINTS.USER_STATE_CATALOG_USAGE(key));
+      const { count } = res.data;
+      if (count > 0) {
+        setDeleteConfirm({ key, label: item?.label, count });
+      } else {
+        await confirmDelete(key);
+      }
+    } catch (err) {
+      logError('handleDelete check', err);
+    }
+  };
+
+  const confirmDelete = async key => {
+    onCatalogChange(prev => prev.filter(c => c.key !== key));
+    setDeleteConfirm(null);
+    try {
+      await axios.patch(ENDPOINTS.USER_STATE_CATALOG_ITEM(key), {
+        isActive: false,
+        requestor: { role: 'Owner' },
+      });
+      toast.success(`State deleted successfully`);
+    } catch (deleteError) {
+      logError('confirmDelete', deleteError);
+    }
+  };
+
+  const handleMoveUp = async idx => {
+    if (idx === 0) return;
+    const reordered = [...catalog];
+    [reordered[idx - 1], reordered[idx]] = [reordered[idx], reordered[idx - 1]];
+    onCatalogChange(reordered);
+    try {
+      await axios.put(ENDPOINTS.USER_STATE_CATALOG_REORDER, {
+        orderedKeys: reordered.map(c => c.key),
+        requestor: { role: 'Owner' },
+      });
+    } catch (moveError) {
+      logError('handleMoveUp', moveError);
+    }
+  };
+
+  const handleMoveDown = async idx => {
+    if (idx === catalog.length - 1) return;
+    const reordered = [...catalog];
+    [reordered[idx], reordered[idx + 1]] = [reordered[idx + 1], reordered[idx]];
+    onCatalogChange(reordered);
+    try {
+      await axios.put(ENDPOINTS.USER_STATE_CATALOG_REORDER, {
+        orderedKeys: reordered.map(c => c.key),
+        requestor: { role: 'Owner' },
+      });
+    } catch (moveError) {
+      logError('handleMoveDown', moveError);
+    }
+  };
+
+  const handleClose = () => {
+    setIsAdding(false);
+    setIsReordering(false);
+    setNewLabel('');
+    setNewEmoji(DEFAULT_EMOJI);
+    setSelectedColor(DEFAULT_COLOR);
+    setShowEmojiPicker(false);
+    handleCancelEdit();
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      toggle={handleClose}
+      size="lg"
+      className={darkMode ? 'text-light' : ''}
+      centered
+    >
+      <ModalHeader toggle={handleClose} className={darkMode ? 'bg-space-cadet' : ''}>
+        Manage States
+      </ModalHeader>
+
+      <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
+        <p
+          className={fontColor}
+          style={{ fontSize: '13px', fontWeight: 600, marginBottom: '10px' }}
+        >
+          Existing States
+        </p>
+
+        <div className={`${styles.existingStatesList} ${themeClass}`}>
+          {catalog.map((item, idx) => {
+            const { bg, text } = getStateColor(item.color, darkMode);
+            const isEditing = editingKey === item.key;
+            return (
+              <div key={item.key}>
+                <div
+                  className={`${styles.catalogRow} ${
+                    isEditing ? styles.catalogRowEditing : ''
+                  } ${themeClass}`}
+                >
+                  <span className={styles.previewBadge} style={{ background: bg, color: text }}>
+                    {item.emoji ? `${item.emoji} ${item.label}` : item.label}
+                  </span>
+                  <div className={styles.catalogRowActions}>
+                    {isReordering && (
+                      <div className={styles.reorderBtns}>
+                        <Button
+                          color="secondary"
+                          size="sm"
+                          onClick={() => handleMoveUp(idx)}
+                          disabled={idx === 0}
+                          style={boxStyling}
+                          title="Move up"
+                        >
+                          <FontAwesomeIcon icon={faChevronUp} />
+                        </Button>
+                        <Button
+                          color="secondary"
+                          size="sm"
+                          onClick={() => handleMoveDown(idx)}
+                          disabled={idx === catalog.length - 1}
+                          style={boxStyling}
+                          title="Move down"
+                        >
+                          <FontAwesomeIcon icon={faChevronDown} />
+                        </Button>
+                      </div>
+                    )}
+                    <Button
+                      color="info"
+                      size="sm"
+                      onClick={() => (isEditing ? handleCancelEdit() : handleStartEdit(item))}
+                      style={boxStyling}
+                    >
+                      {isEditing ? 'Cancel' : 'Edit'}
+                    </Button>
+                    <Button
+                      color="danger"
+                      size="sm"
+                      onClick={() => handleDelete(item.key)}
+                      style={boxStyling}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+
+                {isEditing && (
+                  <div className={`${styles.inlineEditForm} ${themeClass}`}>
+                    <FormGroup>
+                      <Label className={fontColor}>Label</Label>
+                      <div className={styles.labelInputRow}>
+                        <Button
+                          color="secondary"
+                          size="sm"
+                          onClick={() => setShowEditEmojiPicker(prev => !prev)}
+                          title="Pick an emoji"
+                          style={{
+                            ...boxStyling,
+                            width: '38px',
+                            height: '38px',
+                            padding: 0,
+                            fontSize: '20px',
+                            flexShrink: 0,
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          {editEmoji}
+                        </Button>
+                        {showEditEmojiPicker && (
+                          <div className={styles.emojiPickerDropdown}>
+                            <EmojiPicker darkMode={darkMode} onSelect={handleEditEmojiSelect} />
+                          </div>
+                        )}
+                        <Input
+                          type="text"
+                          value={editLabel}
+                          onChange={e => setEditLabel(e.target.value)}
+                          maxLength={30}
+                          onKeyDown={e => e.key === 'Enter' && handleSaveEdit(item.key)}
+                          className={darkMode ? 'bg-yinmn-blue text-light' : ''}
+                        />
+                      </div>
+                    </FormGroup>
+                    <FormGroup>
+                      <Label className={fontColor}>Color</Label>
+                      <ColorPicker selectedColor={editColor} onSelect={setEditColor} />
+                    </FormGroup>
+                    {editLabel.trim() && (
+                      <FormGroup>
+                        <Label className={fontColor}>Preview</Label>
+                        <div>
+                          <span className={styles.previewBadge} style={{ background: editColor }}>
+                            {editEmoji} {editLabel.trim()}
+                          </span>
+                        </div>
+                      </FormGroup>
+                    )}
+                    <div className={styles.formActionBtns}>
+                      <Button
+                        color="success"
+                        onClick={() => handleSaveEdit(item.key)}
+                        style={boxStyling}
+                      >
+                        Save
+                      </Button>
+                      <Button color="danger" onClick={handleCancelEdit} style={boxStyling}>
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {isAdding && (
+          <div className={`${styles.addNewForm} ${themeClass}`}>
+            <p
+              className={fontColor}
+              style={{ fontSize: '13px', fontWeight: 600, marginBottom: '12px' }}
+            >
+              New State
+            </p>
+            <FormGroup>
+              <Label className={fontColor}>Label</Label>
+              <div className={styles.labelInputRow}>
+                <Button
+                  color="secondary"
+                  size="sm"
+                  onClick={() => setShowEmojiPicker(prev => !prev)}
+                  title="Pick an emoji"
+                  style={{
+                    ...boxStyling,
+                    width: '38px',
+                    height: '38px',
+                    padding: 0,
+                    fontSize: '20px',
+                    flexShrink: 0,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  {newEmoji}
+                </Button>
+                {showEmojiPicker && (
+                  <div className={styles.emojiPickerDropdown}>
+                    <EmojiPicker darkMode={darkMode} onSelect={handleEmojiSelect} />
+                  </div>
+                )}
+                <Input
+                  type="text"
+                  value={newLabel}
+                  onChange={e => setNewLabel(e.target.value)}
+                  placeholder="e.g. Star Developer"
+                  maxLength={30}
+                  onKeyDown={e => e.key === 'Enter' && handleAddNew()}
+                  className={darkMode ? 'bg-yinmn-blue text-light' : ''}
+                />
+              </div>
+            </FormGroup>
+            <FormGroup>
+              <Label className={fontColor}>Color</Label>
+              <ColorPicker selectedColor={selectedColor} onSelect={setSelectedColor} />
+            </FormGroup>
+            {newLabel.trim() && (
+              <FormGroup>
+                <Label className={fontColor}>Preview</Label>
+                <div>
+                  <span className={styles.previewBadge} style={{ background: selectedColor }}>
+                    {newEmoji} {newLabel.trim()}
+                  </span>
+                </div>
+              </FormGroup>
+            )}
+            <div className={styles.formActionBtns}>
+              <Button color="success" onClick={handleAddNew} style={boxStyling}>
+                Save
+              </Button>
+              <Button
+                color="danger"
+                onClick={() => {
+                  setIsAdding(false);
+                  setNewLabel('');
+                  setNewEmoji(DEFAULT_EMOJI);
+                  setSelectedColor(DEFAULT_COLOR);
+                  setShowEmojiPicker(false);
+                }}
+                style={boxStyling}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {deleteConfirm && (
+          <div className={`${styles.deleteConfirmBox} ${themeClass}`}>
+            <p className={fontColor} style={{ fontWeight: 600, marginBottom: '8px' }}>
+              ⚠️ Delete &quot;{deleteConfirm.label}&quot;?
+            </p>
+            <p className={fontColor} style={{ fontSize: '13px', marginBottom: '12px' }}>
+              This state is currently assigned to{' '}
+              <strong>
+                {deleteConfirm.count} user{deleteConfirm.count !== 1 ? 's' : ''}
+              </strong>
+              . Deleting it will remove it from all of them.
+            </p>
+            <div className={styles.formActionBtns}>
+              <Button
+                color="danger"
+                onClick={() => confirmDelete(deleteConfirm.key)}
+                style={boxStyling}
+              >
+                Delete & Remove from All Users
+              </Button>
+              <Button color="secondary" onClick={() => setDeleteConfirm(null)} style={boxStyling}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </ModalBody>
+
+      <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
+        <div className="d-flex w-100 align-items-center">
+          <div className={styles.footerLeft}>
+            {!isAdding && (
+              <Button
+                color="success"
+                onClick={() => {
+                  setIsAdding(true);
+                  handleCancelEdit();
+                }}
+                style={boxStyling}
+              >
+                <FontAwesomeIcon icon={faPlus} className="mr-1" /> Add New State
+              </Button>
+            )}
+            <Button
+              color={isReordering ? 'warning' : 'info'}
+              onClick={() => setIsReordering(prev => !prev)}
+              style={boxStyling}
+            >
+              <FontAwesomeIcon icon={isReordering ? faCheck : faArrowsUpDown} className="mr-1" />
+              {isReordering ? 'Done Reordering' : 'Reorder'}
+            </Button>
+          </div>
+          <div className="ml-auto">
+            <Button color="primary" onClick={handleClose} style={boxStyling}>
+              Close
+            </Button>
+          </div>
+        </div>
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+ManageStatesModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  catalog: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string,
+      label: PropTypes.string,
+      emoji: PropTypes.string,
+      color: PropTypes.string,
+    }),
+  ).isRequired,
+  onCatalogChange: PropTypes.func.isRequired,
+  darkMode: PropTypes.bool.isRequired,
+};
+
+export default ManageStatesModal;

--- a/src/components/UserState/UserState.module.css
+++ b/src/components/UserState/UserState.module.css
@@ -1,0 +1,431 @@
+/* ─── Theme variables ─────────────────────────────────────────────────────── */
+
+.light {
+  --us-panel-border: #dee2e6;
+  --us-row-bg: #f8f9fa;
+  --us-edit-form-bg: #f0f4ff;
+  --us-add-form-bg: #f8f9fa;
+  --us-delete-confirm-bg: #fff5f5;
+  --us-emoji-picker-bg: #fff;
+  --us-unselected-toggle-bg: #e8f0fe;
+  --us-unselected-toggle-color: #1a3a6b;
+  --us-divider-color: #dee2e6;
+  --us-action-btn-color: #3498db;
+}
+
+.dark {
+  --us-panel-border: #4a6a9c;
+  --us-row-bg: #2a3a5c;
+  --us-edit-form-bg: #1e2d4a;
+  --us-add-form-bg: #2a3a5c;
+  --us-delete-confirm-bg: #2a1a1a;
+  --us-emoji-picker-bg: #1e2d4a;
+  --us-unselected-toggle-bg: #2a3a5c;
+  --us-unselected-toggle-color: #cdd9f5;
+  --us-divider-color: #4a6a9c;
+  --us-action-btn-color: #5dade2;
+}
+
+/* ─── Glossy shared mixin ─────────────────────────────────────────────────── */
+
+.glossy {
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-shadow: 0 1px 3px rgb(0 0 0 / 40%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  box-shadow:
+    0 4px 12px rgb(0 0 0 / 40%),
+    0 1px 3px rgb(0 0 0 / 30%),
+    inset 0 2px 4px rgb(255 255 255 / 80%),
+    inset 0 -2px 4px rgb(255 255 255 / 40%),
+    inset 0 8px 12px rgb(0 0 0 / 25%),
+    inset 0 -8px 12px rgb(0 0 0 / 25%);
+  background-image:
+    linear-gradient(
+      to right,
+      rgb(0 0 0 / 20%) 0%,
+      rgb(255 255 255 / 15%) 20%,
+      rgb(255 255 255 / 0%) 50%,
+      rgb(255 255 255 / 15%) 80%,
+      rgb(0 0 0 / 20%) 100%
+    ),
+    linear-gradient(
+      to bottom,
+      rgb(255 255 255 / 30%) 0%,
+      rgb(0 0 0 / 20%) 50%,
+      rgb(255 255 255 / 20%) 100%
+    );
+}
+
+/* ─── Layout ─────────────────────────────────────────────────────────────── */
+
+.userStateWrapper {
+  margin-top: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  max-width: 100%;
+  justify-content: center;
+}
+
+.setStateBtn {
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--us-action-btn-color);
+  background: none;
+  border: none;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.setMoreBtn {
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--us-action-btn-color);
+  background: none;
+  border: none;
+  padding: 5px 2px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* ─── Badge ───────────────────────────────────────────────────────────────── */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 14px 6px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  text-shadow: 0 1px 3px rgb(0 0 0 / 40%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  box-shadow:
+    0 4px 12px rgb(0 0 0 / 40%),
+    0 1px 3px rgb(0 0 0 / 30%),
+    inset 0 2px 4px rgb(255 255 255 / 80%),
+    inset 0 -2px 4px rgb(255 255 255 / 40%),
+    inset 0 8px 12px rgb(0 0 0 / 25%),
+    inset 0 -8px 12px rgb(0 0 0 / 25%);
+  background-image:
+    linear-gradient(
+      to right,
+      rgb(0 0 0 / 8%) 0%,
+      rgb(255 255 255 / 20%) 20%,
+      rgb(255 255 255 / 0%) 50%,
+      rgb(255 255 255 / 20%) 80%,
+      rgb(0 0 0 / 8%) 100%
+    ),
+    linear-gradient(
+      to bottom,
+      rgb(255 255 255 / 40%) 0%,
+      rgb(0 0 0 / 20%) 50%,
+      rgb(255 255 255 / 25%) 100%
+    );
+}
+
+.badgeRemoveBtn {
+  font-size: 11px;
+  font-weight: bold;
+  opacity: 0.8;
+  cursor: pointer;
+  line-height: 1;
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+}
+
+/* ─── ColorPicker ─────────────────────────────────────────────────────────── */
+
+.colorPickerWrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.colorPickerLabel {
+  font-size: 12px;
+  color: #666;
+}
+
+.colorSwatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  cursor: pointer;
+  padding: 0;
+}
+
+/* ─── EmojiPicker ─────────────────────────────────────────────────────────── */
+
+.emojiPickerGrid {
+  padding: 6px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 4px;
+  width: 204px;
+  background: var(--us-emoji-picker-bg);
+  border: 1px solid var(--us-panel-border);
+}
+
+.emojiBtn {
+  font-size: 18px;
+  padding: 4px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.emojiBtn:hover {
+  background: var(--us-unselected-toggle-bg);
+}
+
+.emojiTriggerBtn {
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  font-size: 20px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.emojiPickerDropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1100;
+  margin-top: 4px;
+}
+
+/* ─── ManageStatesModal / UserStateModal shared ───────────────────────────── */
+
+.catalogRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: var(--us-row-bg);
+  border: 1px solid var(--us-panel-border);
+}
+
+.catalogRowEditing {
+  border-radius: 8px 8px 0 0;
+  border-bottom: none !important;
+}
+
+.catalogRowActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.reorderBtns {
+  display: flex;
+  gap: 4px;
+}
+
+.inlineEditForm {
+  padding: 16px;
+  border-radius: 0 0 8px 8px;
+  border-top: none;
+  background: var(--us-edit-form-bg);
+  border: 1px solid var(--us-panel-border);
+}
+
+.addNewForm {
+  padding: 16px;
+  border-radius: 8px;
+  background: var(--us-add-form-bg);
+  border: 1px solid var(--us-panel-border);
+}
+
+.labelInputRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  position: relative;
+}
+
+.previewBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: 0.5px;
+  text-shadow: 0 1px 3px rgb(0 0 0 / 40%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  box-shadow:
+    0 4px 12px rgb(0 0 0 / 40%),
+    0 1px 3px rgb(0 0 0 / 30%),
+    inset 0 2px 4px rgb(255 255 255 / 80%),
+    inset 0 -2px 4px rgb(255 255 255 / 40%),
+    inset 0 8px 12px rgb(0 0 0 / 25%),
+    inset 0 -8px 12px rgb(0 0 0 / 25%);
+  background-image:
+    linear-gradient(
+      to right,
+      rgb(0 0 0 / 8%) 0%,
+      rgb(255 255 255 / 20%) 20%,
+      rgb(255 255 255 / 0%) 50%,
+      rgb(255 255 255 / 20%) 80%,
+      rgb(0 0 0 / 8%) 100%
+    ),
+    linear-gradient(
+      to bottom,
+      rgb(255 255 255 / 40%) 0%,
+      rgb(0 0 0 / 20%) 50%,
+      rgb(255 255 255 / 25%) 100%
+    );
+}
+
+.formActionBtns {
+  display: flex;
+  gap: 8px;
+}
+
+.deleteConfirmBox {
+  margin-top: 16px;
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid #e74c3c;
+  background: var(--us-delete-confirm-bg);
+}
+
+.footerLeft {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* ─── UserStateModal catalog buttons ─────────────────────────────────────── */
+
+.stateToggleBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  letter-spacing: 0.5px;
+  text-shadow: 0 1px 3px rgb(0 0 0 / 40%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  box-shadow:
+    0 4px 12px rgb(0 0 0 / 40%),
+    0 1px 3px rgb(0 0 0 / 30%),
+    inset 0 2px 4px rgb(255 255 255 / 80%),
+    inset 0 -2px 4px rgb(255 255 255 / 40%),
+    inset 0 8px 12px rgb(0 0 0 / 25%),
+    inset 0 -8px 12px rgb(0 0 0 / 25%);
+  background-image:
+    linear-gradient(
+      to right,
+      rgb(0 0 0 / 8%) 0%,
+      rgb(255 255 255 / 20%) 20%,
+      rgb(255 255 255 / 0%) 50%,
+      rgb(255 255 255 / 20%) 80%,
+      rgb(0 0 0 / 8%) 100%
+    ),
+    linear-gradient(
+      to bottom,
+      rgb(255 255 255 / 40%) 0%,
+      rgb(0 0 0 / 20%) 50%,
+      rgb(255 255 255 / 25%) 100%
+    );
+}
+
+.currentlySelectedRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.currentlySelectedBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-shadow: 0 1px 3px rgb(0 0 0 / 40%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  box-shadow:
+    0 4px 12px rgb(0 0 0 / 40%),
+    0 1px 3px rgb(0 0 0 / 30%),
+    inset 0 2px 4px rgb(255 255 255 / 80%),
+    inset 0 -2px 4px rgb(255 255 255 / 40%),
+    inset 0 8px 12px rgb(0 0 0 / 25%),
+    inset 0 -8px 12px rgb(0 0 0 / 25%);
+  background-image:
+    linear-gradient(
+      to right,
+      rgb(0 0 0 / 8%) 0%,
+      rgb(255 255 255 / 20%) 20%,
+      rgb(255 255 255 / 0%) 50%,
+      rgb(255 255 255 / 20%) 80%,
+      rgb(0 0 0 / 8%) 100%
+    ),
+    linear-gradient(
+      to bottom,
+      rgb(255 255 255 / 40%) 0%,
+      rgb(0 0 0 / 20%) 50%,
+      rgb(255 255 255 / 25%) 100%
+    );
+}
+
+.currentlySelectedRemoveBtn {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  font-size: 12px;
+  font-weight: bold;
+  opacity: 0.8;
+}
+
+.stateToggleGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.currentlySelectedSection {
+  padding-top: 16px;
+  margin-top: 8px;
+  border-top: 1px solid var(--us-divider-color);
+}
+
+.existingStatesList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.unselectedToggle {
+  background: var(--us-unselected-toggle-bg) !important;
+  color: var(--us-unselected-toggle-color) !important;
+}

--- a/src/components/UserState/UserStateBadge.jsx
+++ b/src/components/UserState/UserStateBadge.jsx
@@ -1,0 +1,63 @@
+import PropTypes from 'prop-types';
+import { getStateColor } from './constants';
+import styles from './UserState.module.css';
+
+function formatDate(dateStr) {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  return `(${d.getMonth() + 1}/${d.getDate()})`;
+}
+
+function UserStateBadge({ item, darkMode, canEdit, onRemove, onClick }) {
+  const { bg, text } = getStateColor(item.color, darkMode);
+  return (
+    <button
+      type="button"
+      title="This is the user's state. Ask an Admin to change it for you if you feel it is not accurate"
+      onClick={onClick}
+      className={styles.badge}
+      style={{
+        background: bg,
+        color: text,
+        cursor: canEdit ? 'pointer' : 'default',
+      }}
+    >
+      {formatDate(item.selectedAt)} {item.emoji ? `${item.emoji} ${item.label}` : item.label}
+      {canEdit && onRemove && (
+        <button
+          type="button"
+          aria-label={`Remove ${item.label}`}
+          onClick={e => {
+            e.stopPropagation();
+            onRemove(item.key);
+          }}
+          className={styles.badgeRemoveBtn}
+        >
+          ×
+        </button>
+      )}
+    </button>
+  );
+}
+
+UserStateBadge.propTypes = {
+  item: PropTypes.shape({
+    key: PropTypes.string,
+    label: PropTypes.string,
+    emoji: PropTypes.string,
+    color: PropTypes.string,
+    selectedAt: PropTypes.string,
+  }).isRequired,
+  darkMode: PropTypes.bool.isRequired,
+  canEdit: PropTypes.bool,
+  onRemove: PropTypes.func,
+  onClick: PropTypes.func,
+};
+
+UserStateBadge.defaultProps = {
+  canEdit: false,
+  onRemove: null,
+  onClick: undefined,
+};
+
+export default UserStateBadge;

--- a/src/components/UserState/UserStateDisplay.jsx
+++ b/src/components/UserState/UserStateDisplay.jsx
@@ -1,306 +1,20 @@
 import axios from 'axios';
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { ENDPOINTS } from '~/utils/URL';
-
-function formatDate(dateStr) {
-  if (!dateStr) return '';
-  const d = new Date(dateStr);
-  return `(${d.getMonth() + 1}/${d.getDate()})`;
-}
-
-const STATE_COLORS = {
-  'closing-out': { bg: '#e74c3c', text: '#fff' },
-  'new-developer': { bg: '#3498db', text: '#fff' },
-  'pr-review-team': { bg: '#9b59b6', text: '#fff' },
-  developer: { bg: '#27ae60', text: '#fff' },
-  'task-requested': { bg: '#e67e22', text: '#fff' },
-};
-
-function getStateColor(key, darkMode) {
-  if (STATE_COLORS[key]) return STATE_COLORS[key];
-  return { bg: darkMode ? '#2a3a5c' : '#607d8b', text: '#fff' };
-}
-
-function EditPanel({
-  catalog,
-  selected,
-  darkMode,
-  isAdding,
-  isReordering,
-  newLabel,
-  onToggle,
-  onMoveUp,
-  onMoveDown,
-  onAddNew,
-  onNewLabelChange,
-  onSetIsAdding,
-  onSetIsReordering,
-  onDeleteCatalogItem,
-  onClose,
-}) {
-  const panelBorder = darkMode ? '#4a6a9c' : '#b0c4de';
-  const panelBg = darkMode ? '#1e2d4a' : '#f8f9ff';
-  const titleColor = darkMode ? '#cdd9f5' : '#1a3a6b';
-  const unselectedBg = darkMode ? '#2a3a5c' : '#e8f0fe';
-  const unselectedColor = darkMode ? '#cdd9f5' : '#1a3a6b';
-  const reorderBtnBg = isReordering ? '#e67e22' : '#3498db';
-  const reorderBtnText = isReordering ? 'Done Reordering' : 'Reorder';
-
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        left: 0,
-        right: 'auto',
-        zIndex: 999,
-        marginTop: '8px',
-        padding: '10px',
-        border: `1px solid ${panelBorder}`,
-        borderRadius: '8px',
-        background: panelBg,
-        minWidth: '260px',
-        maxWidth: '320px',
-        boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-      }}
-    >
-      <div style={{ marginBottom: '8px', fontSize: '12px', fontWeight: 600, color: titleColor }}>
-        Select State:
-      </div>
-
-      {/* FIX 1: Catalog options horizontal with flex wrap */}
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '8px' }}>
-        {catalog.map((item, idx) => {
-          const isItemSelected = selected.some(s => s.key === item.key);
-          const { bg, text } = getStateColor(item.key, darkMode);
-          const btnBg = isItemSelected ? bg : unselectedBg;
-          const btnColor = isItemSelected ? text : unselectedColor;
-          const btnShadow = isItemSelected ? '0 2px 4px rgba(0,0,0,0.2)' : 'none';
-          const btnOpacity = isItemSelected ? 1 : 0.7;
-          return (
-            <div key={item.key} style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
-              <button
-                type="button"
-                onClick={() => onToggle(item.key)}
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '4px',
-                  padding: '4px 10px',
-                  borderRadius: '20px',
-                  fontSize: '12px',
-                  fontWeight: '600',
-                  cursor: 'pointer',
-                  background: btnBg,
-                  color: btnColor,
-                  border: `2px solid ${bg}`,
-                  boxShadow: btnShadow,
-                  opacity: btnOpacity,
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {item.label}
-              </button>
-              <button
-                type="button"
-                aria-label={`Delete ${item.label}`}
-                onClick={e => {
-                  e.stopPropagation();
-                  onDeleteCatalogItem(item.key);
-                }}
-                style={{
-                  marginLeft: '2px',
-                  fontSize: '10px',
-                  fontWeight: 'bold',
-                  opacity: 0.7,
-                  cursor: 'pointer',
-                  lineHeight: 1,
-                  background: 'none',
-                  border: 'none',
-                  padding: 0,
-                  color: 'inherit',
-                }}
-              >
-                ×
-              </button>
-              {isReordering && (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '1px' }}>
-                  <button
-                    type="button"
-                    onClick={() => onMoveUp(idx)}
-                    disabled={idx === 0}
-                    style={{
-                      fontSize: '9px',
-                      padding: '1px 4px',
-                      cursor: 'pointer',
-                      lineHeight: 1,
-                    }}
-                    title="Move up"
-                  >
-                    ▲
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onMoveDown(idx)}
-                    disabled={idx === catalog.length - 1}
-                    style={{
-                      fontSize: '9px',
-                      padding: '1px 4px',
-                      cursor: 'pointer',
-                      lineHeight: 1,
-                    }}
-                    title="Move down"
-                  >
-                    ▼
-                  </button>
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-
-      {isAdding && (
-        <div
-          style={{
-            display: 'flex',
-            gap: '6px',
-            marginBottom: '8px',
-            alignItems: 'center',
-            flexWrap: 'wrap',
-          }}
-        >
-          <input
-            type="text"
-            value={newLabel}
-            onChange={e => onNewLabelChange(e.target.value)}
-            placeholder="e.g. 🌟 Star Developer"
-            maxLength={30}
-            style={{
-              fontSize: '12px',
-              padding: '4px 8px',
-              borderRadius: '4px',
-              border: `1px solid ${panelBorder}`,
-              background: darkMode ? '#1e2d4a' : '#fff',
-              color: darkMode ? '#cdd9f5' : '#1a3a6b',
-              width: '160px',
-            }}
-            onKeyDown={e => e.key === 'Enter' && onAddNew()}
-          />
-          <button
-            type="button"
-            onClick={onAddNew}
-            style={{
-              fontSize: '11px',
-              padding: '3px 8px',
-              borderRadius: '4px',
-              border: 'none',
-              background: '#27ae60',
-              color: '#fff',
-              cursor: 'pointer',
-            }}
-          >
-            Save
-          </button>
-          <button
-            type="button"
-            onClick={() => onSetIsAdding(false)}
-            style={{
-              fontSize: '11px',
-              padding: '3px 8px',
-              borderRadius: '4px',
-              border: 'none',
-              background: '#e74c3c',
-              color: '#fff',
-              cursor: 'pointer',
-            }}
-          >
-            Cancel
-          </button>
-        </div>
-      )}
-
-      <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
-        <button
-          type="button"
-          onClick={() => onSetIsAdding(true)}
-          style={{
-            fontSize: '11px',
-            padding: '3px 10px',
-            borderRadius: '4px',
-            border: 'none',
-            background: '#27ae60',
-            color: '#fff',
-            cursor: 'pointer',
-          }}
-        >
-          ➕ Add new
-        </button>
-        <button
-          type="button"
-          onClick={() => onSetIsReordering(!isReordering)}
-          style={{
-            fontSize: '11px',
-            padding: '3px 10px',
-            borderRadius: '4px',
-            border: 'none',
-            background: reorderBtnBg,
-            color: '#fff',
-            cursor: 'pointer',
-          }}
-        >
-          {`↕️ ${reorderBtnText}`}
-        </button>
-        <button
-          type="button"
-          onClick={onClose}
-          style={{
-            fontSize: '11px',
-            padding: '3px 10px',
-            borderRadius: '4px',
-            border: 'none',
-            background: '#6c757d',
-            color: '#fff',
-            cursor: 'pointer',
-          }}
-        >
-          Close
-        </button>
-      </div>
-    </div>
-  );
-}
-
-EditPanel.propTypes = {
-  catalog: PropTypes.arrayOf(PropTypes.shape({ key: PropTypes.string, label: PropTypes.string }))
-    .isRequired,
-  selected: PropTypes.arrayOf(PropTypes.shape({ key: PropTypes.string })).isRequired,
-  darkMode: PropTypes.bool.isRequired,
-  isAdding: PropTypes.bool.isRequired,
-  isReordering: PropTypes.bool.isRequired,
-  newLabel: PropTypes.string.isRequired,
-  onToggle: PropTypes.func.isRequired,
-  onMoveUp: PropTypes.func.isRequired,
-  onMoveDown: PropTypes.func.isRequired,
-  onAddNew: PropTypes.func.isRequired,
-  onNewLabelChange: PropTypes.func.isRequired,
-  onSetIsAdding: PropTypes.func.isRequired,
-  onSetIsReordering: PropTypes.func.isRequired,
-  onDeleteCatalogItem: PropTypes.func.isRequired,
-  onClose: PropTypes.func.isRequired,
-};
-
-function logError(context, error) {
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line no-console
-    console.error(`[UserStateDisplay] ${context}:`, error?.message || error);
-  }
-}
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import UserStateBadge from './UserStateBadge';
+import UserStateModal from './UserStateModal';
+import ManageStatesModal from './ManageStatesModal';
+import styles from './UserState.module.css';
 
 function UserStateDisplay({
   userId,
+  userName,
   canEdit,
+  canManage,
   catalog,
   onCatalogChange,
   initialSelected,
@@ -308,248 +22,128 @@ function UserStateDisplay({
 }) {
   const darkMode = useSelector(state => state.theme.darkMode);
   const [selected, setSelected] = useState(initialSelected || []);
-  const [isEditing, setIsEditing] = useState(false);
-  const [newLabel, setNewLabel] = useState('');
-  const [isAdding, setIsAdding] = useState(false);
-  const [isReordering, setIsReordering] = useState(false);
+  const [isStateModalOpen, setIsStateModalOpen] = useState(false);
+  const [isManageModalOpen, setIsManageModalOpen] = useState(false);
 
-  const handleToggle = async key => {
-    const isItemSelected = selected.some(s => s.key === key);
-    const updated = isItemSelected
-      ? selected.filter(s => s.key !== key)
-      : [...selected, { key, selectedAt: new Date().toISOString() }];
+  useEffect(() => {
+    setSelected(initialSelected || []);
+  }, [initialSelected]);
+
+  const handleSelectionChange = (uid, updated) => {
     setSelected(updated);
-    onSelectionChange(userId, updated);
-    try {
-      await axios.put(ENDPOINTS.USER_STATE_SELECTION(userId), {
-        selectedKeys: updated.map(s => s.key),
-        requestor: { role: 'Owner' },
-      });
-    } catch (toggleError) {
-      logError('handleToggle', toggleError);
-      setSelected(prev => prev); // revert
-      onSelectionChange(userId, selected);
-    }
+    onSelectionChange(uid, updated);
   };
 
-  const handleAddNew = async () => {
-    const trimmed = newLabel.trim();
-    if (!trimmed) return;
-    try {
-      const res = await axios.post(ENDPOINTS.USER_STATE_CATALOG, {
-        label: trimmed,
-        requestor: { role: 'Owner' },
-      });
-      onCatalogChange(prev => [...prev, res.data.item]);
-      setNewLabel('');
-      setIsAdding(false);
-    } catch (addError) {
-      // eslint-disable-next-line no-alert
-      alert(addError?.response?.data?.error || 'Failed to add new state');
-    }
-  };
-
-  const handleDeleteCatalogItem = async key => {
-    onCatalogChange(prev => prev.filter(c => c.key !== key));
-    setSelected(prev => prev.filter(s => s.key !== key));
-    try {
-      await axios.patch(ENDPOINTS.USER_STATE_CATALOG_ITEM(key), {
-        isActive: false,
-        requestor: { role: 'Owner' },
-      });
-    } catch (deleteError) {
-      logError('handleDeleteCatalogItem', deleteError);
-    }
-  };
-
-  const handleMoveUp = async idx => {
-    if (idx === 0) return;
-    const reordered = [...catalog];
-    [reordered[idx - 1], reordered[idx]] = [reordered[idx], reordered[idx - 1]];
-    onCatalogChange(reordered);
-    try {
-      await axios.put(ENDPOINTS.USER_STATE_CATALOG_REORDER, {
-        orderedKeys: reordered.map(c => c.key),
-        requestor: { role: 'Owner' },
-      });
-    } catch (moveError) {
-      logError('handleMoveUp', moveError);
-    }
-  };
-
-  const handleMoveDown = async idx => {
-    if (idx === catalog.length - 1) return;
-    const reordered = [...catalog];
-    [reordered[idx], reordered[idx + 1]] = [reordered[idx + 1], reordered[idx]];
-    onCatalogChange(reordered);
-    try {
-      await axios.put(ENDPOINTS.USER_STATE_CATALOG_REORDER, {
-        orderedKeys: reordered.map(c => c.key),
-        requestor: { role: 'Owner' },
-      });
-    } catch (moveError) {
-      logError('handleMoveDown', moveError);
-    }
-  };
-
-  const handleClose = () => {
-    setIsEditing(false);
-    setIsAdding(false);
-    setIsReordering(false);
-  };
-
-  const handleToggleReordering = newVal => {
-    const next = Boolean(newVal);
-    setIsReordering(next);
-    if (next) setIsAdding(false);
-  };
-
-  const editPanelProps = {
-    catalog,
-    selected,
-    darkMode,
-    isAdding,
-    isReordering,
-    newLabel,
-    onToggle: handleToggle,
-    onMoveUp: handleMoveUp,
-    onMoveDown: handleMoveDown,
-    onAddNew: handleAddNew,
-    onNewLabelChange: setNewLabel,
-    onSetIsAdding: setIsAdding,
-    onSetIsReordering: handleToggleReordering,
-    onDeleteCatalogItem: handleDeleteCatalogItem,
-    onClose: handleClose,
-  };
-
-  if (selected.length === 0) {
-    if (!canEdit) return null;
-    return (
-      <div
-        style={{
-          marginTop: '6px',
-          position: 'relative',
-          display: 'flex',
-          justifyContent: 'center',
-        }}
-      >
-        <button
-          type="button"
-          onClick={() => setIsEditing(true)}
-          style={{
-            cursor: 'pointer',
-            fontSize: '11px',
-            color: '#3498db',
-            background: 'none',
-            border: 'none',
-            padding: 0,
-          }}
-        >
-          ➕ Set State
-        </button>
-        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-        {isEditing && <EditPanel {...editPanelProps} />}
-      </div>
-    );
-  }
-
-  const selectedItems = catalog
-    .filter(c => selected.some(s => s.key === c.key))
-    .map(c => {
-      const sel = selected.find(s => s.key === c.key);
-      return { ...c, selectedAt: sel.selectedAt };
+  const selectedItems = selected
+    .filter(s => catalog.some(c => c.key === s.key))
+    .map(s => {
+      const catalogItem = catalog.find(c => c.key === s.key);
+      return { ...catalogItem, selectedAt: s.selectedAt };
     });
 
   return (
-    /* FIX 3 & 4: badges horizontal, wrap, no overflow */
-    <div
-      style={{
-        marginTop: '6px',
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: '4px',
-        maxWidth: '100%',
-        overflow: 'visible',
-        position: 'relative',
-        justifyContent: 'center',
-      }}
-    >
-      {selectedItems.map(item => {
-        const { bg, text } = getStateColor(item.key, darkMode);
-        return (
-          <button
-            key={item.key}
-            type="button"
-            title="This is the user's state. Ask an Admin to change it for you if you feel it is not accurate"
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: '4px',
-              padding: '3px 8px 3px 10px',
-              borderRadius: '20px',
-              fontSize: '11px',
-              fontWeight: '600',
-              background: bg,
-              color: text,
-              boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
-              cursor: canEdit ? 'pointer' : 'default',
-              letterSpacing: '0.3px',
-              border: 'none',
-              whiteSpace: 'nowrap',
-            }}
-            onClick={
-              canEdit
-                ? e => {
-                    e.stopPropagation();
-                    setIsEditing(true);
-                  }
-                : undefined
-            }
-          >
-            {formatDate(item.selectedAt)} {item.label}
+    <>
+      <div className={styles.userStateWrapper}>
+        {selectedItems.length > 0 ? (
+          <>
+            {selectedItems.map(item => (
+              <UserStateBadge
+                key={item.key}
+                item={item}
+                darkMode={darkMode}
+                canEdit={canEdit}
+                onRemove={
+                  canEdit
+                    ? async key => {
+                        const updated = selected.filter(s => s.key !== key);
+                        handleSelectionChange(userId, updated);
+                        try {
+                          await axios.put(ENDPOINTS.USER_STATE_SELECTION(userId), {
+                            selectedKeys: updated.map(s => s.key),
+                            requestor: { role: 'Owner' },
+                          });
+                        } catch (err) {
+                          handleSelectionChange(userId, selected);
+                        }
+                      }
+                    : null
+                }
+                onClick={canEdit ? () => setIsStateModalOpen(true) : undefined}
+              />
+            ))}
             {canEdit && (
               <button
                 type="button"
-                aria-label={`Remove ${item.label}`}
-                onClick={e => {
-                  e.stopPropagation();
-                  handleToggle(item.key);
-                }}
-                style={{
-                  fontSize: '11px',
-                  fontWeight: 'bold',
-                  opacity: 0.8,
-                  cursor: 'pointer',
-                  lineHeight: 1,
-                  background: 'none',
-                  border: 'none',
-                  padding: 0,
-                  color: 'inherit',
-                }}
+                onClick={() => setIsStateModalOpen(true)}
+                title="Edit states"
+                className={`${styles.setMoreBtn} ${darkMode ? styles.dark : styles.light}`}
               >
-                ×
+                <FontAwesomeIcon icon={faPlus} /> Set more
               </button>
             )}
-          </button>
-        );
-      })}
-      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-      {canEdit && isEditing && <EditPanel {...editPanelProps} />}
-    </div>
+          </>
+        ) : (
+          canEdit && (
+            <button
+              type="button"
+              onClick={() => setIsStateModalOpen(true)}
+              className={`${styles.setStateBtn} ${darkMode ? styles.dark : styles.light}`}
+            >
+              <FontAwesomeIcon icon={faPlus} /> Set State
+            </button>
+          )
+        )}
+      </div>
+
+      <UserStateModal
+        isOpen={isStateModalOpen}
+        onClose={() => setIsStateModalOpen(false)}
+        userId={userId}
+        userName={userName}
+        catalog={catalog}
+        selected={selected}
+        onSelectionChange={handleSelectionChange}
+        darkMode={darkMode}
+        canManage={canManage}
+        onOpenManage={() => setIsManageModalOpen(true)}
+      />
+
+      <ManageStatesModal
+        isOpen={isManageModalOpen}
+        onClose={() => {
+          setIsManageModalOpen(false);
+          setIsStateModalOpen(true);
+        }}
+        catalog={catalog}
+        onCatalogChange={onCatalogChange}
+        darkMode={darkMode}
+      />
+    </>
   );
 }
 
 UserStateDisplay.propTypes = {
   userId: PropTypes.string.isRequired,
+  userName: PropTypes.string,
   canEdit: PropTypes.bool,
-  catalog: PropTypes.arrayOf(PropTypes.shape({ key: PropTypes.string, label: PropTypes.string })),
+  canManage: PropTypes.bool,
+  catalog: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string,
+      label: PropTypes.string,
+      emoji: PropTypes.string,
+      color: PropTypes.string,
+    }),
+  ),
   onCatalogChange: PropTypes.func,
   initialSelected: PropTypes.arrayOf(PropTypes.shape({ key: PropTypes.string })),
   onSelectionChange: PropTypes.func,
 };
 
 UserStateDisplay.defaultProps = {
+  userName: '',
   canEdit: false,
+  canManage: false,
   catalog: [],
   onCatalogChange: () => {},
   initialSelected: [],

--- a/src/components/UserState/UserStateModal.jsx
+++ b/src/components/UserState/UserStateModal.jsx
@@ -1,0 +1,217 @@
+import axios from 'axios';
+import PropTypes from 'prop-types';
+import { useState, useEffect } from 'react';
+import { toast } from 'react-toastify';
+import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faGear } from '@fortawesome/free-solid-svg-icons';
+import { ENDPOINTS } from '~/utils/URL';
+import { boxStyle, boxStyleDark } from '~/styles';
+import { getStateColor } from './constants';
+import styles from './UserState.module.css';
+
+function logError(context, error) {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.error(`[UserStateModal] ${context}:`, error?.message || error);
+  }
+}
+
+function UserStateModal({
+  isOpen,
+  onClose,
+  userId,
+  userName,
+  catalog,
+  selected,
+  onSelectionChange,
+  darkMode,
+  canManage,
+  onOpenManage,
+}) {
+  const boxStyling = darkMode ? boxStyleDark : boxStyle;
+  const fontColor = darkMode ? 'text-light' : '';
+  const themeClass = darkMode ? styles.dark : styles.light;
+
+  const [localSelected, setLocalSelected] = useState(selected);
+
+  useEffect(() => {
+    setLocalSelected(selected);
+  }, [isOpen, selected]);
+
+  const handleToggle = key => {
+    setLocalSelected(prev => {
+      const isItemSelected = prev.some(s => s.key === key);
+      return isItemSelected
+        ? prev.filter(s => s.key !== key)
+        : [...prev, { key, selectedAt: new Date().toISOString() }];
+    });
+  };
+
+  const handleDone = async () => {
+    const previous = selected;
+    onSelectionChange(userId, localSelected);
+    const count = localSelected.length;
+    toast.success(
+      count > 0
+        ? `${count} state${count !== 1 ? 's' : ''} assigned to ${userName}`
+        : `States cleared for ${userName}`,
+    );
+    onClose();
+    try {
+      await axios.put(ENDPOINTS.USER_STATE_SELECTION(userId), {
+        selectedKeys: localSelected.map(s => s.key),
+        requestor: { role: 'Owner' },
+      });
+    } catch (err) {
+      logError('handleDone', err);
+      toast.error('Failed to save state selection, changes reverted');
+      onSelectionChange(userId, previous);
+    }
+  };
+
+  const handleClose = () => {
+    setLocalSelected(selected);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} toggle={handleClose} className={darkMode ? 'text-light' : ''} centered>
+      <ModalHeader toggle={handleClose} className={darkMode ? 'bg-space-cadet' : ''}>
+        Set State {userName ? `— ${userName}` : ''}
+      </ModalHeader>
+
+      <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
+        <p
+          className={fontColor}
+          style={{ fontSize: '13px', fontWeight: 600, marginBottom: '12px' }}
+        >
+          Select one or more states:
+        </p>
+
+        <div className={`${styles.stateToggleGrid} ${themeClass}`}>
+          {catalog.map(item => {
+            const isItemSelected = localSelected.some(s => s.key === item.key);
+            const { bg, text } = getStateColor(item.color, darkMode);
+            return (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => handleToggle(item.key)}
+                className={`${styles.stateToggleBtn} ${
+                  !isItemSelected ? styles.unselectedToggle : ''
+                } ${themeClass}`}
+                style={
+                  isItemSelected
+                    ? {
+                        background: bg,
+                        color: text,
+                        border: `2px solid ${bg}`,
+                        boxShadow: '0 2px 6px rgba(0,0,0,0.2)',
+                        opacity: 1,
+                      }
+                    : {
+                        border: `2px solid ${bg}`,
+                        opacity: 0.7,
+                        boxShadow: 'none',
+                      }
+                }
+              >
+                {isItemSelected && <span>✓</span>}
+                {item.emoji ? `${item.emoji} ${item.label}` : item.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {localSelected.length > 0 && (
+          <div className={`${styles.currentlySelectedSection} ${themeClass}`}>
+            <p
+              className={fontColor}
+              style={{ fontSize: '12px', fontWeight: 600, marginBottom: '8px' }}
+            >
+              Currently selected:
+            </p>
+            <div className={styles.currentlySelectedRow}>
+              {catalog
+                .filter(c => localSelected.some(s => s.key === c.key))
+                .map(item => {
+                  const { bg, text } = getStateColor(item.color, darkMode);
+                  return (
+                    <span
+                      key={item.key}
+                      className={styles.currentlySelectedBadge}
+                      style={{ background: bg, color: text }}
+                    >
+                      {item.emoji ? `${item.emoji} ${item.label}` : item.label}
+                      <button
+                        type="button"
+                        onClick={() => handleToggle(item.key)}
+                        className={styles.currentlySelectedRemoveBtn}
+                        aria-label={`Remove ${item.label}`}
+                      >
+                        ×
+                      </button>
+                    </span>
+                  );
+                })}
+            </div>
+          </div>
+        )}
+      </ModalBody>
+
+      <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
+        <div className="d-flex w-100 align-items-center">
+          {canManage && (
+            <Button
+              color="secondary"
+              onClick={() => {
+                onClose();
+                onOpenManage();
+              }}
+              style={boxStyling}
+            >
+              <FontAwesomeIcon icon={faGear} className="mr-1" /> Manage States
+            </Button>
+          )}
+          <div className="ml-auto d-flex" style={{ gap: '0.5rem' }}>
+            <Button color="success" onClick={handleDone} style={boxStyling}>
+              Done
+            </Button>
+            <Button color="primary" onClick={handleClose} style={boxStyling}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+UserStateModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  userId: PropTypes.string.isRequired,
+  userName: PropTypes.string,
+  catalog: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string,
+      label: PropTypes.string,
+      emoji: PropTypes.string,
+      color: PropTypes.string,
+    }),
+  ).isRequired,
+  selected: PropTypes.arrayOf(PropTypes.shape({ key: PropTypes.string })).isRequired,
+  onSelectionChange: PropTypes.func.isRequired,
+  darkMode: PropTypes.bool.isRequired,
+  canManage: PropTypes.bool,
+  onOpenManage: PropTypes.func,
+};
+
+UserStateModal.defaultProps = {
+  userName: '',
+  canManage: false,
+  onOpenManage: () => {},
+};
+
+export default UserStateModal;

--- a/src/components/UserState/constants.js
+++ b/src/components/UserState/constants.js
@@ -1,0 +1,57 @@
+export const DEFAULT_EMOJI = '🆕';
+export const EMOJI_OPTIONS = [
+  '🆕',
+  '✅',
+  '💪',
+  '🔒',
+  '🔥',
+  '🚀',
+  '⚡️',
+  '🛠️',
+  '🎯',
+  '🌟',
+  '👀',
+  '🔄',
+  '⏸️',
+  '🏁',
+  '🦾',
+  '🚩',
+  '🎁',
+  '👓',
+  '🌏',
+  '🥇',
+  '🥈',
+  '🥉',
+  '🏅',
+  '⛺️',
+  '⚙️',
+  '📦',
+  '🖥️',
+  '‼️',
+  '❌',
+];
+
+export const COLOR_SWATCHES = [
+  { label: 'Blue', hex: '#3498db' },
+  { label: 'Green', hex: '#27ae60' },
+  { label: 'Purple', hex: '#9b59b6' },
+  { label: 'Orange', hex: '#e67e22' },
+  { label: 'Red', hex: '#e74c3c' },
+  { label: 'Teal', hex: '#16a085' },
+  { label: 'Navy', hex: '#2c3e50' },
+  { label: 'Pink', hex: '#e91e8c' },
+  { label: 'Yellow', hex: '#f1c40f' },
+  { label: 'Indigo', hex: '#3f51b5' },
+  { label: 'Cyan', hex: '#00bcd4' },
+  { label: 'Brown', hex: '#795548' },
+  { label: 'Lime', hex: '#8bc34a' },
+  { label: 'Deep Purple', hex: '#673ab7' },
+  { label: 'Slate', hex: '#607d8b' },
+];
+
+export const DEFAULT_COLOR = '#3498db';
+
+export function getStateColor(catalogColor, darkMode) {
+  if (catalogColor) return { bg: catalogColor, text: '#fff' };
+  return { bg: darkMode ? '#2a3a5c' : '#607d8b', text: '#fff' };
+}

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -431,6 +431,7 @@ export const ENDPOINTS = {
   USER_STATE_CATALOG_ITEM: key => `${APIEndpoint}/userstate/catalog/${key}`,
   USER_STATE_SELECTION: userId => `${APIEndpoint}/userstate/selection/${userId}`,
   USER_STATE_SELECTIONS_BATCH: `${APIEndpoint}/userstate/selections/batch`,
+  USER_STATE_CATALOG_USAGE: key => `${APIEndpoint}/userstate/catalog/${key}/usage`,
 
   CREATE_JOB_FORM: `${APIEndpoint}/jobforms`,
   UPDATE_JOB_FORM: `${APIEndpoint}/jobforms`,


### PR DESCRIPTION
# Description
Implements the User State Feature enhancement on the Team Member Tasks dashboard. This PR introduces a fully refactored User State system that allows Owners and Admins to create, manage, and assign status badges to team members. Fixes state persistence on page reload, batch-fetches all user selections in a single API call, and introduces a polished modal-based UI with glossy badge styling, emoji support, color customization, and dark mode compatibility.

## Related PRS (if any):
This frontend PR is related to the backend PR [#2148](https://github.com/OneCommunityGlobal/HGNRest/pull/2148)

## Main changes explained:
- Update `TeamMemberTask.jsx` to pass `userName`, `canManage`, and `userStateSelection` props to `UserStateDisplay`
- Update `TeamMemberTasks.jsx` to batch-fetch all user state selections in a single `POST /selections/batch` call on `usersWithTasks` load, gating team list render behind `selectionsLoaded` state to prevent badge flash
- Create `src/components/UserState/ColorPicker.jsx` — reusable color swatch selector component
- Create `src/components/UserState/EmojiPicker.jsx` — curated emoji grid (29 emojis, 6 columns) with dark mode support via CSS variables
- Create `src/components/UserState/ManageStatesModal.jsx` — full modal for Owners/Admins to add, edit, delete, and reorder catalog states with emoji picker, color picker, live preview, and delete confirmation showing affected user count
- Create `src/components/UserState/UserState.module.css` — CSS module with `.light`/`.dark` theme variable blocks, glossy badge styling using layered box-shadow and multi-directional gradients
- Create `src/components/UserState/UserStateBadge.jsx` — single badge pill component with glossy styling
- Update `src/components/UserState/UserStateDisplay.jsx` — stripped down to pure display component, opens `UserStateModal` and `ManageStatesModal`, filters orphaned keys from selections
- Create `src/components/UserState/UserStateModal.jsx` — centered modal for selecting/deselecting states per user with local draft state (API only called on Done), batch assignment toast
- Create `src/components/UserState/constants.js` — `EMOJI_OPTIONS` (29), `COLOR_SWATCHES` (15 colorblind-friendly colors), `DEFAULT_COLOR`, `DEFAULT_EMOJI`, `getStateColor`
- Update `src/utils/URL.js` — add `USER_STATE_CATALOG`, `USER_STATE_CATALOG_ITEM`, `USER_STATE_CATALOG_REORDER`, `USER_STATE_CATALOG_USAGE`, `USER_STATE_SELECTION`, `USER_STATE_SELECTIONS_BATCH` endpoints
- Update `TeamMemberTasks.test.jsx` — add `axios.post` mock for batch selections endpoint, fix `queryAllByTestId` assertion, add `waitFor` for `selectionsLoaded` gate
- Update `RolePermissions.test.jsx` — use `findByTestId` for async element lookup, increase timeout
- Update `UserProfileEdit.test.jsx` — add axios mock setup in `beforeEach`, increase timeout

## How to test:
1. Check out to the branch
2. Run `npm install` and start both frontend and backend servers
3. Clear site data/cache
4. Log in as an Owner or Admin account
5. Go to Dashboard → Scroll to the team member tasks area
6. Verify state badges load immediately with the team list
7. Click **+ Set State** under any team member's name — verify the Set State modal opens with all seeded states displayed as glossy colored badges
8. Select one or more states and click **Done** — verify badges appear under the team member's name and persist on page reload
9. Click **⚙️ Manage States** — verify the Manage States modal opens
10. Add a new state with a custom emoji, color, and label — verify it appears in the catalog and the preview renders correctly
11. Edit an existing state — verify label, emoji, and color update correctly
12. Try creating a duplicate state (same label + emoji) — verify a 409 error toast appears
13. Delete a state assigned to a user — verify confirmation dialog shows the affected user count, and on confirm the badge disappears from all assigned users
15. Verify Reorder works — drag states up/down and confirm order persists on reload
17. Test in dark mode — verify all modals, badges, and buttons render correctly with dark theme classes
18. Log in as a non-Owner/Admin — verify any states set are visible and cannot be edited.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/0febb586-ac7e-4dff-b6ec-4601a87333d8

