### PR TITLE
Sayali: 🔥 correct PR Team Analytics navigation to overview page and remove stray blue square item from PR Dashboard dropdown

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -7,7 +7,6 @@ import { toast } from 'react-toastify';
 import {
   Button,
   Card,
-  NavbarToggler,
   DropdownItem,
   DropdownMenu,
   DropdownToggle,
@@ -17,6 +16,7 @@ import {
   ModalHeader,
   Nav,
   Navbar,
+  NavbarToggler,
   NavItem,
   NavLink,
   UncontrolledDropdown
@@ -804,22 +804,12 @@ export function Header(props) {
                       <DropdownItem divider />
                       <DropdownItem
                         tag={Link}
-                        to="/pr-dashboard/analytics"
+                        to="/pr-dashboard/overview"
                         className={fontColor}
                         disabled={headerDisabled}
                       >
                         PR Team Analytics
                       </DropdownItem>
-                      {canAccessBlueSquareEmailManagement && (
-                        <DropdownItem
-                          tag={Link}
-                          to="/bluesquare-email-management"
-                          className={fontColor}
-                          disabled={headerDisabled}
-                        >
-                          {BLUE_SQUARE_EMAIL_MANAGEMENT}
-                        </DropdownItem>
-                      )}
                       <DropdownItem
                         tag={Link}
                         to="/pr-dashboard/analytics"


### PR DESCRIPTION
# Description
This PR fixes a navigation bug introduced in #5120 where "PR Team Analytics" was incorrectly routing to `/pr-dashboard/analytics` (Top 20 Most Popular PRs page) instead of `/pr-dashboard/overview`. Also removes a stray "Blue Square Email Management" item that was mistakenly placed inside the PR Dashboard dropdown.

Fixes #(bug)
Related to #5120

## Related PRs (if any):
This frontend PR is related to #5120

## Main changes explained:
- Fixed `PR Team Analytics` link in PR Dashboard dropdown to navigate to `/pr-dashboard/overview` instead of `/pr-dashboard/analytics`
- Removed duplicate/stray `Blue Square Email Management` dropdown item from inside the PR Dashboard dropdown

## How to test:
1. Check out current branch
2. `npm install` and `npm run start:local`
3. Clear site data/cache
4. Log in as admin
5. Click **PR Dashboard** dropdown in header
6. Verify dropdown shows exactly 6 items (no Blue Square Email Management item)
7. Click **PR Team Analytics** → should navigate to `/pr-dashboard/overview` (PR Dashboard Overview page)
8. Click **PR Analytics** → should navigate to `/pr-dashboard/analytics` (Top 20 Most Popular PRs page)
9. Verify this works in dark mode too

## Screenshots or videos of changes:
<img width="467" height="343" alt="image" src="https://github.com/user-attachments/assets/a498d8b4-426c-42ac-9015-685e7de25468" />
<img width="1910" height="1018" alt="image" src="https://github.com/user-attachments/assets/68e6724b-0176-4960-a4e0-f26880e79908" />
<img width="1919" height="610" alt="image" src="https://github.com/user-attachments/assets/4f6114c4-6873-48db-b322-41bda54b9497" />

## Note:
Frontend-only fix. No backend changes required.