### PR TITLE
som/fix(datePicker): fix toast error in datePicker

### DIFF
--- a/src/components/CommunityPortal/CPDashboard.jsx
+++ b/src/components/CommunityPortal/CPDashboard.jsx
@@ -96,15 +96,22 @@ export function CPDashboard() {
   });
 
   const handleDateChange = date => {
+    if (!date) {
+      setSelectedDate('');
+      return;
+    }
+
     const today = new Date();
-    today.setHours(0, 0, 0, 0); // midnight today
+    today.setHours(0, 0, 0, 0);
 
     if (date < today) {
       toast.error('Past dates are not supported. Please select a future date.');
       setSelectedDate('');
       return;
     }
-    setSelectedDate(date);
+
+    const formatted = date.toISOString().split('T')[0];
+    setSelectedDate(formatted);
   };
 
   const FALLBACK_IMG =


### PR DESCRIPTION
# Description
Fixed an issue where the warning toast would continue to appear after selecting a past date and then clearing the input using the clear (X) button. The date picker state is now properly reset, preventing the error from persisting.

https://github.com/user-attachments/assets/b929b236-92c7-463e-9d9c-9260743e1f52

## Related PRS (if any):
This frontend PR is related to the development backend PR.
This PR is related to  https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4428


## Main changes explained:
- **CPDashboard.jsx:** Updated `handleDateChange` function .


## How to test:
1. Checkout this branch.
2. Run npm install and start the app locally.
3. Clear site data/cache.
4. Log in as an admin user.
5. Navigate to: `/communityportal`
6. Verify:
      - Select a past date in the “Ending After” date picker and confirm that the warning appears.
      - Click the clear (X) button and ensure the date is reset.
      - Select a valid future date and verify that no error message persists.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/732dcc30-eb66-4d00-b691-d96787b233a1


