### PR TITLE
Akshith - Fix: Job Analytics Page - Dark Mode 

### DIFF
--- a/src/components/JobCCDashboard/JobAnalytics/JobAnalytics.jsx
+++ b/src/components/JobCCDashboard/JobAnalytics/JobAnalytics.jsx
@@ -417,8 +417,24 @@ function DateRangeSelector({ dateRange, setDateRange, comparisonPeriod, setCompa
 // ======================== MAIN ========================
 function JobAnalytics({ darkMode, role, hasPermission: hasPerm }) {
   // Theme attribute for global CSS
+  // Sync with Global App Theme (body classes) and Local Component Theme (data-theme)
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', darkMode ? 'dark' : 'light');
+    const root = document.documentElement;
+    const body = document.body;
+
+    if (darkMode) {
+      // 1. Set the attribute for your JobAnalytics.module.css
+      root.setAttribute('data-theme', 'dark');
+
+      // 2. Add the classes required by the global CSS you found
+      body.classList.add('dark-mode');
+      body.classList.add('bm-dashboard-dark');
+    } else {
+      // 3. Clean up when switching back to light mode
+      root.setAttribute('data-theme', 'light');
+      body.classList.remove('dark-mode');
+      body.classList.remove('bm-dashboard-dark');
+    }
   }, [darkMode]);
 
   const canViewAnalytics = hasPerm('getJobReports');
@@ -530,7 +546,14 @@ function JobAnalytics({ darkMode, role, hasPermission: hasPerm }) {
                   <CartesianGrid strokeDasharray="3 3" className={styles.gridStroke} />
                   <XAxis dataKey="displayDate" tick={{ fontSize: 12 }} />
                   <YAxis tick={{ fontSize: 12 }} domain={['dataMin - 100', 'dataMax + 100']} />
-                  <Tooltip />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: darkMode ? '#1f2937' : '#ffffff',
+                      borderColor: darkMode ? '#374151' : '#e5e7eb',
+                      color: darkMode ? '#f9fafb' : '#111827',
+                    }}
+                    itemStyle={{ color: darkMode ? '#f9fafb' : '#111827' }}
+                  />
                   <Legend />
                   <Line
                     type="monotone"
@@ -569,7 +592,14 @@ function JobAnalytics({ darkMode, role, hasPermission: hasPerm }) {
                   <CartesianGrid strokeDasharray="3 3" className={styles.gridStroke} />
                   <XAxis dataKey="displayDate" tick={{ fontSize: 12 }} />
                   <YAxis tick={{ fontSize: 12 }} domain={['dataMin - 500', 'dataMax + 500']} />
-                  <Tooltip />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: darkMode ? '#1f2937' : '#ffffff',
+                      borderColor: darkMode ? '#374151' : '#e5e7eb',
+                      color: darkMode ? '#f9fafb' : '#111827',
+                    }}
+                    itemStyle={{ color: darkMode ? '#f9fafb' : '#111827' }}
+                  />
                   <Legend />
                   <Area
                     type="monotone"
@@ -598,7 +628,17 @@ function JobAnalytics({ darkMode, role, hasPermission: hasPerm }) {
                     height={60}
                   />
                   <YAxis tick={{ fontSize: 12 }} domain={[0, 'dataMax + 500']} />
-                  <Tooltip />
+                  <Tooltip
+                    cursor={{
+                      fill: darkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)',
+                    }}
+                    contentStyle={{
+                      backgroundColor: darkMode ? '#1f2937' : '#ffffff',
+                      borderColor: darkMode ? '#374151' : '#e5e7eb',
+                      color: darkMode ? '#f9fafb' : '#111827',
+                    }}
+                    itemStyle={{ color: darkMode ? '#f9fafb' : '#111827' }}
+                  />
                   <Legend />
                   <Bar
                     dataKey="current"
@@ -638,7 +678,16 @@ function JobAnalytics({ darkMode, role, hasPermission: hasPerm }) {
                       />
                     ))}
                   </Pie>
-                  <Tooltip />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'var(--card)',
+                      borderColor: 'var(--card-border)',
+                      color: 'var(--fg)',
+                      borderRadius: '8px',
+                      boxShadow: 'var(--shadow)',
+                    }}
+                    itemStyle={{ color: 'var(--fg)' }}
+                  />
                 </PieChart>
               </ResponsiveContainer>
             </ChartCard>
