### PR TITLE
SaiSandeep - Fix "No comparison" filter options failing in Total Org Summary Dashboard 

### DIFF
--- a/src/components/TotalOrgSummary/BlueSquareStats/BlueSquareStats.jsx
+++ b/src/components/TotalOrgSummary/BlueSquareStats/BlueSquareStats.jsx
@@ -49,7 +49,7 @@ function BlueSquareStats({ isLoading, blueSquareStats, comparisonType, darkMode 
         <DonutChart
           title="TOTAL BLUE SQUARES"
           totalCount={totalBlueSquares.count}
-          percentageChange={pctChange}
+          percentageChange={Number(pctChange)}
           data={data}
           colors={BLUE_SQUARE_STATS_COLORS}
           comparisonType={comparisonType}

--- a/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
@@ -28,18 +28,17 @@ const ROLE_COLOR_MAP = {
 import CustomTooltip from '../../CustomTooltip';
 
 const RoleDistributionPieChart = ({ roleDistributionStats = [], isLoading, darkMode }) => {
-
   // Reusable function to sort data and assign colors.
-  const sortDataAndAssignColors =(statsData)=>{
+  const sortDataAndAssignColors = statsData => {
     statsData?.sort((a, b) => b.count - a.count);
     const mappedData = statsData?.map((item, index) => ({
-    name: item._id,
-    value: item.count,
-    // Use a stable role mapping first, otherwise fallback by index.
-    color: ROLE_COLOR_MAP[item._id] || COLORS[index % COLORS.length],
-  }));
-  return  mappedData;
-  }
+      name: item._id,
+      value: item.count,
+      // Use a stable role mapping first, otherwise fallback by index.
+      color: ROLE_COLOR_MAP[item._id] || COLORS[index % COLORS.length],
+    }));
+    return mappedData;
+  };
 
   if (isLoading) {
     return (
@@ -51,13 +50,13 @@ const RoleDistributionPieChart = ({ roleDistributionStats = [], isLoading, darkM
     );
   }
 
-  let data=[];
+  let data = [];
   // This is to handle the case when we are comparing the data with other time periods. In that case, the data structure is different and we need to access the comparison data.
-  if(roleDistributionStats?.comparison){ 
-    data = sortDataAndAssignColors(roleDistributionStats?.comparison); 
+  if (roleDistributionStats?.comparison) {
+    data = sortDataAndAssignColors(roleDistributionStats?.comparison);
   }
   // Fallback to the original data structure when we are not comparing the data with other time periods.
-  else{
+  else {
     data = sortDataAndAssignColors(roleDistributionStats);
   }
 

--- a/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerRolesTeamDynamics/RoleDistributionPieChart.jsx
@@ -28,6 +28,19 @@ const ROLE_COLOR_MAP = {
 import CustomTooltip from '../../CustomTooltip';
 
 const RoleDistributionPieChart = ({ roleDistributionStats = [], isLoading, darkMode }) => {
+
+  // Reusable function to sort data and assign colors.
+  const sortDataAndAssignColors =(statsData)=>{
+    statsData?.sort((a, b) => b.count - a.count);
+    const mappedData = statsData?.map((item, index) => ({
+    name: item._id,
+    value: item.count,
+    // Use a stable role mapping first, otherwise fallback by index.
+    color: ROLE_COLOR_MAP[item._id] || COLORS[index % COLORS.length],
+  }));
+  return  mappedData;
+  }
+
   if (isLoading) {
     return (
       <div className="d-flex justify-content-center align-items-center">
@@ -38,13 +51,16 @@ const RoleDistributionPieChart = ({ roleDistributionStats = [], isLoading, darkM
     );
   }
 
-  roleDistributionStats.sort((a, b) => b.count - a.count);
-  const data = roleDistributionStats.map((item, index) => ({
-    name: item._id,
-    value: item.count,
-    // Use a stable role mapping first, otherwise fallback by index.
-    color: ROLE_COLOR_MAP[item._id] || COLORS[index % COLORS.length],
-  }));
+  let data=[];
+  // This is to handle the case when we are comparing the data with other time periods. In that case, the data structure is different and we need to access the comparison data.
+  if(roleDistributionStats?.comparison){ 
+    data = sortDataAndAssignColors(roleDistributionStats?.comparison); 
+  }
+  // Fallback to the original data structure when we are not comparing the data with other time periods.
+  else{
+    data = sortDataAndAssignColors(roleDistributionStats);
+  }
+
   const totalValue = data.reduce((sum, entry) => sum + entry.value, 0);
 
   const RADIAN = Math.PI / 180;


### PR DESCRIPTION
# Description
When users try to filter stats and compare them by week by week or month by month or year by year by selecting one of the options in dropdown , we get an blank page with error details.
<img width="987" height="545" alt="Screenshot 2026-05-14 001530" src="https://github.com/user-attachments/assets/3a0c8741-05d6-4ccf-9eb9-2f9e6600569d" />
<img width="979" height="799" alt="Screenshot 2026-05-14 001538" src="https://github.com/user-attachments/assets/e34f10be-f085-4894-a692-e4472f6d24a7" />

# Fix
Ensured the data passed onto the children component is rendered properly by handling all edge cases and made sure the code is reusable by extracting some portion of code into a function.

## Related PRS :
Not Related to any other PR's

## Main changes explained:
Made sure the data is rendered properly in children component

## How to test:
1. check into current branch
2. do `npm install` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ Total Org Summary
6. Verify all options in "No Comparison" are working properly 

## Screenshots or videos of changes:
<img width="1838" height="964" alt="Screenshot 2026-05-16 022543" src="https://github.com/user-attachments/assets/632d2dca-f37c-4f34-a387-d0cec87b65ae" />
<img width="1846" height="954" alt="Screenshot 2026-05-16 022536" src="https://github.com/user-attachments/assets/c07c170b-185a-43dc-b0b0-a754b2078cd5" />
<img width="1850" height="1035" alt="Screenshot 2026-05-16 022528" src="https://github.com/user-attachments/assets/e724dd79-9a91-4df9-878f-e57d7840e2e1" />

## Changes 

https://github.com/user-attachments/assets/d4218b70-c94f-4f3b-93d3-15cf7b6dea4b





