### PR TITLE
Sayali: 🔥 change promotion-eligibility API call from GET to POST to match …

### DIFF
--- a/src/actions/promotionActions.js
+++ b/src/actions/promotionActions.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { ENDPOINTS } from '../utils/URL';
 
 export const getPromotionEligibility = async () => {
-  const res = await axios.get(ENDPOINTS.PROMOTION_ELIGIBILITY);
+  const res = await axios.post(ENDPOINTS.PROMOTION_ELIGIBILITY, {});
   return res.data;
 };
 


### PR DESCRIPTION
…backend endpoint fix

# Description
Fixes production bug where Promotion Eligibility table showed "Failed to load Reviewers" error.
Changes the getPromotionEligibility API call from axios.get to axios.post to match the backend endpoint fix (backend PR https://github.com/OneCommunityGlobal/HGNRest/pull/2201

## Related PRS (if any):
This frontend PR is related to backend PR  https://github.com/OneCommunityGlobal/HGNRest/pull/2201
To test this frontend PR you need to checkout backend PR https://github.com/OneCommunityGlobal/HGNRest/pull/2201
…

## Main changes explained:
Updated src/actions/promotionActions.js — changed axios.get to axios.post for PROMOTION_ELIGIBILITY endpoint so it matches the updated backend route
…

## How to test:
1. Check out branch Sayali_Fix_PromotionEligibility_Frontend
2. Check out backend branch Sayali_Fix_PromotionEligibility_Requestor (PR #2201)
3. Run npm install and npm run start:local on frontend
4. Run npm install, npm run build, npm run start on backend
5. Clear site data/cache
6. Log in as admin
7. Navigate to localhost:5173/pr-dashboard/promotion-eligibility
8. Verify table loads with reviewer data — no "Failed to load Reviewers" error
9. Verify dark mode works

## Screenshots or videos of changes:
<img width="1919" height="874" alt="image" src="https://github.com/user-attachments/assets/dcb661eb-e360-4446-91d0-8001d2266e01" />

## Note:
This is a one-line frontend fix. The root cause was that the backend GET /api/promotion-eligibility endpoint checks req.body.requestor for permissions, but GET requests don't carry a body in production. Backend fix changes it to POST, this PR updates the frontend call accordingly.