@@ -666,7 +715,15 @@ function JobAnalytics({ darkMode, role, hasPermission: hasPerm }) {
                     tick={{ fontSize: 12 }}
                     domain={[0, 100]}
                   />
-                  <Tooltip />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'var(--card)',
+                      borderColor: 'var(--card-border)',
+                      color: 'var(--fg)',
+                      borderRadius: '8px',
+                    }}
+                    itemStyle={{ color: 'var(--fg)' }}
+                  />
                   <Legend />
                   <Line
                     yAxisId="left"

--- a/src/components/JobCCDashboard/JobAnalytics/JobAnalytics.jsx
+++ b/src/components/JobCCDashboard/JobAnalytics/JobAnalytics.jsx
@@ -66,6 +66,30 @@ const CONFIG = {
   },
 };
 
+// ======================== SHARED CONSTANTS ========================
+const AXIS_TICK = { fontSize: 12 };
+
+const CHART_MARGIN = { top: 10, right: 10, left: 0, bottom: 10 };
+
+const GRID_PROPS = {
+  strokeDasharray: '3 3',
+};
+
+const getTooltipStyles = darkMode => ({
+  contentStyle: {
+    backgroundColor: darkMode ? '#1f2937' : '#ffffff',
+    borderColor: darkMode ? '#374151' : '#e5e7eb',
+    color: darkMode ? '#f9fafb' : '#111827',
+  },
+  itemStyle: {
+    color: darkMode ? '#f9fafb' : '#111827',
+  },
+});
+
+const getCursorStyle = darkMode => ({
+  fill: darkMode ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.05)',
+});
+
 // ======================== UTILITIES ========================
 const calculatePercentageChange = (current, previous) => {
   if (previous === 0) return { value: 100, isPositive: true, formatted: '+100%' };
@@ -542,18 +566,11 @@ function JobAnalytics({ darkMode, role, hasPermission: hasPerm }) {
           <section className={styles.chartsGrid} data-mobile={isMobile ? '1' : '0'}>
             <ChartCard title="User Trend Comparison" icon={TrendingUp}>
               <ResponsiveContainer width="100%" height={320}>
-                <LineChart data={mergedData} margin={{ top: 10, right: 10, left: 0, bottom: 10 }}>
-                  <CartesianGrid strokeDasharray="3 3" className={styles.gridStroke} />
-                  <XAxis dataKey="displayDate" tick={{ fontSize: 12 }} />
-                  <YAxis tick={{ fontSize: 12 }} domain={['dataMin - 100', 'dataMax + 100']} />
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: darkMode ? '#1f2937' : '#ffffff',
-                      borderColor: darkMode ? '#374151' : '#e5e7eb',
-                      color: darkMode ? '#f9fafb' : '#111827',
-                    }}
-                    itemStyle={{ color: darkMode ? '#f9fafb' : '#111827' }}
-                  />
+                <LineChart data={mergedData} margin={CHART_MARGIN}>
+                  <CartesianGrid {...GRID_PROPS} className={styles.gridStroke} />
+                  <XAxis dataKey="displayDate" tick={AXIS_TICK} />
+                  <YAxis tick={AXIS_TICK} domain={['dataMin - 100', 'dataMax + 100']} />
+                  <Tooltip {...getTooltipStyles(darkMode)} />
                   <Legend />
                   <Line
                     type="monotone"
@@ -592,14 +609,7 @@ function JobAnalytics({ darkMode, role, hasPermission: hasPerm }) {
                   <CartesianGrid strokeDasharray="3 3" className={styles.gridStroke} />
                   <XAxis dataKey="displayDate" tick={{ fontSize: 12 }} />
                   <YAxis tick={{ fontSize: 12 }} domain={['dataMin - 500', 'dataMax + 500']} />
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: darkMode ? '#1f2937' : '#ffffff',
-                      borderColor: darkMode ? '#374151' : '#e5e7eb',
-                      color: darkMode ? '#f9fafb' : '#111827',
-                    }}
-                    itemStyle={{ color: darkMode ? '#f9fafb' : '#111827' }}
-                  />
+                  <Tooltip {...getTooltipStyles(darkMode)} />
                   <Legend />
                   <Area
                     type="monotone"
