### PR TITLE
Manoj - revert: remove unwanted BMDashboard commits, retain header persistence and inventory types dropdown

### DIFF
--- a/src/components/BMDashboard/ConsumableList/ConsumableListView.jsx
+++ b/src/components/BMDashboard/ConsumableList/ConsumableListView.jsx
@@ -3,8 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchAllConsumables } from '../../../actions/bmdashboard/consumableActions';
 import ItemListView from '../ItemList/ItemListView';
 import UpdateConsumableModal from '../UpdateConsumables/UpdateConsumableModal';
-import { Link } from 'react-router-dom';
-import styles from '../InventoryTypesList/TypesList.module.css';
 
 function ConsumableListView() {
   const dispatch = useDispatch();
@@ -52,19 +50,13 @@ function ConsumableListView() {
   ];
 
   return (
-    <>
-      <Link to="/bmdashboard/inventorytypes" className={styles.backLink}>
-        All Inventory Types
-      </Link>
-
-      <ItemListView
-        itemType={itemTypeLabel}
-        items={transformedConsumables}
-        errors={errors}
-        UpdateItemModal={UpdateConsumableModal}
-        dynamicColumns={dynamicColumns}
-      />
-    </>
+    <ItemListView
+      itemType={itemTypeLabel}
+      items={transformedConsumables}
+      errors={errors}
+      UpdateItemModal={UpdateConsumableModal}
+      dynamicColumns={dynamicColumns}
+    />
   );
 }
 

--- a/src/components/BMDashboard/Equipment/List/EquipmentList.jsx
+++ b/src/components/BMDashboard/Equipment/List/EquipmentList.jsx
@@ -3,8 +3,6 @@ import useTheme from '../../../../hooks/useTheme';
 import EquipmentsTable from './EquipmentsTable';
 import EquipmentsInputs from './EquipmentsInputs';
 import styles from './Equipments.module.css';
