### PR TITLE
Veda - LBDashboard fix

### DIFF
--- a/src/components/LBDashboard/LBDashboard.jsx
+++ b/src/components/LBDashboard/LBDashboard.jsx
@@ -305,12 +305,17 @@ export function LBDashboard() {
     };
   }, []);
 
-  const dateRange = [
-    moment()
-      .subtract(1, 'year')
-      .startOf('month'),
-    moment().endOf('month'),
-  ];
+  // Stable reference so opening metric dropdowns does not retrigger DemandOverTime's effect
+  // (which would regenerate random series and make the line charts appear to "jump").
+  const dateRange = useMemo(
+    () => [
+      moment()
+        .subtract(1, 'year')
+        .startOf('month'),
+      moment().endOf('month'),
+    ],
+    [],
+  );
 
   const getMetricLabel = () => {
     const all = Object.values(METRIC_OPTIONS).flat();

--- a/src/components/LBDashboard/LbAnalytics/DemandOverTime/DemandOverTime.jsx
+++ b/src/components/LBDashboard/LbAnalytics/DemandOverTime/DemandOverTime.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import styles from './DemandOverTime.module.css';
@@ -41,6 +41,11 @@ const DemandOverTime = ({
 }) => {
   const [data, setData] = useState([]);
 
+  const dateRangeBoundsKey = useMemo(() => {
+    if (!dateRange?.length || dateRange.length < 2) return '';
+    return `${moment(dateRange[0]).valueOf()}-${moment(dateRange[1]).valueOf()}`;
+  }, [dateRange]);
+
   useEffect(() => {
     const getItems = () => {
       return compareType === 'villages'
@@ -75,7 +80,8 @@ const DemandOverTime = ({
     };
 
     setTimeout(() => setData(generateDummyData()), 300);
-  }, [compareType, metric, dateRange]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- dateRange bounds are in dateRangeBoundsKey
+  }, [compareType, metric, dateRangeBoundsKey]);
 
   return (
     <div className={`${styles.container} ${darkMode ? styles.darkContainer : ''}`}>

--- a/src/utils/lbDashboard/chartsUtils.js
+++ b/src/utils/lbDashboard/chartsUtils.js
@@ -38,7 +38,7 @@ export function createChartOptions(metric, darkMode) {
       },
     },
     layout: {
-      padding: 20,
+      padding: { top: 36, right: 20, bottom: 20, left: 20 },
     },
     scales: {
       x: {
@@ -59,6 +59,8 @@ export function createChartOptions(metric, darkMode) {
           color: darkMode ? '#fff' : '#222',
         },
         beginAtZero: true,
+        // Room above the max point so datalabels (align: top) are not clipped at the chart edge
+        grace: '12%',
         ticks: { font: { size: 12 }, color: darkMode ? '#fff' : '#222' },
       },
     },


### PR DESCRIPTION
# Description
<img width="653" height="146" alt="Screenshot 2026-04-09 at 6 51 05 PM" src="https://github.com/user-attachments/assets/599e5278-a683-486b-9533-a6488f9eec37" />

## Related PRS (if any):
This frontend PR is related to the development backend PR.

## Main changes explained:

- LBDashboard.jsx — dateRange is memoized so opening metric dropdowns does not recreate it and retrigger charts.
- DemandOverTime.jsx — Chart loading keys off the actual date range (timestamps), not the array reference, so charts do not refresh unnecessarily.
- chartsUtils .js— Extra top padding + Y-axis grace so high value labels are not clipped.


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to http://localhost:5173/lbdashboard
6. Open/close the caret next to Demand / Vacancy / Revenue without changing metric → line charts should not jump.
Check tall points → numbers above dots should be fully visible.
7. Repeat in dark mode.

## Screenshots or videos of changes:
<img width="1452" height="734" alt="Screenshot 2026-04-09 at 6 53 31 PM" src="https://github.com/user-attachments/assets/5db6925f-7791-448c-a63f-b649c3251dd2" />
<img width="481" height="580" alt="Screenshot 2026-04-09 at 6 53 57 PM" src="https://github.com/user-attachments/assets/4bf0a7e0-a01f-48eb-a072-a49a743be28e" />
