### PR TITLE
Sohail: Role Distribution Showing Incomplete Role Data

### DIFF
--- a/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
@@ -2,21 +2,28 @@ import { ResponsiveContainer, PieChart, Pie, Cell, Legend, Tooltip } from 'recha
 import Loading from '~/components/common/Loading';
 
 const COLORS = [
-  '#F285BB',
-  '#77A9EE',
-  '#F2AB53',
-  '#1B6DDF',
-  '#C92929',
-  '#1BC590',
-  '#7ff0f0',
-  '#6e33cc',
-  '#cc2fa7',
-  '#EE9322',
-  '#86ebcc',
-  '#bafc03',
-  '#cf583a',
-  '#46d130',
+  '#2F80ED', // blue
+  '#56CCF2', // light blue
+  '#27AE60', // green
+  '#6FCF97', // light green
+  '#F2994A', // orange
+  '#F2C94C', // yellow
+  '#E14848', // red
+  '#9B51E0', // purple
+  '#F765A3', // pink
+  '#4F4F4F', // dark
+  '#828282', // grey
 ];
+
+// Explicit role-to-color mapping to keep key roles visually distinct and stable.
+const ROLE_COLOR_MAP = {
+  Volunteer: '#8ebfff',
+  Manager: '#27AE60',
+  Administrator: '#fb0505',
+  'Core Team': '#8100fa',
+  Owner: '#f68d42',
+  Mentor: '#f2ff00',
+};
 
 import CustomTooltip from '../../CustomTooltip';
 
@@ -35,7 +42,8 @@ const RoleDistributionPieChart = ({ roleDistributionStats = [], isLoading, darkM
   const data = roleDistributionStats.map((item, index) => ({
     name: item._id,
     value: item.count,
-    color: COLORS[index],
+    // Use a stable role mapping first, otherwise fallback by index.
+    color: ROLE_COLOR_MAP[item._id] || COLORS[index % COLORS.length],
   }));
   const totalValue = data.reduce((sum, entry) => sum + entry.value, 0);
 


### PR DESCRIPTION
## Description
Original scope (backend):

(PRIORITY HIGH) Yagna: Role Distribution Showing Incomplete Role Data
a. Owner Login → Dashboard → Role Distribution.
b. The Role Distribution chart currently displays only two roles, even though multiple roles exist in the system.
c. As per expected behavior, the chart should display all available roles along with their correct counts and percentages.
d. This leads to inaccurate or misleading reporting, as several existing roles are not included in the visualization.
e. The Role Distribution calculation should be updated to include all roles present in the system, ensuring the chart accurately reflects the organization’s role distribution.

This PR's scope:
- This frontend update improves the Role Distribution chart by making role colors explicit and stable.
- The dashboard Role Distribution chart already shows all roles correctly after the backend fix.
- Previously, role colors were assigned by index and could be too similar or change depending on role sorting order.
- This PR makes each defined role visually distinct and stable in the pie chart.

## Related PRS (if any):
This frontend PR is related to the backend [PR#2078](https://github.com/OneCommunityGlobal/HGNRest/pull/2078).

## Main changes explained:
- Updated `src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx` to use explicit role-to-color mapping.
- Added `ROLE_COLOR_MAP` for the six main roles: Volunteer, Manager, Administrator, Core Team, Owner, Mentor.
- Kept a fallback color palette for any unexpected/unknown roles.
- Removed the previous index-only color assignment logic that caused non-distinct or shifting colors.

## How to test:
1. check into current branch
2. run `npm install` and `npm run dev` to run this PR locally
3. clear site data/cache
4. log in as admin or owner user
5. go to Dashboard → Volunteer Work and Role Distribution → Role Distribution chart
6. verify each role slice now has a distinct and stable color
7. verify the chart legend matches the displayed slice colors
8. verify this new color handling works in dark mode