### PR TITLE
Sayali : update bio status filter criteria to use totalValidWeeklySummaries

### DIFF
--- a/src/components/WeeklySummariesReport/BioFunction.jsx
+++ b/src/components/WeeklySummariesReport/BioFunction.jsx
@@ -28,7 +28,7 @@ function BioFunction(props) {
     <div
       data-testid="bio-announcement"
       id="bio-announcement"
-      style={isMeetCriteria ? { backgroundColor: 'yellow' } : {}}
+      style={isMeetCriteria ? { backgroundColor: 'yellow', color: '#000000' } : {}}
     >
       <div className={styles.bioToggle}>
         <b style={style}>Bio announcement:</b>

--- a/src/components/WeeklySummariesReport/BioFunction.jsx
+++ b/src/components/WeeklySummariesReport/BioFunction.jsx
@@ -1,13 +1,13 @@
 /* eslint-disable no-nested-ternary */
 import { useState } from 'react';
-import styles from './WeeklySummariesReport.module.scss';
 import ToggleSwitch from '../UserProfile/UserProfileEdit/ToggleSwitch';
+import styles from './WeeklySummariesReport.module.scss';
 
 function BioFunction(props) {
   const {
     bioPosted,
     totalTangibleHrs,
-    daysInTeam,
+    totalValidWeeklySummaries,
     textColors,
     summary,
     bioCanEdit,
@@ -17,7 +17,8 @@ function BioFunction(props) {
 
   const [bioStatus, setBioStatus] = useState(bioPosted);
 
-  const isMeetCriteria = totalTangibleHrs > 80 && daysInTeam > 60 && bioPosted !== 'posted';
+  const isMeetCriteria =
+    totalTangibleHrs > 80 && totalValidWeeklySummaries >= 8 && bioPosted !== 'posted';
   const style = {
     color: textColors[summary?.weeklySummaryOption] || textColors.Default,
   };

--- a/src/components/WeeklySummariesReport/BioFunction.jsx
+++ b/src/components/WeeklySummariesReport/BioFunction.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-nested-ternary */
 import { useState } from 'react';
 import ToggleSwitch from '../UserProfile/UserProfileEdit/ToggleSwitch';
+import PropTypes from 'prop-types';
 import styles from './WeeklySummariesReport.module.scss';
 
 function BioFunction(props) {
@@ -54,5 +55,16 @@ function BioFunction(props) {
     </div>
   );
 }
+
+BioFunction.propTypes = {
+  bioPosted: PropTypes.string,
+  totalTangibleHrs: PropTypes.number,
+  totalValidWeeklySummaries: PropTypes.number,
+  textColors: PropTypes.object,
+  summary: PropTypes.object,
+  bioCanEdit: PropTypes.bool,
+  handleProfileChange: PropTypes.func,
+  userId: PropTypes.string,
+};
 
 export default BioFunction;

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
+import PropTypes from 'prop-types';
 import { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import UserStateDisplay from '../UserState/UserStateDisplay';
@@ -34,10 +34,10 @@ import {
 } from 'reactstrap';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { assignStarDotColors, showStar } from '~/utils/leaderboardPermissions';
 import { postLeaderboardData } from '~/actions/leaderBoardData';
 import { toggleUserBio } from '~/actions/weeklySummariesReport';
 import { calculateDurationBetweenDates, showTrophyIcon } from '~/utils/anniversaryPermissions';
+import { assignStarDotColors, showStar } from '~/utils/leaderboardPermissions';
 
 import RoleInfoModal from '~/components/UserProfile/EditableModal/RoleInfoModal';
 import CopyToClipboard from '~/components/common/Clipboard/CopyToClipboard';
@@ -81,7 +81,11 @@ const teamColorMap = {
 };
 
 function ListGroupItem({ children, darkMode }) {
-  return <LGI className={`px-0 border-0 py-1 ${darkMode ? 'bg-yinmn-blue' : ''}`}>{children}</LGI>;
+  return (
+    <LGI className={`px-0 border-0 py-1 ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}>
+      {children}
+    </LGI>
+  );
 }
 
 function FormattedReport({
@@ -311,7 +315,11 @@ function ReportDetails({
     summary.bioPosted !== 'posted';
 
   return (
-    <li className={`list-group-item px-0 ${darkMode ? 'bg-yinmn-blue' : ''}`} ref={ref}>
+    <li
+      className={`list-group-item px-0 ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}
+      style={darkMode ? { backgroundColor: '#3a506b', color: '#ffffff' } : {}}
+      ref={ref}
+    >
       <ListGroup className={`px-0 ${darkMode ? 'bg-yinmn-blue' : ''}`} flush>
         <ListGroupItem darkMode={darkMode}>
           <Index
@@ -329,6 +337,7 @@ function ReportDetails({
           <div
             style={{
               backgroundColor: isMeetCriteria ? '#FFF200' : 'transparent',
+              color: isMeetCriteria ? '#000000' : 'inherit',
               width: '100%',
               padding: '6px 12px 6px 0px',
             }}
@@ -339,13 +348,19 @@ function ReportDetails({
               bioPosted={summary.bioPosted}
               summary={summary}
               getWeeklySummariesReport={getWeeklySummariesReport}
+              isMeetCriteria={isMeetCriteria}
             />
           </div>
         </ListGroupItem>
 
         {/* TWO-COLUMN CONTENT BELOW */}
         <Row className={darkMode ? 'bg-yinmn-blue' : ''}>
-          <Col md="6" xs="12" className={darkMode ? 'bg-yinmn-blue' : ''}>
+          <Col
+            md="6"
+            xs="12"
+            className={darkMode ? 'bg-yinmn-blue' : ''}
+            style={darkMode ? { backgroundColor: '#3a506b', color: '#ffffff' } : {}}
+          >
             <ListGroupItem darkMode={darkMode}>
               <TeamCodeRow
                 canEditTeamCode={canEditTeamCode && !cantEditJaeRelatedRecord}
@@ -383,7 +398,7 @@ function ReportDetails({
             </ListGroupItem>
 
             <ListGroupItem darkMode={darkMode}>
-              <WeeklySummaryMessage summary={summary} weekIndex={weekIndex} />
+              <WeeklySummaryMessage summary={summary} weekIndex={weekIndex} darkMode={darkMode} />
             </ListGroupItem>
           </Col>
 
@@ -407,7 +422,7 @@ function ReportDetails({
   );
 }
 
-function WeeklySummaryMessage({ summary, weekIndex }) {
+function WeeklySummaryMessage({ summary, weekIndex, darkMode }) {
   if (!summary) {
     return (
       <p>
@@ -447,7 +462,7 @@ function WeeklySummaryMessage({ summary, weekIndex }) {
   const summaryContent = (() => {
     if (summaryText) {
       const style = {
-        color: textColors[summary?.weeklySummaryOption] || textColors.Default,
+        color: textColors[summary?.weeklySummaryOption] || (darkMode ? '#ffffff' : '#000000'),
       };
 
       if (currentSummary?.uploadDate) {
@@ -614,7 +629,7 @@ function MediaUrlLink({ summary }) {
 
 function TotalValidWeeklySummaries({ summary, canEditSummaryCount, darkMode }) {
   const style = {
-    color: textColors[summary?.weeklySummaryOption] || textColors.Default,
+    color: textColors[summary?.weeklySummaryOption] || (darkMode ? '#ffffff' : '#000000'),
   };
 
   const [weeklySummariesCount, setWeeklySummariesCount] = useState(
@@ -735,7 +750,7 @@ function BioSwitch({ userId, bioPosted, summary, getWeeklySummariesReport }) {
   );
 }
 
-function BioLabel({ bioPosted, summary }) {
+function BioLabel({ bioPosted, summary, isMeetCriteria }) {
   const style = {
     color: textColors[summary?.weeklySummaryOption] || textColors.Default,
   };
@@ -749,7 +764,7 @@ function BioLabel({ bioPosted, summary }) {
     text = 'Requested';
   }
   return (
-    <div>
+    <div style={style}>
       <b>Bio announcement: </b>
       {text}
     </div>

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -307,7 +307,7 @@ function ReportDetails({
   const isMeetCriteria =
     canSeeBioHighlight &&
     summary.totalTangibleHrs > 80 &&
-    summary.daysInTeam > 60 &&
+    summary.weeklySummariesCount >= 8 &&
     summary.bioPosted !== 'posted';
 
   return (

--- a/src/components/WeeklySummariesReport/FormattedReport.jsx
+++ b/src/components/WeeklySummariesReport/FormattedReport.jsx
@@ -1105,6 +1105,7 @@ Index.propTypes = {
     startDate: PropTypes.string,
     endDate: PropTypes.string,
     trophyFollowedUp: PropTypes.bool,
+    weeklySummariesCount: PropTypes.number,
     timeOffFrom: PropTypes.string,
     timeOffTill: PropTypes.string,
   }).isRequired,

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.jsx
@@ -770,7 +770,7 @@ const WeeklySummariesReport = props => {
 
           const isMeetCriteria =
             summary.totalTangibleHrs > 80 &&
-            summary.daysInTeam > 60 &&
+            summary.weeklySummariesCount >= 8 &&
             summary.bioPosted !== 'posted';
 
           const isBio = !selectedBioStatus || isMeetCriteria;

--- a/src/components/WeeklySummariesReport/WeeklySummariesReport.module.css
+++ b/src/components/WeeklySummariesReport/WeeklySummariesReport.module.css
@@ -696,3 +696,8 @@
 .report-multi-select-filter :global(.dropdown-heading) {
   height: 35px !important;
 }
+
+:global(.bg-yinmn-blue .list-group-item) {
+  background-color: #3a506b !important;
+  color: #ffffff !important;
+}

--- a/src/components/WeeklySummariesReport/__tests__/BioFunction.test.jsx
+++ b/src/components/WeeklySummariesReport/__tests__/BioFunction.test.jsx
@@ -9,7 +9,7 @@ const colors = {
 const baseProps = {
   bioPosted: 'default',
   totalTangibleHrs: 100,
-  daysInTeam: 70,
+  totalValidWeeklySummaries: 10,
   textColors: colors,
   summary: { weeklySummaryOption: 'option1' },
   bioCanEdit: true,

--- a/src/components/WeeklySummariesReport/__tests__/FormattedReport.test.jsx
+++ b/src/components/WeeklySummariesReport/__tests__/FormattedReport.test.jsx
@@ -71,7 +71,7 @@ const dummySummary = {
     .add(1, 'days')
     .format(),
   totalTangibleHrs: 100,
-  daysInTeam: 70,
+  weeklySummariesCount: 10,
   bioPosted: 'default',
   weeklySummaryOption: 'Default',
 };

--- a/src/components/WeeklySummariesReport/__tests__/FormattedReport.test.jsx
+++ b/src/components/WeeklySummariesReport/__tests__/FormattedReport.test.jsx
@@ -59,7 +59,7 @@ const dummySummary = {
       uploadDate: moment().toISOString(),
     },
   ],
-  weeklySummariesCount: '5',
+  weeklySummariesCount: 10,
   teamCode: 'ABC123',
   mediaUrl: 'http://example.com/media',
   adminLinks: [{ Name: 'Media Folder', Link: 'http://example.com/folder' }],
@@ -71,7 +71,6 @@ const dummySummary = {
     .add(1, 'days')
     .format(),
   totalTangibleHrs: 100,
-  weeklySummariesCount: 10,
   bioPosted: 'default',
   weeklySummaryOption: 'Default',
 };


### PR DESCRIPTION

<img width="481" height="605" alt="image" src="https://github.com/user-attachments/assets/1acb2c0d-9b1a-4252-af77-7f986dbefb77" />

# Description
Fixes #1 (Priority High)

## Related PRs:
Replaces PR #3529

## Main changes explained:
- Updated `WeeklySummariesReport.jsx` to use `summary.weeklySummariesCount >= 8` instead of `summary.daysInTeam > 60` in `isMeetCriteria` filter logic
- Updated `FormattedReport.jsx` same criteria fix for bio highlight (yellow background)
- Updated `BioFunction.jsx` to use `totalValidWeeklySummaries` prop instead of `daysInTeam`
- Updated test files `BioFunction.test.jsx` and `FormattedReport.test.jsx` to reflect new prop names

## How to test:
1. Check out branch `Sayali_Task1_BioStatus_ValidWeeklySummaries`
2. `npm install && npm run start:local`
3. Clear cache, log in as admin
4. Navigate to Reports → Weekly Summaries Report
5. Toggle **Bio Status** filter ON
6. Verify only users with 80+ tangible hours AND 8+ Total Valid Weekly Summaries appear
7. Verify eligible users have yellow highlight on Bio announcement row
8. Verify dark mode works

## Screenshots:
<img width="1919" height="867" alt="image" src="https://github.com/user-attachments/assets/e7ff8673-8dd1-47a1-94c6-079088374e8b" />
<img width="1890" height="820" alt="image" src="https://github.com/user-attachments/assets/7f551171-4dcc-46a0-a0d8-112a2b120400" />

## Note:
Frontend-only change. No backend changes required.