### PR TITLE
Diya 🔥 fix(load): Fixed Permission Page Load

### DIFF
--- a/src/components/PermissionsManagement/PermissionChangeLogTable.jsx
+++ b/src/components/PermissionsManagement/PermissionChangeLogTable.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import { useState } from 'react';
-import './PermissionChangeLogTable.module.css';
+import styles from './PermissionChangeLogTable.module.css';
 import { FiChevronLeft, FiChevronRight, FiChevronDown, FiChevronUp } from 'react-icons/fi';
 import { formatDate, formattedAmPmTime } from '~/utils/formatDate';
 import { permissionLabelKeyMappingObj } from './PermissionsConst';


### PR DESCRIPTION
# Description
Fixes a runtime crash on the Permissions Management page caused by `PermissionChangeLogTable` using `styles` CSS module classes without importing the module correctly.

**Fixes:** `ReferenceError: styles is not defined` crash on Permissions Management page

## Related PRs:
N/A — frontend only.

## Main changes explained:
- Updated `src/components/PermissionsManagement/PermissionChangeLogTable.jsx` line 3 to change `import './PermissionChangeLogTable.module.css'` to `import styles from './PermissionChangeLogTable.module.css'` so the `styles` variable is correctly defined

## How to test:
1. Check out current branch
2. Run `npm install --force` and `npm run start:local`
3. Clear site data/cache
4. Log in as Owner or Administrator
5. Navigate to Other Links → Permissions Management
6. Verify the page loads without crashing
7. Verify the Permission Change Log table renders correctly at the bottom

## Note:
The CSS module was imported as a side-effect only (`import './...'`) instead of as a named import (`import styles from './...'`), so all `styles.x` references threw a `ReferenceError` at runtime.