### PR TITLE
Diya 🔥 fix(ui): Fixed Quick Setup Buttons on User Profile Page

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
@@ -91,7 +91,7 @@ function QuickSetupModal(props) {
   }, [stateTeamCodes, props.fetchTeamCodeAllUsers, props.setTeamCodes]);
 
   return (
-    <div className={`container pt-3 ${darkMode ? 'bg-yinmn-blue text-light border-0' : ''}`}>
+    <div className={darkMode ? 'bg-yinmn-blue text-light border-0' : ''}>
       {canAssignTitle || canEditTitle || canAddTitle ? (
         <QuickSetupCodes
           setSaved={props.setSaved}
@@ -109,62 +109,60 @@ function QuickSetupModal(props) {
         ''
       )}
 
-      <div className={`col ${styles['text-center']} mt-3 flex`}>
-        {canAddTitle ? (
+      <div className="d-flex justify-content-start mt-3 gap-2">
+      {canAddTitle ? (
+        <Button
+          color="primary"
+          className="mx-2"
+          onClick={() => setShowAddTitle(true)}
+          style={{ ...(darkMode ? boxStyleDark : boxStyle), width: '150px' }}
+          disabled={editMode == true}
+          title="Click this to add a new Quick Setup Title"
+        >
+          Add New QST
+        </Button>
+      ) : ''}
+      {canAddTitle ? (
+        <Button
+          color="primary"
+          className="mx-2"
+          onClick={() => showEditModal(true)}
+          style={{ ...(darkMode ? boxStyleDark : boxStyle), width: '150px' }}
+          disabled={editMode == true}
+          title="Click this to change the order of QST codes"
+        >
+          Change Order
+        </Button>
+      ) : ''}
+      {canEditTitle ? (
+        !editMode ? (
           <Button
             color="primary"
-            onClick={() => setShowAddTitle(true)}
-            style={darkMode ? boxStyleDark : boxStyle}
-            disabled={editMode == true}
-            title="Click this to add a new Quick Setup Title"
+            className="mx-2"
+            onClick={() => setEditMode(true)}
+            style={{ ...(darkMode ? boxStyleDark : boxStyle), width: '150px' }}
           >
-            Add New QST
+            Edit
           </Button>
         ) : (
-          ''
-        )}
-        {canAddTitle ? (
           <Button
-            color="primary mx-2"
-            onClick={() => showEditModal(true)}
-            style={darkMode ? boxStyleDark : boxStyle}
-            disabled={editMode == true}
-            title="Click this to change the order of QST codes"
+            color="primary"
+            className="mx-2"
+            onClick={() => setEditMode(false)}
+            style={{ ...(darkMode ? boxStyleDark : boxStyle), width: '150px' }}
           >
-            Change Order
+            Save
           </Button>
-        ) : (
-          ''
-        )}
-        {canEditTitle ? (
-          !editMode ? (
-            <Button
-              color="primary mx-2"
-              onClick={() => setEditMode(true)}
-              style={darkMode ? boxStyleDark : boxStyle}
-            >
-              Edit
-            </Button>
-          ) : (
-            <Button
-              color="primary mx-2"
-              onClick={() => setEditMode(false)}
-              style={darkMode ? boxStyleDark : boxStyle}
-            >
-              Save
-            </Button>
-          )
-        ) : (
-          ''
-        )}
-        <EditTitlesModal
-          isOpen={editModal}
-          toggle={() => showEditModal(false)}
-          titles={titles}
-          refreshModalTitles={refreshModalTitles}
-          darkMode={darkMode}
-        />
-      </div>
+        )
+      ) : ''}
+    </div>
+    <EditTitlesModal
+      isOpen={editModal}
+      toggle={() => showEditModal(false)}
+      titles={titles}
+      refreshModalTitles={refreshModalTitles}
+      darkMode={darkMode}
+    />
       {showAddTitle || editMode ? (
         <AddNewTitleModal
           teamsData={props.teamsData}


### PR DESCRIPTION
# Description
Fixes formatting issues with the Quick Setup Title (QST) buttons on the User Profile page, where the Edit/Save button was smaller than the Add New QST and Change Order buttons, and unnecessary padding was making the section look misaligned.

## Related PRs (if any):
None

## Main changes explained:
- Updated `QuickSetupModal.jsx` to remove the `container pt-3` wrapper class, causing unnecessary padding
- Changed the button container div to use `d-flex justify-content-start mt-3 gap-2` for proper button alignment
- Fixed all three buttons (Add New QST, Change Order, Edit/Save) to use `color="primary"` and `className` separately instead of stuffing margin classes into the `color` prop
- Moved `EditTitlesModal` outside the button container div so it no longer affects button sizing in the flex layout

## How to test:
1. Check out the current branch
2. Run `npm install --force` and start the dev server with `npm run start:local`
3. Clear site data/cache
4. Log in as an Owner or Administrator
5. Navigate to any user's profile page
6. Verify the **Add New QST**, **Change Order**, and **Edit/Save** buttons are all the same size and properly aligned
7. Click Edit and verify it switches to Save and remains the same size
8. Verify in dark mode

## Screenshots or videos of changes:
**Before:**
<img width="423" height="710" alt="Screenshot 2026-04-15 at 2 49 53 PM" src="https://github.com/user-attachments/assets/f7f50a99-490f-424a-99a9-87092ebdd6ed" />

**After:**
<img width="416" height="659" alt="Screenshot 2026-04-15 at 2 43 50 PM" src="https://github.com/user-attachments/assets/d3f5b446-2c0b-4901-9dd4-58cf739e6292" />