### PR TITLE
Sayali: add promotion confirmation display box with batch promotion to PR grading screen

### DIFF
--- a/src/components/PRGradingScreen/PRGradingScreen.jsx
+++ b/src/components/PRGradingScreen/PRGradingScreen.jsx
@@ -1,8 +1,10 @@
+import axios from 'axios';
 import { useState } from 'react';
 import { Button, Card, Col, Container, Row } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
 import { v4 as uuidv4 } from 'uuid';
 import styles from './PRGradingScreen.module.css';
+import PromotionConfirmationBox from './PromotionConfirmationBox';
 
 const PRGradingScreen = ({ teamData, reviewers }) => {
   const darkMode = useSelector(state => state.theme.darkMode);
@@ -13,6 +15,10 @@ const PRGradingScreen = ({ teamData, reviewers }) => {
   const [inputError, setInputError] = useState('');
   const [showGradingModal, setShowGradingModal] = useState(null);
   const [isFinalized, setIsFinalized] = useState(false);
+  const [promotionCandidate, setPromotionCandidate] = useState(null);
+  const [confirmedPromotions, setConfirmedPromotions] = useState([]);
+  const [selectedForPromotion, setSelectedForPromotion] = useState([]);
+  const [showBatchConfirm, setShowBatchConfirm] = useState(false);
 
   if (!teamData || !reviewers) {
     return <div>Error: Missing required props</div>;
@@ -130,6 +136,81 @@ const PRGradingScreen = ({ teamData, reviewers }) => {
   const handleFinalize = () => {
     setIsFinalized(true);
   };
+  /* ---------------- PROMOTION ---------------- */
+
+  const handlePromoteClick = async reviewer => {
+    try {
+      const response = await axios.get(
+        `${process.env.REACT_APP_APIENDPOINT}/promotion-details/${reviewer.id}`,
+      );
+      setPromotionCandidate({
+        reviewerId: reviewer.id,
+        reviewerName: response.data.reviewerName || reviewer.reviewer,
+        teamCode: response.data.teamCode || teamData.teamName,
+        teamReviewerName: response.data.teamReviewerName || reviewer.reviewer,
+        weeklyPRs:
+          response.data.weeklyPRs && response.data.weeklyPRs.length > 0
+            ? response.data.weeklyPRs
+            : [{ week: teamData.dateRange.start, count: reviewer.gradedPrs.length }],
+      });
+    } catch (error) {
+      // fallback to local data if API fails
+      setPromotionCandidate({
+        reviewerId: reviewer.id,
+        reviewerName: reviewer.reviewer,
+        teamCode: teamData.teamName,
+        teamReviewerName: reviewer.reviewer,
+        weeklyPRs: [{ week: teamData.dateRange.start, count: reviewer.gradedPrs.length }],
+      });
+    }
+  };
+
+  const handleConfirmPromotion = async (reviewerName, reviewerId) => {
+    try {
+      if (reviewerId) {
+        await axios.post(`${process.env.REACT_APP_APIENDPOINT}/promote-members`, {
+          memberIds: [reviewerId],
+        });
+      }
+    } catch (error) {
+      // silently continue even if API fails
+    }
+    setConfirmedPromotions(prev => [...prev, reviewerName]);
+    setPromotionCandidate(null);
+  };
+
+  const handleCancelPromotion = () => {
+    setPromotionCandidate(null);
+  };
+  /* ---------------- BATCH PROMOTION ---------------- */
+
+  const handleCheckboxChange = reviewerId => {
+    setSelectedForPromotion(prev =>
+      prev.includes(reviewerId) ? prev.filter(id => id !== reviewerId) : [...prev, reviewerId],
+    );
+  };
+
+  const handleBatchConfirm = async () => {
+    try {
+      if (selectedForPromotion.length > 0) {
+        await axios.post(`${process.env.REACT_APP_APIENDPOINT}/promote-members`, {
+          memberIds: selectedForPromotion,
+        });
+      }
+    } catch (error) {
+      // silently continue
+    }
+    const selectedNames = reviewerData
+      .filter(r => selectedForPromotion.includes(r.id))
+      .map(r => r.reviewer);
+    setConfirmedPromotions(prev => [...prev, ...selectedNames]);
+    setSelectedForPromotion([]);
+    setShowBatchConfirm(false);
+  };
+
+  const handleBatchCancel = () => {
+    setShowBatchConfirm(false);
+  };
 
   /* ---------------- RENDER ---------------- */
 
@@ -195,7 +276,56 @@ const PRGradingScreen = ({ teamData, reviewers }) => {
                 <tbody>
                   {reviewerData.map(reviewer => (
                     <tr key={reviewer.id}>
-                      <td>{reviewer.reviewer}</td>
+                      <td>
+                        <div
+                          style={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            gap: '6px',
+                          }}
+                        >
+                          <span>{reviewer.reviewer}</span>
+                          {!confirmedPromotions.includes(reviewer.reviewer) && (
+                            <input
+                              type="checkbox"
+                              title="Select for batch promotion"
+                              checked={selectedForPromotion.includes(reviewer.id)}
+                              onChange={() => handleCheckboxChange(reviewer.id)}
+                              style={{
+                                marginTop: '4px',
+                                cursor: 'pointer',
+                                width: '16px',
+                                height: '16px',
+                              }}
+                            />
+                          )}
+                          {!confirmedPromotions.includes(reviewer.reviewer) ? (
+                            <button
+                              type="button"
+                              onClick={() => handlePromoteClick(reviewer)}
+                              style={{
+                                fontSize: '0.75rem',
+                                padding: '3px 10px',
+                                borderRadius: '4px',
+                                border: 'none',
+                                background: '#ffc107',
+                                color: '#333',
+                                cursor: 'pointer',
+                                fontWeight: '600',
+                              }}
+                            >
+                              🏆 Promote
+                            </button>
+                          ) : (
+                            <span
+                              style={{ fontSize: '0.75rem', color: '#28a745', fontWeight: '600' }}
+                            >
+                              ✅ Promoted
+                            </span>
+                          )}
+                        </div>
+                      </td>
 
                       <td>
                         <input
@@ -397,6 +527,159 @@ const PRGradingScreen = ({ teamData, reviewers }) => {
             </div>
           </div>
         </div>
+      )}
+      {selectedForPromotion.length > 0 && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: '24px',
+            right: '24px',
+            zIndex: 999,
+            display: 'flex',
+            gap: '12px',
+            alignItems: 'center',
+            background: darkMode ? '#2d4059' : '#fff',
+            padding: '12px 20px',
+            borderRadius: '8px',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
+            border: `1px solid ${darkMode ? '#4a5a77' : '#dee2e6'}`,
+          }}
+        >
+          <span style={{ color: darkMode ? '#fff' : '#333', fontWeight: '600' }}>
+            {selectedForPromotion.length} selected
+          </span>
+          <button
+            type="button"
+            onClick={() => setShowBatchConfirm(true)}
+            style={{
+              padding: '8px 20px',
+              borderRadius: '4px',
+              border: 'none',
+              background: '#28a745',
+              color: '#fff',
+              cursor: 'pointer',
+              fontWeight: '600',
+            }}
+          >
+            🏆 Promote Selected
+          </button>
+          <button
+            type="button"
+            onClick={() => setSelectedForPromotion([])}
+            style={{
+              padding: '8px 12px',
+              borderRadius: '4px',
+              border: `1px solid ${darkMode ? '#5a6b88' : '#dee2e6'}`,
+              background: 'transparent',
+              color: darkMode ? '#fff' : '#333',
+              cursor: 'pointer',
+            }}
+          >
+            Clear
+          </button>
+        </div>
+      )}
+      {showBatchConfirm && (
+        <div
+          className={`${styles['pr-grading-screen-modal-overlay']} ${
+            darkMode ? styles['dark-mode'] : ''
+          }`}
+        >
+          <div
+            className={`${styles['pr-grading-screen-modal']} ${
+              darkMode ? styles['dark-mode'] : ''
+            }`}
+          >
+            <div
+              className={`${styles['pr-grading-screen-modal-header']} ${
+                darkMode ? styles['dark-mode'] : ''
+              }`}
+            >
+              <h4 style={{ margin: 0, color: darkMode ? '#fff' : '#333' }}>
+                🏆 Confirm Batch Promotion
+              </h4>
+              <button
+                type="button"
+                className={styles['pr-grading-screen-modal-close']}
+                onClick={handleBatchCancel}
+              >
+                ×
+              </button>
+            </div>
+            <div
+              className={`${styles['pr-grading-screen-modal-body']} ${
+                darkMode ? styles['dark-mode'] : ''
+              }`}
+            >
+              <p style={{ color: darkMode ? '#fff' : '#333', marginBottom: '12px' }}>
+                You are about to promote <strong>{selectedForPromotion.length}</strong> reviewer(s):
+              </p>
+              <ul style={{ color: darkMode ? '#fff' : '#333', marginBottom: '16px' }}>
+                {reviewerData
+                  .filter(r => selectedForPromotion.includes(r.id))
+                  .map(r => (
+                    <li key={r.id} style={{ marginBottom: '4px' }}>
+                      {r.reviewer}
+                    </li>
+                  ))}
+              </ul>
+              <p
+                style={{
+                  color: darkMode ? '#fff' : '#333',
+                  fontWeight: '600',
+                  textAlign: 'center',
+                }}
+              >
+                Are you sure you want to promote all selected reviewers?
+              </p>
+            </div>
+            <div
+              className={`${styles['pr-grading-screen-modal-footer']} ${
+                darkMode ? styles['dark-mode'] : ''
+              }`}
+              style={{ gap: '12px' }}
+            >
+              <button
+                type="button"
+                onClick={handleBatchCancel}
+                style={{
+                  padding: '8px 20px',
+                  borderRadius: '4px',
+                  border: `1px solid ${darkMode ? '#5a6b88' : '#6c757d'}`,
+                  background: darkMode ? '#6c757d' : '#fff',
+                  color: darkMode ? '#fff' : '#6c757d',
+                  cursor: 'pointer',
+                  fontWeight: '600',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleBatchConfirm}
+                style={{
+                  padding: '8px 20px',
+                  borderRadius: '4px',
+                  border: 'none',
+                  background: '#28a745',
+                  color: '#fff',
+                  cursor: 'pointer',
+                  fontWeight: '600',
+                }}
+              >
+                ✅ Confirm All
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {promotionCandidate && (
+        <PromotionConfirmationBox
+          reviewer={promotionCandidate}
+          onConfirm={handleConfirmPromotion}
+          onCancel={handleCancelPromotion}
+          darkMode={darkMode}
+        />
       )}
     </Container>
   );

--- a/src/components/PRGradingScreen/PromotionConfirmationBox.jsx
+++ b/src/components/PRGradingScreen/PromotionConfirmationBox.jsx
@@ -1,0 +1,292 @@
+import PropTypes from 'prop-types';
+import styles from './PRGradingScreen.module.css';
+
+function PromotionConfirmationBox({ reviewer, onConfirm, onCancel, darkMode }) {
+  const { reviewerName, teamCode, teamReviewerName, weeklyPRs } = reviewer;
+
+  const totalPRs = weeklyPRs.reduce((sum, w) => sum + w.count, 0);
+  const avgPRs = weeklyPRs.length > 0 ? (totalPRs / weeklyPRs.length).toFixed(1) : 0;
+  const isConsistent = weeklyPRs.every(w => w.count >= 8);
+
+  return (
+    <div
+      className={`${styles['pr-grading-screen-modal-overlay']} ${
+        darkMode ? styles['dark-mode'] : ''
+      }`}
+    >
+      <div
+        className={`${styles['pr-grading-screen-modal']} ${darkMode ? styles['dark-mode'] : ''}`}
+      >
+        {/* Header */}
+        <div
+          className={`${styles['pr-grading-screen-modal-header']} ${
+            darkMode ? styles['dark-mode'] : ''
+          }`}
+        >
+          <h4 style={{ margin: 0, color: darkMode ? '#fff' : '#333' }}>🏆 Confirm Promotion</h4>
+          <button
+            type="button"
+            className={styles['pr-grading-screen-modal-close']}
+            onClick={onCancel}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Body */}
+        <div
+          className={`${styles['pr-grading-screen-modal-body']} ${
+            darkMode ? styles['dark-mode'] : ''
+          }`}
+        >
+          {/* Reviewer Info */}
+          <div
+            style={{
+              background: darkMode ? '#2d4059' : '#f0f4ff',
+              borderRadius: '8px',
+              padding: '16px',
+              marginBottom: '16px',
+              border: `1px solid ${darkMode ? '#4a5a77' : '#c3d0f0'}`,
+            }}
+          >
+            <p style={{ margin: '4px 0', color: darkMode ? '#fff' : '#333' }}>
+              <strong>Reviewer:</strong> {reviewerName}
+            </p>
+            <p style={{ margin: '4px 0', color: darkMode ? '#fff' : '#333' }}>
+              <strong>Team:</strong> {teamCode}
+            </p>
+            <p style={{ margin: '4px 0', color: darkMode ? '#fff' : '#333' }}>
+              <strong>Team Reviewer Name:</strong> {teamReviewerName}
+            </p>
+          </div>
+
+          {/* Weekly PR Stats */}
+          <h5 style={{ color: darkMode ? '#e8a71c' : '#052C65', marginBottom: '8px' }}>
+            Weekly PR Stats
+          </h5>
+          <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '16px' }}>
+            <thead>
+              <tr>
+                <th
+                  style={{
+                    padding: '8px 12px',
+                    background: darkMode ? '#2d4059' : '#f8f9fa',
+                    color: darkMode ? '#fff' : '#495057',
+                    border: `1px solid ${darkMode ? '#4a5a77' : '#dee2e6'}`,
+                    textAlign: 'left',
+                  }}
+                >
+                  Week
+                </th>
+                <th
+                  style={{
+                    padding: '8px 12px',
+                    background: darkMode ? '#2d4059' : '#f8f9fa',
+                    color: darkMode ? '#fff' : '#495057',
+                    border: `1px solid ${darkMode ? '#4a5a77' : '#dee2e6'}`,
+                    textAlign: 'center',
+                  }}
+                >
+                  PR Count
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {weeklyPRs.map(w => (
+                <tr key={w.week}>
+                  <td
+                    style={{
+                      padding: '8px 12px',
+                      color: darkMode ? '#fff' : '#333',
+                      border: `1px solid ${darkMode ? '#4a5a77' : '#dee2e6'}`,
+                    }}
+                  >
+                    {w.week}
+                  </td>
+                  <td
+                    style={{
+                      padding: '8px 12px',
+                      color: darkMode ? '#fff' : '#333',
+                      border: `1px solid ${darkMode ? '#4a5a77' : '#dee2e6'}`,
+                      textAlign: 'center',
+                      fontWeight: '600',
+                    }}
+                  >
+                    {w.count}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* Summary Stats */}
+          <div
+            style={{
+              display: 'flex',
+              gap: '12px',
+              marginBottom: '16px',
+              flexWrap: 'wrap',
+            }}
+          >
+            <div
+              style={{
+                flex: 1,
+                minWidth: '120px',
+                background: darkMode ? '#1b2a41' : '#e9ecef',
+                borderRadius: '6px',
+                padding: '12px',
+                textAlign: 'center',
+                border: `1px solid ${darkMode ? '#4a5a77' : '#ced4da'}`,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: '1.4rem',
+                  fontWeight: '700',
+                  color: darkMode ? '#4a9eff' : '#052C65',
+                }}
+              >
+                {totalPRs}
+              </div>
+              <div style={{ fontSize: '0.8rem', color: darkMode ? '#b0b8c4' : '#6c757d' }}>
+                Total PRs
+              </div>
+            </div>
+            <div
+              style={{
+                flex: 1,
+                minWidth: '120px',
+                background: darkMode ? '#1b2a41' : '#e9ecef',
+                borderRadius: '6px',
+                padding: '12px',
+                textAlign: 'center',
+                border: `1px solid ${darkMode ? '#4a5a77' : '#ced4da'}`,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: '1.4rem',
+                  fontWeight: '700',
+                  color: darkMode ? '#4a9eff' : '#052C65',
+                }}
+              >
+                {avgPRs}
+              </div>
+              <div style={{ fontSize: '0.8rem', color: darkMode ? '#b0b8c4' : '#6c757d' }}>
+                Avg PRs/Week
+              </div>
+            </div>
+            <div
+              style={{
+                flex: 1,
+                minWidth: '120px',
+                background: isConsistent
+                  ? darkMode
+                    ? '#1a3a2a'
+                    : '#d4edda'
+                  : darkMode
+                  ? '#3a1a1a'
+                  : '#f8d7da',
+                borderRadius: '6px',
+                padding: '12px',
+                textAlign: 'center',
+                border: `1px solid ${isConsistent ? '#c3e6cb' : '#f5c6cb'}`,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: '1.4rem',
+                  fontWeight: '700',
+                  color: isConsistent ? '#28a745' : '#dc3545',
+                }}
+              >
+                {isConsistent ? '✅' : '⚠️'}
+              </div>
+              <div style={{ fontSize: '0.8rem', color: darkMode ? '#b0b8c4' : '#6c757d' }}>
+                {isConsistent ? 'Consistent' : 'Inconsistent'}
+              </div>
+            </div>
+          </div>
+
+          {/* Confirmation question */}
+          <p
+            style={{
+              color: darkMode ? '#fff' : '#333',
+              fontWeight: '600',
+              fontSize: '1rem',
+              textAlign: 'center',
+              marginBottom: '16px',
+            }}
+          >
+            Are you sure you want to confirm promotion for{' '}
+            <span style={{ color: darkMode ? '#e8a71c' : '#052C65' }}>{reviewerName}</span>?
+          </p>
+        </div>
+
+        {/* Footer */}
+        <div
+          className={`${styles['pr-grading-screen-modal-footer']} ${
+            darkMode ? styles['dark-mode'] : ''
+          }`}
+          style={{ gap: '12px' }}
+        >
+          <button
+            type="button"
+            onClick={onCancel}
+            style={{
+              padding: '8px 20px',
+              borderRadius: '4px',
+              border: `1px solid ${darkMode ? '#5a6b88' : '#6c757d'}`,
+              background: darkMode ? '#6c757d' : '#fff',
+              color: darkMode ? '#fff' : '#6c757d',
+              cursor: 'pointer',
+              fontWeight: '600',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(reviewerName, reviewer.reviewerId)}
+            style={{
+              padding: '8px 20px',
+              borderRadius: '4px',
+              border: 'none',
+              background: '#28a745',
+              color: '#fff',
+              cursor: 'pointer',
+              fontWeight: '600',
+            }}
+          >
+            ✅ Confirm Promotion
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+PromotionConfirmationBox.propTypes = {
+  reviewer: PropTypes.shape({
+    reviewerId: PropTypes.string,
+    reviewerName: PropTypes.string.isRequired,
+    teamCode: PropTypes.string,
+    teamReviewerName: PropTypes.string,
+    weeklyPRs: PropTypes.arrayOf(
+      PropTypes.shape({
+        week: PropTypes.string,
+        count: PropTypes.number,
+      }),
+    ),
+  }).isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  darkMode: PropTypes.bool,
+};
+
+PromotionConfirmationBox.defaultProps = {
+  darkMode: false,
+};
+
+export default PromotionConfirmationBox;


### PR DESCRIPTION

<img width="510" height="668" alt="image" src="https://github.com/user-attachments/assets/3e640fbc-5377-445b-aeaa-6bc6347e5aa1" />

# Description
Implements #(PRIORITY URGENT) — PR Review Team Analytics Dashboard: Make a display box for confirming promotions (Frontend)

## Related PRS (if any):
No backend PR needed — backend endpoints (GET /api/promotion-details/:reviewerId and POST /promote-members) were already implemented.
…

## Main changes explained:

- Created src/components/PRGradingScreen/PromotionConfirmationBox.jsx — new modal component that displays reviewer details, team info, weekly PR stats table, total PRs, avg PRs/week, and consistency flag when promoting a reviewer
- Updated src/components/PRGradingScreen/PRGradingScreen.jsx — added 🏆 Promote button per reviewer, wired to GET /api/promotion-details/:reviewerId to fetch real data, added batch promotion with checkboxes + "Promote Selected" button, added batch confirmation modal, and added POST /promote-members API call on confirm for audit logging

…

## How to test:
1. Check out branch Sayali_Promotion_Confirmation_Frontend
2. Run npm install and npm run start:local
3. Clear site data/cache
4. Log in as admin (devadmin@hgn.net)
5. Go to Other Links → PR Team Analytics → navigate to localhost:5173/pr-grading-screen
6. Verify 🏆 Promote button appears under each reviewer name
7. Click Promote — verify confirmation modal shows reviewer info, weekly PR stats, consistency flag
8. Click ✅ Confirm Promotion — verify button changes to ✅ Promoted
9. Select multiple reviewers using checkboxes — verify "Promote Selected" bar appears at bottom
10. Click Promote Selected — verify batch confirmation modal shows all selected names
11. Click ✅ Confirm All — verify all selected show ✅ Promoted
12. Verify all above works in [dark mode]

## Screenshots or videos of changes:
<img width="1887" height="839" alt="image" src="https://github.com/user-attachments/assets/dac1898c-c07c-465a-9a6f-06122180f5a0" />
<img width="1919" height="869" alt="image" src="https://github.com/user-attachments/assets/f011bfce-7b88-4725-8224-97c2ccdca5d7" />
<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/dc74ce6c-6d76-41a2-989d-7a6bb41028d3" />
<img width="1919" height="869" alt="image" src="https://github.com/user-attachments/assets/a629682e-ea88-4589-8d72-8f82738f85ee" />
<img width="1919" height="871" alt="image" src="https://github.com/user-attachments/assets/f5c6bf12-0c5d-4b5e-befe-4ec5253e9d35" />
<img width="1224" height="801" alt="image" src="https://github.com/user-attachments/assets/c00a82ac-0590-4ee7-b5f7-b4309ad96cbd" />
<img width="1463" height="678" alt="image" src="https://github.com/user-attachments/assets/54c06de3-0d49-403e-a9b4-002730769228" />

## Note:
1. Backend endpoints (GET /api/promotion-details/:reviewerId and POST /promote-members) were already fully implemented — no backend changes were required for this task.
2. The promotion confirmation modal fetches real data from GET /api/promotion-details/:reviewerId. If the API call fails (e.g. reviewer not yet in promotionDetails collection), it gracefully falls back to local data from the grading screen so the UI never breaks.
3. The consistency flag (✅ Consistent / ⚠️ Inconsistent) is a visual indicator only it does not block the admin from confirming a promotion. This is intentional per task requirements.
4. Batch promotion calls POST /promote-members with all selected reviewer IDs, which logs the promotion action via PromotionEligibility model and logger.logInfo for auditing.
5. The ✅ Promoted state is session-only (resets on page refresh) persistence would require a separate backend field which is out of scope for this task.
