### PR TITLE
Sayali: replace hardcoded API URL with ENDPOINTS and improve network err…

### DIFF
--- a/src/components/LandingPage/HelpModal.jsx
+++ b/src/components/LandingPage/HelpModal.jsx
@@ -69,7 +69,7 @@ function HelpModal({ show, onHide, auth }) {
     setIsSubmitting(true);
 
     try {
-      await axios.post('http://localhost:4500/api/helprequest/create', {
+      await axios.post(ENDPOINTS.HELP_REQUEST_CREATE, {
         userId,
         topic: selectedOption,
         description: `Help request for: ${selectedOption}`,
@@ -80,9 +80,13 @@ function HelpModal({ show, onHide, auth }) {
       onHide();
     } catch (err) {
       console.error('Help request submission error:', err);
-      const errorMessage =
-        err.response?.data?.message || 'Failed to submit help request. Please try again.';
-      toast.error(errorMessage);
+      if (err.code === 'ERR_NETWORK' || !err.response) {
+        toast.error('Cannot connect to server. Please ensure the backend is running.');
+      } else {
+        const errorMessage =
+          err.response?.data?.message || 'Failed to submit help request. Please try again.';
+        toast.error(errorMessage);
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -246,11 +246,11 @@ export const ENDPOINTS = {
     if (startDate) params.append('startDate', startDate);
     if (endDate) params.append('endDate', endDate);
     if (groupBy) params.append('groupBy', groupBy);
-    
+
     const queryString = params.toString();
     return queryString ? `${url}?${queryString}` : url;
   },
-  
+
   INJURY_PROJECTS: () => `${APIEndpoint}/injuries/projects`,
 
   PRESETS: () => `${APIEndpoint}/rolePreset`,
@@ -301,14 +301,14 @@ export const ENDPOINTS = {
   PERMISSION_CHANGE_LOGS: userId => `${APIEndpoint}/permissionChangeLogs/${userId}`,
 
   GET_TOTAL_COUNTRY_COUNT: () => `${APIEndpoint}/getTotalCountryCount`,
-  
+
   ANALYTICS_AVAILABLE_ROLES: () => `${APIEndpoint}/analytics/roles`,
 
   // Country Application Map Chart endpoints
   COUNTRY_APPLICATION_DATA: (params = {}) => {
     let url = `${APIEndpoint}/analytics/country-applications`;
     const queryParams = new URLSearchParams();
-    
+
     if (params.roles && params.roles.length > 0) {
       queryParams.append('roles', params.roles.join(','));
     }
@@ -325,7 +325,7 @@ export const ENDPOINTS = {
     if (params.customDateRange) {
       queryParams.append('customDateRange', 'true');
     }
-    
+
     const queryString = queryParams.toString();
     return queryString ? `${url}?${queryString}` : url;
   },
@@ -437,8 +437,8 @@ export const ENDPOINTS = {
   BM_ORGS_WITH_LOCATION: `${APIEndpoint}/bm/orgLocation`,
   ORG_DETAILS: projectId => `${APIEndpoint}/bm/orgLocation/${projectId}`,
   BM_PROJECT_MEMBERS: projectId => `${APIEndpoint}/bm/project/${projectId}/users`,
-  BM_UPDATE_NAME_AND_UNIT :invtypeId => `${APIEndpoint}/bm/invtypes/material/${invtypeId}`,
-  BM_ITEM_UPDATE_HISTORY: invtypeId =>`${APIEndpoint}/bm/invtypes/${invtypeId}/history`,
+  BM_UPDATE_NAME_AND_UNIT: invtypeId => `${APIEndpoint}/bm/invtypes/material/${invtypeId}`,
+  BM_ITEM_UPDATE_HISTORY: invtypeId => `${APIEndpoint}/bm/invtypes/${invtypeId}/history`,
 
   PROJECT_GLOBAL_DISTRIBUTION: `${APIEndpoint}/projectglobaldistribution`,
 
@@ -567,6 +567,7 @@ export const ENDPOINTS = {
   LB_LISTING_AVAILABILITY: `${APIEndpoint}/lb/listing/availability`,
   LB_LISTING_BOOK: `${APIEndpoint}/lb/listing/availability/booking`,
   HELP_CATEGORIES: `${APIEndpoint}/help-categories`,
+  HELP_REQUEST_CREATE: `${APIEndpoint}/helprequest/create`,
   APPLICANT_SOURCES: `${APIEndpoint}/applicant-analytics/applicant-sources`,
 
   // job analytics
@@ -645,10 +646,10 @@ export const ENDPOINTS = {
   KI_CALENDAR_EVENTS: (month, year) => `${APIEndpoint}/kitchenandinventory/calendar?month=${month}&year=${year}`,
 
   // Help Request & Feedback Modal endpoints
-HGN_FORM_RANKED: `${APIEndpoint}/hgnform/ranked`,
-HELP_REQUEST_CHECK_MODAL: userId => `${APIEndpoint}/helprequest/check-modal/${userId}`,
-FEEDBACK_CLOSE_PERMANENTLY: `${APIEndpoint}/feedback/close-permanently`,
-FEEDBACK_SUBMIT: `${APIEndpoint}/feedback/submit`,
+  HGN_FORM_RANKED: `${APIEndpoint}/hgnform/ranked`,
+  HELP_REQUEST_CHECK_MODAL: userId => `${APIEndpoint}/helprequest/check-modal/${userId}`,
+  FEEDBACK_CLOSE_PERMANENTLY: `${APIEndpoint}/feedback/close-permanently`,
+  FEEDBACK_SUBMIT: `${APIEndpoint}/feedback/submit`,
   // application time analytics
   APPLICATION_TIME_DATA: (startDate, endDate, roles) => {
     let url = `${APIEndpoint}/analytics/application-time?`;


### PR DESCRIPTION
# Description
Fixes #22 (Priority Medium) - Follow-up fix for HGN Questionnaire Dashboard: Help Request Submission

## Related PRs:
Follow-up to merged PR #4844 (Sayali - Add: Success and Error Feedback to Help Request Submission)

## Main changes explained:
- Replaced hardcoded `http://localhost:4500/api/helprequest/create` URL with `ENDPOINTS.HELP_REQUEST_CREATE` in `HelpModal.jsx`
- Added `HELP_REQUEST_CREATE` endpoint to `src/utils/URL.js`
- Improved error handling to distinguish network errors from API errors in `HelpModal.jsx`

## How to test:
1. Checkout branch `Sayali_Fix_HelpModal_Network_Error`
2. `npm install` and `npm run start:local`
3. Clear site data/cache, log in as admin
4. Navigate to `/hgnhelp`
5. With backend running: select category, submit → verify success toast appears
6. With backend stopped: verify "Failed to load help categories" shows, Submit button disabled

##Screenshots
1. Backend running → success toast "Help request submitted successfully!" 
<img width="434" height="300" alt="image" src="https://github.com/user-attachments/assets/adabe0ea-8caf-4234-b0ad-711f6718a9ff" />

2.Backend stopped → modal showing "Failed to load help categories" + disabled Submit button 
<img width="1150" height="592" alt="image" src="https://github.com/user-attachments/assets/f503632c-255c-4774-ba3a-12401cfeed74" />

## Note:
This fixes the reviewer's reported issue where "Failed to submit" error appeared when backend was stopped, caused by hardcoded localhost URL bypassing the Vite proxy.