### PR TITLE
Neeraj Fix Chart Rendering Issue and Dark Mode Legend

### DIFF
--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
@@ -49,10 +49,6 @@ function ApplicantVolunteerRatio() {
 
       if (validationError) setValidationError('');
 
-      if (selectedRoles.length === 0) {
-        setData([]);
-        return;
-      }
       try {
         setLoading(true);
         const filters = {};
@@ -60,6 +56,8 @@ function ApplicantVolunteerRatio() {
         if (endDate) filters.endDate = endDate.toISOString().split('T')[0];
         if (selectedRoles.length > 0) {
           filters.roles = selectedRoles.map(role => role.value).join(',');
+        } else {
+          filters.roles = ''; // fetch all roles
         }
 
         const response = await getAllApplicantVolunteerRatios(filters);
@@ -111,6 +109,8 @@ function ApplicantVolunteerRatio() {
       document.body.classList.remove('dark-mode-body');
     };
   }, [darkMode]);
+
+  const legendTextColor = darkMode ? '#e0e0e0' : '#333';
 
   if (loading) {
     return (
@@ -280,11 +280,66 @@ function ApplicantVolunteerRatio() {
           >
             {viewMode === 'count' ? (
               <>
-                <span style={{ color: '#1976d2' }}>■ Total Applications</span>
-                <span style={{ color: '#43a047' }}>■ People Hired</span>
+                <span
+                  style={{
+                    color: legendTextColor,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                  }}
+                >
+                  <span
+                    style={{
+                      width: '12px',
+                      height: '12px',
+                      backgroundColor: '#1976d2',
+                      display: 'inline-block',
+                      borderRadius: '2px',
+                    }}
+                  />
+                  Total Applications
+                </span>
+
+                <span
+                  style={{
+                    color: legendTextColor,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                  }}
+                >
+                  <span
+                    style={{
+                      width: '12px',
+                      height: '12px',
+                      backgroundColor: '#43a047',
+                      display: 'inline-block',
+                      borderRadius: '2px',
+                    }}
+                  />
+                  People Hired
+                </span>
               </>
             ) : (
-              <span style={{ color: '#43a047' }}>■ People Hired (%)</span>
+              <span
+                style={{
+                  color: legendTextColor,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                }}
+              >
+                <span
+                  style={{
+                    width: '12px',
+                    height: '12px',
+                    backgroundColor: '#43a047',
+                    display: 'inline-block',
+                    borderRadius: '2px',
+                  }}
+                />
+                People Hired (%)
+              </span>
             )}
           </div>
 


### PR DESCRIPTION
# Description
INITIAL TASK DESCRIPTION:

<img width="1530" height="1156" alt="image" src="https://github.com/user-attachments/assets/135bfae2-d4b9-4aae-8fbb-2545bca0a17c" />

CHANGES REQUESTED:
<img width="826" height="976" alt="image" src="https://github.com/user-attachments/assets/e5d583cd-be33-46ab-96d1-7a820413dca7" />

## Related PRS (if any):
This frontend PR is related to the Development Backend PR.

This PR is hotfix for #4896 

## Main changes explained:
- Fixed an issue where the Hiring Analytics chart was not rendering.
- Updated API filter handling to allow fetching all roles when no roles are selected.
- Fixed dark mode legend display by replacing text-based indicators with styled color blocks to correctly match chart bars.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Navigate to: http://localhost:5173/applicant-volunteer-ratio
6. Verify:
   - Chart loads correctly and does not get stuck on "Loading..."
7. Toggle dark mode:
   - Legend colors should match chart bars (blue for Total Applications, green for People Hired)
   - Legend should be clearly visible and readable

## Screenshots or videos of changes:

<img width="736" height="448" alt="Screenshot 2026-04-09 at 12 26 45 AM" src="https://github.com/user-attachments/assets/1e81574f-4322-4a35-b126-2ad082ea7d18" />

<img width="1280" height="446" alt="Screenshot 2026-04-09 at 12 26 56 AM" src="https://github.com/user-attachments/assets/4cd0c42e-9fb9-4082-8ace-07715dd3f86d" />

## Note:
- This PR specifically addresses post-merge feedback related to chart rendering and dark mode legend visibility