### PR TITLE
Roshini Seelamsetty : Fix fixing the Teams UI

### DIFF
--- a/src/components/Teams/TeamTableHeader.module.css
+++ b/src/components/Teams/TeamTableHeader.module.css
@@ -1,6 +1,13 @@
 .teamNameCol {
   width: 55%;
   white-space: normal;
-  word-break: break-word;
+  word-break: break-all;
   overflow-wrap: anywhere;
+}
+
+/* Media queries for responsive design */
+@media (width <= 575px) {
+  .teamNameCol {
+    font-size: 12px;
+  }
 }

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -207,6 +207,7 @@ class Teams extends React.PureComponent {
               onActiveClick={() => this.setFilter(FILTER_ACTIVE)}
               onInactiveClick={() => this.setFilter(FILTER_INACTIVE)}
               selectedFilter={this.state.selectedFilter}
+              darkMode={darkMode}
             />
             <TeamTableSearchPanel
               onSearch={this.onWildCardSearch}

--- a/src/components/Teams/TeamsOverview.jsx
+++ b/src/components/Teams/TeamsOverview.jsx
@@ -10,6 +10,7 @@ const TeamsOverview = ({
   onInactiveClick,
   onAllClick,
   selectedFilter,
+  darkMode,
 }) => {
   const getCardClass = filterType => {
     const base = [styles.card];
@@ -19,6 +20,8 @@ const TeamsOverview = ({
     if (filterType === 'inactive') base.push(styles.inactiveCard);
 
     if (selectedFilter === filterType) base.push(styles.selectedFilter);
+
+    if (darkMode) base.push(styles.darkMode);
 
     return base.join(' ');
   };

--- a/src/components/Teams/TeamsOverview.module.css
+++ b/src/components/Teams/TeamsOverview.module.css
@@ -36,6 +36,7 @@
   align-items: center;
   justify-content: center;
   margin-top: 5px;
+  font-size: 14px;
 }
 
 .cardTextIcon {
@@ -54,6 +55,22 @@
   color: #dee2e6;
 }
 
+/* Dark mode styles */
+.darkMode.totalCard {
+  background: linear-gradient(to bottom, #2c3e50, #34495e, #2c3e50);
+  color: #ecf0f1;
+}
+
+.darkMode.activeCard {
+  background: linear-gradient(to bottom, #e67e22, #d35400, #e74c3c);
+  color: #ecf0f1;
+}
+
+.darkMode.inactiveCard {
+  background: linear-gradient(to bottom, #7d3c98, #6c3483, #5b2c6f) !important;
+  color: #ecf0f1;
+}
+
 /* If you still use this class elsewhere, we can keep it here too */
 .teamNameCol {
   width: 40%;
@@ -68,4 +85,30 @@
   gap: 16px;
   align-items: center;
   margin: 25px 0;
+}
+
+/* Media queries for responsive design */
+@media (width <= 768px) {
+  .card {
+    width: 250px;
+  }
+  
+  .cardText {
+    font-size: 12px;
+  }
+  
+  .overviewTop {
+    flex-direction: column;
+    gap: 8px;
+  }
+}
+
+@media (width <= 575px) {
+  .card {
+    width: 200px;
+  }
+  
+  .cardText {
+    font-size: 11px;
+  }
 }


### PR DESCRIPTION

# Description

<img width="789" height="548" alt="Screenshot 2026-04-18 at 22 12 31" src="https://github.com/user-attachments/assets/fa83ddeb-9fd9-4d61-9cb6-a81215e069a0" />

<img width="757" height="704" alt="Screenshot 2026-04-18 at 22 13 33" src="https://github.com/user-attachments/assets/605e209a-2253-48ab-ae39-0c632340db3b" />

## Related PRS (if any):
Related to PRs #2416, #2838, #2736


## Main changes explained:
- Updated TeamsOverview.jsx to accept darkMode prop and apply conditional styling
- Updated TeamsOverview.module.css to add responsive media queries and dark mode styles for the top 3 stat cards
- Updated TeamTableHeader.module.css to add responsive font sizing for the Team Names column
- Updated Teams.jsx to pass darkMode prop to TeamOverview component


## How to test:
1. Check into branch Roshini_Fixing_The_Teams_UI
2. Run npm install to install dependencies, then run the app locally (npm start)
3. Clear site data/cache
4. Log as admin/owner user
5. Go to admin/owner profile → Other Links → Teams
6. Verify responsive behavior:

    - At 768px and below: text in top 3 cards should be reduced in size and cards stack vertically
    - At 575px and below: Team Names column font size should be reduced
    - Toggle dark mode: overview cards should display with dark theme colors
 
## Screenshots or videos of changes:


https://github.com/user-attachments/assets/50e2ccae-fadd-4950-b861-6f0a84ee5cf2


https://github.com/user-attachments/assets/79265d22-4a29-4caa-8d3c-49e2410a4aec


