### PR TITLE
Sayali: add Expand All/Truncate All button to Team Member Tasks header

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -8,7 +8,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Modal, ModalBody, ModalFooter, ModalHeader, Progress, Table } from 'reactstrap';
 import CopyToClipboard from '~/components/common/Clipboard/CopyToClipboard';
 import UserStateDisplay from '../UserState/UserStateDisplay';
@@ -53,6 +53,7 @@ const TeamMemberTask = React.memo(
     onCatalogChange,
     userStateSelection = [],
     onSelectionChange,
+    expandAll = false,
   }) => {
     const darkMode = useSelector(state => state.theme.darkMode);
     const taskCounts = useSelector(state => state.dashboard?.taskCounts ?? {});
@@ -133,6 +134,9 @@ const TeamMemberTask = React.memo(
 
     const canTruncate = activeTasks.length > NUM_TASKS_SHOW_TRUNCATE;
     const [isTruncated, setIsTruncated] = useState(canTruncate);
+    useEffect(() => {
+      if (canTruncate) setIsTruncated(!expandAll);
+    }, [expandAll, canTruncate]);
     const [isTimeOffContentOpen, setIsTimeOffContentOpen] = useState(
       showWhoHasTimeOff && (onTimeOff || goingOnTimeOff),
     );
@@ -831,6 +835,7 @@ TeamMemberTask.propTypes = {
   onCatalogChange: PropTypes.func,
   userStateSelection: PropTypes.array,
   onSelectionChange: PropTypes.func,
+  expandAll: PropTypes.bool,
 };
 
 TeamMemberTask.displayName = 'TeamMemberTask';

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -68,6 +68,7 @@ const TeamMemberTasks = React.memo(props => {
   const [userStateCatalog, setUserStateCatalog] = useState([]);
   const [userStateSelections, setUserStateSelections] = useState({});
   const [selectionsLoaded, setSelectionsLoaded] = useState(false);
+  const [expandAll, setExpandAll] = useState(false);
 
   useEffect(() => {
     axios
@@ -78,7 +79,10 @@ const TeamMemberTasks = React.memo(props => {
 
   // Fetch all selections in ONE call once teamList is ready
   useEffect(() => {
-    if (usersWithTasks.length === 0) return;
+    if (usersWithTasks.length === 0) {
+      setSelectionsLoaded(true);
+      return;
+    }
     const userIds = usersWithTasks.map(u => u.personId);
     axios
       .post(ENDPOINTS.USER_STATE_SELECTIONS_BATCH, { userIds })
@@ -448,6 +452,13 @@ const TeamMemberTasks = React.memo(props => {
       <header className={styles['header-box']}>
         <section className={[styles.dFlex, styles.flexColumn].join(' ')}>
           <h1 className={darkMode ? styles.textLight : ''}>Team Member Tasks</h1>
+          <button
+            type="button"
+            className={`btn btn-sm ${darkMode ? 'btn-outline-light' : 'btn-outline-secondary'}`}
+            onClick={() => setExpandAll(prev => !prev)}
+          >
+            {expandAll ? 'Truncate All' : 'Expand All'}
+          </button>
         </section>
 
         {finishLoading ? (
@@ -762,10 +773,10 @@ const TeamMemberTasks = React.memo(props => {
                         onSelectionChange={(uid, updated) =>
                           setUserStateSelections(prev => ({ ...prev, [uid]: updated }))
                         }
+                        expandAll={expandAll}
                       />
                     );
                   }
-
                   return (
                     <Fragment key={user.personId}>
                       <TeamMemberTask
@@ -794,6 +805,7 @@ const TeamMemberTasks = React.memo(props => {
                         onSelectionChange={(uid, updated) =>
                           setUserStateSelections(prev => ({ ...prev, [uid]: updated }))
                         }
+                        expandAll={expandAll}
                       />
 
                       {timeEntriesList.length > 0 &&


### PR DESCRIPTION
<img width="769" height="602" alt="image" src="https://github.com/user-attachments/assets/749862a7-d80f-4d8a-a99a-156d04cc7c69" />
# Description

## Related PRs:
None

## Main changes explained:
- Updated `TeamMemberTasks.jsx` to add `expandAll` state and "Expand All/Truncate All" toggle button next to the "Team Member Tasks" heading
- Updated `TeamMemberTask.jsx` to accept `expandAll` prop and use it to override individual row truncation state
- Fixed skeleton loading issue when `usersWithTasks` is empty by setting `selectionsLoaded` to `true` immediately

## How to test:
1. Check out branch `Sayali-Expand-All-Tasks-Button`
2. `npm install && npm run start:local`
3. Clear cache, log in as admin
4. Navigate to Dashboard → Tasks tab
5. Verify "Expand All" button appears below "Team Member Tasks" heading
6. Click "Expand All" — all task lists with more than 6 tasks should expand and button should change to "Truncate All"
7. Click "Truncate All" — all task lists should collapse back and button reverts to "Expand All"
8. Verify dark mode works

## Screenshots:
<img width="1105" height="471" alt="image" src="https://github.com/user-attachments/assets/e4430a16-44d3-46bb-b4b7-374c748bd00e" />
# ExpnadAll
<img width="1039" height="860" alt="image" src="https://github.com/user-attachments/assets/90feaa24-dadd-4c32-a74b-82e14efd4999" />
# TruncateAll
<img width="1088" height="732" alt="image" src="https://github.com/user-attachments/assets/8212d8d8-65b6-46ca-a52f-465f8aea5bc4" />

## Note:
Task number threshold for truncation remains at 6 tasks (unchanged).