### PR TITLE
Sai Teja - Fix pause/resume permission flow in profile and user management

### DIFF
--- a/src/actions/userManagement.js
+++ b/src/actions/userManagement.js
@@ -203,8 +203,7 @@ export const buildUpdatedUserLifecycleDetails = (user, payload) => {
 };
 
 const buildBackendPayload = (userDetails, action) => {
-  console.log('Building backend payload with:', { userDetails, action });
-  switch (action){
+  switch (action) {
     case UserStatusOperations.ACTIVATE:
       return {
         action: action,
@@ -225,7 +224,7 @@ const buildBackendPayload = (userDetails, action) => {
     case UserStatusOperations.PAUSE:
       return {
         action: action,
-        reactivationDate: userDetails.reactivationDate
+        reactivationDate: userDetails.reactivationDate,
       };
     default:
       throw new Error(`Unknown lifecycle action: ${action}`);
@@ -233,21 +232,62 @@ const buildBackendPayload = (userDetails, action) => {
 };
 
 export const updateUserLifecycle = (updatedUser, payload) => {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const { auth } = getState();
     dispatch(userProfileUpdateAction(updatedUser));
 
-    const backendPayload = buildBackendPayload(updatedUser, payload.action);
+    const requestor = {
+      requestorId: auth.user.userid,
+      role: auth.user.role,
+      permissions: auth.user.permissions,
+    };
+    const backendPayload = {
+      ...buildBackendPayload(updatedUser, payload.action),
+      requestor,
+    };
     try {
-      // console.log('Sending PATCH request to update user lifecycle');
-      await axios.patch(ENDPOINTS.USER_PROFILE(updatedUser._id), backendPayload);
-
+      await axios.patch(ENDPOINTS.USER_PROFILE_FIXED(updatedUser._id), backendPayload);
     } catch (error) {
       toast.error('Error updating user lifecycle:', error);
       dispatch(userProfileUpdateAction(payload.originalUser));
       throw error;
     }
   };
-}
+};
+
+/**
+ * Update the pause/resume status of a user via the dedicated pause endpoint.
+ * Requires the 'interactWithPauseUserButton' permission.
+ * @param {*} user - the user to be paused or resumed
+ * @param {string} status - UserStatus.Active or UserStatus.Inactive
+ * @param {*} reactivationDate - the date on which the user should be reactivated
+ */
+export const updateUserPauseStatus = (user, status, reactivationDate) => {
+  return async (dispatch, getState) => {
+    const userProfile = { ...user };
+    userProfile.isActive = status === UserStatus.Active;
+    userProfile.reactivationDate = reactivationDate;
+    const auth = getState().auth;
+    const requestor = {
+      requestorId: auth.user.userid,
+      role: auth.user.role,
+      permissions: auth.user.permissions,
+      email: auth.user.email,
+    };
+    const patchData = {
+      status,
+      reactivationDate: status === UserStatus.Active ? undefined : reactivationDate,
+      requestor,
+    };
+    try {
+      await axios.patch(ENDPOINTS.USER_PAUSE(user._id), patchData);
+      dispatch(userProfileUpdateAction(userProfile));
+    } catch (error) {
+      toast.error('Error updating user pause status:', error);
+      throw error;
+    }
+  };
+};
 
 /**
  * Update the rehireable status of a user

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -110,7 +110,8 @@ export function Header(props) {
     props.hasPermission('deleteUserProfile', !isAuthUser ) ||
     props.hasPermission('changeUserStatus', !isAuthUser ) ||
     props.hasPermission('getUserProfiles', !isAuthUser ) ||
-    props.hasPermission('setFinalDay', !isAuthUser);
+    props.hasPermission('setFinalDay', !isAuthUser) ||
+    props.hasPermission('interactWithPauseUserButton', !isAuthUser);
 
   // Badges
   const canAccessBadgeManagement =

--- a/src/components/PermissionsManagement/Permissions.json
+++ b/src/components/PermissionsManagement/Permissions.json
@@ -146,11 +146,6 @@
         "description": "Gives the user permission to change the user status of rehireable or not."
       },
       {
-        "label": "Pause User Activity",
-        "key": "pauseUserActivity",
-        "description": "Gives the user permission to use the \"Pause\" button to pause user activity on their profile page."
-      },
-      {
         "label": "Set Final Day",
         "key": "setFinalDay",
         "description": "Gives the user permission to use the set the final working day."

--- a/src/components/PermissionsManagement/Permissions.json
+++ b/src/components/PermissionsManagement/Permissions.json
@@ -101,6 +101,11 @@
         "description": "Gives the user permission to change the invisibility toggle for themselves and others"
       },
       {
+        "label": "Interact with Pause User button",
+        "key": "interactWithPauseUserButton",
+        "description": "Allows the user to view and interact with the Pause/Resume button on a user profile. \"User Profile\" -> \"Basic Information\" -> \"Status\" -> \"Pause/Resume\""
+      },  
+      {
         "label": "Assign Blue Squares",
         "key": "addInfringements",
         "description": "Gives the user permission to add blue squares to any user."

--- a/src/components/UserManagement/PauseAndResumeButton.jsx
+++ b/src/components/UserManagement/PauseAndResumeButton.jsx
@@ -6,7 +6,7 @@ import { PAUSE, RESUME, PROCESSING } from '../../languages/en/ui';
 import { UserStatus } from '../../utils/enums';
 import ActivationDatePopup from './ActivationDatePopup';
 import { boxStyle, boxStyleDark } from '../../styles';
-import { pauseUserAction, activateUserAction } from '../../actions/userLifecycleActions';
+import { updateUserPauseStatus } from '../../actions/userManagement';
 
 /**
  * @param {*} props
@@ -30,29 +30,28 @@ function PauseAndResumeButton(props) {
     if (props.userProfile?.isActive !== undefined) setIsActive(props.userProfile.isActive);
   }, [props.userProfile?.isActive]);
 
-    const canInteractWithPauseUserButton =
-      props.hasPermission?.('interactWithPauseUserButton') ?? false;
+  const canInteractWithPauseUserButton =
+    props.hasPermission?.('interactWithPauseUserButton') ?? false;
 
-    if (!canInteractWithPauseUserButton) return null;
+  if (!canInteractWithPauseUserButton) return null;
+
   /**
    * Call back on Pause confirmation button click to trigger the action to update user status
    */
   const pauseUser = async reActivationDate => {
-    setIsLoading(true); // Start loading indicator
+    setIsLoading(true);
     try {
-      await pauseUserAction(dispatch, props.userProfile, reActivationDate, props.loadUserProfile);
+      await dispatch(updateUserPauseStatus(props.userProfile, UserStatus.Inactive, reActivationDate));
       setIsActive(false);
       setActivationDateOpen(false);
-
-      // Optimistically update the UI
       toast.success('Your Changes were saved successfully.');
     } catch (error) {
       toast.error('Failed to update the user status.');
       // eslint-disable-next-line no-console
       console.error(error);
     } finally {
-      setIsLoading(false); // Stop loading indicator
-      await props.loadUserProfile(); // Ensure state sync
+      setIsLoading(false);
+      await props.loadUserProfile();
     }
   };
 
@@ -61,20 +60,18 @@ function PauseAndResumeButton(props) {
    */
   const onPauseResumeClick = async (user, status) => {
     if (status === UserStatus.Active) {
-      setIsLoading(true); // Start loading indicator
+      setIsLoading(true);
       try {
-        await activateUserAction(dispatch, props.userProfile, props.loadUserProfile);
+        await dispatch(updateUserPauseStatus(props.userProfile, UserStatus.Active, Date.now()));
         setIsActive(true);
-
-        // Optimistically update the UI
         toast.success('Your Changes were saved successfully.');
       } catch (error) {
         toast.error('Failed to update the user status.');
         // eslint-disable-next-line no-console
         console.error(error);
       } finally {
-        setIsLoading(false); // Stop loading indicator
-        await props.loadUserProfile(); // Ensure state sync
+        setIsLoading(false);
+        await props.loadUserProfile();
       }
     } else {
       setActivationDateOpen(true);

--- a/src/components/UserManagement/PauseAndResumeButton.jsx
+++ b/src/components/UserManagement/PauseAndResumeButton.jsx
@@ -30,6 +30,10 @@ function PauseAndResumeButton(props) {
     if (props.userProfile?.isActive !== undefined) setIsActive(props.userProfile.isActive);
   }, [props.userProfile?.isActive]);
 
+    const canInteractWithPauseUserButton =
+      props.hasPermission?.('interactWithPauseUserButton') ?? false;
+
+    if (!canInteractWithPauseUserButton) return null;
   /**
    * Call back on Pause confirmation button click to trigger the action to update user status
    */

--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -21,6 +21,7 @@ import {
   deleteUser,
   enableEditUserInfo,
   disableEditUserInfo,
+  updateUserPauseStatus,
 } from '../../actions/userManagement';
 import UserTableHeader from './UserTableHeader';
 import UserTableData from './UserTableData';
@@ -41,8 +42,6 @@ import SetupNewUserPopup from './setupNewUserPopup';
 import { getAllTimeOffRequests } from '../../actions/timeOffRequestAction';
 import {
   scheduleDeactivationAction,
-  activateUserAction,
-  pauseUserAction,
   deactivateImmediatelyAction,
 } from '../../actions/userLifecycleActions';
 
@@ -217,12 +216,8 @@ class UserManagement extends React.PureComponent {
               activeInactivePopupOpen: false,
             });
           }}
-          onCancelScheduledDeactivation={() =>
-            activateUserAction(this.props.dispatch, this.state.selectedUser, this.props.getAllUserProfile)
-          }
-          onReactivateUser={() =>
-            activateUserAction(this.props.dispatch, this.state.selectedUser, this.props.getAllUserProfile)
-          }
+          onCancelScheduledDeactivation={this.reactivateUser}
+          onReactivateUser={this.reactivateUser}
         />
         <SetUpFinalDayPopUp
           open={this.state.finalDayPopupOpen}
@@ -407,8 +402,13 @@ class UserManagement extends React.PureComponent {
     if (status === UserStatus.Inactive) {
       this.setState({ activationDateOpen: true });
     } else {
-      await activateUserAction(this.props.dispatch, user, this.props.getAllUserProfile);
+      await this.reactivateUser(user);
     }
+  };
+
+  reactivateUser = async (user = this.state.selectedUser) => {
+    await this.props.dispatch(updateUserPauseStatus(user, UserStatus.Active, Date.now()));
+    await this.props.getAllUserProfile();
   };
 
   onUserUpdate = (updatedUser) => {
@@ -466,7 +466,7 @@ class UserManagement extends React.PureComponent {
       return;
     }
     if (status === FinalDay.RemoveFinalDay) {
-      await activateUserAction(this.props.dispatch, user, this.props.getAllUserProfile);
+      await this.reactivateUser(user);
     } else {
       this.setState({
         finalDayDateOpen: true,
@@ -494,14 +494,10 @@ class UserManagement extends React.PureComponent {
   };
 
   pauseUser = async (reactivationDate) => {
-    // eslint-disable-next-line no-console
-    console.log('Pausing user with reactivation date:', reactivationDate);
-    await pauseUserAction(
-      this.props.dispatch,
-      this.state.selectedUser,
-      reactivationDate,
-      this.props.getAllUserProfile,
+    await this.props.dispatch(
+      updateUserPauseStatus(this.state.selectedUser, UserStatus.Inactive, reactivationDate),
     );
+    await this.props.getAllUserProfile();
 
     this.setState({
       activationDateOpen: false,

--- a/src/components/UserManagement/UserTableData.jsx
+++ b/src/components/UserManagement/UserTableData.jsx
@@ -77,6 +77,7 @@ const UserTableDataComponent = props => {
   const canDeleteUsers = props.hasPermission('deleteUserProfile');
   const resetPasswordStatus = props.hasPermission('updatePassword');
   const canChangeUserStatus = props.hasPermission('changeUserStatus');
+  const canInteractWithPauseUserButton = props.hasPermission('interactWithPauseUserButton');
   const canSetFinalDay = props.hasPermission('setFinalDay');
   const canSeeReports = props.hasPermission('getReports');
 
@@ -410,7 +411,7 @@ const UserTableDataComponent = props => {
 
               if (numericValue < 0) {
                 toast.error(
-                  'If negative hours worked, we’d all be on vacation already. Try again, and be sure weekly hours are set to zero or more.',
+                  "If negative hours worked, we'd all be on vacation already. Try again, and be sure weekly hours are set to zero or more.",
                 );
                 return;
               }
@@ -428,7 +429,7 @@ const UserTableDataComponent = props => {
 
       {/* PAUSE/RESUME */}
       <td>
-        {!canChangeUserStatus ? (
+        {!canInteractWithPauseUserButton ? (
           <Tooltip
             placement="bottom"
             isOpen={tooltipPauseOpen}
@@ -446,7 +447,7 @@ const UserTableDataComponent = props => {
           onClick={() => {
             if (cantUpdateDevAdminDetails(props.user.email, props.authEmail)) {
               // eslint-disable-next-line no-alert
-              alert('STOP! YOU SHOULDN’T BE TRYING TO CHANGE THIS. Please reconsider your choices.');
+              alert("STOP! YOU SHOULDN'T BE TRYING TO CHANGE THIS. Please reconsider your choices.");
               return;
             }
             onReset(true);
@@ -456,7 +457,7 @@ const UserTableDataComponent = props => {
             ...(darkMode ? { boxShadow: '0 0 0 0', fontWeight: 'bold' } : boxStyle),
             padding: '5px',
           }}
-          disabled={!canChangeUserStatus}
+          disabled={!canInteractWithPauseUserButton}
           id={`btn-pause-profile-${props.user._id}`}
         >
           {getButtonText()}

--- a/src/components/UserManagement/__tests__/PauseAndResumeButton.test.jsx
+++ b/src/components/UserManagement/__tests__/PauseAndResumeButton.test.jsx
@@ -32,6 +32,7 @@ describe('PauseAndResumeButton', () => {
         isBigBtn
         userProfile={{ ...userProfileMock, isActive: true }}
         loadUserProfile={loadUserProfile}
+        hasPermission={() => true}
       />
     );
 
@@ -46,6 +47,7 @@ describe('PauseAndResumeButton', () => {
         isBigBtn
         userProfile={{ ...userProfileMock, isActive: true }}
         loadUserProfile={loadUserProfile}
+        hasPermission={() => true}
       />
     );
 
@@ -64,6 +66,7 @@ describe('PauseAndResumeButton', () => {
         isBigBtn
         userProfile={{ ...userProfileMock, isActive: true }}
         loadUserProfile={loadUserProfile}
+        hasPermission={() => true}
       />
     );
 
@@ -95,6 +98,7 @@ describe('PauseAndResumeButton', () => {
         isBigBtn
         userProfile={{ ...userProfileMock, isActive: false }}
         loadUserProfile={loadUserProfile}
+        hasPermission={() => true}
       />
     );
 
@@ -108,5 +112,18 @@ describe('PauseAndResumeButton', () => {
         screen.getByRole('button', { name: PAUSE })
       ).toBeInTheDocument();
     });
+  });
+  it('does not render when user lacks interactWithPauseUserButton permission', () => {
+  renderWithProvider(
+    <PauseAndResumeButton
+      isBigBtn
+      userProfile={{ ...userProfileMock, isActive: true }}
+      loadUserProfile={loadUserProfile}
+      hasPermission={() => false}
+    />
+  );
+
+  expect(screen.queryByRole('button', { name: PAUSE })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: RESUME })).not.toBeInTheDocument(); 
   });
 });

--- a/src/components/UserManagement/__tests__/PauseAndResumeButton.test.jsx
+++ b/src/components/UserManagement/__tests__/PauseAndResumeButton.test.jsx
@@ -1,19 +1,15 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor , render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PauseAndResumeButton from '../PauseAndResumeButton';
 import { PAUSE, RESUME } from '../../../languages/en/ui';
 import { userProfileMock } from '../../../__tests__/mockStates';
-import { renderWithProvider } from '../../../__tests__/utils';
 import { vi } from 'vitest';
+import { Provider } from 'react-redux';
 
-import {
-  pauseUserAction,
-  activateUserAction,
-} from '../../../actions/userLifecycleActions';
+import { updateUserPauseStatus } from '../../../actions/userManagement';
 
-vi.mock('../../../actions/userLifecycleActions', () => ({
-  pauseUserAction: vi.fn(() => Promise.resolve()),
-  activateUserAction: vi.fn(() => Promise.resolve()),
+vi.mock('../../../actions/userManagement', () => ({
+  updateUserPauseStatus: vi.fn(() => async () => Promise.resolve()),
 }));
 
 vi.mock('react-toastify', () => ({
@@ -23,11 +19,43 @@ vi.mock('react-toastify', () => ({
   },
 }));
 
+const createThunkStore = () => ({
+  getState: () => ({
+    theme: {
+      darkMode: false,
+    },
+    auth: {
+      user: {
+        userid: userProfileMock._id,
+        role: 'Administrator',
+        permissions: ['interactWithPauseUserButton'],
+        email: 'test@example.com',
+      },
+    },
+  }),
+  dispatch: action =>
+    typeof action === 'function'
+      ? action(() => {}, () => ({}))
+      : action,
+  subscribe: () => () => {},
+});
+
 describe('PauseAndResumeButton', () => {
   const loadUserProfile = vi.fn(() => Promise.resolve());
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderPauseButton = ui =>
+    render(ui, {
+      wrapper: ({ children }) => (
+        <Provider store={createThunkStore()}>{children}</Provider>
+      ),
+    });
+
   it('renders pause button when user is active', () => {
-    renderWithProvider(
+    renderPauseButton(
       <PauseAndResumeButton
         isBigBtn
         userProfile={{ ...userProfileMock, isActive: true }}
@@ -42,7 +70,7 @@ describe('PauseAndResumeButton', () => {
   });
 
   it('opens activation date popup when clicking pause', async () => {
-    renderWithProvider(
+    renderPauseButton(
       <PauseAndResumeButton
         isBigBtn
         userProfile={{ ...userProfileMock, isActive: true }}
@@ -61,7 +89,7 @@ describe('PauseAndResumeButton', () => {
   });
 
   it('pauses user and switches button to RESUME', async () => {
-    renderWithProvider(
+    renderPauseButton(
       <PauseAndResumeButton
         isBigBtn
         userProfile={{ ...userProfileMock, isActive: true }}
@@ -85,15 +113,20 @@ describe('PauseAndResumeButton', () => {
     );
 
     await waitFor(() => {
-      expect(pauseUserAction).toHaveBeenCalledTimes(1);
+      expect(updateUserPauseStatus).toHaveBeenCalled();
       expect(
         screen.getByRole('button', { name: RESUME })
       ).toBeInTheDocument();
-    });
+    })
+    expect(updateUserPauseStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ _id: userProfileMock._id }),
+        'Inactive',
+        expect.anything()
+      );;
   });
 
   it('resumes user and switches button back to PAUSE', async () => {
-    renderWithProvider(
+    renderPauseButton(
       <PauseAndResumeButton
         isBigBtn
         userProfile={{ ...userProfileMock, isActive: false }}
@@ -107,23 +140,28 @@ describe('PauseAndResumeButton', () => {
     );
 
     await waitFor(() => {
-      expect(activateUserAction).toHaveBeenCalledTimes(1);
+      expect(updateUserPauseStatus).toHaveBeenCalled();
       expect(
         screen.getByRole('button', { name: PAUSE })
       ).toBeInTheDocument();
-    });
+    })
+    expect(updateUserPauseStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ _id: userProfileMock._id }),
+        'Active',
+        expect.any(Number)
+      );;
   });
   it('does not render when user lacks interactWithPauseUserButton permission', () => {
-  renderWithProvider(
-    <PauseAndResumeButton
-      isBigBtn
-      userProfile={{ ...userProfileMock, isActive: true }}
-      loadUserProfile={loadUserProfile}
-      hasPermission={() => false}
-    />
-  );
+    renderPauseButton(
+      <PauseAndResumeButton
+        isBigBtn
+        userProfile={{ ...userProfileMock, isActive: true }}
+        loadUserProfile={loadUserProfile}
+        hasPermission={() => false}
+      />
+    );
 
-  expect(screen.queryByRole('button', { name: PAUSE })).not.toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: RESUME })).not.toBeInTheDocument(); 
+    expect(screen.queryByRole('button', { name: PAUSE })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: RESUME })).not.toBeInTheDocument();
   });
 });

--- a/src/components/UserManagement/__tests__/UserManagement.test.jsx
+++ b/src/components/UserManagement/__tests__/UserManagement.test.jsx
@@ -1,49 +1,78 @@
 import { createBaseProps } from './UserManagementTestSetup.jsx';
 
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent , render } from '@testing-library/react';
 import { renderWithProvider } from '../../../__tests__/utils';
 import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
 
 import UserManagement from '../UserManagement';
-import { activateUserAction } from '../../../actions/userLifecycleActions';
+import { updateUserPauseStatus } from '../../../actions/userManagement';
 
-vi.mock('../../../actions/userLifecycleActions', () => ({
-  activateUserAction: vi.fn(),
-}));
+vi.mock('../../../actions/userManagement', async () => {
+  const actual = await vi.importActual('../../../actions/userManagement');
+  return {
+    ...actual,
+    updateUserPauseStatus: vi.fn(() => async () => Promise.resolve()),
+  };
+});
+
+const createThunkStore = () => ({
+  getState: () => ({
+    theme: {
+      darkMode: false,
+    },
+    timeOffRequests: {
+      requests: [],
+    },
+  }),
+  dispatch: action =>
+    typeof action === 'function'
+      ? action(() => {}, () => ({}))
+      : action,
+  subscribe: () => () => {},
+});
 
 describe('UserManagement Component', () => {
   let props;
 
   beforeEach(() => {
     props = createBaseProps();
+    vi.clearAllMocks();
   });
 
+  const renderUserManagement = ui =>
+    render(ui, {
+      wrapper: ({ children }) => (
+        <Provider store={createThunkStore()}>{children}</Provider>
+      ),
+    });
+
   it('renders without errors', () => {
-    renderWithProvider(<UserManagement {...props} />);
+    renderUserManagement(<UserManagement {...props} />);
     expect(screen.getByTestId('user-table-header')).toBeInTheDocument();
     expect(screen.getByTestId('user-table-data-0')).toBeInTheDocument();
   });
 
   it('calls getAllUserProfile and getAllTimeOffRequests on mount', () => {
-    renderWithProvider(<UserManagement {...props} />);
+    renderUserManagement(<UserManagement {...props} />);
     expect(props.getAllUserProfile).toHaveBeenCalled();
     expect(props.getAllTimeOffRequests).toHaveBeenCalled();
   });
 
   it('opens activation date popup when pausing user', () => {
-    renderWithProvider(<UserManagement {...props} />);
+    renderUserManagement(<UserManagement {...props} />);
     fireEvent.click(screen.getByTestId('inactive-button-0'));
     expect(screen.getByTestId('activation-date-popup')).toBeInTheDocument();
   });
 
-  it('calls activateUserAction when resuming user', () => {
-    renderWithProvider(<UserManagement {...props} />);
+  it('calls updateUserPauseStatus when resuming user', () => {
+    renderUserManagement(<UserManagement {...props} />);
     fireEvent.click(screen.getByTestId('pause-resume-button-0'));
-    expect(activateUserAction).toHaveBeenCalled();
+    expect(updateUserPauseStatus).toHaveBeenCalled();
   });
 
   it('handles final day action when clicked', () => {
-    renderWithProvider(<UserManagement {...props} />);
+    renderUserManagement(<UserManagement {...props} />);
 
     expect(() =>
       fireEvent.click(screen.getByTestId('final-day-button-0'))
@@ -51,7 +80,7 @@ describe('UserManagement Component', () => {
   });
 
   it('opens new user popup', () => {
-    renderWithProvider(<UserManagement {...props} />);
+    renderUserManagement(<UserManagement {...props} />);
     fireEvent.click(screen.getByTestId('new-user-button'));
     expect(screen.getByTestId('new-user-popup')).toBeInTheDocument();
   });

--- a/src/components/UserManagement/__tests__/UserTableData.test.jsx
+++ b/src/components/UserManagement/__tests__/UserTableData.test.jsx
@@ -21,7 +21,7 @@ const jaeAccountMock = {
     iat: 1597272666,
     userid: '1',
     permissions: {
-      frontPermissions: ['deleteUserProfile', 'updatePassword', 'changeUserStatus'],
+      frontPermissions: ['deleteUserProfile', 'updatePassword', 'changeUserStatus', 'interactWithPauseUserButton'],
       backPermissions: [],
     },
     role: 'Administrator',
@@ -41,7 +41,7 @@ const nonJaeAccountMock = {
     iat: 1597272666,
     userid: '2',
     permissions: {
-      frontPermissions: ['deleteUserProfile', 'updatePassword', 'changeUserStatus'],
+      frontPermissions: ['deleteUserProfile', 'updatePassword', 'changeUserStatus', 'interactWithPauseUserButton'],
       backPermissions: [],
     },
     role: 'Administrator',
@@ -65,7 +65,7 @@ const ownerAccountMock = {
     iat: 1597272666,
     userid: '3',
     permissions: {
-      frontPermissions: ['deleteUserProfile', 'updatePassword', 'changeUserStatus'],
+      frontPermissions: ['deleteUserProfile', 'updatePassword', 'changeUserStatus', 'interactWithPauseUserButton'],
       backPermissions: [],
     },
     role: 'Owner',
@@ -109,7 +109,7 @@ describe('User Table Data: Non-Jae related Account', () => {
         roles: [
           {
             roleName: nonJaeAccountMock.role,
-            permissions: ['deleteUserProfile', 'updatePassword', 'changeUserStatus'],
+            permissions: ['deleteUserProfile', 'updatePassword', 'changeUserStatus', 'interactWithPauseUserButton'],
           },
         ],
       },
@@ -262,7 +262,7 @@ describe('User Table Data: Jae protected account record and login as Jae related
         roles: [
           {
             roleName: jaeAccountMock.role,
-            permissions: ['deleteUserProfile', 'updatePassword', 'changeUserStatus'],
+            permissions: ['deleteUserProfile', 'updatePassword', 'changeUserStatus', 'interactWithPauseUserButton'],
           },
         ],
       },

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -496,8 +496,7 @@ const BasicInformationTab = props => {
   const [errorOccurred, setErrorOccurred] = useState(false);
   const dispatch = useDispatch();
   const rolesAllowedToEditStatusFinalDay = ['Administrator', 'Owner'];
-  const canEditStatus =
-  rolesAllowedToEditStatusFinalDay.includes(role) || dispatch(hasPermission('pauseUserActivity'));
+  const canEditStatus = props.hasPermission?.('interactWithPauseUserButton');
 
   const canEditEndDate =
   rolesAllowedToEditStatusFinalDay.includes(role) || dispatch(hasPermission('setFinalDay'));
@@ -878,7 +877,6 @@ const BasicInformationTab = props => {
       />
     </>
   );
-
   const statusComponent = (
     <>
       <Col md={desktopDisplay ? '5' : ''}>

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -900,6 +900,7 @@ const BasicInformationTab = props => {
           </Label>
           {canEdit && canEditStatus && (
             <PauseAndResumeButton
+              hasPermission={props.hasPermission}
               setUserProfile={setUserProfile}
               loadUserProfile={loadUserProfile}
               isBigBtn={true}
@@ -955,6 +956,7 @@ const BasicInformationTab = props => {
         &nbsp;
         {canEdit && canEditStatus && (
           <PauseAndResumeButton
+            hasPermission={props.hasPermission}
             setUserProfile={setUserProfile}
             loadUserProfile={loadUserProfile}
             isBigBtn={true}

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -1737,6 +1737,7 @@ setUpdatedTasks(prev => {
                   roles={roles}
                   darkMode={darkMode}
                   hasFinalDay={hasScheduledFinalDay}
+                  hasPermission={props.hasPermission}
                 />
               </TabPane>
               <TabPane tabId="2">
@@ -1946,6 +1947,7 @@ setUpdatedTasks(prev => {
                     canEditRole={canEditUserProfile}
                     roles={roles}
                     darkMode={darkMode}
+                    hasPermission={props.hasPermission}
                   />
                 </ModalBody>
                 <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -6,6 +6,7 @@ export const ENDPOINTS = {
   USER_PROFILE: userId => `${APIEndpoint}/userprofile/${userId}`,
   USER_PROFILE_FIXED: userId => `${APIEndpoint}/userProfile/${userId}`,
   USER_PROFILE_PROPERTY: userId => `${APIEndpoint}/userprofile/${userId}/property`,
+  USER_PAUSE: userId => `${APIEndpoint}/userProfile/${userId}/pause`,
   USER_PROFILES: `${APIEndpoint}/userprofile/`,
   UPDATE_REHIREABLE_STATUS: userId => `${APIEndpoint}/userprofile/${userId}/rehireable`,
   TOGGLE_VISIBILITY: userId => `${APIEndpoint}/userprofile/${userId}/toggleInvisibility`,

--- a/src/utils/routePermissions.js
+++ b/src/utils/routePermissions.js
@@ -5,7 +5,13 @@ const RoutePermissions = {
   weeklySummariesReport: ['getWeeklySummaries'],
   prDashboard: ['accessPRTeamDashboard'],
   weeklyVolunteerSummary: ['getWeeklyVolunteerSummary'],
-  userManagement: ['getUserProfiles', 'postUserProfile', 'deleteUserProfile', 'changeUserStatus'],
+  userManagement: [
+    'getUserProfiles',
+    'postUserProfile',
+    'deleteUserProfile',
+    'changeUserStatus',
+    'interactWithPauseUserButton',
+  ],
   badgeManagement: ['seeBadges', 'createBadges', 'updateBadges', 'deleteBadges', 'assignBadges'],
   projects: [
     'postProject',


### PR DESCRIPTION
# Description
Implements the frontend side of the dedicated pause/resume permission flow and fixes pause/resume behavior across the profile page and User Management table.

This PR updates the app to use the new `interactWithPauseUserButton` permission consistently, routes pause/resume actions through the dedicated pause endpoint, and removes stale permission/bypass logic that caused visibility and behavior mismatches.

Fixes priority high bug(s):
- Pause button visible in some places but backend rejected the action
- Resume/pause behavior inconsistent between profile page and User Management table
- Removing pause permission from Owner/Admin did not hide the button on the profile page
- Old permission key `pauseUserActivity` still affected frontend behavior

## Related PRs (if any):
This frontend PR is related to the backend PR:
- HGNRest PR: `sai/pause-user-permission-backend`

To fully test this frontend PR, you need to run the matching backend PR as well.

## Main changes explained:
- Update `src/actions/userManagement.js` to:
  - send `requestor` in pause/resume requests
  - use the dedicated pause endpoint
  - keep lifecycle updates using the corrected user profile endpoint
- Update `src/utils/URL.js` to include the dedicated `USER_PAUSE` endpoint
- Update `src/components/UserManagement/PauseAndResumeButton.jsx` to use the new pause/resume action path
- Update `src/components/UserManagement/UserManagement.jsx` so table resume/reactivate flows use the dedicated pause endpoint instead of the old lifecycle action
- Update `src/components/UserManagement/UserTableData.jsx` to keep pause/resume table behavior aligned and clean up syntax issues
- Update `src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx` to remove the hardcoded Owner/Admin visibility bypass and rely on the real permission
- Update `src/components/UserProfile/UserProfile.jsx` to pass `hasPermission` into `BasicInformationTab`
- Update `src/components/PermissionsManagement/Permissions.json` to remove the old `pauseUserActivity` entry
- Update `src/utils/routePermissions.js` and `src/components/Header/Header.jsx` to recognize `interactWithPauseUserButton`
- Update related tests for the new pause/resume action flow

## How to test:
1. Check out this branch in `HighestGoodNetworkApp`
2. Run the app locally with the matching backend PR checked out in `HGNRest`
3. Start frontend and backend
4. Clear site data/cache if needed
5. Log in as an Owner or Administrator who has `interactWithPauseUserButton`
6. Open a user profile and verify:
   - the `Pause` button is visible when the permission is present
   - clicking `Pause` successfully pauses the user
   - clicking `Resume` successfully reactivates the user
7. Go to User Management and verify:
   - pause/resume from the table works
   - resume works for a paused user
8. Remove `interactWithPauseUserButton` from an Owner/Admin account and verify:
   - the `Pause` button no longer appears on the profile page
   - the table flow no longer allows pause/resume for that user
9. Grant `interactWithPauseUserButton` to a non-admin user and verify they can use pause/resume appropriately
10. Verify the old `pauseUserActivity` permission is no longer shown/used
11. Verify this behavior in dark mode as well

## Screenshots or videos of changes:

Uploading Screen Recording 2026-04-08 at 9.32.54 PM.mov…

## Note:
This PR should be tested together with the matching backend PR because the dedicated pause route and permission checks are implemented there.