### PR TITLE
Sayali : fix ALL-TIME members list showing incorrect count in Project Report

### DIFF
--- a/src/components/Reports/ProjectMemberTable/ProjectMemberTable.jsx
+++ b/src/components/Reports/ProjectMemberTable/ProjectMemberTable.jsx
@@ -1,9 +1,9 @@
 /* eslint-disable import/prefer-default-export */
 import { useEffect, useState } from 'react';
-import './ProjectMemberTable.css';
 import { Link } from 'react-router-dom';
 import CopyToClipboard from '~/components/common/Clipboard/CopyToClipboard';
 import { Stub } from '../../common/Stub';
+import './ProjectMemberTable.css';
 
 export function ProjectMemberTable({ projectMembers, skip, take, handleMemberCount, darkMode, counts }) {
   const [allMemberList, setAllMemberList] = useState([]);
@@ -12,31 +12,43 @@ export function ProjectMemberTable({ projectMembers, skip, take, handleMemberCou
   const { fetched, foundUsers, members } = projectMembers;
 
   useEffect(() => {
-    handleMemberCount(activeMemberList.length);
-  }, [activeMemberList])
+    setMemberFilter('active');
+  }, [fetched]);
 
   useEffect(() => {
-    if (fetched) {
-      const memberList = [];
-      const activeList = [];
-      const currentActive = new Set();
-      if (foundUsers.length > 0) {
-        foundUsers.forEach(member => {
-          currentActive.add(member._id);
-        });
-      }
-      members.forEach(member => {
-        if (currentActive.has(member._id)) {
-          memberList.push({ ...member, active: true });
-          activeList.push({ ...member, active: true });
-        } else {
-          memberList.push({ ...member, active: false });
-        }
-      });
-      setAllMemberList(memberList);
-      setActiveMemberList(activeList);
+    handleMemberCount(activeMemberList.length);
+  }, [activeMemberList, memberFilter]);
+
+  useEffect(() => {
+  // Reset lists when project changes or data is not yet fetched
+  if (!fetched) {
+    setAllMemberList([]);
+    setActiveMemberList([]);
+    return;
+  }
+
+  const memberList = [];
+  const activeList = [];
+  const currentActive = new Set();
+
+  if (foundUsers.length > 0) {
+    foundUsers.forEach(member => {
+      currentActive.add(member._id);
+    });
+  }
+
+  members.forEach(member => {
+    if (currentActive.has(member._id)) {
+      memberList.push({ ...member, active: true });
+      activeList.push({ ...member, active: true });
+    } else {
+      memberList.push({ ...member, active: false });
     }
-  }, [fetched]);
+  });
+
+  setAllMemberList(memberList);
+  setActiveMemberList(activeList);
+}, [fetched, members, foundUsers]);
 
   const activeMemberTable = activeMemberList.slice(skip, skip + take).map((member, index) => (
     <div className="project-member-table-row" id={`tr_${  member._id}`} key={`ac_${  member._id}`}>
@@ -100,12 +112,9 @@ export function ProjectMemberTable({ projectMembers, skip, take, handleMemberCou
       <div className="project-member-count-head">
       <div className="filter-members-mobile"
         onChange={e => {
-          setMemberFilter(e.target.value);
-          if (e.target.value === 'all-time') {
-            handleMemberCount(allMemberList.length);
-          } else {
-            handleMemberCount(activeMemberList.length);
-          }
+          const val = e.target.value;
+          setMemberFilter(val);
+          handleMemberCount(val === 'all-time' ? allMemberList.length : activeMemberList.length);
         }}
       >
         <input type="radio" name="memberFilter" value="active" id="active" defaultChecked />


### PR DESCRIPTION

<img width="728" height="680" alt="image" src="https://github.com/user-attachments/assets/b770cadf-4659-4bc4-af03-8e1103dd64fb" />

# Description
Fixes #1 (Priority Medium) - Fix the Projects Report incomplete Members list when the ALL-TIME button is selected.

## Related PRs (if any):
This frontend PR is related to this backend PR https://github.com/OneCommunityGlobal/HGNRest/pull/2225
Previous related work: #2532 (already merged).


## Main changes explained:
- Updated ProjectMemberTable.jsx to fix useEffect dependency array to include `members` and `foundUsers` so the member lists rebuild correctly when data changes
- Added reset logic to clear member lists when project is not yet fetched, preventing stale data from previous project
- Added `memberFilter` reset to 'active' when switching between projects
- Fixed member count handler to update correctly when toggling between ACTIVE and ALL-TIME

## How to test:
1. Check out branch Sayali-Fix-AllTime-Members-ProjectReport
2. npm install && npm run start:local
3. Clear site data/cache
4. Log as admin user
5. Go to Reports → Reports → Projects → select any project (e.g. HG Food)
6. Verify ACTIVE and ALL-TIME counts are different
7. Click ALL-TIME — verify it shows more members including inactive ones (hollow dot)
8. Switch to another project — verify members update immediately without showing previous project's members
9. Verify dark mode works

## Screenshots or videos of changes:
<img width="1919" height="875" alt="image" src="https://github.com/user-attachments/assets/bcd6c33a-7a7c-433e-a836-87ddad1cc941" />
<img width="1919" height="870" alt="image" src="https://github.com/user-attachments/assets/0994af90-fc0c-457f-a475-38234d5e8f28" />

## Note:
