### PR TITLE
Aayush insight time filter fixed dropdown width issue

### DIFF
--- a/src/components/CommunityPortal/ResourceUsage/ResourceUsage.module.css
+++ b/src/components/CommunityPortal/ResourceUsage/ResourceUsage.module.css
@@ -29,16 +29,19 @@
 }
 
 .customDropdown {
+  background: transparent !important;
   border: 1px solid #e5e7eb !important;
+  color: #374151 !important;
   padding: 0.5rem 1rem !important;
-  border-radius: 0.375rem !important;
+  width: 8.75rem !important;
   font-size: 0.875rem !important;
-
-  /* Your enhancements */
+  border-radius: 0.375rem !important;
   box-shadow: none !important;
   display: flex !important;
   align-items: center !important;
+  justify-content: space-between !important;
   gap: 0.5rem !important;
+  white-space: nowrap !important;
 }
 
 .customDropdown:hover,


### PR DESCRIPTION
# Description
<img width="434" height="235" alt="Screenshot 2026-05-09 125413" src="https://github.com/user-attachments/assets/bbf9caea-7732-4a03-ac4e-2869706073bd" />


## Related PRS (if any):
…

## Main changes explained:
- Updated ResourceUsage.module.css so the dropdown toggle has a fixed width, keeps the caret aligned, and prevents label wrapping
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to /communityportal/reports/resourceusage
6. verify if the width doesn't change when different dropdown items are selected


## Screenshots or videos of changes:


https://github.com/user-attachments/assets/bfcae765-c17f-4f00-ac31-2f5a82cf5571


