### PR TITLE
Diya 🔥 fix(ui): Fixed State and Team Member UI

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -641,7 +641,12 @@ const TeamMemberTask = React.memo(
                                       </div>
 
                                       {/* Review Button */}
-                                      <div className={styles['team-member-task-review-button']}>
+                                      <div
+                                        className={styles['team-member-task-review-button']}
+                                        style={
+                                          onTimeOff ? { opacity: 0.4, pointerEvents: 'none' } : {}
+                                        }
+                                      >
                                         <ReviewButton
                                           user={user}
                                           userId={userId}

--- a/src/components/UserState/ColorPicker.jsx
+++ b/src/components/UserState/ColorPicker.jsx
@@ -2,25 +2,42 @@ import PropTypes from 'prop-types';
 import { COLOR_SWATCHES } from './constants';
 import styles from './UserState.module.css';
 
-function ColorPicker({ selectedColor, onSelect }) {
+function ColorPicker({ selectedColor, onSelect, usedColors = [] }) {
   return (
     <div className={styles.colorPickerWrapper}>
       <span className={styles.colorPickerLabel}>Color:</span>
-      {COLOR_SWATCHES.map(swatch => (
-        <button
-          key={swatch.hex}
-          type="button"
-          title={swatch.label}
-          onClick={() => onSelect(swatch.hex)}
-          className={styles.colorSwatch}
-          style={{
-            background: swatch.hex,
-            border: selectedColor === swatch.hex ? '3px solid #000' : '2px solid transparent',
-            outline: selectedColor === swatch.hex ? '2px solid #fff' : 'none',
-            outlineOffset: '-4px',
-          }}
-        />
-      ))}
+      <div>
+        <div className={styles.swatchesRow}>
+          {COLOR_SWATCHES.map(swatch => {
+            const isUsed = usedColors.includes(swatch.hex);
+            const isSelected = selectedColor === swatch.hex;
+            return (
+              <div key={swatch.hex} className={styles.swatchWrapper}>
+                <button
+                  type="button"
+                  title={isUsed ? `${swatch.label} (already in use)` : swatch.label}
+                  onClick={() => onSelect(swatch.hex)}
+                  className={styles.colorSwatch}
+                  style={{
+                    background: swatch.hex,
+                    border: isSelected ? '3px solid #000' : '2px solid transparent',
+                    outline: isSelected ? '2px solid #fff' : 'none',
+                    outlineOffset: '-4px',
+                  }}
+                />
+                {isUsed && (
+                  <span className={styles.swatchUsedDot} title="Already in use">
+                    ●
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        {usedColors.includes(selectedColor) && (
+          <p className={styles.colorWarning}>⚠️ This color is already used by another state.</p>
+        )}
+      </div>
     </div>
   );
 }
@@ -28,6 +45,11 @@ function ColorPicker({ selectedColor, onSelect }) {
 ColorPicker.propTypes = {
   selectedColor: PropTypes.string.isRequired,
   onSelect: PropTypes.func.isRequired,
+  usedColors: PropTypes.arrayOf(PropTypes.string),
+};
+
+ColorPicker.defaultProps = {
+  usedColors: [],
 };
 
 export default ColorPicker;

--- a/src/components/UserState/EmojiPicker.jsx
+++ b/src/components/UserState/EmojiPicker.jsx
@@ -2,19 +2,33 @@ import PropTypes from 'prop-types';
 import { EMOJI_OPTIONS } from './constants';
 import styles from './UserState.module.css';
 
-function EmojiPicker({ darkMode, onSelect }) {
+function EmojiPicker({ darkMode, onSelect, usedEmojis = [], selectedEmoji = '' }) {
+  const isSelectedUsed = selectedEmoji && usedEmojis.includes(selectedEmoji);
   return (
     <div className={`${styles.emojiPickerGrid} ${darkMode ? styles.dark : styles.light}`}>
-      {EMOJI_OPTIONS.map(emoji => (
-        <button
-          key={emoji}
-          type="button"
-          onClick={() => onSelect(emoji)}
-          className={styles.emojiBtn}
-        >
-          {emoji}
-        </button>
-      ))}
+      {EMOJI_OPTIONS.map(emoji => {
+        const isUsed = usedEmojis.includes(emoji);
+        return (
+          <div key={emoji} className={styles.swatchWrapper}>
+            <button
+              type="button"
+              onClick={() => onSelect(emoji)}
+              className={`${styles.emojiBtn} ${isUsed ? styles.emojiUsed : ''}`}
+              title={isUsed ? `${emoji} already in use by another state` : emoji}
+            >
+              {emoji}
+            </button>
+            {isUsed && (
+              <span className={styles.swatchUsedDot} title="Already in use">
+                ●
+              </span>
+            )}
+          </div>
+        );
+      })}
+      {isSelectedUsed && (
+        <p className={`${styles.colorWarning} ${styles.emojiWarning}`}>⚠️ Emoji already in use</p>
+      )}
     </div>
   );
 }
@@ -22,6 +36,13 @@ function EmojiPicker({ darkMode, onSelect }) {
 EmojiPicker.propTypes = {
   darkMode: PropTypes.bool.isRequired,
   onSelect: PropTypes.func.isRequired,
+  usedEmojis: PropTypes.arrayOf(PropTypes.string),
+  selectedEmoji: PropTypes.string,
+};
+
+EmojiPicker.defaultProps = {
+  usedEmojis: [],
+  selectedEmoji: '',
 };
 
 export default EmojiPicker;

--- a/src/components/UserState/ManageStatesModal.jsx
+++ b/src/components/UserState/ManageStatesModal.jsx
@@ -53,6 +53,17 @@ function ManageStatesModal({ isOpen, onClose, catalog, onCatalogChange, darkMode
   const fontColor = darkMode ? 'text-light' : '';
   const themeClass = darkMode ? styles.dark : styles.light;
 
+  const usedColors = catalog.map(c => c.color).filter(Boolean);
+  const usedEmojis = catalog.map(c => c.emoji).filter(Boolean);
+  const usedColorsForEdit = catalog
+    .filter(c => c.key !== editingKey)
+    .map(c => c.color)
+    .filter(Boolean);
+  const usedEmojisForEdit = catalog
+    .filter(c => c.key !== editingKey)
+    .map(c => c.emoji)
+    .filter(Boolean);
+
   const handleEmojiSelect = emoji => {
     setNewEmoji(emoji);
     setShowEmojiPicker(false);
@@ -300,7 +311,12 @@ function ManageStatesModal({ isOpen, onClose, catalog, onCatalogChange, darkMode
                         </Button>
                         {showEditEmojiPicker && (
                           <div className={styles.emojiPickerDropdown}>
-                            <EmojiPicker darkMode={darkMode} onSelect={handleEditEmojiSelect} />
+                            <EmojiPicker
+                              darkMode={darkMode}
+                              onSelect={handleEditEmojiSelect}
+                              usedEmojis={usedEmojisForEdit}
+                              selectedEmoji={editEmoji}
+                            />
                           </div>
                         )}
                         <Input
@@ -315,7 +331,11 @@ function ManageStatesModal({ isOpen, onClose, catalog, onCatalogChange, darkMode
                     </FormGroup>
                     <FormGroup>
                       <Label className={fontColor}>Color</Label>
-                      <ColorPicker selectedColor={editColor} onSelect={setEditColor} />
+                      <ColorPicker
+                        selectedColor={editColor}
+                        onSelect={setEditColor}
+                        usedColors={usedColorsForEdit}
+                      />
                     </FormGroup>
                     {editLabel.trim() && (
                       <FormGroup>
@@ -378,7 +398,12 @@ function ManageStatesModal({ isOpen, onClose, catalog, onCatalogChange, darkMode
                 </Button>
                 {showEmojiPicker && (
                   <div className={styles.emojiPickerDropdown}>
-                    <EmojiPicker darkMode={darkMode} onSelect={handleEmojiSelect} />
+                    <EmojiPicker
+                      darkMode={darkMode}
+                      onSelect={handleEmojiSelect}
+                      usedEmojis={usedEmojis}
+                      selectedEmoji={newEmoji}
+                    />
                   </div>
                 )}
                 <Input
@@ -394,7 +419,11 @@ function ManageStatesModal({ isOpen, onClose, catalog, onCatalogChange, darkMode
             </FormGroup>
             <FormGroup>
               <Label className={fontColor}>Color</Label>
-              <ColorPicker selectedColor={selectedColor} onSelect={setSelectedColor} />
+              <ColorPicker
+                selectedColor={selectedColor}
+                onSelect={setSelectedColor}
+                usedColors={usedColors}
+              />
             </FormGroup>
             {newLabel.trim() && (
               <FormGroup>

--- a/src/components/UserState/UserState.module.css
+++ b/src/components/UserState/UserState.module.css
@@ -429,3 +429,52 @@
   background: var(--us-unselected-toggle-bg) !important;
   color: var(--us-unselected-toggle-color) !important;
 }
+
+.swatchesRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.swatchWrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.swatchUsedDot {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  font-size: 8px;
+  color: #e53e3e;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.colorWarning {
+  width: 100%;
+  font-size: 12px;
+  color: #e53e3e;
+  margin-top: 6px;
+  margin-bottom: 0;
+}
+
+.emojiUsed {
+  position: relative;
+  opacity: 0.6;
+}
+
+.emojiUsedIndicator {
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-size: 6px;
+  color: #e53e3e;
+  line-height: 1;
+}
+
+.emojiWarning {
+  grid-column: 1 / -1;
+  margin-top: 4px;
+  margin-bottom: 0;
+}

--- a/src/components/UserState/constants.js
+++ b/src/components/UserState/constants.js
@@ -27,6 +27,7 @@ export const EMOJI_OPTIONS = [
   '⚙️',
   '📦',
   '🖥️',
+  '⚠️',
   '‼️',
   '❌',
 ];


### PR DESCRIPTION
# Description
Implements two UI improvements to the dashboard:
1. Task action buttons (Ready for Review, Submit for Review) are now dimmed and non-interactive when a user is marked as not available/on time off.
2. Added "already in use" indicators in the Manage States modal when selecting a color or emoji that is already used by an existing state. Also added ⚠️ as a new emoji option.

## Related PRs (if any):
None

## Main changes explained:
- Updated `TeamMemberTask.jsx` to apply `opacity: 0.4` and `pointerEvents: none` to the `ReviewButton` wrapper when `onTimeOff` is truthy
- Updated `ColorPicker.jsx` to accept a `usedColors` prop and display a red dot indicator on swatches already in use, plus a warning message when the currently selected color is already used
- Updated `EmojiPicker.jsx` to accept `usedEmojis` and `selectedEmoji` props, display a red dot indicator on emojis already in use, and show an inline warning inside the picker grid when the selected emoji is already used
- Updated `ManageStatesModal.jsx` to compute `usedColors`, `usedEmojis`, `usedColorsForEdit`, and `usedEmojisForEdit` at the component level and pass them to the respective pickers, correctly excluding the item being edited from its own used lists
- Added ⚠️ to the emoji options in `constants.js`
- Added supporting CSS classes to `UserState.module.css` for swatch/emoji used indicators and warning text

## How to test:
1. Check out to the current branch
2. Run `npm install` and start the server
3. Clear site data/cache
4. Log in as an Owner or Administrator

**Test 1 — Review button dimming:**
5. Go to User Profile > Schedule 'Time Off'
6. Verify that the user marked as not available this week (shows the "Is Not Available this Week" banner) has task action buttons (Ready for Review / Submit for Review) that are visually dimmed and cannot be clicked

**Test 2 — Color/Emoji indicators:**
8. Go to Dashboard → any user's state → Set State → Manage States
9. Click Edit on any existing state or click Add New State
10. Open the Color picker and verify that colors already used by other states show a small red dot indicator
11. Select an already-used color and verify the warning "⚠️ This color is already used by another state." appears below the swatches
12. Open the Emoji picker and verify that emojis already in use show a red dot indicator
13. Select an already-used emoji and verify the warning "⚠️ Already in use" appears inside the picker grid
14. Verify that when editing a state, its own current color/emoji are NOT flagged as already in use

15. Verify all of the above work correctly in dark mode

## Screenshots or videos of changes:
**Test 1**

Before:
<img width="1026" height="442" alt="Screenshot 2026-04-09 at 5 36 47 PM" src="https://github.com/user-attachments/assets/eeb57ffa-d3ca-4ec5-bc0a-938081d27448" />

After:
<img width="1027" height="446" alt="Screenshot 2026-04-09 at 5 31 35 PM" src="https://github.com/user-attachments/assets/62389123-e8d3-4b84-9e35-6898af1c9e78" />

**Test 2**

Before:
<img width="778" height="271" alt="Screenshot 2026-04-09 at 5 40 34 PM" src="https://github.com/user-attachments/assets/f2041e7b-ab8b-4282-b42f-3ba3a29e033e" />
<img width="773" height="296" alt="Screenshot 2026-04-09 at 5 40 41 PM" src="https://github.com/user-attachments/assets/58726f9a-abe6-4144-8234-a607c0f6bc92" />

After:
<img width="770" height="295" alt="Screenshot 2026-04-09 at 5 29 57 PM" src="https://github.com/user-attachments/assets/a8addefa-b6b2-4bd4-b829-277de7ae8a1d" />
<img width="773" height="324" alt="Screenshot 2026-04-09 at 5 30 10 PM" src="https://github.com/user-attachments/assets/27f0ce34-ef34-4a1c-99fd-7ef983b2187e" />