### PR TITLE
Diya 🔥 fix(teams): Teams Autosave from UserProfile Page

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { addTeamMember, deleteTeamMember } from '~/actions/allTeamsAction';
 import { toast } from 'react-toastify';
 import AddTeamPopup from './AddTeamPopup';
@@ -33,6 +34,7 @@ function TeamsTab(props) {
   const [addTeamPopupOpen, setaddTeamPopupOpen] = useState(false);
   const [renderedOn, setRenderedOn] = useState(0);
   const [removedTeams, setRemovedTeams] = useState([]);
+  const dispatch = useDispatch();
 
   useEffect(() => {
     if (typeof fetchTeamCodeAllUsers === 'function') {
@@ -57,10 +59,10 @@ function TeamsTab(props) {
     setaddTeamPopupOpen(false);
   };
 
-  const onSelectDeleteTeam = teamId => {
+  const onSelectDeleteTeam = async teamId => {
     try {
       if (userProfile._id) {
-        deleteTeamMember(teamId, userProfile._id);
+        await dispatch(deleteTeamMember(teamId, userProfile._id));
       }
       setUserProfile(prev => ({
       ...prev,
@@ -75,18 +77,27 @@ function TeamsTab(props) {
     }
   };
 
-  const onSelectAssignTeam = team => {
+  const onSelectAssignTeam = async team => {
     try {
       if (userProfile?._id) {
-        addTeamMember(team._id, userProfile._id, userProfile.firstName, userProfile.lastName);
+        await dispatch(addTeamMember(team._id, userProfile._id, userProfile.firstName, userProfile.lastName));
       }
+      const updatedTeams = [...(userProfile?.teams || []), team];
+
       if (setUserProfile) {
       setUserProfile(prev => ({
         ...prev,
-        teams: [...(prev.teams || []), team],
-      }));
-    }
+        teams: updatedTeams,
+        }));
+      }
       onAssignTeam(team);
+      if (typeof handleSubmit === 'function') {
+        await handleSubmit({
+          ...userProfile,
+          teams: updatedTeams.map(t => t._id || t),
+        });
+      }
+
       toast.success('Team assigned successfully');
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/TeamsTab.jsx
@@ -4,6 +4,7 @@ import { addTeamMember, deleteTeamMember } from '~/actions/allTeamsAction';
 import { toast } from 'react-toastify';
 import AddTeamPopup from './AddTeamPopup';
 import UserTeamsTable from './UserTeamsTable';
+import PropTypes from 'prop-types';
 
 function TeamsTab(props) {
   const {
@@ -147,4 +148,14 @@ function TeamsTab(props) {
     </>
   );
 }
+
+TeamsTab.propTypes = {
+  userProfile: PropTypes.shape({
+    _id: PropTypes.string,
+    firstName: PropTypes.string,
+    lastName: PropTypes.string,
+    teams: PropTypes.arrayOf(PropTypes.object),
+  }),
+};
+
 export default TeamsTab;

--- a/src/components/UserProfile/TeamsAndProjects/__tests__/TeamsTab.test.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/__tests__/TeamsTab.test.jsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-// Add this with the other vi.mock() calls at the TOP, before any imports
 vi.mock('react-redux', () => ({
   __esModule: true,
-  useDispatch: () => fn => fn(), // mock dispatch to just call the thunk directly
+  useDispatch: () => fn => Promise.resolve(fn),
 }));
 
 // MUST come before you import TeamsTab!
@@ -41,10 +40,11 @@ vi.mock('../UserTeamsTable', () => ({
 }));
 
 // Stub your action creators
+// REPLACE the allTeamsAction mock with this:
 vi.mock('../../../../actions/allTeamsAction', () => ({
   __esModule: true,
-  addTeamMember: vi.fn(),
-  deleteTeamMember: vi.fn(),
+  addTeamMember: vi.fn(() => 'addTeamMember_result'),
+  deleteTeamMember: vi.fn(() => 'deleteTeamMember_result'),
 }));
 
 // Stub toast

--- a/src/components/UserProfile/TeamsAndProjects/__tests__/TeamsTab.test.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/__tests__/TeamsTab.test.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { vi } from 'vitest';
 
+// Add this with the other vi.mock() calls at the TOP, before any imports
+vi.mock('react-redux', () => ({
+  __esModule: true,
+  useDispatch: () => fn => fn(), // mock dispatch to just call the thunk directly
+}));
+
 // MUST come before you import TeamsTab!
 vi.mock('../AddTeamPopup', () => ({
   __esModule: true,

--- a/src/components/UserProfile/TeamsAndProjects/__tests__/TeamsTab.test.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/__tests__/TeamsTab.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // Add this with the other vi.mock() calls at the TOP, before any imports
 vi.mock('react-redux', () => ({
@@ -55,7 +56,6 @@ vi.mock('react-toastify', () => ({
   },
 }));
 
-import { render, screen, fireEvent } from '@testing-library/react';
 import TeamsTab from '../TeamsTab';
 import { addTeamMember, deleteTeamMember } from '../../../../actions/allTeamsAction';
 import { toast } from 'react-toastify';
@@ -118,28 +118,29 @@ describe('TeamsTab (unit)', () => {
     expect(screen.getByTestId('add-team-popup')).toHaveAttribute('data-open', 'false');
   });
 
-  it('6. calls onDeleteTeam and toast.success on delete', () => {
+  it('6. calls onDeleteTeam and toast.success on delete', async () => {
     render(<TeamsTab {...baseProps} />);
     fireEvent.doubleClick(screen.getByTestId('user-teams-table'));
-    expect(baseProps.onDeleteTeam).toHaveBeenCalledWith('TEAM123');
-    expect(toast.success).toHaveBeenCalledWith('Team Deleted successfully');
+    await waitFor(() => {
+      expect(baseProps.onDeleteTeam).toHaveBeenCalledWith('TEAM123');
+      expect(toast.success).toHaveBeenCalledWith('Team Deleted successfully');
+    });
   });
 
-  it('7. calls onAssignTeam, addTeamMember and toast.success on assign', () => {
+  it('7. calls onAssignTeam, addTeamMember and toast.success on assign', async () => {
     render(<TeamsTab {...baseProps} />);
-    // open popup so it's mounted with open=true
     fireEvent.click(screen.getByTestId('user-teams-table'));
-    // double-click popup to simulate assign
     fireEvent.doubleClick(screen.getByTestId('add-team-popup'));
-
-    expect(baseProps.onAssignTeam).toHaveBeenCalledWith({ _id: 'TEAM999' });
-    expect(addTeamMember).toHaveBeenCalledWith(
-      'TEAM999',
-      baseProps.userProfile._id,
-      baseProps.userProfile.firstName,
-      baseProps.userProfile.lastName,
-    );
-    expect(toast.success).toHaveBeenCalledWith('Team assigned successfully');
+    await waitFor(() => {
+      expect(baseProps.onAssignTeam).toHaveBeenCalledWith({ _id: 'TEAM999' });
+      expect(addTeamMember).toHaveBeenCalledWith(
+        'TEAM999',
+        baseProps.userProfile._id,
+        baseProps.userProfile.firstName,
+        baseProps.userProfile.lastName,
+      );
+      expect(toast.success).toHaveBeenCalledWith('Team assigned successfully');
+    });
   });
 
   it('8. runs the saved→useEffect and clears removedTeams', () => {


### PR DESCRIPTION
# Description
Fixes the Teams tab on the User Profile page where adding a new team required manually clicking "Save Changes" to persist. The team assignment API was being called correctly but handleSubmit was reading stale profile data from the ref, causing the PUT request to send the old team list without the newly added team.

## Related PRS (if any):
None

## Main changes explained:
- Updated TeamsTab.jsx — added useDispatch import and dispatched addTeamMember and deleteTeamMember properly as Redux thunks (previously called without dispatch, so the API calls never fired)
- Updated TeamsTab.jsx — onSelectAssignTeam now constructs updatedTeams before calling handleSubmit, passing the new team list explicitly to avoid a stale closure/ref race condition where userProfileRef.current still held the old teams at the time of the PUT request
- Updated TeamsTab.jsx — onSelectAssignTeam now calls handleSubmit automatically after a successful team assignment, making the save happen without requiring the user to click "Save Changes"

## How to test:
1. Check out the current branch
2. Run npm install and start the dev server
3. Clear site data/cache
4. Log in as admin user
5. Go to any user's profile → click the Teams tab
6. Click Assign Team → select or create a team → click Confirm
7. Verify the team appears in the list and a success toast shows
8. Reload the page → go back to Teams tab → verify the new team is still there (confirming it persisted to the DB)
9. Click Delete on a team → verify it's removed and persists after reload

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/ba9ca0e2-b85e-49cd-bae8-58c0f9e81f58


## Note:
The root cause was two bugs compounding each other. First, addTeamMember and deleteTeamMember are Redux thunks and must be called via dispatch — without it, the function returns a thunk object but never executes the API call. Second, even after fixing the dispatch, handleSubmit was reading userProfileRef.current which hadn't updated yet at call time (React state batching), so the PUT payload was missing the new team. Passing updatedTeams explicitly as an argument to handleSubmit bypasses the stale ref entirely.