@@ -628,17 +638,7 @@ function JobAnalytics({ darkMode, role, hasPermission: hasPerm }) {
                     height={60}
                   />
                   <YAxis tick={{ fontSize: 12 }} domain={[0, 'dataMax + 500']} />
-                  <Tooltip
-                    cursor={{
-                      fill: darkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)',
-                    }}
-                    contentStyle={{
-                      backgroundColor: darkMode ? '#1f2937' : '#ffffff',
-                      borderColor: darkMode ? '#374151' : '#e5e7eb',
-                      color: darkMode ? '#f9fafb' : '#111827',
-                    }}
-                    itemStyle={{ color: darkMode ? '#f9fafb' : '#111827' }}
-                  />
+                  <Tooltip cursor={getCursorStyle(darkMode)} {...getTooltipStyles(darkMode)} />
                   <Legend />
                   <Bar
                     dataKey="current"
@@ -683,10 +683,7 @@ function JobAnalytics({ darkMode, role, hasPermission: hasPerm }) {
                       backgroundColor: 'var(--card)',
                       borderColor: 'var(--card-border)',
                       color: 'var(--fg)',
-                      borderRadius: '8px',
-                      boxShadow: 'var(--shadow)',
                     }}
-                    itemStyle={{ color: 'var(--fg)' }}
                   />
                 </PieChart>
               </ResponsiveContainer>

--- a/src/components/JobCCDashboard/JobAnalytics/JobAnalytics.module.css
+++ b/src/components/JobCCDashboard/JobAnalytics/JobAnalytics.module.css
@@ -1,20 +1,11 @@
 /* Root Page Container */
-.page {
-  min-height: 100vh;
-  padding: 24px;
-  background: var(--bg);
-  color: var(--fg);
-  transition: background-color 0.3s ease, color 0.3s ease;
-}
-
-/* Light Theme Defaults */
 :root {
   --bg: #f9fafb;
   --fg: #111827;
   --muted: #6b7280;
-  --card: #ffffff;
+  --card: #fff;
   --card-border: #e5e7eb;
-  --shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow: 0 1px 3px rgb(0 0 0 / 8%), 0 1px 2px rgb(0 0 0 / 5%);
   --primary: #3b82f6;
   --success: #10b981;
   --warning: #f59e0b;
@@ -24,20 +15,36 @@
   --grid-stroke: #e5e7eb;
 }
 
-/* Dark Theme Support */
 [data-theme='dark'] {
   --bg: #111827;
   --fg: #f9fafb;
   --muted: #9ca3af;
   --card: #1f2937;
   --card-border: #374151;
-  --shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.2);
+  --shadow: 0 1px 3px rgb(0 0 0 / 40%), 0 1px 2px rgb(0 0 0 / 20%);
   --primary: #60a5fa;
   --success: #34d399;
   --warning: #fbbf24;
   --danger: #f87171;
   --purple: #a78bfa;
   --gray: #cbd5e1;
+  --grid-stroke: #374151;
+}
+
+.page {
+  min-height: 100vh;
+  padding: 24px;
+  background-color: var(--bg);
+  color: var(--fg);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* Global body class integration for external sync */
+:global(body.dark-mode) .page {
+  --bg: #111827;
+  --fg: #f9fafb;
+  --card: #1f2937;
+  --card-border: #374151;
   --grid-stroke: #374151;
 }
 
@@ -49,6 +56,7 @@
   align-items: center;
   justify-content: space-between;
 }
+
 .title {
   font-size: 2rem;
   font-weight: 700;
@@ -69,27 +77,33 @@
   cursor: pointer;
   transition: all 0.2s ease;
 }
+
 .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
+
 .btnPrimary {
   background: var(--primary);
   color: #fff;
-  box-shadow: 0 6px 14px rgba(59, 130, 246, 0.25);
+  box-shadow: 0 6px 14px rgb(59 130 246 / 25%);
 }
+
 .btnPrimary:hover:not(:disabled) {
   transform: translateY(-1px);
 }
+
 .btnGhost {
   background: var(--card);
   color: var(--fg);
   border: 1px solid var(--card-border);
 }
+
 .btnGhost:hover:not(:disabled) {
-  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 6px 14px rgb(0 0 0 / 8%);
   transform: translateY(-1px);
 }
+
 .btnLink {
   color: var(--danger);
   border: none;
@@ -107,10 +121,11 @@
   border: 1px solid var(--card-border);
   color-scheme: light;
 }
+
 .input:focus {
   outline: none;
   border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 20%);
 }
 
 [data-theme='dark'] .input {
@@ -131,6 +146,7 @@
   align-items: center;
   flex-direction: column;
 }
+
 .spinner {
   width: 40px;
   height: 40px;
@@ -140,11 +156,13 @@
   animation: spin 1s linear infinite;
   margin-bottom: 12px;
 }
