### PR TITLE
Diya fix(ui): Fixed Owner Message Popup on Image Upload

### DIFF
--- a/src/components/OwnerMessage/OwnerMessage.jsx
+++ b/src/components/OwnerMessage/OwnerMessage.jsx
@@ -54,7 +54,6 @@ function OwnerMessage({
   const isImageMessage = value => typeof value === 'string' && value.includes(';base64');
 
   function toggle() {
-    console.log('toggle called, message:', message, 'ownerMessage:', ownerMessage);
     setModal(!modal);
     setDisableTextInput(isImageMessage(message));
   }

--- a/src/components/OwnerMessage/OwnerMessage.jsx
+++ b/src/components/OwnerMessage/OwnerMessage.jsx
@@ -54,8 +54,9 @@ function OwnerMessage({
   const isImageMessage = value => typeof value === 'string' && value.includes(';base64');
 
   function toggle() {
+    console.log('toggle called, message:', message, 'ownerMessage:', ownerMessage);
     setModal(!modal);
-    setDisableTextInput(false);
+    setDisableTextInput(isImageMessage(message));
   }
 
   function toggleDeleteWarning() {
@@ -97,6 +98,7 @@ function OwnerMessage({
       toast.success(
         isStandard ? 'Standard message update successfully!' : 'Message update successfully!',
       );
+      await getMessage();
     } else {
       toast.error(`Standard message save failed! Error: ${response}`);
     }
@@ -244,12 +246,24 @@ function OwnerMessage({
           <Input
             type="textarea"
             placeholder="Write your message here... (Max 100 characters)"
-            value={message}
+            value={hasSelectedImage ? '✓ Image selected — click Update/Create to save' : message}
             onChange={event => setMessage(event.target.value)}
             maxLength="100"
             disabled={disableTextInput}
             className={styles.inputs}
           />
+          {hasSelectedImage && (
+            <button
+              type="button"
+              style={{ marginTop: '0.5rem', fontSize: '0.8rem', cursor: 'pointer' }}
+              onClick={() => {
+                setMessage('');
+                setDisableTextInput(false);
+              }}
+            >
+              ✕ Remove image
+            </button>
+          )}
           {!hasSelectedImage && (
             <>
               <p className="paragraph" style={{ marginTop: '1rem' }}>


### PR DESCRIPTION
# Description
Fixes two UX issues with the Owner Message image upload flow:

1. After uploading an image, the raw base64 string was displayed in the textarea — replaced with a friendly confirmation message instead
2. After saving an image message and reopening the edit modal, the state was blank (fresh view) instead of showing the image-selected state — caused by `getMessage()` not being called after a successful save, leaving Redux state empty

**Fixes:** Owner Message modal shows raw base64 in textarea and resets to fresh view on reopen after saving image

## Related PRs:
Follow-up to PRs #4769 and #5169.

## Main changes explained:
- Updated `src/components/OwnerMessage/OwnerMessage.jsx` to display a friendly confirmation string in the textarea when an image is selected instead of the raw base64 string
- Updated `src/components/OwnerMessage/OwnerMessage.jsx` to add a "Remove image" button allowing the user to clear the selected image and return to the upload form
- Updated `src/components/OwnerMessage/OwnerMessage.jsx` to call `getMessage()` after a successful save so Redux state is refreshed and reopening the modal correctly shows the image-selected state

## How to test:
1. Check out current branch
2. Run `npm install --force` and `npm run start:local`
3. Clear site data/cache
4. Log in as Owner or a user with `editHeaderMessage` permission
5. Click the edit icon on the owner message in the header
6. Upload a valid `.png`, `.jpg`, or `.jpeg` image
7. Verify the textarea shows `✓ Image selected — click Update/Create to save` instead of a base64 string
8. Verify the upload section (label, size note, file input) disappears
9. Verify a "Remove image" button appears — click it and confirm you return to the fresh upload view
10. Upload an image again and click Create/Update
11. Reopen the modal by clicking the edit icon again
12. Verify the modal shows the image-selected state (not a fresh upload form)

## Note:
The root cause of the reopen issue was that `getMessage()` was never called after saving, so `ownerMessage` in Redux remained empty until page refresh. The textarea confirmation message is display-only — the actual base64 is still stored in `message` state and saved correctly.