### PR TITLE
Diya 🔥 fix(ui): Fixed Timer UI on Single Tasks Page

### DIFF
--- a/src/components/Projects/WBS/SingleTask/SingleTask.jsx
+++ b/src/components/Projects/WBS/SingleTask/SingleTask.jsx
@@ -72,7 +72,7 @@ function SingleTask(props) {
 
   return (
     <>
-      <div className={`${darkMode ? 'bg-oxford-blue' : 'bg-white'} h-100`}>
+      <div className={`${darkMode ? 'bg-oxford-blue' : 'bg-white'} h-100`} style={{ minHeight: '400px' }}>
         <ReactTooltip />
         <div className="container-single-task">
           {canPostProject && (


### PR DESCRIPTION
# Description
Fixes the timer dropdown being clipped/cut off on the Single Task page due to the page having insufficient height to render the full timer dropdown.

## Related PRs (if any):
None

## Main changes explained:
- Updated `SingleTask.jsx` to add `minHeight: '400px'` to the outer wrapper div, giving the page enough height for the timer dropdown to render fully without being clipped

## How to test:
1. Check out the current branch
2. Run `npm install` and start the dev server with `npm run start:local`
3. Clear site data/cache
4. Log in as any user
5. Navigate to any task's single task page (e.g. via `/wbs/tasks/:taskId`)
6. Click the timer dropdown in the header
7. Verify the full timer is visible and not clipped

## Screenshots or videos of changes:
Before:
<img width="1916" height="521" alt="Screenshot 2026-04-14 at 7 32 10 PM" src="https://github.com/user-attachments/assets/eaae5527-cc64-40a6-8b74-c4de311f669a" />


After:
<img width="1920" height="627" alt="Screenshot 2026-04-14 at 7 28 50 PM" src="https://github.com/user-attachments/assets/9b98209a-cf6e-4744-92c9-038f27343ad2" />


## Note:
The page height was too short (only tall enough for the single table row) causing the absolutely positioned timer dropdown to get clipped. Adding `minHeight: 400px` gives the page enough room without affecting layout on larger screens.