### PR TITLE
Diya 🔥 fix(popup): Fixed Project Page Button Popups

### DIFF
--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -94,9 +94,12 @@ const Projects = function(props) {
 
   const onClickArchiveBtn = projectData => {
     setProjectTarget(projectData);
+    const archiveMessage = projectData.isArchived
+      ? `<p style="${darkMode ? 'color: white' : 'color: black'}">Do you want to unarchive <b>${projectData.projectName}</b>? This will restore it and its tasks.</p>`
+      : `<p style="${darkMode ? 'color: white' : 'color: black'}"><b>Hold on!</b><br/>Archiving <b>${projectData.projectName}</b> will deactivate all its WBS, tasks, and time entries, and remove it from all team members' profiles.<br/><b>Sure about this?</b></p>`;
     setModalData({
       showModal: true,
-      modalMessage: `<p style="${darkMode ? 'color: white' : 'color: black'}">Do you want to ${projectData.isArchived ? 'unarchive' : 'archive'} ${projectData.projectName}?</p>`,
+      modalMessage: archiveMessage,
       modalTitle: projectData.isArchived ? 'Confirm Unarchive' : CONFIRM_ARCHIVE,
       hasConfirmBtn: true,
       hasInactiveBtn: false,
@@ -431,7 +434,7 @@ const Projects = function(props) {
         darkMode={darkMode}
         confirmButtonText={isArchiving
           ? (projectTarget.isArchived ? 'Unarchiving...' : 'Archiving...') 
-          : (projectTarget.isArchived ? 'Unarchive' : 'Confirm')
+          : (projectTarget.isArchived ? 'Unarchive' : 'Yes, archive it')
         }
         isConfirmDisabled={isArchiving}
         setInactiveButton={isChangingStatus ? 'Setting Inactive' : 'Yes, hide it all'}

--- a/src/components/common/Modal/Modal.jsx
+++ b/src/components/common/Modal/Modal.jsx
@@ -88,14 +88,42 @@ const ModalExample = props => {
       </ModalBody>
       <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
         {setInactiveModal != null ? (
-          <Button color="danger" onClick={closeModal} style={darkMode ? boxStyleDark : boxStyle}>
-            Nope, changed my mind
-          </Button>
+          <>
+            <Button
+              color="secondary"
+              onClick={closeModal}
+              style={darkMode ? boxStyleDark : boxStyle}
+            >
+              Nope, changed my mind
+            </Button>
+            <Button
+              color="success"
+              disabled={isSetInactiveDisabled}
+              onClick={setInactiveModal}
+              style={darkMode ? boxStyleDark : boxStyle}
+            >
+              {isSetInactiveDisabled ? 'Setting Inactive...' : setInactiveButton}
+            </Button>
+          </>
         ) : null}
         {setActiveModal != null ? (
-          <Button color="danger" onClick={closeModal} style={darkMode ? boxStyleDark : boxStyle}>
-            Nope, leave it buried
-          </Button>
+          <>
+            <Button
+              color="secondary"
+              onClick={closeModal}
+              style={darkMode ? boxStyleDark : boxStyle}
+            >
+              Nope, leave it buried
+            </Button>
+            <Button
+              color="success"
+              disabled={isSetActiveDisabled}
+              onClick={setActiveModal}
+              style={darkMode ? boxStyleDark : boxStyle}
+            >
+              {isSetActiveDisabled ? 'Setting Active...' : setActiveButton}
+            </Button>
+          </>
         ) : null}
         {/*
         {confirmModal != null ? (
@@ -151,7 +179,7 @@ const ModalExample = props => {
         {/* Close button */}
         {confirmModal && (
           <Button color="secondary" onClick={closeModal} style={darkMode ? boxStyleDark : boxStyle}>
-            Close
+            Nope, changed my mind
           </Button>
         )}
 

--- a/src/components/common/Modal/__tests__/Modal.test.jsx
+++ b/src/components/common/Modal/__tests__/Modal.test.jsx
@@ -37,7 +37,7 @@ describe('ModalExample Component', () => {
       </Provider>,
     );
 
-    fireEvent.click(screen.getByText('Close'));
+    fireEvent.click(screen.getByText('Nope, changed my mind'));
     expect(closeModalMock).toHaveBeenCalledTimes(1);
   });
 
@@ -110,7 +110,7 @@ describe('ModalExample Component', () => {
       />,
     );
 
-    fireEvent.click(screen.getByText(/yes, hide it all/i));
+    fireEvent.click(screen.getAllByText(/yes, hide it all/i)[0]);
     expect(setInactiveModalMock).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
# Description
Fixes two issues on the Projects page: archived projects were not viewable, and the project status/archive confirmation modals were missing confirm buttons and lacked descriptive messaging about what the actions actually do.

**Fixes:** Bug — Archived projects not viewable; inactive/archive modals missing confirm actions and context

## Related PRS (if any):
None

## Main changes explained:
- Updated Projects.jsx — added showArchived state and handleFetchArchivedProjects toggle; calls fetchAllArchivedProjects when toggled on and fetchAllProjects when toggled off; fixed generateProjectList to use isShowingArchived parameter to avoid stale closure bug
- Updated Projects.jsx — moved "Show Archived" button out of SearchProjectByPerson into the main toolbar as a standalone button
- Updated Projects.jsx — archive modal now shows a descriptive warning explaining that archiving deactivates all WBS, tasks, time entries and removes the project from all team member profiles
- Updated Projects.jsx — confirm button text now reads "Yes, archive it" / "Unarchive" / "Yes, archive it" contextually, and shows "Archiving..." / "Unarchiving..." while in progress
- Updated Projects.jsx — confirmArchive now toggles isArchived instead of hardcoding true, enabling unarchiving; refreshes the correct project list based on current view
- Updated Project.jsx — Archive button label now shows "Unarchive" when the project is already archived
- Updated Modal/index.jsx — inactive and active confirmation modals now render their confirm buttons ("Yes, hide it all" / "Yes, revive the monster") inline alongside their cancel buttons, matching the archive modal layout

## How to test:
1. Check out the current branch
2. Run npm install and start the dev server
3. Clear site data/cache
4. Log in as admin user
5. Go to the Projects page
6. Click the Active dot on any project → verify the Inactive modal shows the warning message with both "Nope, changed my mind" and "Yes, hide it all" buttons
7. Click "Yes, hide it all" → verify the project goes inactive
8. Click the Inactive dot → verify the Active modal shows with "Nope, leave it buried" and "Yes, revive the monster"
9. Click Archive on any project → verify the modal shows the archiving warning with "Nope, changed my mind" and "Yes, archive it"
10. Click "Yes, archive it" → verify the project disappears from the list
11. Click Show Archived → verify the archived project appears with an Unarchive button
12. Click Unarchive → verify the modal says "Confirm Unarchive" with an Unarchive button → confirm → verify it returns to the main list

## Screenshots or videos of changes:
Before: 
<img width="1022" height="792" alt="AllPre" src="https://github.com/user-attachments/assets/eed4c2ce-469f-4d23-aa8f-31e44de331af" />

After:
<img width="1888" height="1031" alt="AllPost" src="https://github.com/user-attachments/assets/21a3087e-fb31-497c-9846-76b12e3673ff" />