### PR TITLE
Diya fix(permission): Unassign Tasks from Members

### DIFF
--- a/src/components/PermissionsManagement/Permissions.json
+++ b/src/components/PermissionsManagement/Permissions.json
@@ -325,11 +325,6 @@
                 "label": "View and Interact with Task \"X\" on Dashboards",
                 "key": "canDeleteTask",
                 "description": "Gives the user permission to DELETE tasks from the Management Dashboard showing all their team members."
-              },
-              {
-                "label": "Unassign Team Members from Tasks",
-                "key": "deleteDashboardTask",
-                "description": "Gives the user permission to UNASSIGN tasks from only their TEAM members through the Dashboard -> task -> red X."
               }
             ]
           }

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -154,7 +154,7 @@ const TeamMemberTask = React.memo(
     const canSeeReports =
       rolesAllowedToResolveTasks.includes(userRole) || dispatch(hasPermission('getReports'));
     const canUpdateTask = dispatch(hasPermission('updateTask'));
-    const canDeleteTask = dispatch(hasPermission('canDeleteTask'));
+    const canUnassignTask = dispatch(hasPermission('removeUserFromTask'));
     const numTasksToShow = isTruncated ? NUM_TASKS_SHOW_TRUNCATE : activeTasks.length;
 
     const colorsObjs = {
@@ -625,7 +625,7 @@ const TeamMemberTask = React.memo(
                                           />
                                         )}
 
-                                        {(canUpdateTask || canDeleteTask) && (
+                                        {canUnassignTask && (
                                           <FontAwesomeIcon
                                             className={styles['team-member-task-remove']}
                                             icon={faTimesCircle}


### PR DESCRIPTION
# Description
Fixes the "Unassign Team Members from Tasks" permission not being respected on the Dashboard — the red X button was visible to users who did not have the permission, and the permission appeared twice in the permissions list.

**Fixes:** X button visibility not respecting `removeUserFromTask` permission

## Related PRs (if any):
Closes PR #3685 — this PR replaces it with a corrected implementation.

## Main changes explained:
- Updated `src/components/Dashboard/TeamMemberTask.jsx` to change the X button visibility condition from `canUpdateTask || canDeleteTask` to `canUnassignTask` so it correctly respects only the `removeUserFromTask` permission
- Updated `src/components/Dashboard/TeamMemberTask.jsx` to remove unused `canDeleteTask` variable
- Updated `src/components/Dashboard/TeamMemberTask.jsx` to restore the `completedTasks` constant that was accidentally commented out
- Updated `src/data/permissions.json` to remove the duplicate `deleteDashboardTask` entry that was causing "Unassign Team Members from Tasks" to appear twice in the permissions list

## How to test:
1. Check out current branch
2. Run `npm install --force` and `npm run start:local`
3. Clear site data/cache
4. Log in as Owner or Administrator
5. Go to Permissions Management → Manage User Permissions
6. Find a test user and verify "Unassign Team Members from Tasks" appears only once in the permissions list
7. Remove the `removeUserFromTask` permission from the test user
8. Go to Dashboard → Team Member Tasks
9. Verify the red X button is no longer visible for that user's tasks
10. Re-add the permission and verify the X button reappears

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/7a4b8bc0-3425-42ad-9234-2c5dc1010ff5


## Note:
The duplicate `deleteDashboardTask` permission key was causing the two entries to cancel each other out — adding one would clear the other from `removedDefaultPermissions`. Removing the duplicate from the JSON and simplifying the X button condition to use only `removeUserFromTask` resolves both issues.