### PR TITLE
Yu Yan taking over: complete server date protection for timelog and weekly summary

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -4,6 +4,7 @@ import { Provider, useSelector } from 'react-redux';
 import { BrowserRouter as Router, useLocation } from 'react-router-dom';
 import { PersistGate } from 'redux-persist/integration/react';
 import { ModalProvider } from '../context/ModalContext';
+import { ServerTimeProvider } from '../context/ServerTimeContext';
 import { persistor, store } from '../store';
 import initAuth from '../utils/authInit';
 import routes from '../routes';
@@ -229,13 +230,15 @@ class App extends Component {
       <Provider store={store}>
         <PersistGate loading={<Loading />} persistor={persistor}>
           <QueryClientProvider client={queryClient}>
-            <ModalProvider>
-              <Router>
-                <ThemeManager />
-                <UpdateDocumentTitle />
-                {routes}
-              </Router>
-            </ModalProvider>
+            <ServerTimeProvider>
+              <ModalProvider>
+                <Router>
+                  <ThemeManager />
+                  <UpdateDocumentTitle />
+                  {routes}
+                </Router>
+              </ModalProvider>
+            </ServerTimeProvider>
           </QueryClientProvider>
         </PersistGate>
       </Provider>

--- a/src/components/SupportPortal/SupportLogViewer.jsx
+++ b/src/components/SupportPortal/SupportLogViewer.jsx
@@ -36,7 +36,6 @@ export default function SupportLogViewer({ match }) {
 
         setEntries(list);
       } catch (err) {
-        console.error(err);
         if (err.response?.status === 401 || err.response?.status === 403) {
           setError('Access denied. You are not authorized to view this log.');
         } else {

--- a/src/components/SupportPortal/SupportLogin.jsx
+++ b/src/components/SupportPortal/SupportLogin.jsx
@@ -27,7 +27,11 @@ export default function SupportLogin() {
 
       history.push('/support/dashboard');
     } catch (err) {
-      setError('Login failed. Please check your credentials and try again.');
+      if (err.response?.status === 401 || err.response?.status === 403) {
+        setError('Login failed. Please check your credentials and try again.');
+      } else {
+        setError('Unable to reach the support portal right now. Please try again later.');
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/SupportPortal/SupportLogin.jsx
+++ b/src/components/SupportPortal/SupportLogin.jsx
@@ -27,7 +27,6 @@ export default function SupportLogin() {
 
       history.push('/support/dashboard');
     } catch (err) {
-      console.error(err);
       setError('Login failed. Please check your credentials and try again.');
     } finally {
       setIsSubmitting(false);

--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -162,7 +162,7 @@ function TimeEntry(props) {
 >
   {projectName}
   <br />
-  {taskName && `\u2003 鈫?${taskName}`}
+  {taskName && `\u2003 ↳ ${taskName}`}
 </p>
 
             <div className="mb-3">

--- a/src/components/Timelog/TimeEntry.jsx
+++ b/src/components/Timelog/TimeEntry.jsx
@@ -13,6 +13,7 @@ import DeleteModal from './DeleteModal';
 import { editTimeEntry, getTimeEntriesForWeek } from '../../actions/timeEntries';
 import { editTeamMemberTimeEntry } from '../../actions/task';
 import { updateIndividualTaskTime } from '../TeamMemberTasks/actions';
+import { useServerTime } from '~/context/ServerTimeContext';
 import styles from './Timelog.module.css';
 
 /**
@@ -32,6 +33,7 @@ function TimeEntry(props) {
   const { from, data, displayYear, timeEntryUserProfile, tab, darkMode } = props;
   // props from store
   const { authUser } = props;
+  const { getServerDateMoment } = useServerTime();
 
   const { _id: timeEntryUserId } = timeEntryUserProfile;
   const { _id: timeEntryId } = data;
@@ -55,10 +57,7 @@ function TimeEntry(props) {
   const toggle = () => setTimeEntryFormModal(modal => !modal);
 
   const isAuthUser = timeEntryUserId === authUser.userid;
-  const isSameDay =
-    moment()
-      .tz('America/Los_Angeles')
-      .format('YYYY-MM-DD') === dateOfWork;
+  const isSameDay = getServerDateMoment().format('YYYY-MM-DD') === dateOfWork;
 
   // default permission: auth use can edit own sameday timelog entry, but not tangibility
   const isAuthUserAndSameDayEntry = isAuthUser && isSameDay;
@@ -108,7 +107,7 @@ function TimeEntry(props) {
 
   const editFilteredColor = () => {
     try {
-      const daysPast = moment().diff(dateOfWork, 'days');
+      const daysPast = getServerDateMoment().diff(dateOfWork, 'days');
       const choosenColor = hrsFilterBtnColorMap[daysPast + 1] || hrsFilterBtnColorMap[7];
       setFilteredColor(choosenColor);
     } catch (error) {
@@ -163,7 +162,7 @@ function TimeEntry(props) {
 >
   {projectName}
   <br />
-  {taskName && `\u2003 ↳ ${taskName}`}
+  {taskName && `\u2003 鈫?${taskName}`}
 </p>
 
             <div className="mb-3">

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -312,8 +312,8 @@ function TimeEntryForm(props) {
       errorObj.notes = 'Description and reference link are required';
     } else if (!reminder.hasLink && reminder.hasDropboxLink) {
       remindObj.remind =
-        'Halt, Link Wrangler! You鈥檝e tried to share a DropBox link by just copying the DropBox URL from your browser, creating a link like a locked door with no key. Use the DropBox 鈥淪hare鈥?option to create a link that is guest-friendly!';
-      errorObj.notes = 'A valid Dropbox link from the 鈥淪hare鈥?option is required';
+        "Halt, Link Wrangler! You've tried to share a DropBox link by just copying the DropBox URL from your browser, creating a link like a locked door with no key. Use the DropBox 'Share' option to create a link that is guest-friendly!";
+      errorObj.notes = "A valid Dropbox link from the 'Share' option is required";
     }
 
     setErrors(errorObj);
@@ -493,7 +493,7 @@ function TimeEntryForm(props) {
 
     if (from === 'TimeLog' && maxHoursPerEntry && totalHours > maxHours) {
       toast.warning(
-        `Hold up, workhorse! You鈥檝e hit the ${maxHours}-hour limit for a single entry. You can pop in a new time log for any additional hours.`
+        `Hold up, workhorse! You've hit the ${maxHours}-hour limit for a single entry. You can pop in a new time log for any additional hours.`
       );
       setSubmitting(false);
       return;
@@ -594,7 +594,7 @@ function TimeEntryForm(props) {
               // Add task option
               options.push(
                 <option value={`${projectId}/${wbsId}/${taskId}`} key={`TimeEntryForm_${taskId}`}>
-                  {`\u2003\u2003 鈫?${taskName}`}
+                  {`\u2003\u2003 ↳ ${taskName}`}
                 </option>,
               );
             });

--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -27,6 +27,7 @@ import { toast } from 'react-toastify';
 import ReactTooltip from 'react-tooltip';
 import axios from 'axios';
 import { getUserProfile } from '~/actions/userProfile';
+import { useServerTime } from '~/context/ServerTimeContext';
 import hasPermission from '~/utils/permissions';
 import { boxStyle, boxStyleDark } from '~/styles';
 import { postTimeEntry, editTimeEntry, getTimeEntriesForWeek } from '../../../actions/timeEntries';
@@ -88,15 +89,15 @@ function TimeEntryForm(props) {
   // props from store
   const { authUser } = props;
   const dispatch = useDispatch();
+  const { fetchServerTime, getServerDateMoment } = useServerTime();
+
+  const getCurrentServerDateOfWork = () => getServerDateMoment().format('YYYY-MM-DD');
 
   const viewingUser = JSON.parse(sessionStorage.getItem('viewingUser') ?? '{}');
-  const userTimeZone = userProfile?.timeZone || 'America/Los_Angeles';
   const [actualDate, setActualDate] = useState('');
 
   const initialFormValues = {
-    dateOfWork: moment()
-      .tz('America/Los_Angeles')
-      .format('YYYY-MM-DD'),
+    dateOfWork: edit ? data?.dateOfWork || '' : getCurrentServerDateOfWork(),
     personId: viewingUser.userId ?? authUser.userid,
     projectId: '',
     wbsId: '',
@@ -241,14 +242,14 @@ function TimeEntryForm(props) {
 
     if (name === 'hours' || name === 'minutes') {
       const numValue = +value;
-    
+
       const isValid =
         name === 'hours' ? numValue >= 0 && numValue <= 1000 : numValue >= 0 && numValue <= 59;
-    
+
       if (isValid) {
         updateFormValues(name, numValue);
       }
-    
+
       return;
     } else if (name === 'isTangible') {
       updateFormValues(name, checked);
@@ -256,7 +257,7 @@ function TimeEntryForm(props) {
       updateFormValues(name, value);
     }
   };
-  
+
   const handleProjectOrTaskChange = event => {
     const optionValue = event.target.value;
     const ids = optionValue.split('/');
@@ -311,8 +312,8 @@ function TimeEntryForm(props) {
       errorObj.notes = 'Description and reference link are required';
     } else if (!reminder.hasLink && reminder.hasDropboxLink) {
       remindObj.remind =
-        'Halt, Link Wrangler! You’ve tried to share a DropBox link by just copying the DropBox URL from your browser, creating a link like a locked door with no key. Use the DropBox “Share” option to create a link that is guest-friendly!';
-      errorObj.notes = 'A valid Dropbox link from the “Share” option is required';
+        'Halt, Link Wrangler! You鈥檝e tried to share a DropBox link by just copying the DropBox URL from your browser, creating a link like a locked door with no key. Use the DropBox 鈥淪hare鈥?option to create a link that is guest-friendly!';
+      errorObj.notes = 'A valid Dropbox link from the 鈥淪hare鈥?option is required';
     }
 
     setErrors(errorObj);
@@ -344,7 +345,14 @@ function TimeEntryForm(props) {
    * @param {*} closed If true, the form closes after being cleared.
    */
   const clearForm = closed => {
-    setFormValues(initialFormValues);
+    const resetValues = edit
+      ? initialFormValues
+      : {
+          ...initialFormValues,
+          dateOfWork: getCurrentServerDateOfWork(),
+        };
+
+    setFormValues(resetValues);
     setReminder({ ...initialReminder });
     setErrors({});
     setProjectOrTaskId('defaultProject');
@@ -369,7 +377,14 @@ function TimeEntryForm(props) {
     }
 
     const handleFormReset = () => {
-      setFormValues(initialFormValues);
+      const resetValues = edit
+        ? initialFormValues
+        : {
+            ...initialFormValues,
+            dateOfWork: getCurrentServerDateOfWork(),
+          };
+
+      setFormValues(resetValues);
       setReminder(initialReminder);
       if (isOpen) toggle();
       setSubmitting(false);
@@ -412,7 +427,7 @@ function TimeEntryForm(props) {
           break;
         case 'TimeLog': {
           const date = moment(formValues.dateOfWork);
-          const today = moment().tz('America/Los_Angeles');
+          const today = getServerDateMoment();
           const offset = today.week() - date.week();
           props.getTimeEntriesForWeek(timeEntryUserId, Math.min(offset, 3));
           clearForm();
@@ -465,34 +480,34 @@ function TimeEntryForm(props) {
       event.preventDefault();
     }
     setSubmitting(true);
-  
+
     if (edit && isEqual(formValues, initialFormValues)) {
       toast.info(`Nothing is changed for this time entry`);
       setSubmitting(false);
       return;
     }
-  
+
     const maxHours = maxHoursPerEntry || 40;
     const totalHours =
       Number(formValues.hours || 0) + Number(formValues.minutes || 0) / 60;
 
     if (from === 'TimeLog' && maxHoursPerEntry && totalHours > maxHours) {
       toast.warning(
-        `Hold up, workhorse! You’ve hit the ${maxHours}-hour limit for a single entry. You can pop in a new time log for any additional hours.`
+        `Hold up, workhorse! You鈥檝e hit the ${maxHours}-hour limit for a single entry. You can pop in a new time log for any additional hours.`
       );
       setSubmitting(false);
       return;
     }
-  
+
     if (!edit && !formValues.isTangible) {
       setTimelogConfirmationModalVisible(true);
       setSubmitting(false);
       return;
     }
-  
+
     await submitTimeEntry();
   };
-  
+
 
   const handleTangibleTimelogConfirm = async () => {
     setTimelogConfirmationModalVisible(false);
@@ -579,7 +594,7 @@ function TimeEntryForm(props) {
               // Add task option
               options.push(
                 <option value={`${projectId}/${wbsId}/${taskId}`} key={`TimeEntryForm_${taskId}`}>
-                  {`\u2003\u2003 ↳ ${taskName}`}
+                  {`\u2003\u2003 鈫?${taskName}`}
                 </option>,
               );
             });
@@ -623,12 +638,10 @@ function TimeEntryForm(props) {
     }
   };
 
-  const getActualDate = () => {
+  const getActualDate = async () => {
     try {
-      const now = moment()
-        .tz(userTimeZone)
-        .toISOString();
-      setActualDate(now);
+      const syncedServerTime = await fetchServerTime();
+      setActualDate(new Date(syncedServerTime).toISOString());
     } catch (error) {
       setActualDate(null);
       toast.error('Failed to fetch the actual date. Please refresh and try logging time again');
@@ -653,7 +666,7 @@ function TimeEntryForm(props) {
   useEffect(() => {
     if (isOpen) {
       setActualDate(null);
-      getActualDate();
+      getActualDate().catch(() => {});
     }
   }, [isOpen]);
 

--- a/src/components/Timelog/TimeEntryForm/__tests__/TimeEntryForm.test.jsx
+++ b/src/components/Timelog/TimeEntryForm/__tests__/TimeEntryForm.test.jsx
@@ -154,7 +154,7 @@ it('should change Project with user input', async () => {
   const toSelect = userProjectMock.projects[1];
   await userEvent.selectOptions(select, toSelect.projectId);
 
-  // 4) Assert that both the <select>鈥檚 value and the displayed text updated
+  // 4) Assert that both the <select>'s value and the displayed text updated
   expect(select).toHaveValue(toSelect.projectId);
   expect(select).toHaveDisplayValue(toSelect.projectName);
 });

--- a/src/components/Timelog/TimeEntryForm/__tests__/TimeEntryForm.test.jsx
+++ b/src/components/Timelog/TimeEntryForm/__tests__/TimeEntryForm.test.jsx
@@ -11,6 +11,7 @@ import {
   rolesMock,
 } from '../../../../__tests__/mockStates';
 import { renderWithProvider } from '../../../../__tests__/utils';
+import { ServerTimeProvider } from '../../../../context/ServerTimeContext';
 import TimeEntryForm from '../TimeEntryForm';
 
 vi.mock('../../../../actions/timeEntries', async () => {
@@ -28,6 +29,9 @@ vi.mock('axios', async () => {
     __esModule: true,
     ...actual,
     get: vi.fn(url => {
+      if (url.includes('/server/date')) {
+        return Promise.resolve({ data: { currentTime: '2026-04-09T12:00:00.000Z' } });
+      }
       if (url.includes('/userProjects')) {
         return Promise.resolve({ data: userProjectMock.projects });
       }
@@ -67,7 +71,9 @@ describe('<TimeEntryForm edit/>', () => {
 
   const renderForm = () =>
     renderWithProvider(
-      <TimeEntryForm userId={data.personId} data={data} edit toggle={toggle} isOpen />,
+      <ServerTimeProvider>
+        <TimeEntryForm userId={data.personId} data={data} edit toggle={toggle} isOpen />
+      </ServerTimeProvider>,
       { store },
     );
 
@@ -148,7 +154,7 @@ it('should change Project with user input', async () => {
   const toSelect = userProjectMock.projects[1];
   await userEvent.selectOptions(select, toSelect.projectId);
 
-  // 4) Assert that both the <select>’s value and the displayed text updated
+  // 4) Assert that both the <select>鈥檚 value and the displayed text updated
   expect(select).toHaveValue(toSelect.projectId);
   expect(select).toHaveDisplayValue(toSelect.projectName);
 });

--- a/src/components/Timelog/TimeEntryForm/__tests__/TimeEntryForm_edit.test.jsx
+++ b/src/components/Timelog/TimeEntryForm/__tests__/TimeEntryForm_edit.test.jsx
@@ -11,6 +11,7 @@ import {
   rolesMock,
 } from '../../../../__tests__/mockStates';
 import { renderWithProvider } from '../../../../__tests__/utils';
+import { ServerTimeProvider } from '../../../../context/ServerTimeContext';
 import TimeEntryForm from '../TimeEntryForm';
 
 vi.mock('../../../../actions/timeEntries', async () => {
@@ -28,6 +29,9 @@ vi.mock('axios', async () => {
     __esModule: true,
     ...actual,
     get: vi.fn(url => {
+      if (url.includes('/server/date')) {
+        return Promise.resolve({ data: { currentTime: '2026-04-09T12:00:00.000Z' } });
+      }
       if (url.includes('/userProjects')) {
         return Promise.resolve({ data: userProjectMock.projects });
       }
@@ -67,7 +71,9 @@ describe('<TimeEntryForm edit/>', () => {
 
   const renderComponent = () => {
     renderWithProvider(
-      <TimeEntryForm userId={data.personId} data={data} edit toggle={toggle} isOpen />,
+      <ServerTimeProvider>
+        <TimeEntryForm userId={data.personId} data={data} edit toggle={toggle} isOpen />
+      </ServerTimeProvider>,
       { store }
     );
   };

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -142,7 +142,7 @@ const getFilteredPeriodData = () => {
 const formatPeriodHtml = (rows) => {
   const title =
     `<h1 style="margin:0 0 12px 0; font-size:22px;">Time Log Report</h1>
-     <div style="margin: 0 0 4px 0;"><b>Range:</b> ${formatDate(timeLogState.fromDate)} 鈥?${formatDate(timeLogState.toDate)}</div>
+     <div style="margin: 0 0 4px 0;"><b>Range:</b> ${formatDate(timeLogState.fromDate)} - ${formatDate(timeLogState.toDate)}</div>
      <div style="margin: 0 0 12px 0;"><b>User:</b> ${escapeHtml(displayUserProfile?.firstName)} ${escapeHtml(displayUserProfile?.lastName)}</div>`;
 
      const thead =
@@ -464,9 +464,9 @@ const generateAllTimeEntryItems = () => {
           isTimeEntriesLoading: false,
           activeTab: mappedHash,
         }));
-        setInitialTab(null); // so the initialTab effect won鈥檛 override
+        setInitialTab(null); // so the initialTab effect won't override
       } else {
-        // No hash 鈫?fall back to your existing default logic
+        // No hash -> fall back to your existing default logic
         setTimeLogState(s => ({ ...s, isTimeEntriesLoading: false }));
         setInitialTab(defaultTab(data));
       }
@@ -505,13 +505,13 @@ const generateAllTimeEntryItems = () => {
   };
 
   const openInfo = () => {
-    const str = `This is the One Community time log! It is used to show a record of all the time you have volunteered with One Community, what you鈥檝e done for each work session, etc.
-    * 鈥淎dd Time Entry鈥?Button: Clicking this button will only allow you to add 鈥淚ntangible鈥?time. This is for time not related to your tasks OR for time you need a manager to change to 鈥淭angible鈥?for you because you were working away from your computer or made a mistake and are trying to manually log time. Intangible time will not be counted towards your committed time for the week or your tasks. 鈥淚ntangible鈥?time changed by a manager to 鈥淭angible鈥?time WILL be counted towards your committed time for the week and whatever task it is logged towards. For Blue Square purposes, changing Intangible Time to Tangible Time for any reason other than work away from your computer will count and be recorded in the system the same as a time edit.
+    const str = `This is the One Community time log! It is used to show a record of all the time you have volunteered with One Community, what you've done for each work session, etc.
+    * "Add Time Entry" Button: Clicking this button will only allow you to add "Intangible" time. This is for time not related to your tasks OR for time you need a manager to change to "Tangible" for you because you were working away from your computer or made a mistake and are trying to manually log time. Intangible time will not be counted towards your committed time for the week or your tasks. "Intangible" time changed by a manager to "Tangible" time WILL be counted towards your committed time for the week and whatever task it is logged towards. For Blue Square purposes, changing Intangible Time to Tangible Time for any reason other than work away from your computer will count and be recorded in the system the same as a time edit.
     * Viewing Past Work: The current week is always shown by default but past weeks can also be viewed by clicking the tabs or selecting a date range.
     * Sorting by Project and Task: All projects and tasks are shown by default but you can also choose to sort your time log by Project or Task.
-    * Notes: The 鈥淣otes鈥?section is where you write a summary of what you did during the time you are about to log. You must write a minimum of 10 words because we want you to be specific. You must include a link to your work so others can easily confirm and review it.
-    * Tangible Time: By default, the 鈥淭angible鈥?box is clicked. Tangible time is any time spent working on your Projects/Tasks and counts towards your committed time for the week and also the time allocated for your task.
-    * Intangible Time: Clicking the Tangible box OFF will mean you are logging 鈥淚ntangible Time.鈥?This is for time not related to your tasks OR for time you need a manager to change to 鈥淭angible鈥?for you because you were working away from your computer or made a mistake and are trying to manually log time. Intangible time will not be counted towards your committed time for the week or your tasks. 鈥淚ntangible鈥?time changed by a manager to 鈥淭angible鈥?time WILL be counted towards your committed time for the week and whatever task it is logged towards. For Blue Square purposes, changing Intangible Time to Tangible Time for any reason other than work away from your computer will count and be recorded in the system the same as a time edit. `;
+    * Notes: The "Notes" section is where you write a summary of what you did during the time you are about to log. You must write a minimum of 10 words because we want you to be specific. You must include a link to your work so others can easily confirm and review it.
+    * Tangible Time: By default, the "Tangible" box is clicked. Tangible time is any time spent working on your Projects/Tasks and counts towards your committed time for the week and also the time allocated for your task.
+    * Intangible Time: Clicking the Tangible box OFF will mean you are logging "Intangible Time." This is for time not related to your tasks OR for time you need a manager to change to "Tangible" for you because you were working away from your computer or made a mistake and are trying to manually log time. Intangible time will not be counted towards your committed time for the week or your tasks. "Intangible" time changed by a manager to "Tangible" time WILL be counted towards your committed time for the week and whatever task it is logged towards. For Blue Square purposes, changing Intangible Time to Tangible Time for any reason other than work away from your computer will count and be recorded in the system the same as a time edit. `;
 
     setTimeLogState({
       ...timeLogState,
@@ -667,7 +667,7 @@ const generateAllTimeEntryItems = () => {
           // Add task option
           options.push(
             <option className={`${timeLog.responsiveFontSize}`} value={taskId} key={`TimeLog_${taskId}`}>
-              {`\u2003\u2003 鈫?${taskName}`}
+              {`\u2003\u2003 ↳ ${taskName}`}
             </option>,
           );
         });
@@ -913,15 +913,15 @@ return (
                                 }}
                               >
                                 <p>
-                                  Clicking this button only allows for <strong>鈥淚ntangible Time鈥?/strong> to be
+                                  Clicking this button only allows for <strong>Intangible Time</strong> to be
                                   added to your time log. You can manually log Intangible Time, but it does not
                                   count towards your weekly time commitment.
                                 </p>
 
                                 <p>
-                                  <strong>鈥淭angible Time鈥?/strong> is the default for logging time using the timer
+                                  <strong>Tangible Time</strong> is the default for logging time using the timer
                                   at the top of the app. It represents all work done on assigned action items and
-                                  counts towards a person鈥檚 weekly volunteer time commitment.
+                                  counts towards a person's weekly volunteer time commitment.
                                 </p>
 
                                 <p>The only way for a volunteer to log Tangible Time is by using the clock in/out timer.</p>
@@ -946,7 +946,7 @@ return (
                                 <p>
                                   Intangible Time may also be logged by a volunteer when in the field or for other
                                   reasons when the timer was not able to be used. In these cases, the volunteer
-                                  will use this button to log time as 鈥淚ntangible Time鈥?and then request that an
+                                  will use this button to log time as "Intangible Time" and then request that an
                                   Admin manually change the log from Intangible to Tangible.
                                 </p>
                               </div>

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -69,55 +69,51 @@ import WeeklySummaries from './WeeklySummaries';
 import TimestampsTab from './TimestampsTab';
 import Badge from '../Badge';
 import { ENDPOINTS } from '~/utils/URL';
+import { useServerTime } from '~/context/ServerTimeContext';
 // should be clear now too in fixing styling differences
-
-// startOfWeek returns the date of the start of the week based on offset. Offset is the number of weeks before.
-// For example, if offset is 0, returns the start of this week. If offset is 1, returns the start of last week.
-const startOfWeek = offset => {
-  return moment()
-    .tz('America/Los_Angeles')
-    .startOf('week')
-    .subtract(offset, 'weeks')
-    .format('YYYY-MM-DD');
-};
-
-// endOfWeek returns the date of the end of the week based on offset. Offset is the number of weeks before.
-// For example, if offset is 0, returns the end of this week. If offset is 1, returns the end of last week.
-const endOfWeek = offset => {
-  return moment()
-    .tz('America/Los_Angeles')
-    .endOf('week')
-    .subtract(offset, 'weeks')
-    .format('YYYY-MM-DD');
-};
 
 function Timelog(props) {
   const darkMode = useSelector(state => state.theme.darkMode);
+  const { getServerDateMoment, lastSyncTime } = useServerTime();
   const location = useLocation();
+
+  const startOfWeek = offset =>
+    getServerDateMoment()
+      .clone()
+      .startOf('week')
+      .subtract(offset, 'weeks')
+      .format('YYYY-MM-DD');
+
+  const endOfWeek = offset =>
+    getServerDateMoment()
+      .clone()
+      .endOf('week')
+      .subtract(offset, 'weeks')
+      .format('YYYY-MM-DD');
 
   const normalizeNotes = (raw) => {
     if (!raw) return '';
     let s = String(raw);
-  
+
     // Temporary line-break markers
     s = s.replace(/<br\s*\/?>/gi, '\n')
          .replace(/<\/p>\s*<p>/gi, '\n')
          .replace(/<\/?p[^>]*>/gi, '');
-  
+
     // Strip remaining tags
     s = s.replace(/<\/?[^>]+>/g, '');
-  
+
     // Decode entities using the browser
     const txt = document.createElement('textarea');
     txt.innerHTML = s;
     s = txt.value;
-  
+
     // Linkify URLs
     s = s.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1">$1</a>');
-  
+
     // Convert newlines back to <br> for pdfmake line breaks
     s = s.replace(/\n/g, '<br/>');
-  
+
     return s;
   };
 
@@ -146,7 +142,7 @@ const getFilteredPeriodData = () => {
 const formatPeriodHtml = (rows) => {
   const title =
     `<h1 style="margin:0 0 12px 0; font-size:22px;">Time Log Report</h1>
-     <div style="margin: 0 0 4px 0;"><b>Range:</b> ${formatDate(timeLogState.fromDate)} – ${formatDate(timeLogState.toDate)}</div>
+     <div style="margin: 0 0 4px 0;"><b>Range:</b> ${formatDate(timeLogState.fromDate)} 鈥?${formatDate(timeLogState.toDate)}</div>
      <div style="margin: 0 0 12px 0;"><b>User:</b> ${escapeHtml(displayUserProfile?.firstName)} ${escapeHtml(displayUserProfile?.lastName)}</div>`;
 
      const thead =
@@ -219,7 +215,7 @@ const downloadPeriodPdf = () => {
   const html = formatPeriodHtml(rows);
   const content = htmlToPdfmake(html, { tableAutoSize: true });
 
-  const generatedAt = moment().tz('America/Los_Angeles').format('YYYY-MM-DD HH:mm z');
+  const generatedAt = getServerDateMoment().format('YYYY-MM-DD HH:mm z');
 
   const docDefinition = {
     content: [content],
@@ -335,7 +331,7 @@ const downloadPeriodPdf = () => {
     const pid = e?.personId ?? e?.userId ?? e?.person?._id ?? e?.person?._id ?? e?.person?._id;
     return String(pid) === String(displayedId);
   };
-  
+
   const tabMapping = {
     '#tasks': 0,
     '#currentWeek': 1,
@@ -370,7 +366,7 @@ if (role === 'Volunteer' && userHaveTask.length > 0) {
   tab = null;
 }
 
- 
+
     // Sets active tab to "Current Week Timelog" when the Progress bar in Leaderboard is clicked
     if (!props.isDashboard) {
       tab = 1;
@@ -468,9 +464,9 @@ const generateAllTimeEntryItems = () => {
           isTimeEntriesLoading: false,
           activeTab: mappedHash,
         }));
-        setInitialTab(null); // so the initialTab effect won’t override
+        setInitialTab(null); // so the initialTab effect won鈥檛 override
       } else {
-        // No hash → fall back to your existing default logic
+        // No hash 鈫?fall back to your existing default logic
         setTimeLogState(s => ({ ...s, isTimeEntriesLoading: false }));
         setInitialTab(defaultTab(data));
       }
@@ -509,13 +505,13 @@ const generateAllTimeEntryItems = () => {
   };
 
   const openInfo = () => {
-    const str = `This is the One Community time log! It is used to show a record of all the time you have volunteered with One Community, what you’ve done for each work session, etc.
-    * “Add Time Entry” Button: Clicking this button will only allow you to add “Intangible” time. This is for time not related to your tasks OR for time you need a manager to change to “Tangible” for you because you were working away from your computer or made a mistake and are trying to manually log time. Intangible time will not be counted towards your committed time for the week or your tasks. “Intangible” time changed by a manager to “Tangible” time WILL be counted towards your committed time for the week and whatever task it is logged towards. For Blue Square purposes, changing Intangible Time to Tangible Time for any reason other than work away from your computer will count and be recorded in the system the same as a time edit.
+    const str = `This is the One Community time log! It is used to show a record of all the time you have volunteered with One Community, what you鈥檝e done for each work session, etc.
+    * 鈥淎dd Time Entry鈥?Button: Clicking this button will only allow you to add 鈥淚ntangible鈥?time. This is for time not related to your tasks OR for time you need a manager to change to 鈥淭angible鈥?for you because you were working away from your computer or made a mistake and are trying to manually log time. Intangible time will not be counted towards your committed time for the week or your tasks. 鈥淚ntangible鈥?time changed by a manager to 鈥淭angible鈥?time WILL be counted towards your committed time for the week and whatever task it is logged towards. For Blue Square purposes, changing Intangible Time to Tangible Time for any reason other than work away from your computer will count and be recorded in the system the same as a time edit.
     * Viewing Past Work: The current week is always shown by default but past weeks can also be viewed by clicking the tabs or selecting a date range.
     * Sorting by Project and Task: All projects and tasks are shown by default but you can also choose to sort your time log by Project or Task.
-    * Notes: The “Notes” section is where you write a summary of what you did during the time you are about to log. You must write a minimum of 10 words because we want you to be specific. You must include a link to your work so others can easily confirm and review it.
-    * Tangible Time: By default, the “Tangible” box is clicked. Tangible time is any time spent working on your Projects/Tasks and counts towards your committed time for the week and also the time allocated for your task.
-    * Intangible Time: Clicking the Tangible box OFF will mean you are logging “Intangible Time.” This is for time not related to your tasks OR for time you need a manager to change to “Tangible” for you because you were working away from your computer or made a mistake and are trying to manually log time. Intangible time will not be counted towards your committed time for the week or your tasks. “Intangible” time changed by a manager to “Tangible” time WILL be counted towards your committed time for the week and whatever task it is logged towards. For Blue Square purposes, changing Intangible Time to Tangible Time for any reason other than work away from your computer will count and be recorded in the system the same as a time edit. `;
+    * Notes: The 鈥淣otes鈥?section is where you write a summary of what you did during the time you are about to log. You must write a minimum of 10 words because we want you to be specific. You must include a link to your work so others can easily confirm and review it.
+    * Tangible Time: By default, the 鈥淭angible鈥?box is clicked. Tangible time is any time spent working on your Projects/Tasks and counts towards your committed time for the week and also the time allocated for your task.
+    * Intangible Time: Clicking the Tangible box OFF will mean you are logging 鈥淚ntangible Time.鈥?This is for time not related to your tasks OR for time you need a manager to change to 鈥淭angible鈥?for you because you were working away from your computer or made a mistake and are trying to manually log time. Intangible time will not be counted towards your committed time for the week or your tasks. 鈥淚ntangible鈥?time changed by a manager to 鈥淭angible鈥?time WILL be counted towards your committed time for the week and whatever task it is logged towards. For Blue Square purposes, changing Intangible Time to Tangible Time for any reason other than work away from your computer will count and be recorded in the system the same as a time edit. `;
 
     setTimeLogState({
       ...timeLogState,
@@ -671,7 +667,7 @@ const generateAllTimeEntryItems = () => {
           // Add task option
           options.push(
             <option className={`${timeLog.responsiveFontSize}`} value={taskId} key={`TimeLog_${taskId}`}>
-              {`\u2003\u2003 ↳ ${taskName}`}
+              {`\u2003\u2003 鈫?${taskName}`}
             </option>,
           );
         });
@@ -730,6 +726,14 @@ const generateAllTimeEntryItems = () => {
   useEffect(() => {
     props.getBadgeCount(displayUserId);
   }, [displayUserId, props]);
+
+  useEffect(() => {
+    setTimeLogState(prev => ({
+      ...prev,
+      fromDate: prev.activeTab === 4 ? prev.fromDate : startOfWeek(0),
+      toDate: prev.activeTab === 4 ? prev.toDate : endOfWeek(0),
+    }));
+  }, [lastSyncTime]);
 
 
   useEffect(() => {
@@ -909,15 +913,15 @@ return (
                                 }}
                               >
                                 <p>
-                                  Clicking this button only allows for <strong>“Intangible Time”</strong> to be
+                                  Clicking this button only allows for <strong>鈥淚ntangible Time鈥?/strong> to be
                                   added to your time log. You can manually log Intangible Time, but it does not
                                   count towards your weekly time commitment.
                                 </p>
 
                                 <p>
-                                  <strong>“Tangible Time”</strong> is the default for logging time using the timer
+                                  <strong>鈥淭angible Time鈥?/strong> is the default for logging time using the timer
                                   at the top of the app. It represents all work done on assigned action items and
-                                  counts towards a person’s weekly volunteer time commitment.
+                                  counts towards a person鈥檚 weekly volunteer time commitment.
                                 </p>
 
                                 <p>The only way for a volunteer to log Tangible Time is by using the clock in/out timer.</p>
@@ -942,7 +946,7 @@ return (
                                 <p>
                                   Intangible Time may also be logged by a volunteer when in the field or for other
                                   reasons when the timer was not able to be used. In these cases, the volunteer
-                                  will use this button to log time as “Intangible Time” and then request that an
+                                  will use this button to log time as 鈥淚ntangible Time鈥?and then request that an
                                   Admin manually change the log from Intangible to Tangible.
                                 </p>
                               </div>
@@ -1270,8 +1274,8 @@ return (
                       />
                     )}
                     <TabPane tabId={0}>
-                      <TeamMemberTasks 
-                      filteredUserTeamIds={props.filteredUserTeamIds} 
+                      <TeamMemberTasks
+                      filteredUserTeamIds={props.filteredUserTeamIds}
                       />
                     </TabPane>
                     <TabPane tabId={1}>{currentWeekEntries}</TabPane>

--- a/src/components/Timelog/Timelog.jsx
+++ b/src/components/Timelog/Timelog.jsx
@@ -921,7 +921,7 @@ return (
                                 <p>
                                   <strong>Tangible Time</strong> is the default for logging time using the timer
                                   at the top of the app. It represents all work done on assigned action items and
-                                  counts towards a person's weekly volunteer time commitment.
+                                  counts towards a person&apos;s weekly volunteer time commitment.
                                 </p>
 
                                 <p>The only way for a volunteer to log Tangible Time is by using the clock in/out timer.</p>
@@ -946,7 +946,7 @@ return (
                                 <p>
                                   Intangible Time may also be logged by a volunteer when in the field or for other
                                   reasons when the timer was not able to be used. In these cases, the volunteer
-                                  will use this button to log time as "Intangible Time" and then request that an
+                                  will use this button to log time as &quot;Intangible Time&quot; and then request that an
                                   Admin manually change the log from Intangible to Tangible.
                                 </p>
                               </div>

--- a/src/components/Timelog/__tests__/TimeEntry.test.jsx
+++ b/src/components/Timelog/__tests__/TimeEntry.test.jsx
@@ -14,6 +14,7 @@ import {
   rolesMock,
 } from '../../../__tests__/mockStates';
 import { renderWithProvider } from '../../../__tests__/utils';
+import { ServerTimeProvider } from '../../../context/ServerTimeContext';
 import TimeEntry from '../TimeEntry';
 
 const mockStore = configureStore([thunk]);
@@ -42,13 +43,15 @@ describe('<TimeEntry />', () => {
     });
 
     renderWithProvider(
-      <TimeEntry
-        data={data}
-        displayYear
-        from="WeeklyTab"
-        timeEntryUserProfile={userProfileMock}
-        tab={0}
-      />,
+      <ServerTimeProvider>
+        <TimeEntry
+          data={data}
+          displayYear
+          from="WeeklyTab"
+          timeEntryUserProfile={userProfileMock}
+          tab={0}
+        />
+      </ServerTimeProvider>,
       { store }
     );
   };

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -127,7 +127,6 @@ function Timer({ authUser, darkMode, isPopout }) {
 
   // Enhanced function to clear submitted time with better logging
   const clearSubmittedTime = useCallback(() => {
-    console.log(' Clearing submitted time - Timer reset or user change detected');
     setLastSubmittedTime(null);
     setLogTimer({ hours: 0, minutes: 0 });
     setTimerState('idle');
@@ -146,9 +145,6 @@ function Timer({ authUser, darkMode, isPopout }) {
         goal,
         remaining,
       };
-
-      console.log('✅ Time submitted successfully:', submissionRecord);
-
       setLastSubmittedTime(timeKey);
       setSubmissionHistory(prev => [...prev, submissionRecord]);
       setLogTimer({ hours: 0, minutes: 0 });
@@ -159,8 +155,8 @@ function Timer({ authUser, darkMode, isPopout }) {
         const existingHistory = JSON.parse(localStorage.getItem('timerSubmissionHistory') || '[]');
         const updatedHistory = [...existingHistory, submissionRecord].slice(-10); // Keep last 10 entries
         localStorage.setItem('timerSubmissionHistory', JSON.stringify(updatedHistory));
-      } catch (error) {
-        console.warn('Could not save submission history to localStorage:', error);
+      } catch {
+        // Ignore localStorage persistence failures.
       }
     },
     [goal, remaining, sessionId, viewingUserId, authUser?.userid],
@@ -221,7 +217,6 @@ function Timer({ authUser, darkMode, isPopout }) {
   // Enhanced function to handle timer state changes
   const updateTimerState = useCallback(
     newState => {
-      console.log(`🔄 Timer state changed: ${timerState} → ${newState}`);
       setTimerState(newState);
     },
     [timerState],
@@ -248,7 +243,6 @@ function Timer({ authUser, darkMode, isPopout }) {
     }
     const newSessionId = `session_${Date.now()}_${randomPart}`;
     setSessionId(newSessionId);
-    console.log('🚀 Timer session initialized:', newSessionId);
   }, []);
 
   // Enhanced useEffect for timer state management
@@ -470,7 +464,6 @@ function Timer({ authUser, darkMode, isPopout }) {
       return;
     }
 
-    console.log('🛑 Stop button clicked - preparing to log time:', timeToSubmit);
     toggleLogTimeModal();
   }, [logHours, logMinutes, validateTimeForSubmission, toggleLogTimeModal]);
 
@@ -593,7 +586,6 @@ function Timer({ authUser, darkMode, isPopout }) {
     if (lastSubmittedTime !== timeKey && (logHours > 0 || logMinutes > 0)) {
       if (validateTimeForSubmission(currentTimeToLog)) {
         setLogTimer(currentTimeToLog);
-        console.log('⏱️ Time to log updated:', currentTimeToLog);
       }
     }
   }, [remaining, logHours, logMinutes, goal, lastSubmittedTime, validateTimeForSubmission]);
@@ -602,7 +594,6 @@ function Timer({ authUser, darkMode, isPopout }) {
   useEffect(() => {
     if (!started || goal !== lastSubmittedTime?.goal) {
       clearSubmittedTime();
-      console.log('🔄 Timer reset detected - clearing submitted time');
     }
   }, [started, goal, clearSubmittedTime]);
 
@@ -655,14 +646,12 @@ function Timer({ authUser, darkMode, isPopout }) {
   // Enhanced cleanup when viewing user changes
   useEffect(() => {
     clearSubmittedTime();
-    console.log('👤 User changed - clearing timer state');
   }, [viewingUserId, clearSubmittedTime]);
 
   // Enhanced cleanup on component unmount
   useEffect(() => {
     return () => {
       clearSubmittedTime();
-      console.log('🔚 Timer component unmounting - cleanup complete');
     };
   }, [clearSubmittedTime]);
 

--- a/src/components/UserManagement/SetUpFinalDayButton.jsx
+++ b/src/components/UserManagement/SetUpFinalDayButton.jsx
@@ -4,6 +4,7 @@ import { boxStyle } from '../../styles';
 import SetUpFinalDayPopUp from './SetUpFinalDayPopUp';
 import { SET_FINAL_DAY, CANCEL } from '../../languages/en/ui';
 import { scheduleDeactivationAction, activateUserAction } from '../../actions/userLifecycleActions';
+import { toast } from 'react-toastify';
 import styles from './usermanagement.module.css';
 
 function SetUpFinalDayButton(props) {
@@ -17,7 +18,7 @@ function SetUpFinalDayButton(props) {
       try {
         await activateUserAction(dispatch, userProfile, loadUserProfile);
       } catch (error) {
-        console.error(error);
+        toast.error('Unable to cancel the scheduled deactivation right now.');
       }
     } else {
       setFinalDayDateOpen(true);
@@ -29,7 +30,7 @@ function SetUpFinalDayButton(props) {
       await scheduleDeactivationAction(dispatch, userProfile, finalDayDate, loadUserProfile);
       setFinalDayDateOpen(false);
     } catch (error) {
-      console.error(error);
+      toast.error('Unable to save the final day right now.');
     }
   };
 

--- a/src/components/UserManagement/SetUpFinalDayButton.jsx
+++ b/src/components/UserManagement/SetUpFinalDayButton.jsx
@@ -18,7 +18,9 @@ function SetUpFinalDayButton(props) {
       try {
         await activateUserAction(dispatch, userProfile, loadUserProfile);
       } catch (error) {
-        toast.error('Unable to cancel the scheduled deactivation right now.');
+        toast.error(
+          error?.response?.data?.message || 'Unable to cancel the scheduled deactivation right now.',
+        );
       }
     } else {
       setFinalDayDateOpen(true);
@@ -30,7 +32,7 @@ function SetUpFinalDayButton(props) {
       await scheduleDeactivationAction(dispatch, userProfile, finalDayDate, loadUserProfile);
       setFinalDayDateOpen(false);
     } catch (error) {
-      toast.error('Unable to save the final day right now.');
+      toast.error(error?.response?.data?.message || 'Unable to save the final day right now.');
     }
   };
 

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -114,8 +114,7 @@ class UserProfileAdd extends Component {
   normalizeName = s => (s || '').toLowerCase().replace(/[^a-z]/g, '');
 
   productionNameIsIncluded = () => {
-    console.log('NODE_ENV =', process.env.NODE_ENV);
-  // ✅ DO NOT enforce name rules in production
+    // Do not enforce name rules in production.
     if (process.env.NODE_ENV === 'production') {
       return true;
     }
@@ -192,7 +191,7 @@ class UserProfileAdd extends Component {
       
       // Check if response.data exists and is an array
       if (!response.data || !Array.isArray(response.data)) {
-        console.warn('Invalid response format from weekly summaries endpoint:', response.data);
+        toast.error('Unable to load team codes right now.');
         this.setState({ inputAutoComplete: [], isLoading: false });
         return;
       }
@@ -207,8 +206,6 @@ class UserProfileAdd extends Component {
       this.setState({ isLoading: false })
 
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log(error);
       this.setState({ isLoading: false })
       toast.error(`It was not possible to retrieve the team codes. 
       Please try again by clicking the icon inside the input auto complete.`);
@@ -757,8 +754,7 @@ class UserProfileAdd extends Component {
     const location = this.state.userProfile.location.userProvided;
 
     if (!location) {
-      // eslint-disable-next-line no-alert
-      alert('Please enter valid location');
+      toast.warn('Please enter a valid location');
       return;
     }
 

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -207,8 +207,11 @@ class UserProfileAdd extends Component {
 
     } catch (error) {
       this.setState({ isLoading: false })
-      toast.error(`It was not possible to retrieve the team codes. 
-      Please try again by clicking the icon inside the input auto complete.`);
+      toast.error(
+        error?.response?.data?.message ||
+          `It was not possible to retrieve the team codes. 
+      Please try again by clicking the icon inside the input auto complete.`,
+      );
     }
   };
 

--- a/src/components/UserProfile/AssignBadgePopup.jsx
+++ b/src/components/UserProfile/AssignBadgePopup.jsx
@@ -43,8 +43,8 @@ function AssignBadgePopup(props) {
       toast.success('Badge update successfully');
       // 🔹 Clear selected badges in Redux after a successful save
       props.clearNameAndSelected();
-    } catch (e) {
-      toast.error('Badge update failed');
+    } catch (error) {
+      toast.error(error?.response?.data?.message || 'Badge update failed');
     }
     setConfirmButtonDisable(false);
     props.handleSubmit();
@@ -60,7 +60,10 @@ function AssignBadgePopup(props) {
       const response = await axios.get(ENDPOINTS.BADGE());
       setBadgeList(response.data);
       setisLoadingBadge(false);
-    } catch (error) {}
+    } catch (error) {
+      setisLoadingBadge(false);
+      toast.error(error?.response?.data?.message || 'Unable to load badges right now.');
+    }
   };
 
   const filterBadges = (allBadges = []) => {

--- a/src/components/UserProfile/AssignBadgePopup.jsx
+++ b/src/components/UserProfile/AssignBadgePopup.jsx
@@ -29,7 +29,7 @@ function AssignBadgePopup(props) {
   // Update: Added toast message effect for success and error. Added restriction: Jae's badges only editable by Jae or Owner
   const assignBadges = async () => {
     if (props.isRecordBelongsToJaeAndUneditable) {
-      alert(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
+      toast.warn(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
       return;
     }
     try {

--- a/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/AddNewTitleModal.jsx
@@ -272,8 +272,6 @@ function AddNewTitleModal({
   
     const run = editMode ? editTitle : addTitle;
   
-    console.log('Title update payload:', payload); // <--- use this once to inspect
-  
     run(payload)
       .then(resp => {
         if (resp.status !== 200) {
@@ -286,7 +284,6 @@ function AddNewTitleModal({
         }
       })
       .catch(e => {
-        console.log(e);
         setWarningMessage({ title: 'Error', content: 'Unexpected error' });
         setShowMessage(true);
       });

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -121,7 +121,7 @@ function UserProfile(props) {
       setInputAutoStatus(response.status);
   
       return uniqueTeamCodes;
-    } catch (error) {
+    } catch {
       toast.error(`It was not possible to retrieve the team codes.
       Please try again by clicking the icon inside the input auto complete.`);
       return [];
@@ -181,7 +181,7 @@ function UserProfile(props) {
       });
       await loadUserProfile();
       toast.success('Profile Image Removed');
-    } catch (error) {
+    } catch {
       toast.error('Failed to remove profile Image.');
     }
   };
@@ -323,7 +323,7 @@ function UserProfile(props) {
           : '<list all team members names NOT included in the summary>';
   
       return `This week's summary was managed by ${currentManager.firstName} ${currentManager.lastName} and includes ${memberSubmittedString}. These people did NOT provide a summary ${memberDidntSubmitString}. <Insert the proofread and single-paragraph summary created by ChatGPT>`;
-    } catch (error) {
+    } catch {
       return '';
     }
   };
@@ -343,7 +343,9 @@ function UserProfile(props) {
         setTasks(res?.data || []);
         setOriginalTasks(res.data);
       })
-      .catch(() => {});
+      .catch(() => {
+        toast.error('Unable to load tasks right now.');
+      });
   };
 
   const getCurretLoggedinUserEmail = async () => {
@@ -364,7 +366,7 @@ function UserProfile(props) {
           },
         }),
       );
-    } catch (err) {
+    } catch {
       toast.error('Error while getting current logged in user email');
     }
   };
@@ -390,7 +392,7 @@ function UserProfile(props) {
           : '';
         setCalculatedStartDate(createdDate);
       }
-    } catch (error) {
+    } catch {
       // Fallback to createdDate on error
       const createdDate = userProfile?.createdDate
         ? userProfile.createdDate.split('T')[0]
@@ -503,7 +505,7 @@ function UserProfile(props) {
 
       checkIsProjectsEqual();
       setShowLoading(false);
-    } catch (err) {
+    } catch {
       setShowLoading(false);
     }
   };
@@ -518,7 +520,7 @@ function UserProfile(props) {
 
       setSummarySelected(userSummaries);
       setShowSummary(true);
-    } catch (err) {
+    } catch {
       setShowLoading(false);
     }
   };
@@ -537,7 +539,7 @@ function UserProfile(props) {
         label: `View ${item.name}'s summary.`,
       }));
       setSummaries(allSummaries);
-    } catch (err) {
+    } catch {
       toast.error('Could not load leaderboard data.');
     } finally {
       setLoadingSummaries(false);
@@ -567,7 +569,7 @@ function UserProfile(props) {
   try {
     await handleSubmit(updatedUserProfile);  // this already toasts success
     toast.success(`User removed from Project "${removedProject?.projectName || 'Unknown'}"`);
-  } catch (e) {
+  } catch {
     toast.error('Failed to remove project, please try again.');
   }
   return updatedProjects;
@@ -599,7 +601,7 @@ const onAssignProject = async (assignedProject) => {
   try {
     await handleSubmit(updatedUserProfile);  // reuses same pipeline
     toast.success(`User assigned to Project "${assignedProject.projectName || 'Unknown'}"`);
-  } catch (e) {
+  } catch {
     toast.error('Failed to assign project, please try again.');
   }
   return updatedProjects;
@@ -620,7 +622,7 @@ const onUpdateTask = async (taskId, updatedTask, method) => {
       toast.error('Failed to remove task');
     }
     return newTasks;
-  } catch (e) {
+  } catch {
     toast.error('Failed to remove task, please try again.');
     return tasks;
   }
@@ -645,7 +647,7 @@ setUpdatedTasks(prev => {
   try {
     await handleSubmit(updatedUserProfile);
     toast.success("Task updated");
-  } catch (e) {
+  } catch {
     toast.error("Failed to update task");
   }
 };
@@ -695,7 +697,7 @@ setUpdatedTasks(prev => {
         // keep originals in sync so the Save button doesn't light up unnecessarily
         setOriginalUserProfile(nextProfile);
         toast.success('Profile photo updated');
-      } catch (err) {
+      } catch {
         // revert on failure
         setUserProfile(prevProfile);
         toast.error('Failed to save profile photo. Please try again.');
@@ -830,7 +832,7 @@ setUpdatedTasks(prev => {
         }
         setSpecialWarnings(res);
       });
-    } catch (err) {
+    } catch {
       toast.error('Error loading special warnings.');
     }
   };
@@ -958,7 +960,9 @@ setUpdatedTasks(prev => {
     const updatedTask = updatedTasks[i];
     const url = ENDPOINTS.TASK_UPDATE(updatedTask.taskId);
     // consider await here if order matters
-    axios.put(url, updatedTask.updatedTask).catch(() => {});
+    axios.put(url, updatedTask.updatedTask).catch(() => {
+      toast.error('Failed to sync one or more task updates.');
+    });
   }
 
   try {
@@ -985,7 +989,7 @@ setUpdatedTasks(prev => {
   const handleBadgeSubmit = async () => {
     try {
       setSaved(false);
-    } catch (err) {
+    } catch {
       toast.error('An error occurred while reloading the user profile after the badge update.');
     }
   };
@@ -997,12 +1001,7 @@ setUpdatedTasks(prev => {
   });
 
   useEffect(() => {
-    const helper = async () => {
-      try {
-        await updateProjectTouserProfile();
-      } catch (error) {}
-    };
-    helper();
+    updateProjectTouserProfile();
   }, [projects]);
 
   useEffect(() => {
@@ -1084,7 +1083,7 @@ setUpdatedTasks(prev => {
       setIsRehireable(pendingRehireableStatus);
       setUserProfile(updatedUserProfile);
       setOriginalUserProfile(updatedUserProfile);
-    } catch (error) {
+    } catch {
       toast.error('Unable change rehireable status');
     }
   };

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -122,8 +122,6 @@ function UserProfile(props) {
   
       return uniqueTeamCodes;
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log(error);
       toast.error(`It was not possible to retrieve the team codes.
       Please try again by clicking the icon inside the input auto complete.`);
       return [];
@@ -184,8 +182,6 @@ function UserProfile(props) {
       await loadUserProfile();
       toast.success('Profile Image Removed');
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log(error);
       toast.error('Failed to remove profile Image.');
     }
   };
@@ -328,7 +324,6 @@ function UserProfile(props) {
   
       return `This week's summary was managed by ${currentManager.firstName} ${currentManager.lastName} and includes ${memberSubmittedString}. These people did NOT provide a summary ${memberDidntSubmitString}. <Insert the proofread and single-paragraph summary created by ChatGPT>`;
     } catch (error) {
-      console.error('Error fetching team users:', error);
       return '';
     }
   };
@@ -348,8 +343,7 @@ function UserProfile(props) {
         setTasks(res?.data || []);
         setOriginalTasks(res.data);
       })
-      // eslint-disable-next-line no-console
-      .catch(err => console.log(err));
+      .catch(() => {});
   };
 
   const getCurretLoggedinUserEmail = async () => {
@@ -397,8 +391,6 @@ function UserProfile(props) {
         setCalculatedStartDate(createdDate);
       }
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Error fetching calculated start date:', error);
       // Fallback to createdDate on error
       const createdDate = userProfile?.createdDate
         ? userProfile.createdDate.split('T')[0]
@@ -513,8 +505,6 @@ function UserProfile(props) {
       setShowLoading(false);
     } catch (err) {
       setShowLoading(false);
-      // eslint-disable-next-line no-console
-      console.log(err);
     }
   };
 
@@ -548,8 +538,7 @@ function UserProfile(props) {
       }));
       setSummaries(allSummaries);
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.log('Could not load leaderBoard data.', err);
+      toast.error('Could not load leaderboard data.');
     } finally {
       setLoadingSummaries(false);
     }
@@ -580,7 +569,6 @@ function UserProfile(props) {
     toast.success(`User removed from Project "${removedProject?.projectName || 'Unknown'}"`);
   } catch (e) {
     toast.error('Failed to remove project, please try again.');
-    console.error(e);
   }
   return updatedProjects;
 };
@@ -613,7 +601,6 @@ const onAssignProject = async (assignedProject) => {
     toast.success(`User assigned to Project "${assignedProject.projectName || 'Unknown'}"`);
   } catch (e) {
     toast.error('Failed to assign project, please try again.');
-    console.error(e);
   }
   return updatedProjects;
 };
@@ -635,7 +622,6 @@ const onUpdateTask = async (taskId, updatedTask, method) => {
     return newTasks;
   } catch (e) {
     toast.error('Failed to remove task, please try again.');
-    console.error(e);
     return tasks;
   }
   } else {
@@ -661,7 +647,6 @@ setUpdatedTasks(prev => {
     toast.success("Task updated");
   } catch (e) {
     toast.error("Failed to update task");
-    console.error(e);
   }
 };
 
@@ -726,11 +711,9 @@ setUpdatedTasks(prev => {
   const handleBlueSquare = (status = true, type = 'message', blueSquareID = '') => {
     if (targetIsDevAdminUneditable) {
       if (userProfile?.email === DEV_ADMIN_ACCOUNT_EMAIL_DEV_ENV_ONLY) {
-        // eslint-disable-next-line no-alert
-        alert(DEV_ADMIN_ACCOUNT_CUSTOM_WARNING_MESSAGE_DEV_ENV_ONLY);
+        toast.warn(DEV_ADMIN_ACCOUNT_CUSTOM_WARNING_MESSAGE_DEV_ENV_ONLY);
       } else {
-        // eslint-disable-next-line no-alert
-        alert(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
+        toast.warn(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
       }
       return;
     }
@@ -761,16 +744,10 @@ setUpdatedTasks(prev => {
       /* peizhou: check that the date of the blue square is not future or empty. */
       if (moment(dateStamp).isAfter(moment().format('YYYY-MM-DD')) || dateStamp === '') {
         if (moment(dateStamp).isAfter(moment().format('YYYY-MM-DD'))) {
-          // eslint-disable-next-line no-console
-          console.log('WARNING: Future Blue Square');
-          // eslint-disable-next-line no-alert
-          alert('WARNING: Cannot Assign Blue Square with a Future Date');
+          toast.warn('WARNING: Cannot Assign Blue Square with a Future Date');
         }
         if (dateStamp === '') {
-          // eslint-disable-next-line no-console
-          console.log('WARNING: Empty Date');
-          // eslint-disable-next-line no-alert
-          alert('WARNING: Cannot Assign Blue Square with an Empty Date');
+          toast.warn('WARNING: Cannot Assign Blue Square with an Empty Date');
         }
       } else {
         const newBlueSquare = {
@@ -808,8 +785,6 @@ setUpdatedTasks(prev => {
             }));
           })
           .catch(error => {
-            // eslint-disable-next-line no-console
-            console.log('error in modifying bluesquare', error);
             toast.error('Failed to add Blue Square!');
           });
       }
@@ -850,15 +825,13 @@ setUpdatedTasks(prev => {
     try {
       dispatch(getSpecialWarnings(userId)).then(res => {
         if (res.error) {
-          // eslint-disable-next-line no-console
-          console.error('Error fetching special warnings:', res.error);
+          toast.error('Error loading special warnings.');
           return;
         }
         setSpecialWarnings(res);
       });
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error('Error in fetchSpecialWarnings:', err);
+      toast.error('Error loading special warnings.');
     }
   };
 
@@ -961,8 +934,7 @@ setUpdatedTasks(prev => {
         toast.success(toastMessage);
       })
       .catch(err => {
-        // eslint-disable-next-line no-console
-        console.error('Error updating user profile:', err);
+        toast.error('Error updating user profile.');
       });
   };
 
@@ -986,8 +958,7 @@ setUpdatedTasks(prev => {
     const updatedTask = updatedTasks[i];
     const url = ENDPOINTS.TASK_UPDATE(updatedTask.taskId);
     // consider await here if order matters
-    // eslint-disable-next-line no-console
-    axios.put(url, updatedTask.updatedTask).catch(err => console.error(err));
+    axios.put(url, updatedTask.updatedTask).catch(() => {});
   }
 
   try {
@@ -1001,8 +972,7 @@ setUpdatedTasks(prev => {
     setSaved(false);
   } catch (err) {
     if (err?.response?.data?.error) {
-      // eslint-disable-next-line no-alert
-      alert(err.response.data.error.join('\n'));
+      toast.error(err.response.data.error.join(' '));
     }
     return err;
   }
@@ -1016,8 +986,7 @@ setUpdatedTasks(prev => {
     try {
       setSaved(false);
     } catch (err) {
-      // eslint-disable-next-line no-alert
-      alert('An error occurred while reload user profile after badge udpate.');
+      toast.error('An error occurred while reloading the user profile after the badge update.');
     }
   };
 
@@ -1463,8 +1432,7 @@ setUpdatedTasks(prev => {
                 onClick={() => {
                   if (cantDeactivateOwner(userProfile, requestorRole)) {
                     // Owner user cannot be deactivated by another user that is not an Owner.
-                    // eslint-disable-next-line no-alert
-                    alert('You are not authorized to deactivate an owner.');
+                    toast.warn('You are not authorized to deactivate an owner.');
                     return;
                   }
                   setActiveInactivePopupOpen(true);
@@ -1843,7 +1811,7 @@ setUpdatedTasks(prev => {
                   onClick={() => {
                     if (targetIsDevAdminUneditable) {
                       // eslint-disable-next-line no-alert
-                      alert(
+                      toast.warn(
                         'STOP! YOU SHOULDN’T BE TRYING TO CHANGE THIS PASSWORD. ' +
                           'You shouldn’t even be using this account except to create your own accounts to use. ' +
                           'Please re-read the Local Setup Doc to understand why and what you should be doing instead of what you are trying to do now.',
@@ -1977,7 +1945,7 @@ setUpdatedTasks(prev => {
                           onClick={() => {
                             if (targetIsDevAdminUneditable) {
                               // eslint-disable-next-line no-alert
-                              alert(
+                              toast.warn(
                                 'STOP! YOU SHOULDN’T BE TRYING TO CHANGE THIS PASSWORD. ' +
                                   'You shouldn’t even be using this account except to create your own accounts to use. ' +
                                   'Please re-read the Local Setup Doc to understand why and what you should be doing instead of what you are trying to do now.',
@@ -2429,4 +2397,3 @@ export default connect(
   mapStateToProps,
   { hasPermission, updateUserProfile, getTimeEntriesForWeek }
 )(UserProfile);
-

--- a/src/components/Warnings/Warnings.jsx
+++ b/src/components/Warnings/Warnings.jsx
@@ -133,8 +133,6 @@ export default function Warning({ personId, username, userRole, displayUser }) {
               toast.success('Successfully logged and Blue Square issued on profile and by email.');
             })
             .catch(error => {
-              // eslint-disable-next-line no-console
-              console.log('error in adding bluesquare', error);
               toast.error('Failed to add Blue Square!');
             });
         }
@@ -143,9 +141,7 @@ export default function Warning({ personId, username, userRole, displayUser }) {
           toast.success(toastMessage);
         }
       })
-      .catch(err => {
-        console.log(err);
-      });
+      .catch(() => {});
   };
 
   const warnings = !toggle

--- a/src/components/Warnings/Warnings.jsx
+++ b/src/components/Warnings/Warnings.jsx
@@ -141,7 +141,9 @@ export default function Warning({ personId, username, userRole, displayUser }) {
           toast.success(toastMessage);
         }
       })
-      .catch(() => {});
+      .catch(() => {
+        toast.error('Unable to refresh warnings right now.');
+      });
   };
 
   const warnings = !toggle

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -145,7 +145,7 @@ export class WeeklySummary extends Component {
       .regex(this.regexPattern)
       .label('Minimum 50 words'),
 
-    // allow 0 so your default state (0) doesn鈥檛 error
+    // allow 0 so your default state (0) doesn't error
     wordCount: Joi.number()
       .min(50)
       .allow(0)
@@ -206,7 +206,7 @@ export class WeeklySummary extends Component {
 
     weeklySummariesCount: Joi.any(),
 
-    // these three 鈥渋nvalid(false)鈥?rules will fail if false
+    // these three invalid(false) rules will fail if false
     mediaConfirm: Joi.boolean().invalid(false),
     editorConfirm: Joi.boolean().invalid(false),
     proofreadConfirm: Joi.boolean().invalid(false),
@@ -434,7 +434,7 @@ export class WeeklySummary extends Component {
       } else if (key === 'proofreadConfirm') {
         customMessage = 'Please confirm that you have proofread your summary.';
       } else {
-        // leave Joi鈥檚 default message for everything else
+        // leave Joi's default message for everything else
         customMessage = message;
       }
       return { ...errs, [key]: customMessage };
@@ -451,7 +451,7 @@ export class WeeklySummary extends Component {
     const rule = this.fieldSchemas[name];
     if (!rule) return null;
 
-    // build a one鈥恌ield schema and validate
+    // build a one-field schema and validate
     const singleSchema = Joi.object({ [name]: rule });
     const { error } = singleSchema.validate({ [name]: attr });
 
@@ -468,7 +468,7 @@ export class WeeklySummary extends Component {
       return 'Please confirm that you have proofread your summary.';
     }
 
-    // otherwise, return Joi鈥檚 default
+    // otherwise, return Joi's default
     return error.details[0].message;
   };
 
@@ -631,7 +631,7 @@ export class WeeklySummary extends Component {
   // Handler for success scenario after save
   handleSaveSuccess = async toastIdOnSave => {
     const { displayUserId, currentUser } = this.props;
-    toast.success('鉁?The data was saved successfully!', {
+    toast.success('The data was saved successfully!', {
       toastId: toastIdOnSave,
       pauseOnFocusLoss: false,
       autoClose: 3000,
@@ -642,7 +642,7 @@ export class WeeklySummary extends Component {
 
   // Handler for error scenario after save
   handleSaveError = toastIdOnSave => {
-    toast.error('鉁?The data could not be saved!', {
+    toast.error('The data could not be saved!', {
       toastId: toastIdOnSave,
       pauseOnFocusLoss: false,
       autoClose: 3000,
@@ -768,7 +768,7 @@ export class WeeklySummary extends Component {
     const TINY_MCE_INIT_OPTIONS = {
       license_key: 'gpl',
       menubar: false,
-      placeholder: `Did you: Write it in 3rd person with a minimum of 50-words? Remember to run it through ChatGPT or other AI editor using the 鈥淐urrent AI Editing Prompt鈥?from above? Remember to read and do a final edit before hitting Save?`,
+      placeholder: `Did you: Write it in 3rd person with a minimum of 50 words? Remember to run it through ChatGPT or another AI editor using the "Current AI Editing Prompt" from above? Remember to read and do a final edit before hitting Save?`,
       plugins: 'advlist autolink autoresize lists link charmap table help wordcount',
       toolbar:
         'bold italic underline link removeformat | bullist numlist outdent indent | styleselect fontsizeselect | table| strikethrough forecolor backcolor | subscript superscript charmap | help',
@@ -1049,7 +1049,7 @@ export class WeeklySummary extends Component {
                         style={boxStyling}
                         disabled={this.state.isSavingMove || this.state.moveSelect === '-1'}
                       >
-                        {this.state.isSavingMove ? 'Saving鈥? : 'Confirm and Save'}
+                        {this.state.isSavingMove ? 'Saving...' : 'Confirm and Save'}
                       </Button>
                       <Button
                         onClick={this.toggleMovePopup}

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -50,7 +50,35 @@ import {
   updateWeeklySummaries,
 } from '../../actions/weeklySummaries';
 import CurrentPromptModal from './CurrentPromptModal';
+import { useServerTime } from '~/context/ServerTimeContext';
 // import WriteItForMeModal from './WriteForMeModal';
+
+const SERVER_TIMEZONE = 'America/Los_Angeles';
+
+const buildDueDateState = serverDateISO => {
+  const serverMoment = serverDateISO
+    ? moment(serverDateISO).tz(SERVER_TIMEZONE)
+    : moment().tz(SERVER_TIMEZONE);
+
+  const dueDate = serverMoment.clone().endOf('week').toISOString();
+  const dueDateLastWeek = serverMoment.clone().subtract(1, 'week').endOf('week').toISOString();
+  const dueDateBeforeLast = serverMoment.clone().subtract(2, 'week').endOf('week').toISOString();
+  const dueDateThreeWeeksAgo = serverMoment.clone().subtract(3, 'week').endOf('week').toISOString();
+
+  return {
+    dueDate,
+    dueDateLastWeek,
+    dueDateBeforeLast,
+    dueDateThreeWeeksAgo,
+    uploadDatesElements: {
+      uploadDate: dueDate,
+      uploadDateLastWeek: dueDateLastWeek,
+      uploadDateBeforeLast: dueDateBeforeLast,
+      uploadDateThreeWeeksAgo: dueDateThreeWeeksAgo,
+    },
+    submittedDate: serverMoment.toISOString(),
+  };
+};
 
 // Images are not allowed in weekly summary
 const customImageUploadHandler = () =>
@@ -61,68 +89,44 @@ const customImageUploadHandler = () =>
 
 // Need this export here in order for automated testing to work.
 export class WeeklySummary extends Component {
-  // eslint-disable-next-line react/state-in-constructor
-  state = {
-    summariesCountShowing: 0,
-    originSummaries: {
-      summary: '',
-      summaryLastWeek: '',
-      summaryBeforeLast: '',
-      summaryThreeWeeksAgo: '',
-    },
-    formElements: {
-      summary: '',
-      wordCount: 0,
-      summaryLastWeek: '',
-      summaryBeforeLast: '',
-      summaryThreeWeeksAgo: '',
-      mediaUrl: '',
-      weeklySummariesCount: 0,
-      mediaConfirm: false,
-      editorConfirm: false,
-      proofreadConfirm: false,
-    },
-    dueDate: moment()
-      .tz('America/Los_Angeles')
-      .endOf('week')
-      .toISOString(),
-    dueDateLastWeek: moment()
-      .tz('America/Los_Angeles')
-      .endOf('week')
-      .subtract(1, 'week')
-      .toISOString(),
-    dueDateBeforeLast: moment()
-      .tz('America/Los_Angeles')
-      .endOf('week')
-      .subtract(2, 'week')
-      .toISOString(),
-    dueDateThreeWeeksAgo: moment()
-      .tz('America/Los_Angeles')
-      .endOf('week')
-      .subtract(3, 'week')
-      .toISOString(),
-    uploadDatesElements: {
-      uploadDate: this.dueDate,
-      uploadDateLastWeek: this.dueDateLastWeek,
-      uploadDateBeforeLast: this.dueDateBeforeLast,
-      uploadDateThreeWeeksAgo: this.dueDateThreeWeeksAgo,
-    },
-    submittedDate: moment()
-      .tz('America/Los_Angeles')
-      .toISOString(),
-    submittedCountInFourWeeks: 0,
-    activeTab: '1',
-    errors: {},
-    fetchError: null,
-    loading: true,
-    editPopup: false,
-    mediaChangeConfirm: false,
-    mediaFirstChange: false,
-    moveSelect: '-1',
-    movePopup: false,
-    moveConfirm: false,
-    isSavingMove: false,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      summariesCountShowing: 0,
+      originSummaries: {
+        summary: '',
+        summaryLastWeek: '',
+        summaryBeforeLast: '',
+        summaryThreeWeeksAgo: '',
+      },
+      formElements: {
+        summary: '',
+        wordCount: 0,
+        summaryLastWeek: '',
+        summaryBeforeLast: '',
+        summaryThreeWeeksAgo: '',
+        mediaUrl: '',
+        weeklySummariesCount: 0,
+        mediaConfirm: false,
+        editorConfirm: false,
+        proofreadConfirm: false,
+      },
+      ...buildDueDateState(props.serverDateISO),
+      submittedCountInFourWeeks: 0,
+      activeTab: '1',
+      errors: {},
+      fetchError: null,
+      loading: true,
+      editPopup: false,
+      mediaChangeConfirm: false,
+      mediaFirstChange: false,
+      moveSelect: '-1',
+      movePopup: false,
+      moveConfirm: false,
+      isSavingMove: false,
+    };
+  }
 
   // Minimum word count of 50 (handle words that also use non-ASCII characters by counting whitespace rather than word character sequences).
   regexPattern = /^\s*(?:\S+(?:\s+|$)){50,}$/;
@@ -141,7 +145,7 @@ export class WeeklySummary extends Component {
       .regex(this.regexPattern)
       .label('Minimum 50 words'),
 
-    // allow 0 so your default state (0) doesn’t error
+    // allow 0 so your default state (0) doesn鈥檛 error
     wordCount: Joi.number()
       .min(50)
       .allow(0)
@@ -202,14 +206,14 @@ export class WeeklySummary extends Component {
 
     weeklySummariesCount: Joi.any(),
 
-    // these three “invalid(false)” rules will fail if false
+    // these three 鈥渋nvalid(false)鈥?rules will fail if false
     mediaConfirm: Joi.boolean().invalid(false),
     editorConfirm: Joi.boolean().invalid(false),
     proofreadConfirm: Joi.boolean().invalid(false),
   });
 
   async componentDidMount() {
-    const { dueDate: _dueDate } = this.state;
+    const { dueDate: fallbackDueDate } = buildDueDateState(this.props.serverDateISO);
     // eslint-disable-next-line no-shadow
     const {
       getWeeklySummaries,
@@ -248,8 +252,7 @@ export class WeeklySummary extends Component {
     }
 
     const dueDateThisWeek = weeklySummaries && weeklySummaries[0] && weeklySummaries[0].dueDate;
-    // Make sure server dueDate is not before the localtime dueDate.
-    const dueDate = moment(dueDateThisWeek).isBefore(_dueDate) ? _dueDate : dueDateThisWeek;
+    const dueDate = dueDateThisWeek || fallbackDueDate;
 
     // Calculate due dates for the last three weeks by subtracting 1, 2, and 3 weeks from the current due date
     // and then setting the due date to the end of the ISO week (Saturday) for each respective week
@@ -321,12 +324,15 @@ export class WeeklySummary extends Component {
   }
 
   doesDateBelongToWeek = (dueDate, weekIndex) => {
-    const pstStartOfWeek = moment()
-      .tz('America/Los_Angeles')
+    const referenceMoment = this.props.serverDateISO
+      ? moment(this.props.serverDateISO).tz(SERVER_TIMEZONE)
+      : moment().tz(SERVER_TIMEZONE);
+    const pstStartOfWeek = referenceMoment
+      .clone()
       .startOf('week')
       .subtract(weekIndex, 'week');
-    const pstEndOfWeek = moment()
-      .tz('America/Los_Angeles')
+    const pstEndOfWeek = referenceMoment
+      .clone()
       .endOf('week')
       .subtract(weekIndex, 'week');
     const fromDate = moment(pstStartOfWeek).toDate();
@@ -428,7 +434,7 @@ export class WeeklySummary extends Component {
       } else if (key === 'proofreadConfirm') {
         customMessage = 'Please confirm that you have proofread your summary.';
       } else {
-        // leave Joi’s default message for everything else
+        // leave Joi鈥檚 default message for everything else
         customMessage = message;
       }
       return { ...errs, [key]: customMessage };
@@ -445,7 +451,7 @@ export class WeeklySummary extends Component {
     const rule = this.fieldSchemas[name];
     if (!rule) return null;
 
-    // build a one‐field schema and validate
+    // build a one鈥恌ield schema and validate
     const singleSchema = Joi.object({ [name]: rule });
     const { error } = singleSchema.validate({ [name]: attr });
 
@@ -462,7 +468,7 @@ export class WeeklySummary extends Component {
       return 'Please confirm that you have proofread your summary.';
     }
 
-    // otherwise, return Joi’s default
+    // otherwise, return Joi鈥檚 default
     return error.details[0].message;
   };
 
@@ -625,7 +631,7 @@ export class WeeklySummary extends Component {
   // Handler for success scenario after save
   handleSaveSuccess = async toastIdOnSave => {
     const { displayUserId, currentUser } = this.props;
-    toast.success('✔ The data was saved successfully!', {
+    toast.success('鉁?The data was saved successfully!', {
       toastId: toastIdOnSave,
       pauseOnFocusLoss: false,
       autoClose: 3000,
@@ -636,7 +642,7 @@ export class WeeklySummary extends Component {
 
   // Handler for error scenario after save
   handleSaveError = toastIdOnSave => {
-    toast.error('✘ The data could not be saved!', {
+    toast.error('鉁?The data could not be saved!', {
       toastId: toastIdOnSave,
       pauseOnFocusLoss: false,
       autoClose: 3000,
@@ -762,7 +768,7 @@ export class WeeklySummary extends Component {
     const TINY_MCE_INIT_OPTIONS = {
       license_key: 'gpl',
       menubar: false,
-      placeholder: `Did you: Write it in 3rd person with a minimum of 50-words? Remember to run it through ChatGPT or other AI editor using the “Current AI Editing Prompt” from above? Remember to read and do a final edit before hitting Save?`,
+      placeholder: `Did you: Write it in 3rd person with a minimum of 50-words? Remember to run it through ChatGPT or other AI editor using the 鈥淐urrent AI Editing Prompt鈥?from above? Remember to read and do a final edit before hitting Save?`,
       plugins: 'advlist autolink autoresize lists link charmap table help wordcount',
       toolbar:
         'bold italic underline link removeformat | bullist numlist outdent indent | styleselect fontsizeselect | table| strikethrough forecolor backcolor | subscript superscript charmap | help',
@@ -1043,7 +1049,7 @@ export class WeeklySummary extends Component {
                         style={boxStyling}
                         disabled={this.state.isSavingMove || this.state.moveSelect === '-1'}
                       >
-                        {this.state.isSavingMove ? 'Saving…' : 'Confirm and Save'}
+                        {this.state.isSavingMove ? 'Saving鈥? : 'Confirm and Save'}
                       </Button>
                       <Button
                         onClick={this.toggleMovePopup}
@@ -1181,6 +1187,7 @@ WeeklySummary.propTypes = {
   summaries: PropTypes.object.isRequired,
   updateWeeklySummaries: PropTypes.func.isRequired,
   initialActiveTab: PropTypes.string,
+  serverDateISO: PropTypes.string,
 };
 
 const mapStateToProps = ({ auth, weeklySummaries }) => ({
@@ -1199,4 +1206,15 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(WeeklySummary);
+const WeeklySummaryWithServerTime = props => {
+  const { getServerDateISO } = useServerTime();
+
+  return <WeeklySummary {...props} serverDateISO={getServerDateISO()} />;
+};
+
+WeeklySummaryWithServerTime.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  currentUser: PropTypes.object,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(WeeklySummaryWithServerTime);

--- a/src/components/WeeklySummary/WeeklySummary.jsx
+++ b/src/components/WeeklySummary/WeeklySummary.jsx
@@ -60,10 +60,25 @@ const buildDueDateState = serverDateISO => {
     ? moment(serverDateISO).tz(SERVER_TIMEZONE)
     : moment().tz(SERVER_TIMEZONE);
 
-  const dueDate = serverMoment.clone().endOf('week').toISOString();
-  const dueDateLastWeek = serverMoment.clone().subtract(1, 'week').endOf('week').toISOString();
-  const dueDateBeforeLast = serverMoment.clone().subtract(2, 'week').endOf('week').toISOString();
-  const dueDateThreeWeeksAgo = serverMoment.clone().subtract(3, 'week').endOf('week').toISOString();
+  const dueDate = serverMoment
+    .clone()
+    .endOf('week')
+    .toISOString();
+  const dueDateLastWeek = serverMoment
+    .clone()
+    .subtract(1, 'week')
+    .endOf('week')
+    .toISOString();
+  const dueDateBeforeLast = serverMoment
+    .clone()
+    .subtract(2, 'week')
+    .endOf('week')
+    .toISOString();
+  const dueDateThreeWeeksAgo = serverMoment
+    .clone()
+    .subtract(3, 'week')
+    .endOf('week')
+    .toISOString();
 
   return {
     dueDate,
@@ -367,8 +382,7 @@ export class WeeklySummary extends Component {
   handleMove = () => {
     const { isNotAllowedToEdit } = this.props;
     if (isNotAllowedToEdit) {
-      // eslint-disable-next-line no-alert
-      alert(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
+      toast.warn(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
       return;
     }
     const { moveSelect, formElements, activeTab, movePopup } = this.state;
@@ -678,11 +692,9 @@ export class WeeklySummary extends Component {
     const { isNotAllowedToEdit, displayUserEmail } = this.props;
     if (isNotAllowedToEdit) {
       if (displayUserEmail === DEV_ADMIN_ACCOUNT_EMAIL_DEV_ENV_ONLY) {
-        // eslint-disable-next-line no-alert, prettier/prettier
-        alert(DEV_ADMIN_ACCOUNT_CUSTOM_WARNING_MESSAGE_DEV_ENV_ONLY);
+        toast.warn(DEV_ADMIN_ACCOUNT_CUSTOM_WARNING_MESSAGE_DEV_ENV_ONLY);
       } else {
-        // eslint-disable-next-line no-alert, prettier/prettier
-        alert(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
+        toast.warn(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
       }
       return;
     }
@@ -705,11 +717,9 @@ export class WeeklySummary extends Component {
     const { isNotAllowedToEdit, displayUserEmail } = this.props;
     if (isNotAllowedToEdit) {
       if (displayUserEmail === DEV_ADMIN_ACCOUNT_EMAIL_DEV_ENV_ONLY) {
-        // eslint-disable-next-line no-alert, prettier/prettier
-        alert(DEV_ADMIN_ACCOUNT_CUSTOM_WARNING_MESSAGE_DEV_ENV_ONLY);
+        toast.warn(DEV_ADMIN_ACCOUNT_CUSTOM_WARNING_MESSAGE_DEV_ENV_ONLY);
       } else {
-        // eslint-disable-next-line no-alert, prettier/prettier
-        alert(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
+        toast.warn(PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE);
       }
       return;
     }

--- a/src/components/common/FilePreview/FilePreview.jsx
+++ b/src/components/common/FilePreview/FilePreview.jsx
@@ -9,7 +9,6 @@ const FilePreview = ({ file, index, darkMode, onRemove }) => {
 
   const handleImageError = useCallback(
     e => {
-      console.error('Failed to load preview for:', file?.name);
       e.target.style.display = 'none';
       const fallback = e.target.parentElement.querySelector('.preview-fallback');
       if (fallback) {

--- a/src/context/ServerTimeContext.jsx
+++ b/src/context/ServerTimeContext.jsx
@@ -125,4 +125,3 @@ export function ServerTimeProvider({ children }) {
 ServerTimeProvider.propTypes = {
   children: PropTypes.node.isRequired,
 };
-

--- a/src/context/ServerTimeContext.jsx
+++ b/src/context/ServerTimeContext.jsx
@@ -1,0 +1,128 @@
+import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import axios from 'axios';
+import moment from 'moment-timezone';
+import { ENDPOINTS } from '../utils/URL';
+
+const DEFAULT_TIMEZONE = 'America/Los_Angeles';
+const SYNC_INTERVAL_MS = 30000;
+const CLOCK_DRIFT_THRESHOLD_MS = 5000;
+
+const ServerTimeContext = createContext(null);
+
+const parseServerTime = data => data?.currentTime || data?.date || data?.datetime || data;
+
+export const useServerTime = () => {
+  const context = useContext(ServerTimeContext);
+
+  if (!context) {
+    throw new Error('useServerTime must be used within a ServerTimeProvider');
+  }
+
+  return context;
+};
+
+export function ServerTimeProvider({ children }) {
+  const [serverTimeOffset, setServerTimeOffset] = useState(0);
+  const [lastSyncTime, setLastSyncTime] = useState(null);
+  const [isInitialized, setIsInitialized] = useState(false);
+  const lastKnownClientTimeRef = useRef(Date.now());
+
+  const syncServerTime = async () => {
+    try {
+      const response = await axios.get(ENDPOINTS.GET_SERVER_DATE);
+      const serverTimeString = parseServerTime(response.data);
+      const serverTime = new Date(serverTimeString).getTime();
+
+      if (Number.isNaN(serverTime)) {
+        throw new Error('Server response does not contain a valid date');
+      }
+
+      const clientTime = Date.now();
+      setServerTimeOffset(serverTime - clientTime);
+      setLastSyncTime(clientTime);
+      lastKnownClientTimeRef.current = clientTime;
+      setIsInitialized(true);
+
+      return serverTime;
+    } catch (error) {
+      const clientTime = Date.now();
+      setServerTimeOffset(0);
+      setLastSyncTime(clientTime);
+      lastKnownClientTimeRef.current = clientTime;
+      setIsInitialized(true);
+
+      return clientTime;
+    }
+  };
+
+  const detectClockChange = () => {
+    const currentTime = Date.now();
+    const expectedTime = lastKnownClientTimeRef.current + 1000;
+    const timeDifference = Math.abs(currentTime - expectedTime);
+
+    if (timeDifference > CLOCK_DRIFT_THRESHOLD_MS) {
+      syncServerTime().catch(() => {});
+    }
+
+    lastKnownClientTimeRef.current = currentTime;
+  };
+
+  const getServerSyncedTime = () => Date.now() + serverTimeOffset;
+
+  const getServerDateISO = () => new Date(getServerSyncedTime()).toISOString();
+
+  const getServerDateMoment = (timezone = DEFAULT_TIMEZONE) =>
+    moment(getServerDateISO()).tz(timezone);
+
+  useEffect(() => {
+    syncServerTime().catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const syncInterval = window.setInterval(() => {
+      syncServerTime().catch(() => {});
+    }, SYNC_INTERVAL_MS);
+
+    const clockCheckInterval = window.setInterval(() => {
+      detectClockChange();
+    }, 1000);
+
+    return () => {
+      window.clearInterval(syncInterval);
+      window.clearInterval(clockCheckInterval);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleFocus = () => {
+      syncServerTime().catch(() => {});
+    };
+
+    window.addEventListener('focus', handleFocus);
+
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      fetchServerTime: syncServerTime,
+      getServerSyncedTime,
+      getServerDateISO,
+      getServerDateMoment,
+      isInitialized,
+      lastSyncTime,
+      serverTimeOffset,
+    }),
+    [isInitialized, lastSyncTime, serverTimeOffset],
+  );
+
+  return <ServerTimeContext.Provider value={value}>{children}</ServerTimeContext.Provider>;
+}
+
+ServerTimeProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+

--- a/src/hooks/useProjectsData.js
+++ b/src/hooks/useProjectsData.js
@@ -13,7 +13,7 @@ export function useProjectsData() {
       let response;
       try {
         response = await axios.get(ENDPOINTS.BM_PROJECTS_WITH_LOCATION);
-      } catch (projectError) {
+      } catch {
         response = await axios.get(ENDPOINTS.BM_ORGS_WITH_LOCATION);
       }
 
@@ -26,7 +26,7 @@ export function useProjectsData() {
         setOrgs(data);
       }
       return data;
-    } catch (error) {
+    } catch {
       const pseudoData = MapUtils.getPseudoOrgs();
       setOrgs(pseudoData);
       return [];

--- a/src/hooks/useProjectsData.js
+++ b/src/hooks/useProjectsData.js
@@ -14,14 +14,12 @@ export function useProjectsData() {
       try {
         response = await axios.get(ENDPOINTS.BM_PROJECTS_WITH_LOCATION);
       } catch (projectError) {
-        console.log('Projects with location endpoint not available, using organization data');
         response = await axios.get(ENDPOINTS.BM_ORGS_WITH_LOCATION);
       }
 
       const data = response.data.data || [];
 
       if (data.length === 0) {
-        console.log('No data from backend, using pseudo data');
         const pseudoData = MapUtils.getPseudoOrgs();
         setOrgs(pseudoData);
       } else {
@@ -29,7 +27,6 @@ export function useProjectsData() {
       }
       return data;
     } catch (error) {
-      console.error('Error fetching project/org data:', error);
       const pseudoData = MapUtils.getPseudoOrgs();
       setOrgs(pseudoData);
       return [];

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -3,6 +3,7 @@ const APIEndpoint =
 
 export const ENDPOINTS = {
   APIEndpoint: () => APIEndpoint,
+  GET_SERVER_DATE: `${APIEndpoint}/server/date`,
   USER_PROFILE: userId => `${APIEndpoint}/userprofile/${userId}`,
   USER_PROFILE_FIXED: userId => `${APIEndpoint}/userProfile/${userId}`,
   USER_PROFILE_PROPERTY: userId => `${APIEndpoint}/userprofile/${userId}/property`,
@@ -244,11 +245,11 @@ export const ENDPOINTS = {
     if (startDate) params.append('startDate', startDate);
     if (endDate) params.append('endDate', endDate);
     if (groupBy) params.append('groupBy', groupBy);
-    
+
     const queryString = params.toString();
     return queryString ? `${url}?${queryString}` : url;
   },
-  
+
   INJURY_PROJECTS: () => `${APIEndpoint}/injuries/projects`,
 
   PRESETS: () => `${APIEndpoint}/rolePreset`,

--- a/src/utils/authInit.js
+++ b/src/utils/authInit.js
@@ -22,7 +22,7 @@ export default function initAuth() {
       httpService.setjwt(token);
       store.dispatch(setCurrentUser(decoded));
     }
-  } catch (error) {
+  } catch {
     // Handle invalid or malformed token
     localStorage.removeItem(config.tokenKey);
     store.dispatch(logoutUser());

--- a/src/utils/authInit.js
+++ b/src/utils/authInit.js
@@ -24,7 +24,6 @@ export default function initAuth() {
     }
   } catch (error) {
     // Handle invalid or malformed token
-    console.error('Invalid token detected, clearing authentication:', error);
     localStorage.removeItem(config.tokenKey);
     store.dispatch(logoutUser());
   }


### PR DESCRIPTION
# Description
<img width="1540" height="2298" alt="image" src="https://github.com/user-attachments/assets/3a19eb8d-6a00-409c-95e0-3b90009d46f8" />

This PR takes over and replaces the abandoned work from PR #4312 to fully protect timelog and weekly summary flows from local/system date manipulation.

## Related PRs
- Replaces frontend PR: #4312
- Related backend PR: https://github.com/OneCommunityGlobal/HGNRest/pull/1875
- Original related frontend reference from notes: #3335

## Main changes explained
- Added `ServerTimeContext` to centralize authoritative server-date access and periodic re-sync logic.
- Wrapped the app in `ServerTimeProvider` so time-sensitive flows can use the same server-based date source.
- Added `GET_SERVER_DATE` frontend endpoint wiring for the related backend API.
- Updated `TimeEntryForm` to initialize and refresh `dateOfWork` from server time instead of the local machine clock.
- Updated `TimeEntry` same-day checks to use server time rather than local time.
- Updated `Timelog` week boundary calculations and date labels to use server time.
- Updated `WeeklySummary` due-date initialization and week-belonging checks so the dashboard due date no longer follows modified local/system time.
- Updated affected unit tests to render through `ServerTimeProvider`.

## Why this replaces PR #4312
Review feedback on #4312 showed that changing the computer date/time could still:
- Shift the weekly summary due date on the dashboard
- Change the default date used in time entry flows
- Allow users to log time into the wrong week

This replacement PR keeps the original server-date approach but closes the remaining gaps where local `moment()` usage was still leaking into weekly summary and timelog behavior.

## How to test
1. Check out `codex/yuyan-pr4312-server-date`.
2. Run the related backend from PR #1875.
3. Start the frontend locally.
4. Change your computer date/time to a different week or month.
5. Verify the time-entry date still reflects server time.
6. Verify the weekly summary due date still reflects server time.
7. Verify the behavior in both light mode and dark mode.

