### PR TITLE
Sayali: fix selected skill button text color in dark mode

### DIFF
--- a/src/components/HGNSkillsDashboard/SkillsProfilePage/styles/Skills.module.css
+++ b/src/components/HGNSkillsDashboard/SkillsProfilePage/styles/Skills.module.css
@@ -91,6 +91,6 @@
   background-color: #444;
 }
 
-:global(.dark-mode) .skills button.selected {
-  color: #8ab4f8;
+.darkMode button.selected {
+  color: #8ab4f8 !important;
 }


### PR DESCRIPTION
# Description
Fixes #21 (Priority High) - Follow-up fix for HGN Questionnaire Dashboard Skills Profile Page

## Related PRs:
Follow-up to merged PR #4971 (Sayali - Fix Dashboard Chart Resize and Dark Mode Styling)

## Main changes explained:
- Fixed selected skill button text color not showing blue in dark mode
- Added `.darkMode button.selected` CSS rule in `Skills.module.css`
- Root cause: CSS specificity issue where dark mode button color was overriding selected state color

## How to test:
1. Checkout branch `Sayali_Fix_Skills_DarkMode_Button`
2. `npm install` && `npm run start:local`
3. Clear cache, log in as admin
4. Navigate to `http://localhost:5173/hgn/profile/skills`
5. Switch to dark mode
6. Click any skill button (Dashboard, Frontend, Backend, etc.)
7. Verify selected button shows blue text in dark mode
8. Verify light mode still works correctly

## Screenshots or videos of changes:
<img width="958" height="540" alt="image" src="https://github.com/user-attachments/assets/4a4bb990-1d3e-4a77-b7b3-f418007b3ce2" />

## Note:
Fix for reviewer feedback on PR #4971 - selected skill button color not changing to blue in dark mode.