-import { Link } from 'react-router-dom';
-import stylesList from '../../InventoryTypesList/TypesList.module.css';
 
 function EquipmentList() {
   const [equipment, setEquipment] = useState({ label: 'All Equipments', value: '0' });
@@ -14,30 +12,25 @@ function EquipmentList() {
   useTheme();
 
   return (
-    <>
-      <Link to="/bmdashboard/inventorytypes" className={stylesList.backLink}>
-        All Inventory Types
-      </Link>
-      <div className={`${styles.PageViewContainer}`}>
-        <div className={`${styles.Page}`}>
-          <div className={`${styles.Box}`}>
-            <div className={`${styles.BuildingTitle}`}>EQUIPMENTS</div>
-            <EquipmentsInputs
-              equipment={equipment}
-              setEquipment={setEquipment}
-              project={project}
-              setProject={setProject}
-            />
-            <EquipmentsTable
-              equipment={equipment}
-              setEquipment={setEquipment}
-              project={project}
-              setProject={setProject}
-            />
-          </div>
+    <div className={`${styles.PageViewContainer}`}>
+      <div className={`${styles.Page}`}>
+        <div className={`${styles.Box}`}>
+          <div className={`${styles.BuildingTitle}`}>EQUIPMENTS</div>
+          <EquipmentsInputs
+            equipment={equipment}
+            setEquipment={setEquipment}
+            project={project}
+            setProject={setProject}
+          />
+          <EquipmentsTable
+            equipment={equipment}
+            setEquipment={setEquipment}
+            project={project}
+            setProject={setProject}
+          />
         </div>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/src/components/BMDashboard/InventoryTypesList/InventoryTypesList.jsx
+++ b/src/components/BMDashboard/InventoryTypesList/InventoryTypesList.jsx
@@ -1,25 +1,31 @@
 import { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
+
 import { fetchInvTypeByType } from '~/actions/bmdashboard/invTypeActions';
 import { fetchInvUnits } from '~/actions/bmdashboard/invUnitActions';
-import { Accordion, Card } from 'react-bootstrap';
+import { Accordion, Card, Button } from 'react-bootstrap';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+
 import BMError from '../shared/BMError';
+import TypesTable from './TypesTable';
 import UnitsTable from './invUnitsTable';
 import AccordionToggle from './AccordionToggle';
 import styles from './TypesList.module.css';
 
-const categories = [
-  { label: 'Materials', route: '/bmdashboard/materials' },
-  { label: 'Consumables', route: '/bmdashboard/consumables' },
-  { label: 'Equipments', route: '/bmdashboard/equipment' },
-  { label: 'Reusables', route: '/bmdashboard/reusables' },
-  { label: 'Tools', route: '/bmdashboard/tools' },
-];
-
 export function InventoryTypesList(props) {
   const { invUnits, errors, dispatch } = props;
+  const history = useHistory();
+
+  const categories = ['Materials', 'Consumables', 'Equipments', 'Reusables', 'Tools'];
+
   const [isError, setIsError] = useState(false);
+  const [currentTime, setCurrentTime] = useState(new Date());
+
+  const handleBack = () => {
+    history.goBack();
+  };
 
   useEffect(() => {
     dispatch(fetchInvTypeByType('Materials'));
@@ -44,38 +50,52 @@ export function InventoryTypesList(props) {
   }
 
   return (
-    <div className={styles.typesListContainer}>
-      {/* Page Header */}
-      <div className={styles.pageHeader}>
-        <h1 className={styles.pageTitle}>All Inventory Types</h1>
-        <p className={styles.pageSubtitle}>Select a category to view and manage inventory</p>
+    <div className={`${styles.typesListContainer}`}>
+      <h1>All Inventory Types</h1>
+
+      <div className={`${styles.timestampContainer}`}>
+        <span>Time:</span>
+        <DatePicker
+          selected={currentTime}
+          onChange={date => setCurrentTime(date)}
+          dateFormat="MM-dd-yyyy hh:mm:ss"
+          id="timestamp"
+          showTimeInput
+        />
       </div>
 
-      {/* Category Cards Grid */}
-      <div className={styles.categoryGrid}>
-        {categories.map(({ label, route }) => (
-          <Link key={label} to={route} className={styles.categoryCard}>
-            <span className={styles.categoryCardLabel}>{label}</span>
-            <div className={styles.categoryCardArrow}>›</div>
-          </Link>
-        ))}
-      </div>
+      <Accordion>
+        {categories?.map((category, index) => {
+          return (
+            <Card key={category}>
+              <AccordionToggle as={Card.Header} eventKey={index + 1}>
+                {category}
+              </AccordionToggle>
+              <Accordion.Collapse eventKey={index + 1}>
+                <Card.Body className={`${styles.accordionCollapse}`}>
+                  <TypesTable category={category} />
+                </Card.Body>
+              </Accordion.Collapse>
+            </Card>
+          );
+        })}
 
-      {/* Unit of Measurement */}
-      <div className={styles.unitSection}>
-        <h2 className={styles.unitSectionTitle}>Unit of Measurement</h2>
-        <Accordion>
-          <Card className={styles.unitCard}>
-            <AccordionToggle as={Card.Header} eventKey={1} className={styles.cardHeader}>
-              View all units
-            </AccordionToggle>
-            <Accordion.Collapse eventKey={1}>
-              <Card.Body className={styles.accordionCollapse}>
-                <UnitsTable invUnits={invUnits} />
-              </Card.Body>
-            </Accordion.Collapse>
-          </Card>
-        </Accordion>
+        <Card>
+          <AccordionToggle as={Card.Header} eventKey={categories.length + 1}>
+            Unit of Measurement
+          </AccordionToggle>
+          <Accordion.Collapse eventKey={categories.length + 1}>
+            <Card.Body className={`${styles.accordionCollapse}`}>
+              <UnitsTable invUnits={invUnits} />
+            </Card.Body>
+          </Accordion.Collapse>
+        </Card>
+      </Accordion>
+
+      <div className={`${styles.buttonContainer}`}>
+        <Button variant="primary" className={`${styles.backButton}`} onClick={handleBack}>
+          Back to previous list page
+        </Button>
       </div>
     </div>
   );

--- a/src/components/BMDashboard/InventoryTypesList/TypesList.module.css
+++ b/src/components/BMDashboard/InventoryTypesList/TypesList.module.css
@@ -1,17 +1,16 @@
-:root {
+/* stylelint-disable no-descending-specificity */
+.typesListContainer {
+  width: 100%;
+  max-width: 1080px;
+  margin: 1rem auto;
+  padding: 0 1rem;
+
   --color-h50: #e8f4f9;
   --color-h100: #78bdda;
   --color-h500: #0d5675;
   --color-n0: #fff;
   --color-text: #1c8bcc;
   --font-clickable: roboto;
-}
-
-.typesListContainer {
-  width: 100%;
-  max-width: 1080px;
-  margin: 1rem auto;
-  padding: 0 1rem;
 }
 
 /* Dark mode support */
@@ -260,86 +259,16 @@
   font-size: 10px;
 }
 
-/* ---- Page Header ---- */
-.pageHeader {
-  margin-bottom: 28px;
-  padding-bottom: 16px;
-  border-bottom: 2px solid var(--color-h50);
-}
-
-.pageTitle {
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--color-h500);
-  margin: 0 0 6px;
-}
-
-.pageSubtitle {
-  font-size: 14px;
-  color: #6c757d;
-  margin: 0;
-}
-
-/* ---- Category Cards Grid ---- */
-.categoryGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 16px;
-  margin-bottom: 36px;
-}
-
-.categoryCard {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 20px 24px;
-  background-color: var(--color-n0);
-  border: 1.5px solid var(--color-h50);
-  border-radius: 12px;
-  text-decoration: none !important;
-  color: inherit !important;
-  transition: all 0.2s ease;
-  box-shadow: 0 1px 4px rgb(0 0 0 / 6%);
-}
-
-.categoryCardLabel {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--color-h500);
-}
-
-.categoryCardArrow {
-  font-size: 22px;
-  color: var(--color-h100);
-  font-weight: 300;
-  flex-shrink: 0;
-}
-
-/* ---- Unit Section ---- */
-.unitSection {
-  margin-top: 8px;
-}
-
-.unitSectionTitle {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: var(--color-h500);
-  margin-bottom: 12px;
-}
-
-.unitCard {
-  border: 1.5px solid var(--color-h50) !important;
-  border-radius: 10px !important;
-  overflow: hidden;
-}
-
-/* Main container dark mode */
-:global(.bm-dashboard-dark) .typesListContainer {
+/* Dark mode table styling */
+:global(.dark-mode) .typesListContainer table,
+:global(.bm-dashboard-dark) .typesListContainer table {
   color: #fff;
 }
 
-:global(.bm-dashboard-dark) .typesListContainer h1 {
-  color: #fff !important;
+:global(.dark-mode) .typesListContainer table tbody tr,
+:global(.bm-dashboard-dark) .typesListContainer table tbody tr {
+  background-color: #2a2a2a;
+  color: #fff;
 }
 
 :global(.dark-mode) .typesListContainer table tbody tr:hover,
@@ -398,10 +327,12 @@
   color: #fff !important;
 }
 
-:global(.bm-dashboard-dark) #timestamp {
-  background-color: #2e5061 !important;
+/* Dark mode react-datepicker styling */
+:global(.dark-mode) .timestampContainer :global(.react-datepicker-wrapper) input,
+:global(.bm-dashboard-dark) .timestampContainer :global(.react-datepicker-wrapper) input {
+  background-color: #3a3a3a !important;
   color: #fff !important;
-  border-color: #3a506b !important;
+  border-color: rgb(255 255 255 / 20%) !important;
 }
 
 :global(.dark-mode) :global(.react-datepicker),
@@ -627,12 +558,6 @@
   box-shadow: 0 0 0 0.2rem rgb(106 241 234 / 25%) !important;
 }
 
-:global(.bm-dashboard-dark) .typesListContainer :global(.react-datepicker-time__input) input {
-  background-color: #1c2541 !important;
-  color: #fff !important;
-  border-color: #3a506b !important;
-}
-
 /* Autocomplete styling */
 :global(.bm-dashboard-dark) .typesListContainer input:-webkit-autofill,
 :global(.bm-dashboard-dark) .typesListContainer input:-webkit-autofill:hover,
@@ -693,111 +618,8 @@
   color: #fff !important;
 }
 
-/* ---- New page element dark mode (before hover rules) ---- */
-:global(.bm-dashboard-dark) .pageTitle {
-  color: #fff !important;
-}
-
-:global(.bm-dashboard-dark) .pageSubtitle {
-  color: #b5bac5 !important;
-}
-
-:global(.bm-dashboard-dark) .pageHeader {
-  border-color: #3a506b !important;
-}
-
-:global(.bm-dashboard-dark) .categoryCard {
+:global(.bm-dashboard-dark) .typesListContainer :global(.react-datepicker-time__input) input {
   background-color: #1c2541 !important;
+  color: #fff !important;
   border-color: #3a506b !important;
-  color: #fff !important;
-}
-
-:global(.bm-dashboard-dark) .categoryCardLabel {
-  color: #fff !important;
-}
-
-:global(.bm-dashboard-dark) .categoryCardArrow {
-  color: #6af1ea !important;
-}
-
-:global(.bm-dashboard-dark) .unitSectionTitle {
-  color: #fff !important;
-}
-
-:global(.bm-dashboard-dark) .unitCard {
-  border-color: #3a506b !important;
-}
-
-/* ---- Hover rules AFTER dark mode overrides ---- */
-.categoryCard:hover {
-  border-color: var(--color-h100);
-  box-shadow: 0 4px 12px rgb(13 86 117 / 12%);
-  transform: translateY(-2px);
-  text-decoration: none !important;
-}
-
-:global(.bm-dashboard-dark) .categoryCard:hover {
-  border-color: #5a7a9b !important;
-  box-shadow: 0 4px 12px rgb(0 0 0 / 30%) !important;
-}
-
-/* ---- Back link ---- */
-.backLink {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 20px;
-  padding: 8px 16px;
-  background-color: #e8f4f9;
-  color: #0d5675 !important;
-  text-decoration: none !important;
-  font-size: 14px;
-  font-weight: 600;
-  border-radius: 25px;
-  border: 1.5px solid #78bdda;
-  transition: all 0.2s ease;
-}
-
-.backLink::before {
-  content: '';
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-left: 2px solid #0d5675;
-  border-bottom: 2px solid #0d5675;
-  transform: rotate(45deg);
-  transition: border-color 0.2s ease;
-  margin-right: 2px;
-}
-
-.backLink:hover {
-  background-color: #0d5675;
-  color: #fff !important;
-  border-color: #0d5675;
-  text-decoration: none !important;
-  transform: translateX(-2px);
-}
-
-.backLink:hover::before {
-  border-color: #fff;
-}
-
-:global(.bm-dashboard-dark) .backLink {
-  background-color: #1c2541 !important;
-  color: #6af1ea !important;
-  border-color: #3a506b !important;
-}
-
-:global(.bm-dashboard-dark) .backLink::before {
-  border-color: #6af1ea !important;
-}
-
-:global(.bm-dashboard-dark) .backLink:hover {
-  background-color: #2e5061 !important;
-  color: #fff !important;
-  border-color: #5a7a9b !important;
-}
-
-:global(.bm-dashboard-dark) .backLink:hover::before {
-  border-color: #fff !important;
 }

--- a/src/components/BMDashboard/MaterialList/MaterialListView.jsx
+++ b/src/components/BMDashboard/MaterialList/MaterialListView.jsx
@@ -12,8 +12,6 @@ import {
 import { fetchAllMaterials, resetMaterialUpdate } from '~/actions/bmdashboard/materialsActions';
 import ItemListView from '../ItemList/ItemListView';
 import UpdateMaterialModal from '../UpdateMaterials/UpdateMaterialModal';
-import { Link } from 'react-router-dom';
-import styles from '../InventoryTypesList/TypesList.module.css';
 
 function MaterialListView() {
   const dispatch = useDispatch();
@@ -84,47 +82,42 @@ function MaterialListView() {
   ];
 
   return (
-    <>
-      <Link to="/bmdashboard/inventorytypes" className={styles.backLink}>
-        All Inventory Types
-      </Link>
-      <Container fluid className="p-0 mt-3">
-        <ItemListView
-          itemType="Materials"
-          items={filteredMaterials}
-          errors={errors}
-          UpdateItemModal={UpdateMaterialModal}
-          dynamicColumns={dynamicColumns}
-        >
-          <FormGroup check className="m-0 d-flex align-items-center">
-            <Label check style={{ fontWeight: '600', cursor: 'pointer', margin: 0 }}>
-              <Input
-                type="checkbox"
-                checked={showOnlyLowStock}
-                onChange={() => setShowOnlyLowStock(!showOnlyLowStock)}
-              />{' '}
-              Show only low-stock materials
-            </Label>
-          </FormGroup>
-          <InputGroup style={{ width: '350px' }}>
+    <Container fluid className="p-0 mt-3">
+      <ItemListView
+        itemType="Materials"
+        items={filteredMaterials}
+        errors={errors}
+        UpdateItemModal={UpdateMaterialModal}
+        dynamicColumns={dynamicColumns}
+      >
+        <FormGroup check className="m-0 d-flex align-items-center">
+          <Label check style={{ fontWeight: '600', cursor: 'pointer', margin: 0 }}>
             <Input
-              type="text"
-              placeholder="Search Material, PID, Unit..."
-              value={searchTerm}
-              onChange={e => setSearchTerm(e.target.value)}
-            />
-            {searchTerm && (
-              <InputGroupAddon addonType="append">
-                <Button color="secondary" onClick={() => setSearchTerm('')}>
-                  <i className="fa fa-times" aria-hidden="true" style={{ marginRight: '5px' }}></i>{' '}
-                  Clear
-                </Button>
-              </InputGroupAddon>
-            )}
-          </InputGroup>
-        </ItemListView>
-      </Container>
-    </>
+              type="checkbox"
+              checked={showOnlyLowStock}
+              onChange={() => setShowOnlyLowStock(!showOnlyLowStock)}
+            />{' '}
+            Show only low-stock materials
+          </Label>
+        </FormGroup>
+        <InputGroup style={{ width: '350px' }}>
+          <Input
+            type="text"
+            placeholder="Search Material, PID, Unit..."
+            value={searchTerm}
+            onChange={e => setSearchTerm(e.target.value)}
+          />
+          {searchTerm && (
+            <InputGroupAddon addonType="append">
+              <Button color="secondary" onClick={() => setSearchTerm('')}>
+                <i className="fa fa-times" aria-hidden="true" style={{ marginRight: '5px' }}></i>{' '}
+                Clear
+              </Button>
+            </InputGroupAddon>
+          )}
+        </InputGroup>
+      </ItemListView>
+    </Container>
   );
 }
 

--- a/src/components/BMDashboard/ReusableList/ReusableListView.jsx
+++ b/src/components/BMDashboard/ReusableList/ReusableListView.jsx
@@ -3,8 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchAllReusables } from '~/actions/bmdashboard/reusableActions';
 import ItemListView from '../ItemList/ItemListView';
 import UpdateReusableModal from '../UpdateReusables/UpdateReusableModal';
-import { Link } from 'react-router-dom';
-import styles from '../InventoryTypesList/TypesList.module.css';
 
 function ReusableListView() {
   const dispatch = useDispatch();
@@ -46,18 +44,13 @@ function ReusableListView() {
   ];
 
   return (
-    <>
-      <Link to="/bmdashboard/inventorytypes" className={styles.backLink}>
-        All Inventory Types
-      </Link>
-      <ItemListView
-        itemType={itemType}
-        items={reusablesWithId}
-        errors={errors}
-        UpdateItemModal={UpdateReusableModal}
-        dynamicColumns={dynamicColumns}
-      />
-    </>
+    <ItemListView
+      itemType={itemType}
+      items={reusablesWithId}
+      errors={errors}
+      UpdateItemModal={UpdateReusableModal}
+      dynamicColumns={dynamicColumns}
+    />
   );
 }
 

--- a/src/components/BMDashboard/Tools/ToolsList.jsx
+++ b/src/components/BMDashboard/Tools/ToolsList.jsx
@@ -3,8 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchTools } from '../../../actions/bmdashboard/toolActions';
 import ToolItemListView from '../ToolItemList/ToolItemListView';
 import UpdateToolModal from '../UpdateTools/UpdateToolModal';
-import { Link } from 'react-router-dom';
-import styles from '../InventoryTypesList/TypesList.module.css';
 
 function ToolsList() {
   const dispatch = useDispatch();
@@ -49,18 +47,13 @@ function ToolsList() {
   ];
 
   return (
-    <>
-      <Link to="/bmdashboard/inventorytypes" className={styles.backLink}>
-        All Inventory Types
-      </Link>
-      <ToolItemListView
-        itemType={itemType}
-        items={toolsWithId}
-        errors={errors}
-        UpdateItemModal={UpdateToolModal}
-        dynamicColumns={dynamicColumns}
-      />
-    </>
+    <ToolItemListView
+      itemType={itemType}
+      items={toolsWithId}
+      errors={errors}
+      UpdateItemModal={UpdateToolModal}
+      dynamicColumns={dynamicColumns}
+    />
   );
 }
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -531,6 +531,9 @@ export function Header(props) {
                       }`}
                       disabled={headerDisabled}
                     >
+                      <DropdownItem tag={Link} to="/bmdashboard/inventorytypes" className={fontColor}>
+                        All Inventory Types
+                      </DropdownItem>
                       <DropdownItem tag={Link} to="/bmdashboard/materials/add" className={fontColor}>
                         Add Material
                       </DropdownItem>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -57,6 +57,7 @@ import {
   VIEW_PROFILE,
   WEEKLY_SUMMARIES_REPORT,
   WELCOME,
+  BM_DASHBOARD
 } from '../../languages/en/ui';
 import hasPermission, { cantUpdateDevAdminDetails } from '../../utils/permissions';
 import PermissionWatcher from '../Auth/PermissionWatcher';
@@ -407,6 +408,9 @@ export function Header(props) {
   if (location.pathname === '/login') return null;
 
   const viewingUser = JSON.parse(window.sessionStorage.getItem('viewingUser'));
+
+  const showBMDashboard = location.pathname.startsWith('/bmdashboard');
+
   return (
     <div className={`${styles.headerWrapper}`} data-testid="header">
       <Navbar className={`py-3 ${styles.navbar}`} color="dark" dark expand="xl">
@@ -503,6 +507,13 @@ export function Header(props) {
                   </NavLink>
                 </NavItem>
 
+                {showBMDashboard && (<NavItem>
+                  <NavLink tag={Link} to="/bmdashboard" disabled={headerDisabled}>
+                    <span>{BM_DASHBOARD}</span>
+                  </NavLink>
+                </NavItem>
+                )}
+  
                 <NavItem>
                   <NavLink tag={Link} to="/timelog#currentWeek" disabled={headerDisabled}>
                     <span>{TIMELOG}</span>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -39,7 +39,6 @@ import {
   BLUE_SQUARE_EMAIL_MANAGEMENT,
   DASHBOARD,
   JOB_ANALYTICS_REPORT,
-  BM_DASHBOARD,
   LOGOUT,
   OTHER_LINKS,
   PERMISSIONS_MANAGEMENT,
@@ -408,10 +407,6 @@ export function Header(props) {
   if (location.pathname === '/login') return null;
 
   const viewingUser = JSON.parse(window.sessionStorage.getItem('viewingUser'));
-
-  const showBMDashboard = location.pathname.startsWith('/bmdashboard');
-
-
   return (
     <div className={`${styles.headerWrapper}`} data-testid="header">
       <Navbar className={`py-3 ${styles.navbar}`} color="dark" dark expand="xl">
@@ -508,14 +503,6 @@ export function Header(props) {
                   </NavLink>
                 </NavItem>
 
-                {showBMDashboard && (
-                  <NavItem>
-                    <NavLink tag={Link} to="/bmdashboard" disabled={headerDisabled}>
-                      <span>{BM_DASHBOARD}</span>
-                    </NavLink>
-                  </NavItem>
-                )}
-  
                 <NavItem>
                   <NavLink tag={Link} to="/timelog#currentWeek" disabled={headerDisabled}>
                     <span>{TIMELOG}</span>
@@ -533,9 +520,6 @@ export function Header(props) {
                       }`}
                       disabled={headerDisabled}
                     >
-                      <DropdownItem tag={Link} to="/bmdashboard/inventorytypes" className={fontColor}>
-                        All Inventory Types
-                      </DropdownItem>
                       <DropdownItem tag={Link} to="/bmdashboard/materials/add" className={fontColor}>
                         Add Material
                       </DropdownItem>


### PR DESCRIPTION
This reverts commit c558692f9228ebacefc80068d2d1ca2e32894a88, reversing changes made to 9432058237a1705a25bc3c03053eeff4dad1d847.

# Description
<img width="685" height="741" alt="Screenshot 2026-03-27 at 10 50 46 AM" src="https://github.com/user-attachments/assets/1cb7d1f8-15e1-4b78-b6d5-4ea37e480274" />
<img width="685" height="741" alt="Screenshot 2026-03-27 at 10 51 01 AM" src="https://github.com/user-attachments/assets/377a9e2e-c088-48a7-be76-2f40ff7bef07" />


## Related PRS (if any):
This is a revert of this PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5172
- Re-adds only "bmdashboard header persistence"
- Re-adds only "added all inventory types to project dropdown"

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to /bmdashboard
6. verify bmdashboard header persistence
7. verify this new feature “All Inventory Types” in the project dropdown

## Screenshots or videos of changes:

## Notes: 
This is a clean PR related to #5172, in which add links to categories in “All Inventory Types” page has been reverted back to the original development
