### PR TITLE
Sai Teja: Hide owner message upload after image selection

### DIFF
--- a/src/components/OwnerMessage/OwnerMessage.jsx
+++ b/src/components/OwnerMessage/OwnerMessage.jsx
@@ -51,8 +51,7 @@ function OwnerMessage({
   const [modalWrongPictureFormatWarning, setModalWrongPictureFormatWarning] = useState(false);
 
   const canEditHeaderMessage = dispatch(hasPermission('editHeaderMessage'));
-
-  const isImage = /;base64/g;
+  const isImageMessage = value => typeof value === 'string' && value.includes(';base64');
 
   function toggle() {
     setModal(!modal);
@@ -116,14 +115,14 @@ function OwnerMessage({
   }
 
   function getContent(messages) {
-    if (isImage.test(messages)) {
+    if (isImageMessage(messages)) {
       return <img src={messages} alt="" className={styles.ownerMessageImg} />;
     }
     return <span className={styles.message}>{messages}</span>;
   }
 
   function getHistoryContent(messages) {
-    if (isImage.test(messages)) {
+    if (isImageMessage(messages)) {
       return <img src={messages} alt="" className={styles.ownerMessageImg} />;
     }
     return <span>{messages}</span>;
@@ -165,6 +164,7 @@ function OwnerMessage({
   const headerBg = darkMode ? 'bg-space-cadet' : '';
   const bodyBg = darkMode ? 'bg-yinmn-blue' : '';
   const boxStyling = darkMode ? boxStyleDark : boxStyle;
+  const hasSelectedImage = isImageMessage(message);
 
   return (
     <div className={styles.messageContainer}>
@@ -250,20 +250,25 @@ function OwnerMessage({
             disabled={disableTextInput}
             className={styles.inputs}
           />
-          <p className="paragraph" style={{ marginTop: '1rem' }}>
-            Or upload a picture:
-          </p>
-          <span style={{ marginTop: '-1.25rem', marginBottom: '1rem', fontSize: '.8rem' }}>
-            (max size 1000 x 400 pixels and 100 KB)
-          </span>
-          <Input
-            id="image"
-            name="file"
-            type="file"
-            label="Choose Image"
-            onChange={event => handleImageUpload(event)}
-            className={styles.inputs}
-          />
+          {!hasSelectedImage && (
+            <>
+              <p className="paragraph" style={{ marginTop: '1rem' }}>
+                Or upload a picture:
+              </p>
+              <span style={{ marginTop: '-1.25rem', marginBottom: '1rem', fontSize: '.8rem' }}>
+                (max size 1000 x 400 pixels and 100 KB)
+              </span>
+              <Input
+                id="image"
+                name="file"
+                type="file"
+                label="Choose Image"
+                aria-label="Choose owner message image"
+                onChange={event => handleImageUpload(event)}
+                className={styles.inputs}
+              />
+            </>
+          )}
         </ModalBody>
 
         <ModalFooter

--- a/src/components/OwnerMessage/__tests__/OwnerMessage.test.jsx
+++ b/src/components/OwnerMessage/__tests__/OwnerMessage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -12,94 +12,99 @@ vi.mock('utils/permissions', () => {
 describe('OwnerMessage Component', () => {
   const middlewares = [thunk];
   const mockStore = configureStore(middlewares);
-
-  it('should render without errors', () => {
-    const initialState = {
-      auth: {
-        user: {
-          role: 'Owner',
+  const baseState = {
+    auth: {
+      user: {
+        role: 'Owner',
+      },
+    },
+    ownerMessage: {
+      message: 'Sample Message',
+      standardMessage: 'Sample Standard Message',
+      history: {
+        data: [],
+        pagination: {
+          page: 1,
+          totalPages: 1,
         },
       },
-      ownerMessage: {
-        message: 'Sample Message',
-        standardMessage: 'Sample Standard Message',
-      },
-      theme: {
-        darkMode: false,
-      },
-    };
+    },
+    theme: {
+      darkMode: false,
+    },
+  };
 
-    // Create a mock store with initial state
+  function renderComponent(initialState = baseState) {
     const store = mockStore(initialState);
-
-    // Mock the action creators
     store.dispatch = vi.fn();
 
-    // Render with Provider
     render(
       <Provider store={store}>
         <OwnerMessage />
       </Provider>,
     );
 
-    // Basic assertion to check if the component rendered
+    return store;
+  }
+
+  it('should render without errors', () => {
+    renderComponent();
+
     expect(screen.getByText('Sample Message')).toBeInTheDocument();
   });
 
   it('should display standard message when no owner message exists', () => {
-    const initialState = {
-      auth: {
-        user: {
-          role: 'Owner',
-        },
-      },
+    renderComponent({
+      ...baseState,
       ownerMessage: {
+        ...baseState.ownerMessage,
         message: null,
-        standardMessage: 'Sample Standard Message',
       },
-      theme: {
-        darkMode: false,
-      },
-    };
-
-    const store = mockStore(initialState);
-    store.dispatch = vi.fn();
-
-    render(
-      <Provider store={store}>
-        <OwnerMessage />
-      </Provider>,
-    );
+    });
 
     expect(screen.getByText('Sample Standard Message')).toBeInTheDocument();
   });
 
   it('should show edit and delete buttons for owner role', () => {
-    const initialState = {
-      auth: {
-        user: {
-          role: 'Owner',
-        },
-      },
-      ownerMessage: {
-        message: 'Sample Message',
-        standardMessage: 'Sample Standard Message',
-      },
-      theme: {
-        darkMode: false,
-      },
-    };
-
-    const store = mockStore(initialState);
-    store.dispatch = vi.fn();
-
-    render(
-      <Provider store={store}>
-        <OwnerMessage />
-      </Provider>,
-    );
+    renderComponent();
 
     expect(screen.getByTitle('Edit this header')).toBeInTheDocument();
     expect(screen.getByTitle('Click to restore header to standard message')).toBeInTheDocument();
+  });
+
+  it('hides the image upload controls after a photo is selected', async () => {
+    const originalFileReader = global.FileReader;
+
+    class MockFileReader {
+      onloadend = null;
+
+      readAsDataURL() {
+        this.result = 'data:image/png;base64,mock-image-payload';
+        queueMicrotask(() => {
+          this.onloadend?.();
+        });
+      }
+    }
+
+    global.FileReader = MockFileReader;
+
+    renderComponent();
+
+    fireEvent.click(screen.getByLabelText('Edit header message'));
+    expect(screen.getByText('Or upload a picture:')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Choose owner message image'), {
+      target: {
+        files: [new File(['mock'], 'owner-message.png', { type: 'image/png' })],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Or upload a picture:')).not.toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText('Choose owner message image')).not.toBeInTheDocument();
+
+    global.FileReader = originalFileReader;
   });
 });


### PR DESCRIPTION
# Description
<img width="677" height="649" alt="Screenshot 2026-04-17 at 11 19 03 PM" src="https://github.com/user-attachments/assets/8ad9708a-8808-4113-9023-53d6ec13fe17" />

Implements the follow-up owner message UI fix to hide the image upload section once a valid photo is selected in the owner message modal. This is a frontend-only change related to the existing owner message flow and prevents the modal from continuing to show upload controls after the message has already become an image payload.

Implements # (PRIORITY HIGH) Hide image payload when a photo is chosen for owner message

## Related PRS (if any):
This is a frontend-only PR.
It is a follow-up to the earlier owner message work introduced in PR #4769.

## Main changes explained:
- Update `src/components/OwnerMessage/OwnerMessage.jsx` to detect image-based owner messages with a stable string-based helper instead of the previous regex-based check.
- Update `src/components/OwnerMessage/OwnerMessage.jsx` to hide the image upload text, size note, and file input once a valid image has been selected.
- Update `src/components/OwnerMessage/OwnerMessage.jsx` to add an accessible label to the image input for clearer targeting and testability.
- Update `src/components/OwnerMessage/__tests__/OwnerMessage.test.jsx` to add a focused test that verifies the upload controls disappear after image selection.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as a user with permission to edit the owner message.
5. Go to the Dashboard and look at the top header owner message area.
6. Click the owner message edit icon to open the Create message modal.
7. Verify that before selecting an image, the modal shows:
- the text area
- Or upload a picture:
- the size note
- the file input
8. Select a valid .png, .jpg, or .jpeg image.
9. Verify that after image selection:
- Or upload a picture: is no longer visible
- the size note is no longer visible
- the file input is no longer visible
- the text area remains visible and is disabled
10. Save the message and verify the owner message image still displays correctly in the header.
11. Reopen the modal and confirm the upload controls remain hidden for the image-based owner message.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/929d88b4-b97d-4566-ac8c-70e7170c3b9f

## Note:
Include the information the reviewers need to know.
