### PR TITLE
Revert:  add links to categories in “All Inventory Types” page.

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -517,6 +517,9 @@ export function Header(props) {
                       }`}
                       disabled={headerDisabled}
                     >
+                      <DropdownItem tag={Link} to="/bmdashboard/inventorytypes" className={fontColor}>
+                        All Inventory Types
+                      </DropdownItem>
                       <DropdownItem tag={Link} to="/bmdashboard/materials/add" className={fontColor}>
                         Add Material
                       </DropdownItem>


### PR DESCRIPTION
# Description
<img width="685" height="741" alt="Screenshot 2026-03-27 at 10 50 46 AM" src="https://github.com/user-attachments/assets/1cb7d1f8-15e1-4b78-b6d5-4ea37e480274" />
<img width="685" height="741" alt="Screenshot 2026-03-27 at 10 51 01 AM" src="https://github.com/user-attachments/assets/377a9e2e-c088-48a7-be76-2f40ff7bef07" />


## Related PRS (if any):
This is a revert of this PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5172
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to /bmdashboard
6. verify bmdashboard header persistence
7. verify this new feature “All Inventory Types” in the project dropdown

## Screenshots or videos of changes:

## Notes: 
This is a clean PR related to #5172, in which add links to categories in “All Inventory Types” page has been reverted back to the original development
