### PR TITLE
Diya 🔥 fix(format): Fixed Weekly Summary Filter Format

### DIFF
--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -2042,17 +2042,6 @@ const WeeklySummariesReport = props => {
               ))}
             </div>
           )}
-          <div className={styles.filterRow} style={{ marginTop: '12px' }}>
-            <WeeklySummariesToggleFilter
-              state={state}
-              setState={setState}
-              hasPermissionToFilter={hasPermissionToFilter}
-              editable={true}
-              formId="report"
-              hasPermission={props.hasPermission}
-              darkMode={darkMode}
-            />
-          </div>
         </Col>
         <Col lg={{ size: 5 }} md={{ size: 6 }} xs={{ size: 12 }}>
           <div>Select Color</div>
@@ -2133,6 +2122,17 @@ const WeeklySummariesReport = props => {
                 )}
               </div>
             )}
+          </div>
+          <div className={styles.filterRow} style={{ marginTop: '8px' }}>
+            <WeeklySummariesToggleFilter
+              state={state}
+              setState={setState}
+              hasPermissionToFilter={hasPermissionToFilter}
+              editable={true}
+              formId="report"
+              hasPermission={props.hasPermission}
+              darkMode={darkMode}
+            />
           </div>
         </Col>
       </Row>


### PR DESCRIPTION
# Description
Moves the Bio Status / Trophies / Over Hours toggle filters from the left column to the right column on the Weekly Summaries Report page, placing them below the Special Colors filter section for better visual grouping.

**Fixes:** Weekly Summaries Report — Bio Status, Trophies, and Over Hours toggles misplaced in left column

## Related PRs:
N/A — frontend only.

## Main changes explained:
- Updated `src/components/WeeklySummariesReport/WeeklySummariesReport.jsx` to move the `WeeklySummariesToggleFilter` component from the left column (below team code selector) to the right column (below the Special Colors filter section)

## How to test:
1. Check out current branch
2. Run `npm install --force` and `npm run start:local`
3. Clear site data/cache
4. Log in as Owner or Administrator
5. Navigate to Reports → Weekly Summaries Report
6. Verify Bio Status, Trophies, and Over Hours toggles appear on the **right** side, below the Special Colors (Purple/Green/Navy) toggles
7. Verify the left column no longer has those toggles
8. Verify all three toggles still function correctly — toggling each one filters the summaries as expected

## Screenshots or videos of changes:
Before: 
<img width="1598" height="334" alt="Screenshot 2026-05-08 at 3 29 36 PM" src="https://github.com/user-attachments/assets/44c97954-84ab-4ba3-a80c-15681c295e77" />

After:
<img width="1610" height="402" alt="Screenshot 2026-05-08 at 3 25 14 PM" src="https://github.com/user-attachments/assets/fdfb74cd-297f-4548-8b7f-9df97e36bbc6" />

## Note:
No logic changes — purely a layout move. The toggles were previously in the left column beneath the team code selector; they now live in the right column beneath the Special Colors section for better visual grouping.