### PR TITLE
Diya 🔥 fix(ui): Fixed Hamburger Menu

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -73,41 +73,28 @@
   }
 }
 
-/*
-  position: absolute;
-  top: 0;
-  left: 0;
-  padding: 12px;
-} */
-
 /* Timer Message Section */
 .timer-message-section {
   display: flex;
   align-items: center;
   justify-content: space-between;
-
-  /* flex-wrap: wrap; */
   width: 100%;
   gap: 1rem;
 }
 
 .cardContent {
-  /* padding shorthand: top right bottom left */
   padding: 15px 40px;
   white-space: pre-line;
   color: white;
   font-size: medium;
   line-height: 1.4;
-
-  /* overflow-wrap replaces deprecated word-wrap */
   overflow-wrap: break-word;
   box-sizing: border-box;
   width: 100%;
   margin: 0;
 }
 
-.headerCard { /* Remove left margin */ /* Remove right margin */
-  /* Use full viewport width */
+.headerCard {
   margin-left: 0;
   margin-right: 0;
   width: 100vw;
@@ -115,16 +102,12 @@
   box-sizing: border-box;
   overflow: hidden;
   position: relative;
-
-  /* Ensure card extends to full width */
   left: 0;
   right: 0;
 }
 
 .cardWrapper {
   padding: 1rem 0;
-
-  /* Ensure wrapper uses full width */
   width: 100%;
   margin: 0;
   box-sizing: border-box;
@@ -202,6 +185,22 @@
   display: none;
 }
 
+/* Hamburger toggle — hidden on wide screens */
+.navbarToggler {
+  display: none;
+  margin-left: 1rem;
+  flex-shrink: 0;
+}
+
+/* Collapsed nav — hidden on wide screens */
+.navCollapse {
+  display: none;
+}
+
+.navCollapseHidden {
+  display: none;
+}
+
 /* max-width: 1700px */
 @media (width <= 1700px) {
   .hideInTablet {
@@ -220,18 +219,6 @@
   }
 }
 
-@media screen and (width <= 1199px) {
-  .menuContainer {
-    align-items: start;
-    flex-direction: column !important;
-
-    /* width: 100%; */
-.navbarToggler {
-  display: none;
-  margin-left: 1rem;
-  flex-shrink: 0;
-}
-
 /* max-width: 1199px */
 @media (width <= 1199px) {
   .navbarToggler {
@@ -240,6 +227,7 @@
   }
 
   .navCollapse {
+    display: block;
     position: absolute;
     top: 100%;
     right: 0;
@@ -247,8 +235,6 @@
     min-width: 220px;
     background-color: #343a40;
     border-radius: 0 0 6px 6px;
-
-    /* rgb() modern notation with alpha as percentage */
     box-shadow: 0 6px 16px rgb(0 0 0 / 40%);
     z-index: 999;
     max-height: 0;
@@ -256,11 +242,19 @@
     transition: max-height 0.25s ease-out;
   }
 
+  .navCollapseHidden {
+    display: none;
+  }
+
   .navCollapseOpen {
     max-height: 600px;
+    overflow-y: auto;
     transition: max-height 0.25s ease-in;
   }
 
+  .menuContainer {
+    align-items: start;
+    flex-direction: column !important;
     padding-left: 50px;
     max-height: 80vh;
     overflow-y: auto;
@@ -271,12 +265,10 @@
     border: none !important;
   }
 
-  .mobileDropdownText{
+  .mobileDropdownText {
     color: rgb(255 255 255 / 50%) !important;
   }
 
-  .mobileDropdownItem:hover{
-  .mobileDropdownText {
   .mobileDropdownItem:hover {
     background-color: #343a40 !important;
     color: rgb(255 255 255 / 75%) !important;
@@ -370,8 +362,6 @@
   min-width: fit-content;
 }
 
-/* Responsive behavior - prevent icon overlap on smaller screens */
-
 /* max-width: 1200px */
 @media (width <= 1200px) {
   .left-section,
@@ -397,8 +387,6 @@
   }
 }
 
-/* Medium screens - better balance */
-
 /* max-width: 900px */
 @media (width <= 900px) {
   .center-section {
@@ -406,8 +394,6 @@
     font-size: 0.9rem;
   }
 }
-
-/* Mobile specific - stack vertically to prevent overlap */
 
 /* max-width: 768px */
 @media (width <= 768px) {
@@ -423,7 +409,4 @@
     width: 100% !important;
     justify-content: center !important;
   }
-}
-
-}}
 }


### PR DESCRIPTION
# Description
Fixes the hamburger menu on the Header navbar which was rendering but not functioning on narrow screens. The CSS file had malformed syntax — unclosed braces, rules nested inside other rules, and duplicate selectors — which caused the toggle and collapse styles to never apply correctly.

**Fixes:** [Hamburger menu not working on narrow screens](https://www.loom.com/share/52842e3b8a95481c915a50978aa19dc7)

## Main changes explained:
- Updated `src/components/Header/Header.module.css` to fix malformed CSS — removed unclosed braces, duplicate selectors, and incorrectly nested rules
- Moved `.navbarToggler`, `.navCollapse`, and `.navCollapseHidden` to proper top-level rules so they are correctly hidden on wide screens
- Inside `@media (width <= 1199px)`, `.navbarToggler` now correctly shows and `.navCollapse` animates open/closed using `max-height` transition when toggled

## How to test:
1. Check out current branch
2. Run `npm install --force` and `npm run start:local`
3. Clear site data/cache
4. Log in as any user
5. Narrow the browser window below 1199px
6. Verify the hamburger icon appears in the top right
7. Click the hamburger — verify the nav menu slides open
8. Click again — verify it closes
9. Click outside the menu — verify it closes

## Screenshots or videos of changes:
Before:
<img width="1920" height="586" alt="Screenshot 2026-05-06 at 8 05 58 PM" src="https://github.com/user-attachments/assets/fa290282-84ea-4099-8f04-b72214f47ed5" />

After:
<img width="1920" height="598" alt="Screenshot 2026-05-06 at 8 04 21 PM" src="https://github.com/user-attachments/assets/e0c9e5d7-a22f-4b7e-904d-b9c9f3bbb783" />

## Note:
The CSS file had broken syntax that was likely introduced when hamburger menu styles were added in a previous commit. The stylelint disable comment at the top has been kept as-is.