### PR TITLE
Sayali: fix dark mode styling issues on Skills Overview page

### DIFF
--- a/src/components/HGNHelpSkillsDashboard/FilterButtons.jsx
+++ b/src/components/HGNHelpSkillsDashboard/FilterButtons.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import { availablePreferences, availableSkills, formatSkillName, toggleItem } from './FilerData.js';
-import styles from './style/CommunityMembersPage.module.css';
+import styles from './style/SkillsOverviewPage.module.css';
 
-export function SkillFilterButtons({ selectedSkills, setSelectedSkills }) {
+export function SkillFilterButtons({ selectedSkills, setSelectedSkills, darkMode }) {
   return (
     <div className={styles.filterGroup}>
       {availableSkills.map(skillKey => (
@@ -12,7 +12,7 @@ export function SkillFilterButtons({ selectedSkills, setSelectedSkills }) {
           onClick={() => toggleItem(skillKey, selectedSkills, setSelectedSkills)}
           className={`${styles.skillButton} ${
             selectedSkills.includes(skillKey) ? styles.selected : ''
-          }`}
+          } ${darkMode ? styles.darkButton : ''}`}
         >
           {formatSkillName(skillKey)}
         </button>
@@ -21,7 +21,7 @@ export function SkillFilterButtons({ selectedSkills, setSelectedSkills }) {
   );
 }
 
-export function PreferenceFilterButtons({ selectedPreferences, setSelectedPreferences }) {
+export function PreferenceFilterButtons({ selectedPreferences, setSelectedPreferences, darkMode }) {
   return (
     <div className={styles.filterGroup}>
       {availablePreferences.map(pref => (
@@ -31,7 +31,7 @@ export function PreferenceFilterButtons({ selectedPreferences, setSelectedPrefer
           onClick={() => toggleItem(pref, selectedPreferences, setSelectedPreferences)}
           className={`${styles.preferenceButton} ${
             selectedPreferences.includes(pref) ? styles.selected : ''
-          }`}
+          } ${darkMode ? styles.darkButton : ''}`}
         >
           {pref}
         </button>
@@ -43,9 +43,11 @@ export function PreferenceFilterButtons({ selectedPreferences, setSelectedPrefer
 SkillFilterButtons.propTypes = {
   selectedSkills: PropTypes.arrayOf(PropTypes.string).isRequired,
   setSelectedSkills: PropTypes.func.isRequired,
+  darkMode: PropTypes.bool,
 };
 
 PreferenceFilterButtons.propTypes = {
   selectedPreferences: PropTypes.arrayOf(PropTypes.string).isRequired,
   setSelectedPreferences: PropTypes.func.isRequired,
+  darkMode: PropTypes.bool,
 };

--- a/src/components/HGNHelpSkillsDashboard/SkillsOverviewPage.jsx
+++ b/src/components/HGNHelpSkillsDashboard/SkillsOverviewPage.jsx
@@ -39,7 +39,11 @@ function SkillsOverviewPage() {
 
       {/* Skill Filters */}
       <Accordion title="Filter by Skills" defaultOpen darkMode={darkMode}>
-        <SkillFilterButtons selectedSkills={selectedSkills} setSelectedSkills={setSelectedSkills} />
+        <SkillFilterButtons
+          selectedSkills={selectedSkills}
+          setSelectedSkills={setSelectedSkills}
+          darkMode={darkMode}
+        />
       </Accordion>
 
       {/* Preference Filters */}
@@ -47,6 +51,7 @@ function SkillsOverviewPage() {
         <PreferenceFilterButtons
           selectedPreferences={selectedPreferences}
           setSelectedPreferences={setSelectedPreferences}
+          darkMode={darkMode}
         />
       </Accordion>
 

--- a/src/components/HGNHelpSkillsDashboard/style/SkillsOverviewPage.module.css
+++ b/src/components/HGNHelpSkillsDashboard/style/SkillsOverviewPage.module.css
@@ -221,3 +221,9 @@
   justify-content: center;
   padding: 2rem 0;
 }
+
+.darkButton {
+  background-color: #1f2937 !important;
+  color: #f9fafb !important;
+  border-color: #4b5563 !important;
+}


### PR DESCRIPTION

<img width="875" height="689" alt="image" src="https://github.com/user-attachments/assets/18dda297-5f3c-44da-b54b-c08b8a35bbf8" />

# Description
Fixes (Priority Medium) — HGN Questionnaire Dashboard: Team Member's Skill Overview Page – Fix Dark Mode Styling Issues

## Related PRs:
PR4977, PR3360

## Main changes explained:
- Updated FilterButtons.jsx to accept darkMode prop and apply dark styles to skill/preference filter pills
- Fixed FilterButtons.jsx to use SkillsOverviewPage.module.css instead of CommunityMembersPage.module.css
- Updated SkillsOverviewPage.jsx to pass darkMode prop to SkillFilterButtons and PreferenceFilterButtons
- Added .darkButton class to SkillsOverviewPage.module.css for proper dark mode pill styling

## How to test:
1. Check out branch `Sayali_SkillsOverview_DarkModeFix`
2. `npm install && npm run start:local`
3. Clear cache, log in as admin
4. Navigate to `http://localhost:5173/hgnhelp/skills-overview`
5. Switch to dark mode
6. Verify skill filter pills have dark background with visible text
7. Verify preference filter pills are correctly styled in dark mode
8. Toggle dark mode off — verify light mode still works correctly

## Screenshots:
<img width="1918" height="879" alt="image" src="https://github.com/user-attachments/assets/afacc326-575c-4a4d-ae03-e4cc6dda52e0" />

## Note:
Frontend-only change. No backend changes required.