### PR TITLE
Maithili - fix: modify the css file that is used

### DIFF
--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -255,12 +255,12 @@
 }
 
 .isActive i {
-  color: lawngreen;
+  color: lawngreen !important;
   margin-top: 10px;
 }
 
 .isNotActive i {
-  color: #dee2e6;
+  color: #dee2e6 !important;
   margin-top: 10px;
 
 }


### PR DESCRIPTION
# Description
Fix dark mode active/inactive team indicator in the Team list
<img width="641" height="111" alt="Screenshot 2026-04-15 at 11 16 41 AM" src="https://github.com/user-attachments/assets/95d02bfb-a5e8-4f78-adec-8830165c5dab" />

## Related PRS (if any):
N/A
This is just the Front End PR

## Main changes explained:
- changes made to UserProfile.css file to use !important so that no amount of specificity can override it
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→  Other Links → Teams → Click on Active column header in the table 
6. verify - In both Dark and Light mode Active teams have green dot, inactive- gray dot 

## Screenshots or videos of changes:
<img width="980" height="888" alt="Screenshot 2026-04-10 at 11 10 38 AM" src="https://github.com/user-attachments/assets/33cd9c37-fc80-4f29-8f04-37399bb40bf8" />
<img width="1094" height="830" alt="Screenshot 2026-04-10 at 11 10 30 AM" src="https://github.com/user-attachments/assets/43287ba2-1af0-497a-b01c-c4ec801e8ab8" />

