### PR TITLE
Sayali: resolve Firefox timer not stopping and audio not playing

### DIFF
--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -156,7 +156,9 @@ function Timer({ authUser, darkMode, isPopout }) {
         const existingHistory = JSON.parse(localStorage.getItem('timerSubmissionHistory') || '[]');
         const updatedHistory = [...existingHistory, submissionRecord].slice(-10); // Keep last 10 entries
         localStorage.setItem('timerSubmissionHistory', JSON.stringify(updatedHistory));
-      } catch (error) {}
+      } catch (_error) {
+        // Ignore localStorage errors
+      }
     },
     [goal, remaining, sessionId, viewingUserId, authUser?.userid],
   );
@@ -262,15 +264,18 @@ function Timer({ authUser, darkMode, isPopout }) {
   useEffect(() => {
     const unlockAudio = () => {
       if (audioUnlockedRef.current) return;
-      [timeIsOverAudioRef, forcedPausedAudioRef].forEach(ref => {
-        if (ref.current) {
-          ref.current
-            .play()
-            .then(() => ref.current.pause())
-            .catch(() => {});
-          ref.current.currentTime = 0;
-        }
-      });
+      const tryUnlockRef = ref => {
+        if (!ref.current) return;
+        ref.current
+          .play()
+          .then(() => {
+            ref.current.pause();
+          })
+          .catch(() => {});
+        ref.current.currentTime = 0;
+      };
+      tryUnlockRef(timeIsOverAudioRef);
+      tryUnlockRef(forcedPausedAudioRef);
       audioUnlockedRef.current = true;
     };
     document.addEventListener('click', unlockAudio, { once: true });

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -506,6 +506,10 @@ function Timer({ authUser, darkMode, isPopout }) {
   const checkRemainingTime = () => {
     if (remaining === 0) {
       sendPause();
+      if (!timeIsOverModalOpen && !weekEndModal) {
+        setTimeIsOverModalIsOpen(true);
+        sendStartChime(true);
+      }
     }
   };
 

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -1,30 +1,29 @@
 /* eslint-disable jsx-a11y/media-has-caption */
+import cs from 'classnames';
 import moment from 'moment';
-import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Modal, ModalHeader, ModalBody, ModalFooter, Button, Progress } from 'reactstrap';
-import useWebSocket, { ReadyState } from 'react-use-websocket';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BsAlarmFill, BsArrowClockwise } from 'react-icons/bs';
 import {
-  FaPlusCircle,
   FaMinusCircle,
-  FaPlayCircle,
   FaPauseCircle,
+  FaPlayCircle,
+  FaPlusCircle,
   FaStopCircle,
   FaUndoAlt,
 } from 'react-icons/fa';
-import { toast } from 'react-toastify';
-import cs from 'classnames';
 import { connect, useDispatch } from 'react-redux';
-import css from './Timer.module.css';
-import '../Header/index.css';
+import { toast } from 'react-toastify';
+import useWebSocket, { ReadyState } from 'react-use-websocket';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader, Progress } from 'reactstrap';
 import { ENDPOINTS } from '~/utils/URL';
 import config from '../../config.json';
+import '../Header/index.css';
 import TimeEntryForm from '../Timelog/TimeEntryForm';
 import Countdown from './Countdown';
-import TimerStatus from './TimerStatus';
+import css from './Timer.module.css';
 import TimerPopout from './TimerPopout';
-import { postTimeEntry, editTimeEntry } from '../../actions/timeEntries';
+import TimerStatus from './TimerStatus';
 
 function Timer({ authUser, darkMode, isPopout }) {
   const dispatch = useDispatch();
@@ -118,6 +117,7 @@ function Timer({ authUser, darkMode, isPopout }) {
   const isWSOpenRef = useRef(0);
   const timeIsOverAudioRef = useRef(null);
   const forcedPausedAudioRef = useRef(null);
+  const audioUnlockedRef = useRef(false);
 
   const timeToLog = moment.duration(goal - remaining);
   const logHours = timeToLog.hours();
@@ -127,7 +127,6 @@ function Timer({ authUser, darkMode, isPopout }) {
 
   // Enhanced function to clear submitted time with better logging
   const clearSubmittedTime = useCallback(() => {
-    console.log(' Clearing submitted time - Timer reset or user change detected');
     setLastSubmittedTime(null);
     setLogTimer({ hours: 0, minutes: 0 });
     setTimerState('idle');
@@ -147,8 +146,6 @@ function Timer({ authUser, darkMode, isPopout }) {
         remaining,
       };
 
-      console.log('✅ Time submitted successfully:', submissionRecord);
-
       setLastSubmittedTime(timeKey);
       setSubmissionHistory(prev => [...prev, submissionRecord]);
       setLogTimer({ hours: 0, minutes: 0 });
@@ -159,9 +156,7 @@ function Timer({ authUser, darkMode, isPopout }) {
         const existingHistory = JSON.parse(localStorage.getItem('timerSubmissionHistory') || '[]');
         const updatedHistory = [...existingHistory, submissionRecord].slice(-10); // Keep last 10 entries
         localStorage.setItem('timerSubmissionHistory', JSON.stringify(updatedHistory));
-      } catch (error) {
-        console.warn('Could not save submission history to localStorage:', error);
-      }
+      } catch (error) {}
     },
     [goal, remaining, sessionId, viewingUserId, authUser?.userid],
   );
@@ -221,7 +216,6 @@ function Timer({ authUser, darkMode, isPopout }) {
   // Enhanced function to handle timer state changes
   const updateTimerState = useCallback(
     newState => {
-      console.log(`🔄 Timer state changed: ${timerState} → ${newState}`);
       setTimerState(newState);
     },
     [timerState],
@@ -252,7 +246,6 @@ function Timer({ authUser, darkMode, isPopout }) {
     }
     const newSessionId = `session_${Date.now()}_${randomPart}`;
     setSessionId(newSessionId);
-    console.log('🚀 Timer session initialized:', newSessionId);
   }, []);
 
   // Enhanced useEffect for timer state management
@@ -265,6 +258,24 @@ function Timer({ authUser, darkMode, isPopout }) {
       updateTimerState('idle');
     }
   }, [running, paused, started, updateTimerState]);
+
+  useEffect(() => {
+    const unlockAudio = () => {
+      if (audioUnlockedRef.current) return;
+      [timeIsOverAudioRef, forcedPausedAudioRef].forEach(ref => {
+        if (ref.current) {
+          ref.current
+            .play()
+            .then(() => ref.current.pause())
+            .catch(() => {});
+          ref.current.currentTime = 0;
+        }
+      });
+      audioUnlockedRef.current = true;
+    };
+    document.addEventListener('click', unlockAudio, { once: true });
+    return () => document.removeEventListener('click', unlockAudio);
+  }, []);
 
   useEffect(() => {
     const handleStorageEvent = () => {
@@ -474,7 +485,6 @@ function Timer({ authUser, darkMode, isPopout }) {
       return;
     }
 
-    console.log('🛑 Stop button clicked - preparing to log time:', timeToSubmit);
     toggleLogTimeModal();
   }, [logHours, logMinutes, validateTimeForSubmission, toggleLogTimeModal]);
 
@@ -567,22 +577,14 @@ function Timer({ authUser, darkMode, isPopout }) {
   }, [running]);
 
   useEffect(() => {
-    /**
-     * This useEffect will run upon message change,
-     * and message is a state as a copy of the lastJsonMessage,
-     * here message works as a buffer, for details see above
-     */
-    let interval;
-    if (running) {
-      updateRemaining();
-      interval = setInterval(() => {
-        updateRemaining();
-      }, 1000);
-    } else {
+    if (!running) {
       setRemaining(time);
-      clearInterval(interval);
+      return undefined;
     }
-
+    updateRemaining();
+    const interval = setInterval(() => {
+      updateRemaining();
+    }, 1000);
     return () => clearInterval(interval);
   }, [running, message]);
 
@@ -597,7 +599,6 @@ function Timer({ authUser, darkMode, isPopout }) {
     if (lastSubmittedTime !== timeKey && (logHours > 0 || logMinutes > 0)) {
       if (validateTimeForSubmission(currentTimeToLog)) {
         setLogTimer(currentTimeToLog);
-        console.log('⏱️ Time to log updated:', currentTimeToLog);
       }
     }
   }, [remaining, logHours, logMinutes, goal, lastSubmittedTime, validateTimeForSubmission]);
@@ -606,14 +607,16 @@ function Timer({ authUser, darkMode, isPopout }) {
   useEffect(() => {
     if (!started || goal !== lastSubmittedTime?.goal) {
       clearSubmittedTime();
-      console.log('🔄 Timer reset detected - clearing submitted time');
     }
   }, [started, goal, clearSubmittedTime]);
 
   useEffect(() => {
     if (timeIsOverModalOpen) {
       window.focus();
-      timeIsOverAudioRef.current.play();
+      const playPromise = timeIsOverAudioRef.current.play();
+      if (playPromise !== undefined) {
+        playPromise.catch(() => {});
+      }
     } else {
       window.focus();
       timeIsOverAudioRef.current.pause();
@@ -631,7 +634,10 @@ function Timer({ authUser, darkMode, isPopout }) {
   useEffect(() => {
     if (inacModal) {
       window.focus();
-      forcedPausedAudioRef.current.play();
+      const playPromise = forcedPausedAudioRef.current.play();
+      if (playPromise !== undefined) {
+        playPromise.catch(() => {});
+      }
     } else {
       window.focus();
       forcedPausedAudioRef.current.pause();
@@ -642,7 +648,10 @@ function Timer({ authUser, darkMode, isPopout }) {
   useEffect(() => {
     if (weekEndModal) {
       window.focus();
-      timeIsOverAudioRef.current.play();
+      const playPromise = timeIsOverAudioRef.current.play();
+      if (playPromise !== undefined) {
+        playPromise.catch(() => {});
+      }
     } else {
       window.focus();
       timeIsOverAudioRef.current.pause();
@@ -659,14 +668,12 @@ function Timer({ authUser, darkMode, isPopout }) {
   // Enhanced cleanup when viewing user changes
   useEffect(() => {
     clearSubmittedTime();
-    console.log('👤 User changed - clearing timer state');
   }, [viewingUserId, clearSubmittedTime]);
 
   // Enhanced cleanup on component unmount
   useEffect(() => {
     return () => {
       clearSubmittedTime();
-      console.log('🔚 Timer component unmounting - cleanup complete');
     };
   }, [clearSubmittedTime]);
 

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -157,7 +157,8 @@ function Timer({ authUser, darkMode, isPopout }) {
         const updatedHistory = [...existingHistory, submissionRecord].slice(-10); // Keep last 10 entries
         localStorage.setItem('timerSubmissionHistory', JSON.stringify(updatedHistory));
       } catch (_error) {
-        // Ignore localStorage errors
+        // localStorage unavailable - non-critical, safe to ignore
+        void _error;
       }
     },
     [goal, remaining, sessionId, viewingUserId, authUser?.userid],
@@ -261,21 +262,23 @@ function Timer({ authUser, darkMode, isPopout }) {
     }
   }, [running, paused, started, updateTimerState]);
 
+  const pauseAudioRef = ref => {
+    if (!ref.current) return;
+    ref.current.pause();
+    ref.current.currentTime = 0;
+  };
+
   useEffect(() => {
     const unlockAudio = () => {
       if (audioUnlockedRef.current) return;
-      const tryUnlockRef = ref => {
-        if (!ref.current) return;
-        ref.current
-          .play()
-          .then(() => {
-            ref.current.pause();
-          })
-          .catch(() => {});
-        ref.current.currentTime = 0;
-      };
-      tryUnlockRef(timeIsOverAudioRef);
-      tryUnlockRef(forcedPausedAudioRef);
+      if (timeIsOverAudioRef.current) {
+        timeIsOverAudioRef.current.play().catch(() => {});
+        pauseAudioRef(timeIsOverAudioRef);
+      }
+      if (forcedPausedAudioRef.current) {
+        forcedPausedAudioRef.current.play().catch(() => {});
+        pauseAudioRef(forcedPausedAudioRef);
+      }
       audioUnlockedRef.current = true;
     };
     document.addEventListener('click', unlockAudio, { once: true });


### PR DESCRIPTION
<img width="823" height="73" alt="image" src="https://github.com/user-attachments/assets/32ffae2b-56c6-422b-9246-4437e4843978" />

# Description
Fixes Firefox Timer Bug (Priority Medium)

## Related PRs:
None — frontend only

## Main changes explained:
- Fixed `Timer.jsx` interval cleanup so the timer properly stops in Firefox by restructuring the `useEffect` to always return the `clearInterval` cleanup function with the correct interval ID
- Fixed Firefox audio autoplay policy by wrapping all `.play()` calls in Promise handlers with `.catch(() => {})` to prevent unhandled rejection errors
- Added `audioUnlockedRef` and an unlock `useEffect` that silently primes both audio elements on first user click, bypassing Firefox's autoplay restrictions

## How to test:
1. Check out branch `Sayali_Fix_Firefox_Timer_Bug`
2. `npm install && npm run start:local`
3. Clear cache, log in as admin
4. Open Firefox and go to localhost:5173
5. Click anywhere on the page (to unlock audio)
6. Start the timer and let it run to 0 — verify it stops automatically
7. Verify the ding sound plays when timer hits 0
8. Verify the Stop button manually stops the timer
9. Verify dark mode works

## Screenshots:
<img width="437" height="279" alt="image" src="https://github.com/user-attachments/assets/411e730a-7d6e-48a7-a542-207aa278cc00" />

## Note:
This is a frontend-only fix. No backend changes required. Bug was confirmed in Firefox — timer would not stop automatically and ding sound was silenced due to Firefox's strict autoplay policy.