+
 @keyframes spin {
   to {
     transform: rotate(360deg);
   }
 }
+
 .loadingText {
   color: var(--muted);
 }
@@ -158,11 +176,13 @@
   margin: 16px 0;
   color: #991b1b;
 }
+
 [data-theme='dark'] .errorBox {
   background: #7f1d1d;
   border-color: #991b1b;
   color: #fee2e2;
 }
+
 .errorText {
   margin: 0 0 8px;
 }
@@ -173,6 +193,7 @@
   display: grid;
   place-items: center;
 }
+
 .accessCard {
   background: var(--card);
   border: 1px solid var(--card-border);
@@ -182,6 +203,7 @@
   max-width: 500px;
   text-align: center;
 }
+
 .accessIcon {
   width: 64px;
   height: 64px;
@@ -198,35 +220,42 @@
   box-shadow: var(--shadow);
   margin-bottom: 24px;
 }
+
 .selectorRow {
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
   align-items: flex-end;
 }
+
 .selectorCol {
   flex: 1 1 320px;
   min-width: 260px;
 }
+
 .selectorColNarrow {
   min-width: 200px;
 }
+
 .label {
   font-size: 0.875rem;
   font-weight: 600;
   margin-bottom: 8px;
   color: var(--muted);
 }
+
 .quickRow {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
+
 .datesRow {
   display: flex;
   align-items: center;
   gap: 8px;
 }
+
 .to {
   color: var(--muted);
 }
@@ -238,6 +267,7 @@
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   margin-bottom: 24px;
 }
+
 .metricCard {
   background: var(--card);
   border: 1px solid var(--card-border);
@@ -246,41 +276,51 @@
   box-shadow: var(--shadow);
   transition: transform 0.15s ease;
 }
+
 .metricCard:hover {
   transform: translateY(-3px);
 }
+
 .metricTop {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 8px;
 }
+
 .metricIconWrap {
-  background: rgba(0, 0, 0, 0.05);
+  background: rgb(0 0 0 / 5%);
   padding: 10px;
   border-radius: 10px;
 }
+
 [data-theme='dark'] .metricIconWrap {
-  background: rgba(255, 255, 255, 0.06);
+  background: rgb(255 255 255 / 6%);
 }
+
 .metricIcon {
   color: var(--muted);
 }
+
 .change {
   font-weight: 600;
   display: flex;
   gap: 4px;
 }
+
 .positive {
   color: var(--success);
 }
+
 .negative {
   color: var(--danger);
 }
+
 .metricValue {
   font-size: 2rem;
   font-weight: 700;
 }
+
 .metricTitle {
   color: var(--muted);
   font-size: 0.9rem;
@@ -299,14 +339,14 @@
 }
 
 /* Tablet */
-@media (min-width: 641px) and (max-width: 1199px) {
+@media (width >= 641px) and (width <= 1199px) {
   .chartsGrid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
 /* Desktop + Large Screens */
-@media (min-width: 1200px) {
+@media (width >= 1200px) {
   .chartsGrid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -324,6 +364,7 @@
   box-shadow: var(--shadow);
   transition: transform 0.15s ease;
 }
+
 .chartCard:hover {
   transform: translateY(-3px);
 }
@@ -334,21 +375,26 @@
   gap: 12px;
   margin-bottom: 16px;
 }
+
 .chartIconWrap {
-  background: rgba(0, 0, 0, 0.05);
+  background: rgb(0 0 0 / 5%);
   padding: 8px;
   border-radius: 10px;
 }
+
 [data-theme='dark'] .chartIconWrap {
-  background: rgba(255, 255, 255, 0.06);
+  background: rgb(255 255 255 / 6%);
 }
+
 .chartIcon {
   color: var(--muted);
 }
+
 .chartTitle {
   margin: 0;
   font-weight: 700;
 }
+
 .chartBody {
   margin: 0 -4px;
 }


### PR DESCRIPTION
# Description
<img width="650" height="257" alt="image" src="https://github.com/user-attachments/assets/c95d1dd2-efe6-4e98-ae05-ebf3cbc55bae" />

## Related PRS (if any):
This frontend PR is not related to any other PR.
…

## Main changes explained:
- Fixed conflicting styling which prevented dark mode from being applied to the components
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ http://localhost:5173/application/analytics
6. Switch mode to dark mode
7. Check if page renders in dark mode
8. Check all the charts and hover display in dark mode.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/a3da4711-ae50-43e1-90cc-9b8b4de5583c



## Note:
Include the information the reviewers need to know.
