### PR TITLE
Diya 🔥 fix(bs): Fixed Blue Square Issues

### DIFF
--- a/src/components/UserProfile/BlueSquaresTable/BlueSquaresTable.jsx
+++ b/src/components/UserProfile/BlueSquaresTable/BlueSquaresTable.jsx
@@ -32,7 +32,7 @@ const BlueSquaresTable = ({ userProfile ,canEdit, isPrivate , handleUserProfile 
       </div>
       {canEdit ? (
         <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} darkMode={darkMode}/>
-      ) : !isPrivate ? (
+      ) : isPrivate ? (
         <div className="pl-1">Blue Square Info is Private</div>
       ) : (
         <BlueSquare blueSquares={userProfile?.infringements} handleBlueSquare={handleBlueSquare} darkMode={darkMode}/>


### PR DESCRIPTION
# Description
Fixes Blue Square visibility bug where the private/public toggle was inverted, causing blue square data to show when it should be hidden and vice versa.

## Related PRS (if any):
This frontend PR is related to the backend [PR #2218](https://github.com/OneCommunityGlobal/HGNRest/pull/2218)

## Main changes explained:
- Updated `BlueSquaresTable.jsx` to fix inverted `isPrivate` condition — changed `!isPrivate` to `isPrivate` so the "Blue Square Info is Private" message shows correctly when the toggle is set to private
## How to test:
1. Check out current branch
2. Run `npm install` and `npm start`
3. Log in as a non-admin user and navigate to another user's profile
4. Toggle blue squares to private — verify the message "Blue Square Info is Private" appears
5. Toggle blue squares to public — verify the blue squares are visible
6. Verify this works correctly in dark mode
## Screenshots or videos of changes:
 
## Note:
The condition was inverted — `!isPrivate` was used where `isPrivate` was needed, causing the privacy message to show when data was public and the data to show when it was private.