### PR TITLE
Sayali: add Show/Hide Trackers button to Dashboard Tasks Tab header

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -8,7 +8,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Modal, ModalBody, ModalFooter, ModalHeader, Progress, Table } from 'reactstrap';
 import CopyToClipboard from '~/components/common/Clipboard/CopyToClipboard';
 import UserStateDisplay from '../UserState/UserStateDisplay';
@@ -46,6 +46,7 @@ const TeamMemberTask = React.memo(
     userId,
     updateTaskStatus,
     showWhoHasTimeOff,
+    showTrackers,
     onTimeOff,
     goingOnTimeOff,
     displayUser,
@@ -547,213 +548,217 @@ const TeamMemberTask = React.memo(
                   </td>
                   <td colSpan={3} className={`${darkMode ? 'bg-yinmn-blue' : ''}`}>
                     <div className={styles['grid-container']}>
-                      <Table borderless className={styles['team-member-tasks-subtable']}>
-                        <tbody>
-                          {user.tasks &&
-                            activeTasks.slice(0, numTasksToShow).map(task => {
-                              return (
-                                <tr
-                                  key={`${task._id}`}
-                                  className={`${styles['task-break']} ${
-                                    darkMode ? 'bg-yinmn-blue' : ''
-                                  }`}
-                                >
-                                  <td
-                                    data-label="Task(s)"
-                                    className={`${styles['task-align']} ${
-                                      darkMode ? 'bg-yinmn-blue text-light' : ''
+                      {showTrackers && (
+                        <Table borderless className={styles['team-member-tasks-subtable']}>
+                          <tbody>
+                            {user.tasks &&
+                              activeTasks.slice(0, numTasksToShow).map(task => {
+                                return (
+                                  <tr
+                                    key={`${task._id}`}
+                                    className={`${styles['task-break']} ${
+                                      darkMode ? 'bg-yinmn-blue' : ''
                                     }`}
                                   >
-                                    <div className={styles.taskColumnLayout}>
-                                      {/* Task title */}
-                                      <div className={styles['team-member-tasks-content']}>
-                                        <Link
-                                          className={styles['team-member-tasks-content-link']}
-                                          to={task.projectId ? `/wbs/tasks/${task._id}` : '/'}
-                                          data-testid={`${task.taskName}`}
-                                          title={`Created by: ${getTaskCreatorName(task)}`}
-                                          style={{ color: darkMode ? '#339CFF' : undefined }}
-                                        >
-                                          <span className={styles.taskTitle}>
-                                            {`${task.num} ${task.taskName}`}
-                                          </span>
-                                        </Link>
+                                    <td
+                                      data-label="Task(s)"
+                                      className={`${styles['task-align']} ${
+                                        darkMode ? 'bg-yinmn-blue text-light' : ''
+                                      }`}
+                                    >
+                                      <div className={styles.taskColumnLayout}>
+                                        {/* Task title */}
+                                        <div className={styles['team-member-tasks-content']}>
+                                          <Link
+                                            className={styles['team-member-tasks-content-link']}
+                                            to={task.projectId ? `/wbs/tasks/${task._id}` : '/'}
+                                            data-testid={`${task.taskName}`}
+                                            title={`Created by: ${getTaskCreatorName(task)}`}
+                                            style={{ color: darkMode ? '#339CFF' : undefined }}
+                                          >
+                                            <span className={styles.taskTitle}>
+                                              {`${task.num} ${task.taskName}`}
+                                            </span>
+                                          </Link>
 
-                                        <CopyToClipboard
-                                          writeText={task.taskName}
-                                          message="Task Copied!"
-                                        />
-                                      </div>
+                                          <CopyToClipboard
+                                            writeText={task.taskName}
+                                            message="Task Copied!"
+                                          />
+                                        </div>
 
-                                      {/* Icons UNDER task name */}
-                                      <div className={styles.taskIconsUnderName}>
-                                        {task.taskNotifications.length > 0 &&
-                                          task.taskNotifications.some(
-                                            notification =>
-                                              Object.prototype.hasOwnProperty.call(
-                                                notification,
-                                                'userId',
-                                              ) && notification.userId === user.personId,
-                                          ) && (
+                                        {/* Icons UNDER task name */}
+                                        <div className={styles.taskIconsUnderName}>
+                                          {task.taskNotifications.length > 0 &&
+                                            task.taskNotifications.some(
+                                              notification =>
+                                                Object.prototype.hasOwnProperty.call(
+                                                  notification,
+                                                  'userId',
+                                                ) && notification.userId === user.personId,
+                                            ) && (
+                                              <FontAwesomeIcon
+                                                className={styles['team-member-tasks-bell']}
+                                                title="Task Info Changes"
+                                                icon={faBell}
+                                                onClick={() => {
+                                                  const taskNotificationId = task.taskNotifications.filter(
+                                                    taskNotification =>
+                                                      taskNotification.userId === user.personId,
+                                                  );
+                                                  handleOpenTaskNotificationModal(
+                                                    user.personId,
+                                                    task,
+                                                    taskNotificationId,
+                                                  );
+                                                }}
+                                              />
+                                            )}
+
+                                          {isAllowedToResolveTasks && (
                                             <FontAwesomeIcon
-                                              className={styles['team-member-tasks-bell']}
-                                              title="Task Info Changes"
-                                              icon={faBell}
+                                              className={styles['team-member-tasks-done']}
+                                              icon={faCheckCircle}
+                                              title="Mark as Done"
                                               onClick={() => {
-                                                const taskNotificationId = task.taskNotifications.filter(
-                                                  taskNotification =>
-                                                    taskNotification.userId === user.personId,
-                                                );
-                                                handleOpenTaskNotificationModal(
-                                                  user.personId,
-                                                  task,
-                                                  taskNotificationId,
-                                                );
+                                                handleMarkAsDoneModal(user.personId, task);
+                                                handleTaskModalOption('Checkmark');
                                               }}
                                             />
                                           )}
 
-                                        {isAllowedToResolveTasks && (
-                                          <FontAwesomeIcon
-                                            className={styles['team-member-tasks-done']}
-                                            icon={faCheckCircle}
-                                            title="Mark as Done"
-                                            onClick={() => {
-                                              handleMarkAsDoneModal(user.personId, task);
-                                              handleTaskModalOption('Checkmark');
-                                            }}
-                                          />
-                                        )}
-
-                                        {canUnassignTask && (
-                                          <FontAwesomeIcon
-                                            className={styles['team-member-task-remove']}
-                                            icon={faTimesCircle}
-                                            title="Remove User from Task"
-                                            onClick={() => {
-                                              handleRemoveFromTaskModal(user.personId, task);
-                                              handleTaskModalOption('XMark');
-                                            }}
-                                          />
-                                        )}
-
-                                        <TeamMemberTaskIconsInfo />
-                                      </div>
-
-                                      {/* Review Button */}
-                                      <div
-                                        className={styles['team-member-task-review-button']}
-                                        style={
-                                          onTimeOff ? { opacity: 0.4, pointerEvents: 'none' } : {}
-                                        }
-                                      >
-                                        <ReviewButton
-                                          user={user}
-                                          userId={userId}
-                                          task={task}
-                                          updateTask={updateTaskStatus}
-                                        />
-                                      </div>
-                                    </div>
-                                  </td>
-                                  {task.hoursLogged != null && task.estimatedHours != null && (
-                                    <td
-                                      data-label="Progress"
-                                      className={`${styles['team-task-progress']} ${
-                                        darkMode ? 'bg-yinmn-blue text-light' : ''
-                                      }`}
-                                    >
-                                      <div className={styles['progress-wrapper']}>
-                                        <div className={styles['team-task-progress-container']}>
-                                          <div
-                                            data-testid={`times-${task.taskName}`}
-                                            className={`${darkMode ? 'text-light ' : ''} ${
-                                              canSeeFollowUpCheckButton
-                                                ? styles['team-task-progress-time']
-                                                : styles['team-task-progress-time-volunteers']
-                                            }`}
-                                          >
-                                            <p
-                                              className={`${styles['progress-text']} ${
-                                                darkMode ? 'text-light' : ''
-                                              }`}
-                                            >
-                                              {`${parseFloat(
-                                                task.hoursLogged.toFixed(2),
-                                              )} of ${parseFloat(task.estimatedHours.toFixed(2))}`}
-                                            </p>
-                                          </div>
-                                          {canSeeFollowUpCheckButton && (
-                                            <div className={styles['task-followup-icon']}>
-                                              <FollowupCheckButton
-                                                moseoverText={followUpMouseoverText(task)}
-                                                user={user}
-                                                task={task}
-                                              />
-                                              <div className={styles['followup-info-override']}>
-                                                <FollowUpInfoModal />
-                                                {isAllowedToSeeDeadlineCount && (
-                                                  <span
-                                                    className={styles['deadlineCount']}
-                                                    title="Click to view task change history"
-                                                    data-testid={`deadline-${task.taskName}`}
-                                                    onClick={() => handleOpenTaskChangeLog(task)}
-                                                    onKeyDown={e => {
-                                                      if (e.key === 'Enter' || e.key === ' ') {
-                                                        e.preventDefault();
-                                                        handleOpenTaskChangeLog(task);
-                                                      }
-                                                    }}
-                                                    role="button"
-                                                    tabIndex={0}
-                                                    style={{ cursor: 'pointer' }}
-                                                  >
-                                                    {taskCounts[task._id] ??
-                                                      task.deadlineCount ??
-                                                      0}
-                                                  </span>
-                                                )}
-                                              </div>
-                                            </div>
+                                          {canUnassignTask && (
+                                            <FontAwesomeIcon
+                                              className={styles['team-member-task-remove']}
+                                              icon={faTimesCircle}
+                                              title="Remove User from Task"
+                                              onClick={() => {
+                                                handleRemoveFromTaskModal(user.personId, task);
+                                                handleTaskModalOption('XMark');
+                                              }}
+                                            />
                                           )}
+
+                                          <TeamMemberTaskIconsInfo />
                                         </div>
-                                        <Progress
-                                          color={getProgressColor(
-                                            task.hoursLogged,
-                                            task.estimatedHours,
-                                            true,
-                                          )}
-                                          value={getProgressValue(
-                                            task.hoursLogged,
-                                            task.estimatedHours,
-                                          )}
-                                          className={styles['team-task-progress-bar']}
-                                        />
+
+                                        {/* Review Button */}
+                                        <div
+                                          className={styles['team-member-task-review-button']}
+                                          style={
+                                            onTimeOff ? { opacity: 0.4, pointerEvents: 'none' } : {}
+                                          }
+                                        >
+                                          <ReviewButton
+                                            user={user}
+                                            userId={userId}
+                                            task={task}
+                                            updateTask={updateTaskStatus}
+                                          />
+                                        </div>
                                       </div>
                                     </td>
-                                  )}
-                                </tr>
-                              );
-                            })}
-                          {canTruncate && (
-                            <tr key="truncate-button-row" className={styles['task-break']}>
-                              <td className={styles['task-align']}>
-                                <button
-                                  type="button"
-                                  onClick={handleTruncateTasksButtonClick}
-                                  className={`${styles.truncateTasksBtn} ${
-                                    darkMode ? 'text-light' : ''
-                                  }`}
-                                >
-                                  {isTruncated
-                                    ? `Show All (${activeTasks.length}) Tasks`
-                                    : 'Truncate Tasks'}
-                                </button>
-                              </td>
-                            </tr>
-                          )}
-                        </tbody>
-                      </Table>
+                                    {task.hoursLogged != null && task.estimatedHours != null && (
+                                      <td
+                                        data-label="Progress"
+                                        className={`${styles['team-task-progress']} ${
+                                          darkMode ? 'bg-yinmn-blue text-light' : ''
+                                        }`}
+                                      >
+                                        <div className={styles['progress-wrapper']}>
+                                          <div className={styles['team-task-progress-container']}>
+                                            <div
+                                              data-testid={`times-${task.taskName}`}
+                                              className={`${darkMode ? 'text-light ' : ''} ${
+                                                canSeeFollowUpCheckButton
+                                                  ? styles['team-task-progress-time']
+                                                  : styles['team-task-progress-time-volunteers']
+                                              }`}
+                                            >
+                                              <p
+                                                className={`${styles['progress-text']} ${
+                                                  darkMode ? 'text-light' : ''
+                                                }`}
+                                              >
+                                                {`${parseFloat(
+                                                  task.hoursLogged.toFixed(2),
+                                                )} of ${parseFloat(
+                                                  task.estimatedHours.toFixed(2),
+                                                )}`}
+                                              </p>
+                                            </div>
+                                            {canSeeFollowUpCheckButton && (
+                                              <div className={styles['task-followup-icon']}>
+                                                <FollowupCheckButton
+                                                  moseoverText={followUpMouseoverText(task)}
+                                                  user={user}
+                                                  task={task}
+                                                />
+                                                <div className={styles['followup-info-override']}>
+                                                  <FollowUpInfoModal />
+                                                  {isAllowedToSeeDeadlineCount && (
+                                                    <span
+                                                      className={styles['deadlineCount']}
+                                                      title="Click to view task change history"
+                                                      data-testid={`deadline-${task.taskName}`}
+                                                      onClick={() => handleOpenTaskChangeLog(task)}
+                                                      onKeyDown={e => {
+                                                        if (e.key === 'Enter' || e.key === ' ') {
+                                                          e.preventDefault();
+                                                          handleOpenTaskChangeLog(task);
+                                                        }
+                                                      }}
+                                                      role="button"
+                                                      tabIndex={0}
+                                                      style={{ cursor: 'pointer' }}
+                                                    >
+                                                      {taskCounts[task._id] ??
+                                                        task.deadlineCount ??
+                                                        0}
+                                                    </span>
+                                                  )}
+                                                </div>
+                                              </div>
+                                            )}
+                                          </div>
+                                          <Progress
+                                            color={getProgressColor(
+                                              task.hoursLogged,
+                                              task.estimatedHours,
+                                              true,
+                                            )}
+                                            value={getProgressValue(
+                                              task.hoursLogged,
+                                              task.estimatedHours,
+                                            )}
+                                            className={styles['team-task-progress-bar']}
+                                          />
+                                        </div>
+                                      </td>
+                                    )}
+                                  </tr>
+                                );
+                              })}
+                            {canTruncate && (
+                              <tr key="truncate-button-row" className={styles['task-break']}>
+                                <td className={styles['task-align']}>
+                                  <button
+                                    type="button"
+                                    onClick={handleTruncateTasksButtonClick}
+                                    className={`${styles.truncateTasksBtn} ${
+                                      darkMode ? 'text-light' : ''
+                                    }`}
+                                  >
+                                    {isTruncated
+                                      ? `Show All (${activeTasks.length}) Tasks`
+                                      : 'Truncate Tasks'}
+                                  </button>
+                                </td>
+                              </tr>
+                            )}
+                          </tbody>
+                        </Table>
+                      )}
                       <Modal
                         isOpen={isDashboardModalOpen}
                         toggle={closeDashboardModal}
@@ -825,6 +830,7 @@ TeamMemberTask.propTypes = {
     timeOffTill: PropTypes.string,
   }).isRequired,
   userRole: PropTypes.string.isRequired,
+  showTrackers: PropTypes.bool,
   userId: PropTypes.string.isRequired,
   displayUser: PropTypes.object,
   userStateCatalog: PropTypes.array,

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -680,9 +680,9 @@ const TeamMemberTask = React.memo(
                                                   darkMode ? 'text-light' : ''
                                                 }`}
                                               >
-                                                {`${parseFloat(
+                                                {`${Number.parseFloat(
                                                   task.hoursLogged.toFixed(2),
-                                                )} of ${parseFloat(
+                                                )} of ${Number.parseFloat(
                                                   task.estimatedHours.toFixed(2),
                                                 )}`}
                                               </p>

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -655,12 +655,18 @@ const TeamMemberTasks = React.memo(props => {
                 >
                   <thead className={darkMode ? styles.darkStickyHeader : ''}>
                     <tr>
-                      <th className={darkMode ? styles.darkStickyHeader : ''}>User Status</th>
+                      <th
+                        className={darkMode ? styles.darkStickyHeader : ''}
+                        style={{ background: 'transparent' }}
+                      >
+                        User Status
+                      </th>
                       <th
                         className={[
                           styles['team-member-tasks-headers'],
                           styles['team-member-tasks-user-name'],
                           darkMode ? styles.darkStickyHeader : '',
+                          darkMode ? styles.transparentHeader : '',
                         ].join(' ')}
                       >
                         Team Member
@@ -690,7 +696,7 @@ const TeamMemberTasks = React.memo(props => {
                           icon={faClock}
                           title="Total Remaining Hours"
                         />
-                        <div>
+                        <div style={{ background: 'transparent' }}>
                           <button
                             type="button"
                             onClick={handleShowTrackers}

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -49,6 +49,7 @@ const TeamMemberTasks = React.memo(props => {
   const [isTimeFilterActive, setIsTimeFilterActive] = useState(false);
   const [taskModalOption, setTaskModalOption] = useState('');
   const [showWhoHasTimeOff, setShowWhoHasTimeOff] = useState(true);
+  const [showTrackers, setShowTrackers] = useState(false);
 
   const userOnTimeOff = useSelector(state => state.timeOffRequests.onTimeOff);
   const userGoingOnTimeOff = useSelector(state => state.timeOffRequests.goingOnTimeOff);
@@ -78,7 +79,10 @@ const TeamMemberTasks = React.memo(props => {
 
   // Fetch all selections in ONE call once teamList is ready
   useEffect(() => {
-    if (usersWithTasks.length === 0) return;
+    if (usersWithTasks.length === 0) {
+      setSelectionsLoaded(true);
+      return;
+    }
     const userIds = usersWithTasks.map(u => u.personId);
     axios
       .post(ENDPOINTS.USER_STATE_SELECTIONS_BATCH, { userIds })
@@ -384,6 +388,10 @@ const TeamMemberTasks = React.memo(props => {
     setShowWhoHasTimeOff(prev => !prev);
   };
 
+  const handleShowTrackers = () => {
+    setShowTrackers(prev => !prev);
+  };
+
   const handleSelectTeamNames = event => {
     filteredUserTeamIds?.length > 0 && setTeamList(usersWithTasks);
     setSelectedTeamNames(event);
@@ -681,6 +689,29 @@ const TeamMemberTasks = React.memo(props => {
                           icon={faClock}
                           title="Total Remaining Hours"
                         />
+                        <div>
+                          <button
+                            type="button"
+                            onClick={handleShowTrackers}
+                            className={[
+                              styles.m1,
+                              darkMode ? styles.boxShadowDark : styles.boxShadowLight,
+                            ].join(' ')}
+                            style={{
+                              marginTop: '6px',
+                              padding: '2px 8px',
+                              fontSize: '12px',
+                              borderRadius: '4px',
+                              border: '1px solid #17a2b8',
+                              backgroundColor: showTrackers ? '#17a2b8' : 'white',
+                              color: showTrackers ? 'white' : '#17a2b8',
+                              cursor: 'pointer',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {showTrackers ? 'Hide Trackers' : 'Show Trackers'}
+                          </button>
+                        </div>
                       </th>
                     </tr>
                   </thead>
@@ -753,6 +784,7 @@ const TeamMemberTasks = React.memo(props => {
                         updateTaskStatus={updateTaskStatus}
                         userId={displayUser._id}
                         showWhoHasTimeOff={showWhoHasTimeOff}
+                        showTrackers={showTrackers}
                         onTimeOff={userOnTimeOff[user.personId]}
                         goingOnTimeOff={userGoingOnTimeOff[user.personId]}
                         displayUser={displayUser}
@@ -786,6 +818,7 @@ const TeamMemberTasks = React.memo(props => {
                         updateTaskStatus={updateTaskStatus}
                         userId={displayUser._id}
                         showWhoHasTimeOff={showWhoHasTimeOff}
+                        showTrackers={showTrackers}
                         onTimeOff={userOnTimeOff[user.personId]}
                         goingOnTimeOff={userGoingOnTimeOff[user.personId]}
                         userStateCatalog={userStateCatalog}

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -3,6 +3,7 @@ import { faClock } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import axios from 'axios';
 import moment from 'moment';
+import PropTypes from 'prop-types';
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { MultiSelect } from 'react-multi-select-component';
 import { connect, useDispatch, useSelector } from 'react-redux';
@@ -388,9 +389,9 @@ const TeamMemberTasks = React.memo(props => {
     setShowWhoHasTimeOff(prev => !prev);
   };
 
-  const handleShowTrackers = () => {
+  function handleShowTrackers() {
     setShowTrackers(prev => !prev);
-  };
+  }
 
   const handleSelectTeamNames = event => {
     filteredUserTeamIds?.length > 0 && setTeamList(usersWithTasks);
@@ -859,6 +860,22 @@ const TeamMemberTasks = React.memo(props => {
     </div>
   );
 });
+
+TeamMemberTasks.propTypes = {
+  authUser: PropTypes.shape({
+    userid: PropTypes.string,
+    role: PropTypes.string,
+  }),
+  displayUser: PropTypes.shape({
+    _id: PropTypes.string,
+    role: PropTypes.string,
+    email: PropTypes.string,
+  }),
+  usersWithTasks: PropTypes.arrayOf(PropTypes.object),
+  usersWithTimeEntries: PropTypes.arrayOf(PropTypes.object),
+  darkMode: PropTypes.bool,
+  filteredUserTeamIds: PropTypes.arrayOf(PropTypes.string),
+};
 
 const mapStateToProps = state => ({
   authUser: state.auth.user,

--- a/src/components/TeamMemberTasks/__tests__/TeamMemberTask.test.jsx
+++ b/src/components/TeamMemberTasks/__tests__/TeamMemberTask.test.jsx
@@ -1,11 +1,11 @@
-import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import TeamMemberTask from '~/components/TeamMemberTasks/TeamMemberTask';
-import { authMock, rolesMock, userProfileMock, themeMock } from '../../../__tests__/mockStates.js';
-import thunk from 'redux-thunk';
-import { configureStore } from 'redux-mock-store';
-import { MemoryRouter } from 'react-router-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { configureStore } from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import TeamMemberTask from '~/components/TeamMemberTasks/TeamMemberTask';
+import { authMock, rolesMock, themeMock, userProfileMock } from '../../../__tests__/mockStates.js';
 
 // sample props used for testing purpose. You can change the props according to your test.
 // currently used admin props to conduct the test
@@ -70,6 +70,7 @@ const renderComponent = mockProps => {
               userRole={mockProps.role}
               userId={mockProps.personId}
               updateTaskStatus={updateTaskStatus}
+              showTrackers
             />
           </tbody>
         </table>


### PR DESCRIPTION
<img width="948" height="569" alt="image" src="https://github.com/user-attachments/assets/e4bb3908-a40b-4316-bb4f-76654166d65c" />

# Description
Implements #2 (Priority Medium)

## Related PRs:
No backend changes required.

## Main changes explained:
- Updated TeamMemberTasks.jsx to add `showTrackers` state, `handleShowTrackers` toggle function, and "Show Trackers / Hide Trackers" button below the clock icons in the Tasks Tab header
- Updated TeamMemberTask.jsx to accept `showTrackers` prop and conditionally render the task table based on its value

## How to test:
1. Check out branch `ExpandAllTrackers-Dashboard`
2. `npm install && npm run start:local`
3. Clear cache, log in as admin
4. Navigate to `http://localhost:5173/dashboard` → Tasks tab
5. Verify "Show Trackers" button appears below the clock icons in the header
6. Click it — all task rows should expand and button text changes to "Hide Trackers"
7. Click again — all task rows should collapse and button reverts to "Show Trackers"
8. Verify dark mode works correctly

## Screenshots:
<img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/cdc8df2c-d2df-4e66-8d73-b01cece740b9" />
<img width="1919" height="875" alt="image" src="https://github.com/user-attachments/assets/1fc7303d-39ad-4b6b-b98f-24227f3e590c" />

## Note:
Frontend-only change. No backend required.