### PR TITLE
Shravya bugfix duplicate pagination 4196

### DIFF
--- a/src/components/CommunityPortal/Activities/activityId/ActivityComments.jsx
+++ b/src/components/CommunityPortal/Activities/activityId/ActivityComments.jsx
@@ -357,9 +357,6 @@ function ActivityComments() {
 
   // Mock API function to simulate fetching more comments
   const fetchMoreComments = async page => {
-    // Simulate API delay
-    await new Promise(resolve => setTimeout(resolve, 1000));
-
     // Generate unique users pool for variety
     const usersPool = [
       { id: 1, name: 'Michael Johnson', profilePic: '/profilepic.webp' },

--- a/src/components/CommunityPortal/Activities/activityId/ActivityComments.jsx
+++ b/src/components/CommunityPortal/Activities/activityId/ActivityComments.jsx
@@ -292,7 +292,7 @@ function ActivityComments() {
 
   const [activeTab, setActiveTab] = useState('Engagement');
   const [commentTab, setCommentTab] = useState('Comment');
-  const [comments, setComments] = useState(loadStoredComments);
+  const [comments, setComments] = useState(mockComments);
   const [commentInput, setCommentInput] = useState('');
   const [sortType, setSortType] = useState('Newest');
 
@@ -300,7 +300,7 @@ function ActivityComments() {
   const [currentPage, setCurrentPage] = useState(1);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [hasMoreComments, setHasMoreComments] = useState(true);
-  const [totalComments, setTotalComments] = useState(loadStoredComments().length + 10); // Simulating more comments exist
+  const [totalComments, setTotalComments] = useState(20);
   const commentsPerPage = 5;
 
   // Reply states
@@ -329,13 +329,13 @@ function ActivityComments() {
   ];
 
   // Save comments to localStorage whenever they change
-  useEffect(() => {
-    try {
-      localStorage.setItem('activityComments', JSON.stringify(comments));
-    } catch (error) {
-      // Failed to save to localStorage - continue without persistence
-    }
-  }, [comments]);
+  // useEffect(() => {
+  //   try {
+  //     localStorage.setItem('activityComments', JSON.stringify(comments));
+  //   } catch (error) {
+  //     // Failed to save to localStorage - continue without persistence
+  //   }
+  // }, [comments]);
 
   // Save feedbacks to localStorage whenever they change
   useEffect(() => {
@@ -360,15 +360,37 @@ function ActivityComments() {
     // Simulate API delay
     await new Promise(resolve => setTimeout(resolve, 1000));
 
-    // Generate additional mock comments for pagination
+    // Generate unique users pool for variety
+    const usersPool = [
+      { id: 1, name: 'Michael Johnson', profilePic: '/profilepic.webp' },
+      { id: 2, name: 'Jennifer Smith', profilePic: '/pfp-default.png' },
+      { id: 3, name: 'Patricia Davis', profilePic: '/pfp-default-header.png' },
+      { id: 4, name: 'Robert Wilson', profilePic: '/Portrait_Placeholder.png' },
+      { id: 5, name: 'Amanda Lee', profilePic: '/pfp-default.png' },
+      { id: 6, name: 'David Brown', profilePic: '/profilepic.webp' },
+      { id: 7, name: 'Michelle Kim', profilePic: '/pfp-default-header.png' },
+      { id: 8, name: 'Christopher Martinez', profilePic: '/Portrait_Placeholder.png' },
+      { id: 9, name: 'Rachel Green', profilePic: '/pfp-default.png' },
+      { id: 10, name: 'Thomas Anderson', profilePic: '/profilepic.webp' },
+    ];
+
+    // Get 2 unique users for this page
+    const startIdx = ((page - 1) * 2) % usersPool.length;
+    const pageUsers = [
+      usersPool[startIdx % usersPool.length],
+      usersPool[(startIdx + 1) % usersPool.length],
+    ];
+
+    // Generate 2 comments for pagination
+    const baseCommentNum = 6; // Start after initial 5 comments
     const additionalComments = [
       {
         id: 100 + page * 10 + 1,
-        name: 'Michael Johnson',
-        profilePic: '/profilepic.webp',
+        name: pageUsers[0].name,
+        profilePic: pageUsers[0].profilePic,
         createdAt: new Date(Date.now() - (page + 5) * 60 * 60 * 1000),
         fixedTimestamp: `${page + 5} hours ago`,
-        text: `This is an additional comment from page ${page}. The discussion continues with more insights and perspectives from the community.`,
+        text: `Comment ${(page - 1) * 2 + baseCommentNum} - Really enjoyed the event!`,
         visibility: 'Public',
         upvotes: getSecureRandomInt(0, 10),
         downvotes: getSecureRandomInt(0, 3),
@@ -376,44 +398,22 @@ function ActivityComments() {
       },
       {
         id: 100 + page * 10 + 2,
-        name: 'Jennifer Smith',
-        profilePic: '/pfp-default.png',
+        name: pageUsers[1].name,
+        profilePic: pageUsers[1].profilePic,
         createdAt: new Date(Date.now() - (page + 6) * 60 * 60 * 1000),
         fixedTimestamp: `${page + 6} hours ago`,
-        text: `Another perspective on this topic. I found the event very educational and would recommend it to others in our field.`,
+        text: `Comment ${(page - 1) * 2 + baseCommentNum + 1} - Thanks for organizing this!`,
         visibility: 'Public',
         upvotes: getSecureRandomInt(5, 15),
         downvotes: getSecureRandomInt(0, 2),
-        replies: [
-          {
-            id: 200 + page * 10 + 1,
-            name: 'Robert Wilson',
-            profilePic: '/Portrait_Placeholder.png',
-            createdAt: new Date(Date.now() - (page + 5) * 60 * 60 * 1000),
-            fixedTimestamp: `${page + 5} hours ago`,
-            text: 'I completely agree! Thanks for sharing your thoughts.',
-            visibility: 'Public',
-          },
-        ],
-      },
-      {
-        id: 100 + page * 10 + 3,
-        name: 'Patricia Davis',
-        profilePic: '/pfp-default-header.png',
-        createdAt: new Date(Date.now() - (page + 7) * 60 * 60 * 1000),
-        fixedTimestamp: `${page + 7} hours ago`,
-        text: `Great follow-up discussion! Looking forward to implementing some of these ideas in my own work.`,
-        visibility: 'Public',
-        upvotes: getSecureRandomInt(1, 8),
-        downvotes: 0,
         replies: [],
       },
     ];
 
     return {
       comments: additionalComments,
-      hasMore: page < 3, // Simulate having 3 pages total
-      total: 20, // Simulate total of 20 comments
+      hasMore: page < 10,
+      total: 20,
     };
   };
 

--- a/src/components/CommunityPortal/Activities/activityId/ActivityComments.jsx
+++ b/src/components/CommunityPortal/Activities/activityId/ActivityComments.jsx
@@ -300,7 +300,7 @@ function ActivityComments() {
   const [currentPage, setCurrentPage] = useState(1);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [hasMoreComments, setHasMoreComments] = useState(true);
-  const [totalComments, setTotalComments] = useState(20);
+  const [totalComments, setTotalComments] = useState(5); // Start with initial 5
   const commentsPerPage = 5;
 
   // Reply states
@@ -378,11 +378,12 @@ function ActivityComments() {
       usersPool[(startIdx + 1) % usersPool.length],
     ];
 
-    // Generate 2 comments for pagination
+    // Generate 2 comments for pagination - use unique IDs
     const baseCommentNum = 6; // Start after initial 5 comments
+    const uniqueOffset = (page - 1) * 1000; // Ensure unique IDs per page
     const additionalComments = [
       {
-        id: 100 + page * 10 + 1,
+        id: uniqueOffset + (page * 2 - 1),
         name: pageUsers[0].name,
         profilePic: pageUsers[0].profilePic,
         createdAt: new Date(Date.now() - (page + 5) * 60 * 60 * 1000),
@@ -394,7 +395,7 @@ function ActivityComments() {
         replies: [],
       },
       {
-        id: 100 + page * 10 + 2,
+        id: uniqueOffset + page * 2,
         name: pageUsers[1].name,
         profilePic: pageUsers[1].profilePic,
         createdAt: new Date(Date.now() - (page + 6) * 60 * 60 * 1000),
@@ -410,7 +411,7 @@ function ActivityComments() {
     return {
       comments: additionalComments,
       hasMore: page < 10,
-      total: 20,
+      total: baseCommentNum + (page - 1) * 2 + 2, // Accurate cumulative total
     };
   };
 
@@ -423,10 +424,21 @@ function ActivityComments() {
       const nextPage = currentPage + 1;
       const result = await fetchMoreComments(nextPage);
 
-      setComments(prevComments => [...prevComments, ...result.comments]);
-      setCurrentPage(nextPage);
-      setHasMoreComments(result.hasMore);
-      setTotalComments(result.total);
+      // Filter out duplicates by ID before appending
+      const existingIds = new Set(comments.map(c => c.id));
+      const newComments = result.comments.filter(c => !existingIds.has(c.id));
+
+      // Only append if there are genuinely new comments
+      if (newComments.length > 0) {
+        setComments(prevComments => [...prevComments, ...newComments]);
+        setCurrentPage(nextPage);
+        setHasMoreComments(result.hasMore);
+        // Accumulate total comments rather than replacing
+        setTotalComments(prevTotal => prevTotal + newComments.length);
+      } else {
+        // No new comments - we've reached the end
+        setHasMoreComments(false);
+      }
     } catch (error) {
       // console.error('Error loading more comments:', error);
       // In a real app, you might show an error message to the user

--- a/src/components/CommunityPortal/Activities/activityId/ActivityComments.jsx
+++ b/src/components/CommunityPortal/Activities/activityId/ActivityComments.jsx
@@ -670,7 +670,7 @@ function ActivityComments() {
     });
 
   return (
-    <div>
+    <div className={styles.container}>
       {/* Event Card */}
       <div className={styles.eventCard}>
         <div>

--- a/src/components/CommunityPortal/Activities/activityId/ActivityComments.module.css
+++ b/src/components/CommunityPortal/Activities/activityId/ActivityComments.module.css
@@ -1,6 +1,10 @@
 /* stylelint-disable  */
 /* ActivityComments.module.css - pixel-perfect styles for Engagement tab */
 
+.container {
+  padding: 20px;
+}
+
 .eventCard {
   display: flex;
   background: #fff;


### PR DESCRIPTION
# Description
Fixes #4196
821 Phase - 3: Fix Comment Duplication, Improve Pagination, and Allow Multiple Replies to Stay Open Related PR: #4196
<img width="1200" height="1402" alt="image" src="https://github.com/user-attachments/assets/76a795ab-ba8e-4031-af48-2fd562fa047f" />
<img width="1263" height="1124" alt="image" src="https://github.com/user-attachments/assets/e881512b-6e52-421e-a62b-5b7230d4b40c" />



## Related PRS (if any):
This frontend PR is related to the development backend PR.

## Main changes explained:

1. Duplicate prevention - Added ID check before appending:
      const existingIds = new Set(comments.map(c => c.id));
      const newComments = result.comments.filter(c => !existingIds.has(c.id));
   
2. Unique IDs - Changed from 100 + page * 10 + 1 to (page - 1) * 1000 + page * 2 to prevent collisions

3. Total count - Now accumulates instead of replacing:
      setTotalComments(prevTotal => prevTotal + newComments.length);
   
4. Reply interactions - Already worked correctly with comment IDs, no changes needed


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache, and local storage
4. log as admin user
5. go to path→ "/communityportal/activity/1/engagement/Comments"
6. verify Load more comments, works, mo duplicates are shown, and its fast and performant and 2 replies are visible in the screen
## Screenshots or videos of changes:
<img width="2842" height="1654" alt="image" src="https://github.com/user-attachments/assets/00767fc6-3820-41ab-994e-9f086972431b" />


## Note:
Include the information the reviewers need to know.
