### PR TITLE
Diya fix(navbar): Fixed Navbar Issue

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -430,7 +430,7 @@ export function Header(props) {
             <NavbarToggler onClick={toggle} ref={toggleRef} className={styles.navbarToggler} />
             <div
               ref={collapseRef}
-              className={`${styles.navCollapse} ${isOpen ? styles.navCollapseOpen : styles.navCollapseHidden}`}
+              className={`${styles.navCollapse} ${isOpen ? styles.navCollapseOpen : ''}`}
               role="menu"
               tabIndex={-1}
               onKeyDown={(e) => {

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -194,11 +194,8 @@
 
 /* Collapsed nav — hidden on wide screens */
 .navCollapse {
-  display: none;
-}
-
-.navCollapseHidden {
-  display: none;
+  display: flex;
+  align-items: center;
 }
 
 /* max-width: 1700px */
@@ -243,7 +240,7 @@
   }
 
   .navCollapseHidden {
-    display: none;
+    display: none !important;
   }
 
   .navCollapseOpen {


### PR DESCRIPTION
# Description
Fixes a regression introduced in the hamburger menu PR where all navbar items were hidden on wide screens. The `navCollapseHidden` class (display: none) was being applied by default when the menu was closed, overriding the `navCollapse` class (display: flex) on wide screens.

**Fixes:** Navbar items hidden on wide screens after hamburger menu PR

## Related PRs (if any):
This PR is a follow-up fix to the hamburger menu PR #5231.

## Main changes explained:
- Updated `src/components/Header/index.jsx` to remove `navCollapseHidden` class from the collapse div — the closed state no longer explicitly hides the nav on wide screens
- Updated `src/components/Header/Header.module.css` to move `display: none` for `.navCollapseHidden` inside the `@media (width <= 1199px)` block only, so it only hides the nav on narrow screens when the hamburger is closed

## How to test:
1. Check out current branch
2. Run `npm install --force` and `npm run start:local`
3. Clear site data/cache
4. Log in as any user
5. On a wide screen (>1199px) — verify all navbar items are visible (Dashboard, Timelog, Reports, Other Links, Welcome etc.)
6. Narrow the browser below 1199px — verify only the hamburger icon is visible
7. Click the hamburger — verify the menu slides open with all nav items
8. Click outside — verify the menu closes

## Note:
The root cause was that `navCollapseHidden` was applied unconditionally when `isOpen` was false, and since `display: none` has higher specificity than `display: flex`, it hid the nav on all screen sizes. The fix scopes `navCollapseHidden` to only apply within the narrow screen media query.