### PR TITLE
Diya 🔥 fix(weeklyReport): Fixed Stars Visible on Hours Logged

### DIFF
--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -846,7 +846,6 @@ function Index({
   darkMode,
 }) {
   const colors = ['purple', 'green', 'navy'];
-  const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
   const tangibleHoursLogged = (summary.totalTangibleSeconds?.[weekIndex] || 0) / 3600;
   const currentDate = moment.tz(TZ).startOf('day');
   const [setTrophyFollowedUp] = useState(summary?.trophyFollowedUp);
@@ -1092,23 +1091,31 @@ function Index({
   );
 }
 
-// FormattedReport.propTypes = {
-//   // eslint-disable-next-line react/forbid-prop-types
-//   summaries: PropTypes.arrayOf(PropTypes.object).isRequired,
-//   weekIndex: PropTypes.number.isRequired,
-
-//   // Adding these to clarify structure for Sonar:
-//   // summary: PropTypes.shape({
-//   //   _id: PropTypes.string,
-//   //   filterColor: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-//   //   promisedHoursByWeek: PropTypes.arrayOf(PropTypes.number),
-//   //   weeklySummaries: PropTypes.arrayOf(
-//   //     PropTypes.shape({
-//   //       summary: PropTypes.string,
-//   //     }),
-//   //   ),
-//   // }),
-// };
+Index.propTypes = {
+  summary: PropTypes.shape({
+    _id: PropTypes.string,
+    firstName: PropTypes.string,
+    lastName: PropTypes.string,
+    role: PropTypes.string,
+    totalSeconds: PropTypes.arrayOf(PropTypes.number),
+    totalTangibleSeconds: PropTypes.arrayOf(PropTypes.number),
+    promisedHoursByWeek: PropTypes.arrayOf(PropTypes.number),
+    filterColor: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+    adminLinks: PropTypes.array,
+    startDate: PropTypes.string,
+    endDate: PropTypes.string,
+    trophyFollowedUp: PropTypes.bool,
+    timeOffFrom: PropTypes.string,
+    timeOffTill: PropTypes.string,
+  }).isRequired,
+  weekIndex: PropTypes.number.isRequired,
+  allRoleInfo: PropTypes.array,
+  auth: PropTypes.object,
+  loadTrophies: PropTypes.bool,
+  handleSpecialColorDotClick: PropTypes.func,
+  isFinalWeek: PropTypes.bool,
+  darkMode: PropTypes.bool,
+};
 
 FormattedReport.propTypes = {
   summaries: PropTypes.arrayOf(

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -302,6 +302,7 @@ function ReportDetails({
   const totalSecondsArray = summary.totalSeconds || [];
   const promisedHoursArray = summary.promisedHoursByWeek || [];
   const hoursLogged = ((totalSecondsArray[weekIndex] || 0) / 3600).toFixed(2);
+  const tangibleHoursLogged = (summary.totalTangibleSeconds?.[weekIndex] || 0) / 3600;
   const promisedHours = promisedHoursArray[weekIndex] ?? 0;
 
   const isMeetCriteria =
@@ -847,6 +848,7 @@ function Index({
 }) {
   const colors = ['purple', 'green', 'navy'];
   const hoursLogged = (summary.totalSeconds[weekIndex] || 0) / 3600;
+  const tangibleHoursLogged = (summary.totalTangibleSeconds?.[weekIndex] || 0) / 3600;
   const currentDate = moment.tz(TZ).startOf('day');
   const [setTrophyFollowedUp] = useState(summary?.trophyFollowedUp);
   const dispatch = useDispatch();
@@ -1040,12 +1042,15 @@ function Index({
       )}
       {Array.isArray(summary.promisedHoursByWeek) &&
         summary.promisedHoursByWeek.length > weekIndex &&
-        showStar(hoursLogged, summary.promisedHoursByWeek[weekIndex]) && (
+        showStar(tangibleHoursLogged, summary.promisedHoursByWeek[weekIndex]) && (
           <i
             className="fa fa-star"
             title={`Weekly Committed: ${summary.promisedHoursByWeek[weekIndex]} hours`}
             style={{
-              color: assignStarDotColors(hoursLogged, summary.promisedHoursByWeek[weekIndex]),
+              color: assignStarDotColors(
+                tangibleHoursLogged,
+                summary.promisedHoursByWeek[weekIndex],
+              ),
               fontSize: '55px',
               marginLeft: '10px',
               verticalAlign: 'middle',
@@ -1063,7 +1068,9 @@ function Index({
                 fontSize: '10px',
               }}
             >
-              +{Math.round((hoursLogged / summary.promisedHoursByWeek[weekIndex] - 1) * 100)}%
+              +
+              {Math.round((tangibleHoursLogged / summary.promisedHoursByWeek[weekIndex] - 1) * 100)}
+              %
             </span>
           </i>
         )}
@@ -1082,40 +1089,6 @@ function Index({
           </small>
         </p>
       )}
-      {/* //newly added */}
-      {Array.isArray(summary.promisedHoursByWeek) &&
-        summary.promisedHoursByWeek.length > weekIndex &&
-        weekIndex !== null &&
-        weekIndex !== undefined &&
-        summary.promisedHoursByWeek[weekIndex] !== undefined &&
-        showStar(hoursLogged, summary.promisedHoursByWeek[weekIndex]) && (
-          <i
-            className="fa fa-star"
-            title={`Weekly Committed: ${summary.promisedHoursByWeek[weekIndex]} hours`}
-            style={{
-              color: assignStarDotColors(hoursLogged, summary.promisedHoursByWeek[weekIndex]),
-              fontSize: '55px',
-              marginLeft: '10px',
-              verticalAlign: 'middle',
-              position: 'relative',
-            }}
-          >
-            <span
-              style={{
-                position: 'absolute',
-                top: '50%',
-                left: '50%',
-                transform: 'translate(-50%, -50%)',
-                color: 'white',
-                fontWeight: 'bold',
-                fontSize: '10px',
-              }}
-            >
-              +{Math.round((hoursLogged / summary.promisedHoursByWeek[weekIndex] - 1) * 100)}%
-              {/* +{Math.round((hoursLogged / promisedHoursByWeek[weekIndex] - 1) * 100)}% */}
-            </span>
-          </i>
-        )}
     </>
   );
 }

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -302,7 +302,6 @@ function ReportDetails({
   const totalSecondsArray = summary.totalSeconds || [];
   const promisedHoursArray = summary.promisedHoursByWeek || [];
   const hoursLogged = ((totalSecondsArray[weekIndex] || 0) / 3600).toFixed(2);
-  const tangibleHoursLogged = (summary.totalTangibleSeconds?.[weekIndex] || 0) / 3600;
   const promisedHours = promisedHoursArray[weekIndex] ?? 0;
 
   const isMeetCriteria =
@@ -1117,7 +1116,8 @@ FormattedReport.propTypes = {
       _id: PropTypes.string,
       filterColor: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
       promisedHoursByWeek: PropTypes.arrayOf(PropTypes.number),
-      totalSeconds: PropTypes.number,
+      totalSeconds: PropTypes.arrayOf(PropTypes.number),
+      totalTangibleSeconds: PropTypes.arrayOf(PropTypes.number),
       weeklySummaries: PropTypes.arrayOf(PropTypes.shape({ summary: PropTypes.string })),
     }),
   ).isRequired,


### PR DESCRIPTION
# Description
Fixes two bugs on the Weekly Summaries Report related to stars:
1. Stars were being awarded based on total (tangible + intangible) hours instead of tangible-only hours
2. A duplicate star was rendering for each user due to a second star block that was active JSX

**Fixes:** Weekly Summaries Report — duplicate star and intangible time counted toward star threshold

## Related PRs:
This frontend PR is related to backend PR [#2205](https://github.com/OneCommunityGlobal/HGNRest/pull/2205).

## Main changes explained:
- Updated `src/components/WeeklySummariesReport/FormattedReport.jsx`:
  - Added `tangibleHoursLogged` derived from `summary.totalTangibleSeconds?.[weekIndex]` in the `Index` function
  - Updated `showStar`, `assignStarDotColors`, and the percentage label to use `tangibleHoursLogged` instead of `hoursLogged` — `hoursLogged` is kept unchanged for the "Hours logged: X / Y" display
  - Commented out the duplicate second star block that was rendering two stars per user

## How to test:
1. Check out the current branch alongside backend PR [#2205](https://github.com/OneCommunityGlobal/HGNRest/pull/2205)
2. Run `npm install --force` and `npm run start:local`
3. Clear site data/cache
4. Log in as Owner or Administrator
5. Find a test user and set their `weeklycommittedHours` to `5` from their UserProfile page.
6. Log `6.5 hours` of **tangible** time for them this week
7. Go to Weekly Summaries Report → This Week tab
8. Verify exactly **one** star appears with `+30%`
9. Change the time entry to **intangible** — verify the star disappears
10. Verify "Hours logged" display still shows the full hours regardless of tangible/intangible

## Screenshots or videos of changes:
<img width="1881" height="1339" alt="TimeLoggedStars" src="https://github.com/user-attachments/assets/5229b02b-1eb5-4e06-8fb9-9af6b1f49b74" />

## Note:
The `hoursLogged` variable in `ReportDetails` (used for the hours display) is intentionally kept as total seconds ÷ 3600 — it should continue to show all logged hours including intangible. Only the star uses `tangibleHoursLogged`.