### PR TITLE
Siri Sudheeksha Vavila: Fix hgn questionnaire skill filter user details

### DIFF
--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
@@ -60,7 +60,19 @@ function TopCommunityMembers() {
         const response = await httpService.get(
           ENDPOINTS.HGN_FORM_GET_TEAM_MEMBERS_BY_SKILL(selectedSkill),
         );
-        setMembers(response.data);
+        const primaryData = Array.isArray(response?.data) ? response.data : [];
+
+        if (primaryData.length > 0) {
+          setMembers(primaryData);
+          return;
+        }
+
+        // Fallback: team-level endpoint can return data even when the userProfile endpoint is empty.
+        const fallbackResponse = await httpService.get(
+          ENDPOINTS.HGN_FORM_GET_TEAM_MEMBERS_BY_SKILL_FALLBACK(selectedSkill),
+        );
+        const fallbackData = Array.isArray(fallbackResponse?.data) ? fallbackResponse.data : [];
+        setMembers(fallbackData);
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('Error fetching members:', error);

--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
@@ -27,6 +27,33 @@ function TopCommunityMembers() {
   const [members, setMembers] = useState([]);
   const darkMode = useSelector(state => state.theme.darkMode);
 
+  const normalizeMember = member => {
+    const fullName = [member?.firstName, member?.lastName]
+      .filter(Boolean)
+      .join(' ')
+      .trim();
+
+    const phoneValue = Array.isArray(member?.phoneNumber)
+      ? member.phoneNumber[0]
+      : member?.phoneNumber || member?.phone || member?.contact?.phoneNumber;
+
+    return {
+      id: member?._id || member?.id || member?.userId || member?.user_id,
+      name: member?.name || member?.userInfo?.name || member?.fullName || fullName || null,
+      email: member?.email || member?.userInfo?.email || member?.contact?.email || null,
+      slack:
+        member?.slack ||
+        member?.slackID ||
+        member?.slackId ||
+        member?.userInfo?.slack ||
+        member?.userInfo?.slackID ||
+        null,
+      phoneNumber: phoneValue || null,
+      rating: member?.rating,
+      skillScore: member?.skillScore,
+    };
+  };
+
   useEffect(() => {
     const fetchMembers = async () => {
       try {
@@ -56,7 +83,8 @@ function TopCommunityMembers() {
     if (typeof m?.skillScore === 'number') return m.skillScore;
     return 0;
   };
-  const sortedMembers = [...members].sort((a, b) => scoreOf(b) - scoreOf(a));
+  const normalizedMembers = members.map(normalizeMember);
+  const sortedMembers = [...normalizedMembers].sort((a, b) => scoreOf(b) - scoreOf(a));
 
   return (
     <div
@@ -93,15 +121,16 @@ function TopCommunityMembers() {
           </tr>
         </thead>
         <tbody>
-          {sortedMembers.slice(0, 15).map(member => {
+          {sortedMembers.slice(0, 15).map((member, index) => {
             const scoreVal = scoreOf(member);
             return (
-              <tr key={member._id || member.id}>
-                <td>{member.name}</td>
+              <tr key={member.id || `${member.name || 'member'}-${index}`}>
+                <td>{member.name || 'Unavailable'}</td>
                 <td>
                   {!member.email ? (
-                    <span className={styles.private} title="No ID was found">
+                    <span className={styles.private} title="Email is private or unavailable">
                       <FaEnvelope style={{ color: '#ccc', cursor: 'not-allowed' }} />
+                      &nbsp;Private
                     </span>
                   ) : (
                     <a
@@ -110,13 +139,13 @@ function TopCommunityMembers() {
                       aria-label={`Email ${member.name}`}
                       className={darkMode ? styles.iconLinkDark : styles.iconLink}
                     >
-                      <FaEnvelope />
+                      <FaEnvelope /> {member.email}
                     </a>
                   )}
                 </td>
                 <td>
-                  {!member.slack && !member.slackID ? (
-                    <span title="No ID was found">
+                  {!member.slack ? (
+                    <span className={styles.private} title="Slack is private or unavailable">
                       <img
                         src={slackLogo}
                         alt="Slack"
@@ -127,23 +156,26 @@ function TopCommunityMembers() {
                           cursor: 'not-allowed',
                         }}
                       />
+                      &nbsp;Private
                     </span>
                   ) : (
                     <a
-                      href={`https://highest-good.slack.com/team/@${member.slack ||
-                        member.slackID}`}
+                      href={`https://highest-good.slack.com/team/@${member.slack}`}
                       target="_blank"
                       rel="noreferrer"
-                      title={member.slack || member.slackID}
+                      title={member.slack}
+                      className={darkMode ? styles.iconLinkDark : styles.iconLink}
                     >
-                      <img src={slackLogo} alt="Slack" style={{ width: '20px', height: '20px' }} />
+                      <img src={slackLogo} alt="Slack" style={{ width: '20px', height: '20px' }} />{' '}
+                      {member.slack}
                     </a>
                   )}
                 </td>
                 <td>
                   {!member.phoneNumber ? (
-                    <span className={styles.private} title="Phone number not found">
+                    <span className={styles.private} title="Phone number is private or unavailable">
                       <FaPhone style={{ color: '#ccc', cursor: 'not-allowed' }} />
+                      &nbsp;Private
                     </span>
                   ) : (
                     <a

--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
@@ -27,56 +27,26 @@ function TopCommunityMembers() {
   const [members, setMembers] = useState([]);
   const darkMode = useSelector(state => state.theme.darkMode);
 
-  const normalizeMember = member => {
-    const fullName = [member?.firstName, member?.lastName]
-      .filter(Boolean)
-      .join(' ')
-      .trim();
-
-    const phoneValue = Array.isArray(member?.phoneNumber)
-      ? member.phoneNumber[0]
-      : member?.phoneNumber || member?.phone || member?.contact?.phoneNumber;
-
-    return {
-      id: member?._id || member?.id || member?.userId || member?.user_id,
-      name: member?.name || member?.userInfo?.name || member?.fullName || fullName || null,
-      email: member?.email || member?.userInfo?.email || member?.contact?.email || null,
-      slack:
-        member?.slack ||
-        member?.slackID ||
-        member?.slackId ||
-        member?.userInfo?.slack ||
-        member?.userInfo?.slackID ||
-        null,
-      phoneNumber: phoneValue || null,
-      rating: member?.rating,
-      skillScore: member?.skillScore,
-    };
-  };
+  const normalizeMember = member => ({
+    id: member?._id || member?.id,
+    name: member?.name || null,
+    email: member?.email || null,
+    slack: member?.slack || null,
+    phoneNumber: member?.phoneNumber || null,
+    score: typeof member?.score === 'number' ? member.score : 0,
+  });
 
   useEffect(() => {
     const fetchMembers = async () => {
       try {
-        const response = await httpService.get(
-          ENDPOINTS.HGN_FORM_GET_TEAM_MEMBERS_BY_SKILL(selectedSkill),
-        );
-        const primaryData = Array.isArray(response?.data) ? response.data : [];
-
-        if (primaryData.length > 0) {
-          setMembers(primaryData);
-          return;
-        }
-
-        // Fallback: team-level endpoint can return data even when the userProfile endpoint is empty.
-        const fallbackResponse = await httpService.get(
-          ENDPOINTS.HGN_FORM_GET_TEAM_MEMBERS_BY_SKILL_FALLBACK(selectedSkill),
-        );
-        const fallbackData = Array.isArray(fallbackResponse?.data) ? fallbackResponse.data : [];
-        setMembers(fallbackData);
+        const response = await httpService.get(ENDPOINTS.HGN_FORM_RANKED, {
+          params: { skills: selectedSkill },
+        });
+        setMembers(Array.isArray(response?.data) ? response.data : []);
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('Error fetching members:', error);
-        setMembers([]); // fallback in case of error
+        setMembers([]);
       }
     };
 
@@ -85,16 +55,7 @@ function TopCommunityMembers() {
     }
   }, [selectedSkill]);
 
-  // normalize rating for sorting and display: supports "7/10" or numeric skillScore
-  const scoreOf = m => {
-    if (typeof m?.rating === 'string') {
-      const [n] = m.rating.split('/');
-      const num = parseInt(n, 10);
-      return Number.isFinite(num) ? num : 0;
-    }
-    if (typeof m?.skillScore === 'number') return m.skillScore;
-    return 0;
-  };
+  const scoreOf = m => (typeof m?.score === 'number' ? m.score : 0);
   const normalizedMembers = members.map(normalizeMember);
   const sortedMembers = [...normalizedMembers].sort((a, b) => scoreOf(b) - scoreOf(a));
 
@@ -213,7 +174,7 @@ function TopCommunityMembers() {
         </tbody>
       </table>
       <Link
-        to="/hgnhelp/community"
+        to={{ pathname: '/hgnhelp/community', state: { initialSkills: [selectedSkill] } }}
         className={darkMode ? styles.underlineLinkDark : styles.underlineLink}
       >
         Show your team members &gt;

--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
@@ -101,9 +101,13 @@ function TopCommunityMembers() {
                 <td>{member.name || 'Unavailable'}</td>
                 <td>
                   {!member.email ? (
-                    <span className={styles.private} title="Email is private or unavailable">
+                    <span
+                      className={styles.private}
+                      title="Email is private or unavailable"
+                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                    >
                       <FaEnvelope style={{ color: '#ccc', cursor: 'not-allowed' }} />
-                      &nbsp;Private
+                      Private
                     </span>
                   ) : (
                     <a
@@ -151,9 +155,13 @@ function TopCommunityMembers() {
                 </td>
                 <td>
                   {!member.phoneNumber ? (
-                    <span className={styles.private} title="Phone number is private or unavailable">
+                    <span
+                      className={styles.private}
+                      title="Phone number is private or unavailable"
+                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                    >
                       <FaPhone style={{ color: '#ccc', cursor: 'not-allowed' }} />
-                      &nbsp;Private
+                      Private
                     </span>
                   ) : (
                     <a

--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
@@ -117,7 +117,19 @@ function TopCommunityMembers() {
                   )}
                 </td>
                 <td>
-                  {!member.slack ? (
+                  {member.slack ? (
+                    <a
+                      href={`https://highest-good.slack.com/team/@${member.slack}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      title={member.slack}
+                      className={darkMode ? styles.iconLinkDark : styles.iconLink}
+                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                    >
+                      <img src={slackLogo} alt="Slack" style={{ width: '20px', height: '20px' }} />
+                      {member.slack}
+                    </a>
+                  ) : (
                     <span className={styles.private} title="Slack is private or unavailable">
                       <img
                         src={slackLogo}
@@ -131,17 +143,6 @@ function TopCommunityMembers() {
                       />
                       &nbsp;Private
                     </span>
-                  ) : (
-                    <a
-                      href={`https://highest-good.slack.com/team/@${member.slack}`}
-                      target="_blank"
-                      rel="noreferrer"
-                      title={member.slack}
-                      className={darkMode ? styles.iconLinkDark : styles.iconLink}
-                    >
-                      <img src={slackLogo} alt="Slack" style={{ width: '20px', height: '20px' }} />{' '}
-                      {member.slack}
-                    </a>
                   )}
                 </td>
                 <td>

--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
@@ -130,7 +130,11 @@ function TopCommunityMembers() {
                       {member.slack}
                     </a>
                   ) : (
-                    <span className={styles.private} title="Slack is private or unavailable">
+                    <span
+                      className={styles.private}
+                      title="Slack is private or unavailable"
+                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                    >
                       <img
                         src={slackLogo}
                         alt="Slack"
@@ -141,7 +145,7 @@ function TopCommunityMembers() {
                           cursor: 'not-allowed',
                         }}
                       />
-                      &nbsp;Private
+                      Private
                     </span>
                   )}
                 </td>

--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
@@ -67,8 +67,8 @@ function TopCommunityMembers() {
     >
       <h2>Top 15 Community Members</h2>
 
-      <div style={{ marginBottom: '20px' }}>
-        <label htmlFor="skill-select">Select Skill: </label>
+      <div className={styles.filterRow}>
+        <label htmlFor="skill-select">Select Skill:</label>
         <select
           id="skill-select"
           className={darkMode ? styles.selectDark : styles.select}
@@ -83,6 +83,7 @@ function TopCommunityMembers() {
         </select>
       </div>
 
+      <div style={{ overflowX: 'auto', width: '100%' }}>
       <table className={darkMode ? styles.tableDark : styles.table}>
         <thead>
           <tr>
@@ -94,6 +95,13 @@ function TopCommunityMembers() {
           </tr>
         </thead>
         <tbody>
+          {sortedMembers.length === 0 && (
+            <tr>
+              <td colSpan={5} className={styles.emptyState}>
+                No members found for this skill.
+              </td>
+            </tr>
+          )}
           {sortedMembers.slice(0, 15).map((member, index) => {
             const scoreVal = scoreOf(member);
             return (
@@ -189,6 +197,7 @@ function TopCommunityMembers() {
           })}
         </tbody>
       </table>
+      </div>
       <Link
         to={{ pathname: '/hgnhelp/community', state: { initialSkills: [selectedSkill] } }}
         className={darkMode ? styles.underlineLinkDark : styles.underlineLink}

--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
@@ -84,119 +84,123 @@ function TopCommunityMembers() {
       </div>
 
       <div style={{ overflowX: 'auto', width: '100%' }}>
-      <table className={darkMode ? styles.tableDark : styles.table}>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Slack ID</th>
-            <th>Phone Number</th>
-            <th>Skill Score</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedMembers.length === 0 && (
+        <table className={darkMode ? styles.tableDark : styles.table}>
+          <thead>
             <tr>
-              <td colSpan={5} className={styles.emptyState}>
-                No members found for this skill.
-              </td>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Slack ID</th>
+              <th>Phone Number</th>
+              <th>Skill Score</th>
             </tr>
-          )}
-          {sortedMembers.slice(0, 15).map((member, index) => {
-            const scoreVal = scoreOf(member);
-            return (
-              <tr key={member.id || `${member.name || 'member'}-${index}`}>
-                <td>{member.name || 'Unavailable'}</td>
-                <td>
-                  {!member.email ? (
-                    <span
-                      className={styles.private}
-                      title="Email is private or unavailable"
-                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-                    >
-                      <FaEnvelope style={{ color: '#ccc', cursor: 'not-allowed' }} />
-                      <span>Private</span>
-                    </span>
-                  ) : (
-                    <a
-                      href={`mailto:${member.email}`}
-                      title={member.email}
-                      aria-label={`Email ${member.name}`}
-                      className={darkMode ? styles.iconLinkDark : styles.iconLink}
-                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-                    >
-                      <FaEnvelope />
-                      <span>{member.email}</span>
-                    </a>
-                  )}
-                </td>
-                <td>
-                  {member.slack ? (
-                    <a
-                      href={`https://highest-good.slack.com/team/@${member.slack}`}
-                      target="_blank"
-                      rel="noreferrer"
-                      title={member.slack}
-                      className={darkMode ? styles.iconLinkDark : styles.iconLink}
-                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-                    >
-                      <img src={slackLogo} alt="Slack" style={{ width: '20px', height: '20px' }} />
-                      <span>{member.slack}</span>
-                    </a>
-                  ) : (
-                    <span
-                      className={styles.private}
-                      title="Slack is private or unavailable"
-                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-                    >
-                      <img
-                        src={slackLogo}
-                        alt="Slack"
-                        style={{
-                          width: '20px',
-                          height: '20px',
-                          opacity: 0.4,
-                          cursor: 'not-allowed',
-                        }}
-                      />
-                      <span>Private</span>
-                    </span>
-                  )}
-                </td>
-                <td>
-                  {!member.phoneNumber ? (
-                    <span
-                      className={styles.private}
-                      title="Phone number is private or unavailable"
-                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-                    >
-                      <FaPhone style={{ color: '#ccc', cursor: 'not-allowed' }} />
-                      <span>Private</span>
-                    </span>
-                  ) : (
-                    <a
-                      href={`tel:${member.phoneNumber}`}
-                      title={member.phoneNumber}
-                      aria-label={`Call ${member.name}`}
-                      className={darkMode ? styles.iconLinkDark : styles.iconLink}
-                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-                    >
-                      <FaPhone />
-                      <span>{member.phoneNumber}</span>
-                    </a>
-                  )}
-                </td>
-                <td>
-                  <span className={scoreVal < 5 ? styles.lowScore : styles.highScore}>
-                    {scoreVal}
-                  </span>
-                  /10
+          </thead>
+          <tbody>
+            {sortedMembers.length === 0 && (
+              <tr>
+                <td colSpan={5} className={styles.emptyState}>
+                  No members found for this skill.
                 </td>
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            )}
+            {sortedMembers.slice(0, 15).map((member, index) => {
+              const scoreVal = scoreOf(member);
+              return (
+                <tr key={member.id || `${member.name || 'member'}-${index}`}>
+                  <td>{member.name || 'Unavailable'}</td>
+                  <td>
+                    {!member.email ? (
+                      <span
+                        className={styles.private}
+                        title="Email is private or unavailable"
+                        style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                      >
+                        <FaEnvelope style={{ color: '#ccc', cursor: 'not-allowed' }} />
+                        <span>Private</span>
+                      </span>
+                    ) : (
+                      <a
+                        href={`mailto:${member.email}`}
+                        title={member.email}
+                        aria-label={`Email ${member.name}`}
+                        className={darkMode ? styles.iconLinkDark : styles.iconLink}
+                        style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                      >
+                        <FaEnvelope />
+                        <span>{member.email}</span>
+                      </a>
+                    )}
+                  </td>
+                  <td>
+                    {member.slack ? (
+                      <a
+                        href={`https://highest-good.slack.com/team/@${member.slack}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        title={member.slack}
+                        className={darkMode ? styles.iconLinkDark : styles.iconLink}
+                        style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                      >
+                        <img
+                          src={slackLogo}
+                          alt="Slack"
+                          style={{ width: '20px', height: '20px' }}
+                        />
+                        <span>{member.slack}</span>
+                      </a>
+                    ) : (
+                      <span
+                        className={styles.private}
+                        title="Slack is private or unavailable"
+                        style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                      >
+                        <img
+                          src={slackLogo}
+                          alt="Slack"
+                          style={{
+                            width: '20px',
+                            height: '20px',
+                            opacity: 0.4,
+                            cursor: 'not-allowed',
+                          }}
+                        />
+                        <span>Private</span>
+                      </span>
+                    )}
+                  </td>
+                  <td>
+                    {!member.phoneNumber ? (
+                      <span
+                        className={styles.private}
+                        title="Phone number is private or unavailable"
+                        style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                      >
+                        <FaPhone style={{ color: '#ccc', cursor: 'not-allowed' }} />
+                        <span>Private</span>
+                      </span>
+                    ) : (
+                      <a
+                        href={`tel:${member.phoneNumber}`}
+                        title={member.phoneNumber}
+                        aria-label={`Call ${member.name}`}
+                        className={darkMode ? styles.iconLinkDark : styles.iconLink}
+                        style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                      >
+                        <FaPhone />
+                        <span>{member.phoneNumber}</span>
+                      </a>
+                    )}
+                  </td>
+                  <td>
+                    <span className={scoreVal < 5 ? styles.lowScore : styles.highScore}>
+                      {scoreVal}
+                    </span>
+                    /10
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       </div>
       <Link
         to={{ pathname: '/hgnhelp/community', state: { initialSkills: [selectedSkill] } }}

--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.jsx
@@ -107,7 +107,7 @@ function TopCommunityMembers() {
                       style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
                     >
                       <FaEnvelope style={{ color: '#ccc', cursor: 'not-allowed' }} />
-                      Private
+                      <span>Private</span>
                     </span>
                   ) : (
                     <a
@@ -115,8 +115,10 @@ function TopCommunityMembers() {
                       title={member.email}
                       aria-label={`Email ${member.name}`}
                       className={darkMode ? styles.iconLinkDark : styles.iconLink}
+                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
                     >
-                      <FaEnvelope /> {member.email}
+                      <FaEnvelope />
+                      <span>{member.email}</span>
                     </a>
                   )}
                 </td>
@@ -131,7 +133,7 @@ function TopCommunityMembers() {
                       style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
                     >
                       <img src={slackLogo} alt="Slack" style={{ width: '20px', height: '20px' }} />
-                      {member.slack}
+                      <span>{member.slack}</span>
                     </a>
                   ) : (
                     <span
@@ -149,7 +151,7 @@ function TopCommunityMembers() {
                           cursor: 'not-allowed',
                         }}
                       />
-                      Private
+                      <span>Private</span>
                     </span>
                   )}
                 </td>
@@ -161,7 +163,7 @@ function TopCommunityMembers() {
                       style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
                     >
                       <FaPhone style={{ color: '#ccc', cursor: 'not-allowed' }} />
-                      Private
+                      <span>Private</span>
                     </span>
                   ) : (
                     <a
@@ -169,9 +171,10 @@ function TopCommunityMembers() {
                       title={member.phoneNumber}
                       aria-label={`Call ${member.name}`}
                       className={darkMode ? styles.iconLinkDark : styles.iconLink}
+                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
                     >
-                      <FaPhone style={{ marginRight: '5px' }} />
-                      {member.phoneNumber}
+                      <FaPhone />
+                      <span>{member.phoneNumber}</span>
                     </a>
                   )}
                 </td>

--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.module.css
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.module.css
@@ -299,8 +299,6 @@
   text-decoration: none;
 }
 
-
-
 .iconLink {
   font-size: 18px;
   margin: 0 5px;
@@ -343,14 +341,14 @@
 }
 
 .componentBox {
-  border: 1px solid #ccc;        /* Light gray border */
+  border: 1px solid #ccc; /* Light gray border */
   padding: 20px;
   border-radius: 10px; /* Rounded corners */
   box-shadow: 0 4px 8px rgb(0 0 0 / 10%); /* Soft shadow */
   background-color: #fff; /* Optional: white background */
-  border-radius: 10px;           /* Rounded corners */
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);  /* Soft shadow */
-  background-color: #fff;        /* Optional: white background */
+  border-radius: 10px; /* Rounded corners */
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Soft shadow */
+  background-color: #fff; /* Optional: white background */
   width: 90%;
   max-width: 700px;
   margin: auto;
@@ -361,7 +359,8 @@
   width: 100%;
 }
 
-.table th, .table td {
+.table th,
+.table td {
   padding: 12px 20px; /* Adjust as needed for vertical & horizontal spacing */
   text-align: left;
 }
@@ -374,7 +373,8 @@
   background-color: #f9f9f9;
 }
 
-.table td a, .table td span {
+.table td a,
+.table td span {
   display: inline-flex;
   align-items: center;
   gap: 5px; /* gap between icon and text if needed */
@@ -433,7 +433,8 @@
   color: #fff;
 }
 
-.tableDark th, .tableDark td {
+.tableDark th,
+.tableDark td {
   padding: 12px 20px;
   text-align: left;
   border: 1px solid #4a5a77;
@@ -456,7 +457,8 @@
   background-color: #2f4157;
 }
 
-.tableDark td a, .tableDark td span {
+.tableDark td a,
+.tableDark td span {
   display: inline-flex;
   align-items: center;
   gap: 5px;

--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.module.css
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.module.css
@@ -1,51 +1,305 @@
 /* stylelint-disable  */
-.top-members-container {
-  padding: 20px;
-  font-family: Arial, sans-serif;
+
+/* ============================================
+   PAGE WRAPPER
+   ============================================ */
+.centerContainer {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  min-height: 100vh;
+  flex-direction: column;
+  padding: 2rem 1rem;
 }
 
-.members-table {
+.componentBox {
+  border: 1px solid #e0e4ea;
+  padding: 2rem 2.5rem 2.5rem;
+  border-radius: 14px;
+  box-shadow: 0 4px 18px rgb(0 0 0 / 8%);
+  background-color: #fff;
   width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+/* ============================================
+   HEADING
+   ============================================ */
+.componentBox h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1a2a40;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid #e0e4ea;
+  letter-spacing: 0.01em;
+}
+
+/* ============================================
+   SKILL SELECTOR ROW
+   ============================================ */
+.filterRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.filterRow label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #444;
+  white-space: nowrap;
+}
+
+.select {
+  padding: 7px 14px;
+  border: 1px solid #ced4da;
+  border-radius: 6px;
+  background-color: #fff;
+  color: #333;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.select:focus {
+  border-color: #4a90d9;
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(74 144 217 / 20%);
+}
+
+/* ============================================
+   TABLE - LIGHT MODE
+   ============================================ */
+.table {
   border-collapse: collapse;
-  margin-top: 15px;
+  width: 100%;
+  font-size: 0.875rem;
+  margin-bottom: 1.25rem;
 }
 
-.members-table th,
-.members-table td {
-  border: 1px solid #ddd;
-  padding: 10px;
-  text-align: center;
+.table th {
+  padding: 10px 14px;
+  text-align: left;
+  background-color: #f0f4f8;
+  color: #3a4a5c;
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 2px solid #dce3ec;
 }
 
+.table td {
+  padding: 10px 14px;
+  text-align: left;
+  border-bottom: 1px solid #eef0f3;
+  vertical-align: middle;
+  color: #2d3748;
+}
+
+.table tr:last-child td {
+  border-bottom: none;
+}
+
+.table tbody tr:hover {
+  background-color: #f7f9fc;
+}
+
+.table td a,
+.table td span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+/* ============================================
+   SCORE & PRIVATE HELPERS
+   ============================================ */
 .lowScore {
-  color: red;
-  font-weight: bold;
+  color: #e53e3e;
+  font-weight: 700;
 }
 
 .highScore {
-  color: green;
-  font-weight: bold;
+  color: #38a169;
+  font-weight: 700;
 }
 
 .private {
-  color: gray;
+  color: #a0aec0;
   cursor: help;
   font-style: italic;
+  font-size: 0.82rem;
 }
 
-.team-btn {
-  background-color: #007bff;
-  color: white;
-  padding: 10px 20px;
-  margin-top: 20px;
-  border: none;
-  border-radius: 6px;
+/* ============================================
+   ICON LINKS
+   ============================================ */
+.iconLink {
+  color: #3182ce;
+  transition: color 0.2s;
+  font-size: 0.875rem;
+}
+
+.iconLink:hover {
+  color: #1a5fa8;
+  text-decoration: underline;
+}
+
+.iconSlack {
+  color: #611f69;
+  font-size: 18px;
+  transition: color 0.2s ease;
+}
+
+.iconSlack:hover {
+  color: #400d40;
+}
+
+/* ============================================
+   FOOTER LINK
+   ============================================ */
+.underlineLink {
+  display: inline-block;
+  margin-top: 0.5rem;
+  text-decoration: underline;
+  color: #3182ce;
   cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: color 0.2s;
 }
 
-.team-btn:hover {
-  background-color: #0056b3;
+.underlineLink:hover {
+  color: #1a5fa8;
+  text-decoration: none;
 }
+
+/* ============================================
+   EMPTY STATE
+   ============================================ */
+.emptyState {
+  text-align: center;
+  color: #888;
+  padding: 2rem 0;
+  font-size: 0.95rem;
+}
+
+/* ============================================
+   DARK MODE
+   ============================================ */
+.darkMode {
+  background-color: #111827;
+  color: #f1f5f9;
+}
+
+.darkMode.componentBox {
+  background-color: #1e2c3f;
+  border-color: #2f4157;
+  box-shadow: 0 4px 18px rgb(0 0 0 / 30%);
+}
+
+.darkMode h2 {
+  color: #e2e8f0;
+  border-bottom-color: #2f4157;
+}
+
+.darkMode .filterRow label {
+  color: #cbd5e0;
+}
+
+.selectDark {
+  padding: 7px 14px;
+  border: 1px solid #4a5a77;
+  border-radius: 6px;
+  background-color: #2d3f55;
+  color: #e2e8f0;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.selectDark:focus {
+  border-color: #e8a71c;
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(232 167 28 / 25%);
+}
+
+.tableDark {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.875rem;
+  margin-bottom: 1.25rem;
+  color: #e2e8f0;
+}
+
+.tableDark th {
+  padding: 10px 14px;
+  text-align: left;
+  background-color: #243447;
+  color: #94a3b8;
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 2px solid #2f4157;
+}
+
+.tableDark td {
+  padding: 10px 14px;
+  text-align: left;
+  border-bottom: 1px solid #2a3a4e;
+  vertical-align: middle;
+  color: #e2e8f0;
+}
+
+.tableDark tr:last-child td {
+  border-bottom: none;
+}
+
+.tableDark tbody tr:hover {
+  background-color: #1e3248;
+}
+
+.tableDark td a,
+.tableDark td span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.iconLinkDark {
+  color: #60a5fa;
+  transition: color 0.2s;
+  font-size: 0.875rem;
+}
+
+.iconLinkDark:hover {
+  color: #93c5fd;
+  text-decoration: underline;
+}
+
+.underlineLinkDark {
+  display: inline-block;
+  margin-top: 0.5rem;
+  text-decoration: underline;
+  color: #60a5fa;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+
+.underlineLinkDark:hover {
+  color: #93c5fd;
+  text-decoration: none;
+}
+
+
 
 .iconLink {
   font-size: 18px;

--- a/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.module.css
+++ b/src/components/HGNForm/TopCommunityMembers/TopCommunityMembers.module.css
@@ -246,19 +246,20 @@
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  border-bottom: 2px solid #2f4157;
+  border: 1px solid #2f4157;
+  border-bottom-width: 2px;
 }
 
 .tableDark td {
   padding: 10px 14px;
   text-align: left;
-  border-bottom: 1px solid #2a3a4e;
+  border: 1px solid #2a3a4e;
   vertical-align: middle;
   color: #e2e8f0;
 }
 
 .tableDark tr:last-child td {
-  border-bottom: none;
+  border-bottom: 1px solid #2a3a4e;
 }
 
 .tableDark tbody tr:hover {
@@ -320,83 +321,7 @@
   color: #400d40; /* darker shade on hover */
 }
 
-.centerContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 100vh; /* Full height of viewport */
-  flex-direction: column;
-}
 
-.underlineLink {
-  text-decoration: underline;
-  color: rgb(3 3 7);
-  cursor: pointer;
-  font-size: 16px;
-}
-
-.underlineLink:hover {
-  text-decoration: none;
-  color: rgb(3 3 7);
-}
-
-.componentBox {
-  border: 1px solid #ccc; /* Light gray border */
-  padding: 20px;
-  border-radius: 10px; /* Rounded corners */
-  box-shadow: 0 4px 8px rgb(0 0 0 / 10%); /* Soft shadow */
-  background-color: #fff; /* Optional: white background */
-  border-radius: 10px; /* Rounded corners */
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Soft shadow */
-  background-color: #fff; /* Optional: white background */
-  width: 90%;
-  max-width: 700px;
-  margin: auto;
-}
-
-.table {
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.table th,
-.table td {
-  padding: 12px 20px; /* Adjust as needed for vertical & horizontal spacing */
-  text-align: left;
-}
-
-.table thead {
-  background-color: #f2f2f2;
-}
-
-.table tr:nth-child(even) {
-  background-color: #f9f9f9;
-}
-
-.table td a,
-.table td span {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px; /* gap between icon and text if needed */
-}
-
-.select {
-  padding: 8px 12px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  background-color: #fff;
-  color: #333;
-  font-size: 14px;
-}
-
-/* ============================================
-   DARK MODE STYLES
-   ============================================ */
-
-.darkMode {
-  background-color: #1b2a41 !important;
-  color: #fff !important;
-}
 
 .darkMode .componentBox {
   background-color: #2b3e59 !important;

--- a/src/components/HGNHelpSkillsDashboard/CommunityMembersPage.jsx
+++ b/src/components/HGNHelpSkillsDashboard/CommunityMembersPage.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import Accordion from './Accordion';
 import { PreferenceFilterButtons, SkillFilterButtons } from './FilterButtons';
 import RankedUserList from './RankedUserList';
@@ -7,7 +8,8 @@ import SearchBar from './SearchBar';
 import styles from './style/CommunityMembersPage.module.css';
 
 function CommunityMembersPage() {
-  const [selectedSkills, setSelectedSkills] = useState([]);
+  const location = useLocation();
+  const [selectedSkills, setSelectedSkills] = useState(location.state?.initialSkills || []);
   const [selectedPreferences, setSelectedPreferences] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
   const darkMode = useSelector(state => state.theme.darkMode);

--- a/src/components/HGNHelpSkillsDashboard/CommunityMembersPage.jsx
+++ b/src/components/HGNHelpSkillsDashboard/CommunityMembersPage.jsx
@@ -24,13 +24,18 @@ function CommunityMembersPage() {
       <SearchBar searchQuery={searchQuery} setSearchQuery={setSearchQuery} darkMode={darkMode} />
 
       <Accordion title="Filter by Skills" defaultOpen darkMode={darkMode}>
-        <SkillFilterButtons selectedSkills={selectedSkills} setSelectedSkills={setSelectedSkills} />
+        <SkillFilterButtons
+          selectedSkills={selectedSkills}
+          setSelectedSkills={setSelectedSkills}
+          darkMode={darkMode}
+        />
       </Accordion>
 
       <Accordion title="Filter by Preferences" darkMode={darkMode}>
         <PreferenceFilterButtons
           selectedPreferences={selectedPreferences}
           setSelectedPreferences={setSelectedPreferences}
+          darkMode={darkMode}
         />
       </Accordion>
 

--- a/src/components/HGNHelpSkillsDashboard/style/CommunityMembersPage.module.css
+++ b/src/components/HGNHelpSkillsDashboard/style/CommunityMembersPage.module.css
@@ -103,6 +103,14 @@
   color: #f9fafb;
 }
 
+.darkMode .accordion {
+  border-color: #4b5563;
+}
+
+.darkMode .accordionContent {
+  background-color: #1b2a41;
+}
+
 .darkMode .skillButton,
 .darkMode .preferenceButton {
   background-color: #1f2937;

--- a/src/components/HGNHelpSkillsDashboard/style/RankedUserList.module.css
+++ b/src/components/HGNHelpSkillsDashboard/style/RankedUserList.module.css
@@ -16,7 +16,6 @@
   flex-direction: column;
   align-items: center;
   padding: 15px;
-  background-color: white;
   transition: transform 0.2s, background 0.3s, border-color 0.3s, box-shadow 0.3s;
 }
 

--- a/src/components/HGNHelpSkillsDashboard/style/SkillsOverviewPage.module.css
+++ b/src/components/HGNHelpSkillsDashboard/style/SkillsOverviewPage.module.css
@@ -228,3 +228,15 @@
   color: #f9fafb !important;
   border-color: #4b5563 !important;
 }
+
+.skillButton.darkButton.selected {
+  background-color: #3b82f6 !important;
+  border-color: #3b82f6 !important;
+  color: #fff !important;
+}
+
+.preferenceButton.darkButton.selected {
+  background-color: #22c55e !important;
+  border-color: #22c55e !important;
+  color: #fff !important;
+}

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -484,6 +484,7 @@ export const ENDPOINTS = {
   USER_STATE_CATALOG_USAGE: key => `${APIEndpoint}/userstate/catalog/${key}/usage`,
 
   HGN_FORM_GET_TEAM_MEMBERS_BY_SKILL: skill => `${APIEndpoint}/userProfile/skills/${skill}`,
+  HGN_FORM_GET_TEAM_MEMBERS_BY_SKILL_FALLBACK: skill => `${APIEndpoint}/team-skills/${skill}`,
 
   CREATE_JOB_FORM: `${APIEndpoint}/jobforms`,
   UPDATE_JOB_FORM: `${APIEndpoint}/jobforms`,


### PR DESCRIPTION
# Description

<img width="743" height="347" alt="image" src="https://github.com/user-attachments/assets/1958bf18-83ce-4e29-9e0b-a2b8330b592f" />

Fixes the TopCommunityMembers component as it was not displaying any member data after selecting a skill from the dropdown, and navigating to the Community Members page via "Show your team members" required manually re-selecting filters before any members would appear.

Root causes:

TopCommunityMembers was calling /userProfile/skills/:skill and /team-skills/:skill — endpoints that return empty arrays for most users because they depend on HGN form responses being linked to the logged-in user's team. Members were never shown.
The "Show your team members" link navigated to /hgnhelp/community with no state, so CommunityMembersPage started with no filters selected, hiding the member list entirely.

## Related PRS (if any):
This frontend PR is related to  [PR 4214](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4214)

…

## Main changes explained:

- Update TopCommunityMembers.jsx — switched from the non-functional /userProfile/skills/:skill and /team-skills/:skill endpoints to GET /hgnform/ranked?skills=skill, the same endpoint already used by CommunityMembersPage/RankedUserList that returns live data. Simplified normalizeMember and scoreOf helpers to match the actual response shape (name, email, slack, score). Updated "Show your team members" Link to pass { state: { initialSkills: [selectedSkill] } } to the community page.
- Update CommunityMembersPage.jsx — reads location.state?.initialSkills on mount via useLocation() and uses it to pre-populate selectedSkills, so the member list renders immediately without requiring the user to re-select filters.
- Update URL.js— added HGN_FORM_GET_TEAM_MEMBERS_BY_SKILL and HGN_FORM_GET_TEAM_MEMBERS_BY_SKILL_FALLBACK constants (earlier commits; superseded by the final fix using HGN_FORM_RANKED).

…

## How to test:

1. Check out branch fix-hgn-questionnaire-skill-filter-user-details
2. Run npm install then npm run start:local
3. Clear site data / cache in the browser
4. Log in as any user (volunteer or admin)
5. Navigate to /topcommunityembers
6. Verify: selecting a skill from the dropdown (e.g. HTML) immediately populates the table with ranked members — Name, Email, Slack ID, Phone Number, and Skill Score
7. Click "Show your team members >"
8. Verify: the Community Members page opens with the same skill already selected as an active filter and the member cards display immediately — no manual re-selection required
9. verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

Before:

<img width="1086" height="900" alt="image" src="https://github.com/user-attachments/assets/7c85272c-30eb-4c84-82ea-4e964354e14b" />

After :

<img width="1427" height="900" alt="image" src="https://github.com/user-attachments/assets/e3308cff-2f8f-49ed-9bda-57d078274c35" />

<img width="1427" height="900" alt="image" src="https://github.com/user-attachments/assets/6abda846-6276-4f8e-a45b-987250f2d65b" />

<img width="1427" height="900" alt="image" src="https://github.com/user-attachments/assets/f2eafe24-13b2-4bb9-ae66-acd3cdcbc0b1" />

## Note:
Include the information the reviewers need to know.
