### PR TITLE
Sayali : pass reviewerCount and reviewerNames to PR grading screen for DB…

### DIFF
--- a/src/components/PRGradingScreen/PRGradingTest.jsx
+++ b/src/components/PRGradingScreen/PRGradingTest.jsx
@@ -33,6 +33,8 @@ const PRGradingTest = () => {
             cfg.testDataType
           }${cfg.notes ? ` — ${cfg.notes}` : ''}`,
           fromDB: true,
+          reviewerCount: cfg.reviewerCount,
+          reviewerNames: cfg.reviewerNames || [],
         }));
         setDynamicTeams(fetched);
       } catch {
@@ -47,7 +49,8 @@ const PRGradingTest = () => {
   const allTeams = [...STATIC_TEAMS, ...dynamicTeams];
 
   const handleTeamSelect = teamId => {
-    history.push('/pr-grading-screen', { teamId });
+    const team = allTeams.find(t => t.id === teamId);
+    history.push('/pr-grading-screen', { teamId, config: team });
   };
 
   const handleDeleteConfig = async (e, teamId) => {

--- a/src/components/PRGradingScreen/index.jsx
+++ b/src/components/PRGradingScreen/index.jsx
@@ -1,15 +1,36 @@
-import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
 import { getDataByTeamId } from './mockData';
 import PRGradingScreen from './PRGradingScreen';
 
+const STATIC_IDS = ['team1', 'team2', 'team3'];
+
 const PRGradingScreenContainer = () => {
   const location = useLocation();
-
-  // Get teamId from router state, fallback to default
   const teamId = location.state?.teamId || 'team1';
-  const data = getDataByTeamId(teamId);
+  const config = location.state?.config || null;
 
+  if (!STATIC_IDS.includes(teamId) && config) {
+    const reviewers = Array.from({ length: config.reviewerCount }, (_, i) => ({
+      id: uuidv4(),
+      reviewer: config.reviewerNames?.[i] || `Reviewer ${i + 1}`,
+      prsNeeded: 10,
+      prsReviewed: 0,
+      gradedPrs: [],
+    }));
+
+    const teamData = {
+      teamName: config.teamName,
+      dateRange: {
+        start: new Date().toLocaleDateString(),
+        end: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toLocaleDateString(),
+      },
+    };
+
+    return <PRGradingScreen teamData={teamData} reviewers={reviewers} />;
+  }
+
+  const data = getDataByTeamId(teamId);
   return <PRGradingScreen teamData={data.teamData} reviewers={data.reviewers} />;
 };
 


### PR DESCRIPTION
# Description
Fixes #33 (Priority High) - Follow-up fix for PR Grading Screen: DB configs now show correct reviewer count

## Related PRs:
Follow-up to merged PR #4935 (Sayali - add Create Test Configuration button and modal to PR Grading Screen)

## Main changes explained:
- Updated `PRGradingTest.jsx` to store `reviewerCount` and `reviewerNames` in dynamic team objects fetched from DB
- Updated `PRGradingScreen/index.jsx` to generate correct number of reviewers from DB config when a non-static team is selected

## How to test:
1. Checkout branch `Sayali_Fix_PRGrading_ReviewerCount`
2. `npm install` && `npm run start:local`
3. Clear cache, log in as admin
4. Navigate to `/pr-grading-test`
5. Click `+ Create Test Configuration` with Reviewer Count = 4 and some reviewer names
6. Click the newly created config
7. Verify exactly 4 reviewers appear in the grading screen
8. Verify reviewer names match what was entered

## Screenshots or videos of changes:
1.Config list showing "testingnumber" with 5 reviewers:
<img width="1007" height="660" alt="image" src="https://github.com/user-attachments/assets/2030f224-0bed-406b-8568-5323928f4d54" />

2.Grading screen showing exactly 5 reviewers (Alice, Bob, Prajwal, Sayali, Reviewer 5)
<img width="1918" height="815" alt="image" src="https://github.com/user-attachments/assets/7db4752f-f6df-4251-a6ca-37a86dc581e0" />

## Note:
Fix for reviewer feedback on PR #4935 - DB configs were always showing 8 reviewers (from default static team1) because reviewerCount was not being passed to the grading screen.