### PR TITLE
Sohail: Job Posting Page Analytics: UI Fix for applicants by experience donut chart

### DIFF
--- a/src/components/ExperienceDonutChart/ExperienceDonutChart.jsx
+++ b/src/components/ExperienceDonutChart/ExperienceDonutChart.jsx
@@ -61,9 +61,12 @@ export default function ExperienceDonutChart() {
       Boolean(
         appliedFilters.startDate ||
           appliedFilters.endDate ||
-          (appliedFilters.roles?.length ?? 0) > 0,
+          (appliedFilters.roles?.length ?? 0) > 0 ||
+          startDate ||
+          endDate ||
+          selectedRoles.length > 0,
       ),
-    [appliedFilters],
+    [appliedFilters, startDate, endDate, selectedRoles],
   );
 
   const fetchData = async () => {
@@ -138,6 +141,19 @@ export default function ExperienceDonutChart() {
 
   const [hoveredIndex, setHoveredIndex] = useState(null);
 
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' && window.innerWidth < 450,
+  );
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < 450);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+  const pieMargin = isMobile
+    ? { top: 5, right: 5, bottom: 5, left: 5 }
+    : { top: 20, right: 115, bottom: 20, left: 115 };
+
   // Renders the hovered segment with a slightly larger outer radius
   const renderActiveShape = props => {
     const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill } = props;
@@ -172,7 +188,7 @@ export default function ExperienceDonutChart() {
         dominantBaseline="central"
         fill={getContrastColor(visibleChartData[index]?.color ?? '#000')}
         style={{
-          fontSize: isHovered ? '1.2rem' : '1.05rem',
+          fontSize: isHovered ? '1.35rem' : '1.2rem',
           fontWeight: 800,
           pointerEvents: 'none',
           transition: 'font-size 0.15s ease',
@@ -186,11 +202,13 @@ export default function ExperienceDonutChart() {
   // Draws name on top line, percentage below — outside the segment, only after animation completes
   const renderOutsideLabel = ({ cx, cy, midAngle, outerRadius, name, percent, index }) => {
     if (!animationDone) return null;
+    // On very small screens hide outside labels — inside counts are still visible
+    if (isMobile) return null;
     const isHovered = index === hoveredIndex;
     const RADIAN = Math.PI / 180;
     const expandedOuter = isHovered ? outerRadius + 10 : outerRadius;
     const lineStart = expandedOuter + 8;
-    const lineEnd = expandedOuter + 50;
+    const lineEnd = expandedOuter + (isMobile ? 30 : 50);
     const sx = cx + lineStart * Math.cos(-midAngle * RADIAN);
     const sy = cy + lineStart * Math.sin(-midAngle * RADIAN);
     const ex = cx + lineEnd * Math.cos(-midAngle * RADIAN);
@@ -202,8 +220,8 @@ export default function ExperienceDonutChart() {
     const pct = `${(percent * 100).toFixed(1)}%`;
     const labelColor = darkMode ? '#f8fafc' : '#0f172a';
     const lineColor = darkMode ? '#94a3b8' : '#64748b';
-    const nameFontSize = isHovered ? '1.05rem' : '0.95rem';
-    const pctFontSize = isHovered ? '0.95rem' : '0.85rem';
+    const nameFontSize = isHovered ? '1.2rem' : '1.05rem';
+    const pctFontSize = isHovered ? '1.05rem' : '0.95rem';
     const strokeWidth = isHovered ? 2.5 : 1.5;
 
     return (
@@ -230,10 +248,6 @@ export default function ExperienceDonutChart() {
         </text>
       </g>
     );
-  };
-
-  const onRolesChange = e => {
-    setSelectedRoles(Array.from(e.target.selectedOptions, o => o.value));
   };
 
   const applyFilters = () => {
@@ -302,22 +316,32 @@ export default function ExperienceDonutChart() {
             </div>
 
             <div className={styles['filter-group']}>
-              <label className={styles['filter-label']} htmlFor="roles">
-                Roles
-              </label>
-              <select
-                id="roles"
-                className={styles['filter-select']}
-                multiple
-                value={selectedRoles}
-                onChange={onRolesChange}
-              >
-                <option value="Frontend Developer">Frontend Developer</option>
-                <option value="DevOps Engineer">DevOps Engineer</option>
-                <option value="Project Manager">Project Manager</option>
-                <option value="Junior Developer">Junior Developer</option>
-                <option value="Full Stack Developer">Full Stack Developer</option>
-              </select>
+              <fieldset className={styles['checkbox-fieldset']}>
+                <legend className={styles['filter-label']}>Roles</legend>
+                <div className={styles['checkbox-list']}>
+                  {[
+                    'Frontend Developer',
+                    'DevOps Engineer',
+                    'Project Manager',
+                    'Junior Developer',
+                    'Full Stack Developer',
+                  ].map(role => (
+                    <label key={role} className={styles['checkbox-item']}>
+                      <input
+                        type="checkbox"
+                        value={role}
+                        checked={selectedRoles.includes(role)}
+                        onChange={e => {
+                          setSelectedRoles(prev =>
+                            e.target.checked ? [...prev, role] : prev.filter(r => r !== role),
+                          );
+                        }}
+                      />
+                      {role}
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
             </div>
           </div>
 
@@ -326,7 +350,9 @@ export default function ExperienceDonutChart() {
               Apply
             </button>
             <button
-              className={`${styles.btn} ${styles.ghost}`}
+              className={`${styles.btn} ${styles.ghost} ${
+                hasFilters ? styles['ghost-active'] : ''
+              }`}
               onClick={resetFilters}
               disabled={!hasFilters}
             >
@@ -340,68 +366,87 @@ export default function ExperienceDonutChart() {
             {loading && <Spinner />}
 
             {!loading && !error && chartData && total > 0 && (
-              <div className={styles['chart-canvas']}>
-                <ResponsiveContainer width="100%" aspect={1}>
-                  <PieChart margin={{ top: 50, right: 100, bottom: 50, left: 100 }}>
-                    <Pie
-                      data={visibleChartData}
-                      cx="50%"
-                      cy="50%"
-                      dataKey="value"
-                      innerRadius="42%"
-                      outerRadius="78%"
-                      stroke={darkMode ? '#1c2441' : '#fff'}
-                      strokeWidth={3}
-                      labelLine={false}
-                      label={renderOutsideLabel}
-                      isAnimationActive={!PREFERS_REDUCED_MOTION}
-                      onAnimationEnd={() => setAnimationDone(true)}
-                      activeIndex={hoveredIndex}
-                      activeShape={renderActiveShape}
-                      onMouseEnter={(_, index) => setHoveredIndex(index)}
-                      onMouseLeave={() => setHoveredIndex(null)}
-                    >
-                      {visibleChartData.map(d => (
-                        <Cell key={d.name} fill={d.color} className={styles['pie-cell']} />
-                      ))}
-                    </Pie>
-                    {/* Inside counts rendered as a second label pass — animation disabled to prevent double-sweep */}
-                    <Pie
-                      data={visibleChartData}
-                      cx="50%"
-                      cy="50%"
-                      dataKey="value"
-                      innerRadius="42%"
-                      outerRadius="78%"
-                      stroke="none"
-                      strokeWidth={0}
-                      labelLine={false}
-                      label={renderInsideCount}
-                      isAnimationActive={false}
-                      style={{ pointerEvents: 'none' }}
-                    >
-                      {visibleChartData.map(d => (
-                        <Cell key={d.name} fill="transparent" />
-                      ))}
-                    </Pie>
-                    {animationDone && (
-                      <text
-                        x="50%"
-                        y="50%"
-                        dominantBaseline="middle"
-                        textAnchor="middle"
-                        style={{
-                          fontWeight: 800,
-                          fontSize: '1.1rem',
-                          fill: darkMode ? '#f8fafc' : '#0f172a',
-                        }}
+              <>
+                <div className={styles['chart-canvas']}>
+                  <ResponsiveContainer width="100%" aspect={1.2}>
+                    <PieChart margin={pieMargin}>
+                      <Pie
+                        data={visibleChartData}
+                        cx="50%"
+                        cy="50%"
+                        dataKey="value"
+                        innerRadius="42%"
+                        outerRadius="78%"
+                        stroke={darkMode ? '#1c2441' : '#fff'}
+                        strokeWidth={3}
+                        labelLine={false}
+                        label={renderOutsideLabel}
+                        isAnimationActive={!PREFERS_REDUCED_MOTION}
+                        onAnimationEnd={() => setAnimationDone(true)}
+                        activeIndex={hoveredIndex}
+                        activeShape={renderActiveShape}
+                        onMouseEnter={(_, index) => setHoveredIndex(index)}
+                        onMouseLeave={() => setHoveredIndex(null)}
                       >
-                        {total.toLocaleString()}
-                      </text>
-                    )}
-                  </PieChart>
-                </ResponsiveContainer>
-              </div>
+                        {visibleChartData.map(d => (
+                          <Cell key={d.name} fill={d.color} className={styles['pie-cell']} />
+                        ))}
+                      </Pie>
+                      {/* Inside counts rendered as a second label pass — animation disabled to prevent double-sweep */}
+                      <Pie
+                        data={visibleChartData}
+                        cx="50%"
+                        cy="50%"
+                        dataKey="value"
+                        innerRadius="42%"
+                        outerRadius="78%"
+                        stroke="none"
+                        strokeWidth={0}
+                        labelLine={false}
+                        label={renderInsideCount}
+                        isAnimationActive={false}
+                        style={{ pointerEvents: 'none' }}
+                      >
+                        {visibleChartData.map(d => (
+                          <Cell key={d.name} fill="transparent" />
+                        ))}
+                      </Pie>
+                      {animationDone && (
+                        <text
+                          x="50%"
+                          y="50%"
+                          dominantBaseline="middle"
+                          textAnchor="middle"
+                          style={{
+                            fontWeight: 800,
+                            fontSize: '1.25rem',
+                            fill: darkMode ? '#f8fafc' : '#0f172a',
+                          }}
+                        >
+                          {total.toLocaleString()}
+                        </text>
+                      )}
+                    </PieChart>
+                  </ResponsiveContainer>
+                </div>
+                {isMobile && (
+                  <div className={styles['mobile-legend']}>
+                    {visibleChartData.map(d => {
+                      const pct = total > 0 ? ((d.value / total) * 100).toFixed(1) : 0;
+                      return (
+                        <div key={d.name} className={styles['mobile-legend-item']}>
+                          <span
+                            className={styles['mobile-legend-dot']}
+                            style={{ backgroundColor: d.color }}
+                          />
+                          <span className={styles['mobile-legend-name']}>{d.name}</span>
+                          <span className={styles['mobile-legend-pct']}>{pct}%</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </>
             )}
 
             {!loading && !error && (!chartData || total === 0) && <p>No Data Available 😢</p>}

--- a/src/components/ExperienceDonutChart/ExperienceDonutChart.jsx
+++ b/src/components/ExperienceDonutChart/ExperienceDonutChart.jsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import axios from 'axios'; // Added axios import to fix network request errors
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
+import { PieChart, Pie, Cell, ResponsiveContainer, Sector } from 'recharts';
 import styles from './ExperienceDonutChart.module.css';
 
 const SEGMENT_COLORS = [
@@ -16,11 +16,14 @@ const SEGMENT_COLORS = [
 
 const EXPERIENCE_LABELS = ['0-1 years', '1-3 years', '3-5 years', '5+ years'];
 
-// ✅ Crypto-based RNG (safer than Math.random)
-function secureRandomInt(min, max) {
-  const array = new Uint32Array(1);
-  crypto.getRandomValues(array);
-  return min + (array[0] % (max - min + 1));
+function getContrastColor(hexColor) {
+  const hex = hexColor.replace('#', '');
+  const bigint = parseInt(hex, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+  return brightness > 150 ? '#111827' : '#ffffff';
 }
 
 function Spinner() {
@@ -31,6 +34,13 @@ function Spinner() {
     </div>
   );
 }
+
+const TODAY = new Date().toISOString().split('T')[0];
+
+const PREFERS_REDUCED_MOTION =
+  typeof window !== 'undefined'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    : false;
 
 export default function ExperienceDonutChart() {
   const [startDate, setStartDate] = useState('');
@@ -44,7 +54,6 @@ export default function ExperienceDonutChart() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const [activeIndex, setActiveIndex] = useState(null);
   const darkMode = useSelector(state => state.theme.darkMode);
 
   const hasFilters = useMemo(
@@ -60,17 +69,14 @@ export default function ExperienceDonutChart() {
   const fetchData = async () => {
     setLoading(true);
     setError(null);
-    setActiveIndex(null);
 
     try {
       const token = localStorage.getItem('token');
       if (!token) throw new Error('No token found. Please log in.');
 
-      // Fixed API endpoint path to include /applicant-analytics
       const url = `${process.env.REACT_APP_APIENDPOINT}/applicant-analytics/experience-breakdown`;
       const params = {};
 
-      // Replaced undefined filter variables with correctly scoped appliedFilters
       if (appliedFilters.startDate && appliedFilters.endDate) {
         params.startDate = appliedFilters.startDate;
         params.endDate = appliedFilters.endDate;
@@ -88,24 +94,23 @@ export default function ExperienceDonutChart() {
 
       if (!data || data.length === 0) {
         setChartData(null);
-        setLoading(false);
+        setTotal(0);
         return;
       }
 
-      // Re-formatted chart data as an array of objects for Recharts compatibility
       const formattedData = EXPERIENCE_LABELS.map((label, index) => {
         const found = data.find(d => d.experience === label);
         return {
           name: label,
           value: found ? found.count : 0,
-          color: SEGMENT_COLORS[index % SEGMENT_COLORS.length], // Fixed case sensitivity for constants
+          color: SEGMENT_COLORS[index % SEGMENT_COLORS.length],
         };
       });
 
       const totalCount = formattedData.reduce((a, b) => a + b.value, 0);
 
       setChartData(formattedData);
-      setTotal(totalCount); // Added state update for chart center total
+      setTotal(totalCount);
     } catch (err) {
       setError(err.response?.data?.message || err.message || 'Error fetching data.');
       setChartData(null);
@@ -120,18 +125,127 @@ export default function ExperienceDonutChart() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appliedFilters]);
 
+  const visibleChartData = useMemo(() => chartData?.filter(d => d.value > 0) ?? [], [chartData]);
+
+  // Hide counts until the sweep animation finishes so they don't bleed through
+  const [animationDone, setAnimationDone] = useState(false);
+  useEffect(() => {
+    setAnimationDone(PREFERS_REDUCED_MOTION);
+  }, [chartData]);
+
+  const [hoveredIndex, setHoveredIndex] = useState(null);
+
+  // Renders the hovered segment with a slightly larger outer radius
+  const renderActiveShape = props => {
+    const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill } = props;
+    return (
+      <Sector
+        cx={cx}
+        cy={cy}
+        innerRadius={innerRadius - 3}
+        outerRadius={outerRadius + 10}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        fill={fill}
+      />
+    );
+  };
+
+  // Draws the count at the visual center of each segment — only after animation completes
+  const renderInsideCount = ({ cx, cy, midAngle, innerRadius, outerRadius, value, index }) => {
+    if (!value || !animationDone) return null;
+    const isHovered = index === hoveredIndex;
+    const RADIAN = Math.PI / 180;
+    const expandedOuter = isHovered ? outerRadius + 10 : outerRadius;
+    const radius = (innerRadius - (isHovered ? 3 : 0) + expandedOuter) * 0.5;
+    const x = cx + radius * Math.cos(-midAngle * RADIAN);
+    const y = cy + radius * Math.sin(-midAngle * RADIAN);
+    return (
+      <text
+        x={x}
+        y={y}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill={getContrastColor(visibleChartData[index]?.color ?? '#000')}
+        style={{
+          fontSize: isHovered ? '1.2rem' : '1.05rem',
+          fontWeight: 800,
+          pointerEvents: 'none',
+          transition: 'font-size 0.15s ease',
+        }}
+      >
+        {value.toLocaleString()}
+      </text>
+    );
+  };
+
+  // Draws name on top line, percentage below — outside the segment, only after animation completes
+  const renderOutsideLabel = ({ cx, cy, midAngle, outerRadius, name, percent, index }) => {
+    if (!animationDone) return null;
+    const isHovered = index === hoveredIndex;
+    const RADIAN = Math.PI / 180;
+    const expandedOuter = isHovered ? outerRadius + 10 : outerRadius;
+    const lineStart = expandedOuter + 8;
+    const lineEnd = expandedOuter + 50;
+    const sx = cx + lineStart * Math.cos(-midAngle * RADIAN);
+    const sy = cy + lineStart * Math.sin(-midAngle * RADIAN);
+    const ex = cx + lineEnd * Math.cos(-midAngle * RADIAN);
+    const ey = cy + lineEnd * Math.sin(-midAngle * RADIAN);
+    const isRight = ex > cx;
+    const elbowX = ex + (isRight ? 18 : -18);
+    const textX = elbowX + (isRight ? 4 : -4);
+    const textAnchor = isRight ? 'start' : 'end';
+    const pct = `${(percent * 100).toFixed(1)}%`;
+    const labelColor = darkMode ? '#f8fafc' : '#0f172a';
+    const lineColor = darkMode ? '#94a3b8' : '#64748b';
+    const nameFontSize = isHovered ? '1.05rem' : '0.95rem';
+    const pctFontSize = isHovered ? '0.95rem' : '0.85rem';
+    const strokeWidth = isHovered ? 2.5 : 1.5;
+
+    return (
+      <g style={{ transition: 'all 0.15s ease' }}>
+        <path
+          d={`M${sx},${sy} L${ex},${ey} L${elbowX},${ey}`}
+          fill="none"
+          stroke={lineColor}
+          strokeWidth={strokeWidth}
+        />
+        <text
+          x={textX}
+          y={ey}
+          textAnchor={textAnchor}
+          fill={labelColor}
+          style={{ fontWeight: 700 }}
+        >
+          <tspan x={textX} dy="-0.55em" style={{ fontSize: nameFontSize }}>
+            {name}
+          </tspan>
+          <tspan x={textX} dy="1.2em" style={{ fontSize: pctFontSize, opacity: 0.75 }}>
+            {pct}
+          </tspan>
+        </text>
+      </g>
+    );
+  };
+
   const onRolesChange = e => {
     setSelectedRoles(Array.from(e.target.selectedOptions, o => o.value));
   };
 
   const applyFilters = () => {
-    if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
-      setError(null);
-      setChartData(null);
-      setTotal(0);
-      setLoading(false);
+    if (startDate && startDate > TODAY) {
+      setError('Start date cannot be in the future.');
       return;
     }
+    if (endDate && endDate > TODAY) {
+      setError('End date cannot be in the future.');
+      return;
+    }
+    if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
+      setError('Start date must be before end date.');
+      return;
+    }
+    setError(null);
     setAppliedFilters({ startDate, endDate, roles: selectedRoles });
   };
 
@@ -139,49 +253,8 @@ export default function ExperienceDonutChart() {
     setStartDate('');
     setEndDate('');
     setSelectedRoles([]);
+    setError(null);
     setAppliedFilters({ startDate: '', endDate: '', roles: [] });
-  };
-
-  const DetailsPanel = () => {
-    if (!chartData || total === 0) return null;
-
-    return (
-      <div className={styles['chart-details']}>
-        {chartData.map((d, idx) => {
-          const pct = total > 0 ? ((d.value / total) * 100).toFixed(1) : 0;
-          return (
-            <div
-              key={d.name}
-              className={`${styles['detail-item']} ${activeIndex === idx ? styles.active : ''}`}
-              onMouseEnter={() => setActiveIndex(idx)}
-              onMouseLeave={() => setActiveIndex(null)}
-            >
-              <span className={styles['detail-dot']} style={{ backgroundColor: d.color }} />
-              <span className={styles['detail-name']}>{d.name}</span>
-              <span className={styles['detail-count']}>{d.value.toLocaleString()}</span>
-              <span className={styles['detail-pct']}>{pct}%</span>
-            </div>
-          );
-        })}
-      </div>
-    );
-  };
-
-  const CustomTooltip = ({ active, payload }) => {
-    if (!active || !payload?.length) return null;
-    const d = payload[0]?.payload;
-    const pct = total > 0 ? ((d.value / total) * 100).toFixed(1) : 0;
-
-    return (
-      <div className={styles['custom-tooltip']}>
-        {/* Corrected tooltip to use name and value from payload for visibility */}
-        <strong>{d.name}</strong>
-        <br />
-        Count: {d.value}
-        <br />
-        {pct}% of applicants
-      </div>
-    );
   };
 
   return (
@@ -205,6 +278,7 @@ export default function ExperienceDonutChart() {
                 type="date"
                 className={styles['filter-input']}
                 value={startDate}
+                max={TODAY}
                 onChange={e => setStartDate(e.target.value)}
               />
             </div>
@@ -218,6 +292,7 @@ export default function ExperienceDonutChart() {
                 type="date"
                 className={styles['filter-input']}
                 value={endDate}
+                max={TODAY}
                 onChange={e => setEndDate(e.target.value)}
               />
             </div>
@@ -261,32 +336,51 @@ export default function ExperienceDonutChart() {
             {loading && <Spinner />}
 
             {!loading && !error && chartData && total > 0 && (
-              <>
-                <div className={styles['chart-canvas']}>
-                  <ResponsiveContainer width="100%" aspect={1}>
-                    <PieChart>
-                      <Pie
-                        data={chartData}
-                        cx="50%"
-                        cy="50%"
-                        dataKey="value"
-                        innerRadius="55%"
-                        outerRadius="82%"
-                        stroke={darkMode ? '#1c2441' : '#fff'}
-                        strokeWidth={3}
-                        onMouseEnter={(_, i) => setActiveIndex(i)}
-                        onMouseLeave={() => setActiveIndex(null)}
-                      >
-                        {chartData.map((d, i) => (
-                          <Cell
-                            key={d.name}
-                            fill={d.color}
-                            className={styles['pie-cell']}
-                            opacity={activeIndex == null || activeIndex === i ? 1 : 0.45}
-                          />
-                        ))}
-                      </Pie>
-                      <Tooltip content={<CustomTooltip />} />
+              <div className={styles['chart-canvas']}>
+                <ResponsiveContainer width="100%" aspect={1}>
+                  <PieChart margin={{ top: 50, right: 100, bottom: 50, left: 100 }}>
+                    <Pie
+                      data={visibleChartData}
+                      cx="50%"
+                      cy="50%"
+                      dataKey="value"
+                      innerRadius="42%"
+                      outerRadius="78%"
+                      stroke={darkMode ? '#1c2441' : '#fff'}
+                      strokeWidth={3}
+                      labelLine={false}
+                      label={renderOutsideLabel}
+                      isAnimationActive={!PREFERS_REDUCED_MOTION}
+                      onAnimationEnd={() => setAnimationDone(true)}
+                      activeIndex={hoveredIndex}
+                      activeShape={renderActiveShape}
+                      onMouseEnter={(_, index) => setHoveredIndex(index)}
+                      onMouseLeave={() => setHoveredIndex(null)}
+                    >
+                      {visibleChartData.map(d => (
+                        <Cell key={d.name} fill={d.color} className={styles['pie-cell']} />
+                      ))}
+                    </Pie>
+                    {/* Inside counts rendered as a second label pass — animation disabled to prevent double-sweep */}
+                    <Pie
+                      data={visibleChartData}
+                      cx="50%"
+                      cy="50%"
+                      dataKey="value"
+                      innerRadius="42%"
+                      outerRadius="78%"
+                      stroke="none"
+                      strokeWidth={0}
+                      labelLine={false}
+                      label={renderInsideCount}
+                      isAnimationActive={false}
+                      style={{ pointerEvents: 'none' }}
+                    >
+                      {visibleChartData.map(d => (
+                        <Cell key={d.name} fill="transparent" />
+                      ))}
+                    </Pie>
+                    {animationDone && (
                       <text
                         x="50%"
                         y="50%"
@@ -294,18 +388,16 @@ export default function ExperienceDonutChart() {
                         textAnchor="middle"
                         style={{
                           fontWeight: 800,
-                          fontSize: '1rem',
+                          fontSize: '1.1rem',
                           fill: darkMode ? '#f8fafc' : '#0f172a',
                         }}
                       >
                         {total.toLocaleString()}
                       </text>
-                    </PieChart>
-                  </ResponsiveContainer>
-                </div>
-
-                <DetailsPanel />
-              </>
+                    )}
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
             )}
 
             {!loading && !error && (!chartData || total === 0) && <p>No Data Available 😢</p>}

--- a/src/components/ExperienceDonutChart/ExperienceDonutChart.jsx
+++ b/src/components/ExperienceDonutChart/ExperienceDonutChart.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+﻿import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import axios from 'axios'; // Added axios import to fix network request errors
 import { PieChart, Pie, Cell, ResponsiveContainer, Sector } from 'recharts';
@@ -38,7 +38,7 @@ function Spinner() {
 const TODAY = new Date().toISOString().split('T')[0];
 
 const PREFERS_REDUCED_MOTION =
-  typeof window !== 'undefined'
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
     ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
     : false;
 
@@ -74,9 +74,11 @@ export default function ExperienceDonutChart() {
       const token = localStorage.getItem('token');
       if (!token) throw new Error('No token found. Please log in.');
 
+      // Fixed API endpoint path to include /applicant-analytics
       const url = `${process.env.REACT_APP_APIENDPOINT}/applicant-analytics/experience-breakdown`;
       const params = {};
 
+      // Replaced undefined filter variables with correctly scoped appliedFilters
       if (appliedFilters.startDate && appliedFilters.endDate) {
         params.startDate = appliedFilters.startDate;
         params.endDate = appliedFilters.endDate;
@@ -98,19 +100,20 @@ export default function ExperienceDonutChart() {
         return;
       }
 
+      // Re-formatted chart data as an array of objects for Recharts compatibility
       const formattedData = EXPERIENCE_LABELS.map((label, index) => {
         const found = data.find(d => d.experience === label);
         return {
           name: label,
           value: found ? found.count : 0,
-          color: SEGMENT_COLORS[index % SEGMENT_COLORS.length],
+          color: SEGMENT_COLORS[index % SEGMENT_COLORS.length], // Fixed case sensitivity for constants
         };
       });
 
       const totalCount = formattedData.reduce((a, b) => a + b.value, 0);
 
       setChartData(formattedData);
-      setTotal(totalCount);
+      setTotal(totalCount); // Added state update for chart center total
     } catch (err) {
       setError(err.response?.data?.message || err.message || 'Error fetching data.');
       setChartData(null);
@@ -156,6 +159,7 @@ export default function ExperienceDonutChart() {
     if (!value || !animationDone) return null;
     const isHovered = index === hoveredIndex;
     const RADIAN = Math.PI / 180;
+    // Push centroid outward slightly when hovered to stay centered in the expanded segment
     const expandedOuter = isHovered ? outerRadius + 10 : outerRadius;
     const radius = (innerRadius - (isHovered ? 3 : 0) + expandedOuter) * 0.5;
     const x = cx + radius * Math.cos(-midAngle * RADIAN);

--- a/src/components/ExperienceDonutChart/ExperienceDonutChart.module.css
+++ b/src/components/ExperienceDonutChart/ExperienceDonutChart.module.css
@@ -312,6 +312,19 @@
   margin: 0;
 }
 
+.error-message {
+  margin: 1.25rem auto 0;
+  padding: 0.9rem 1rem;
+  max-width: 680px;
+  width: 100%;
+  color: #dc2626;
+  background: #fef3f2;
+  border: 1px solid #fca5a5;
+  border-radius: 10px;
+  font-weight: 700;
+  text-align: center;
+}
+
 /* ===================== Print & prefers-color-scheme ===================== */
 @media print {
   .experience-donut-chart-dark-mode .experience-chart-container {

--- a/src/components/ExperienceDonutChart/ExperienceDonutChart.module.css
+++ b/src/components/ExperienceDonutChart/ExperienceDonutChart.module.css
@@ -12,7 +12,7 @@
   width: 100%;
   max-width: 1100px;
   margin: 2rem auto;
-  padding: 1.75rem;
+  padding: 1.75rem 1.75rem 0.5rem;
   background: #fff;
   border-radius: 16px;
   box-shadow: 0 1px 0 rgb(0 0 0 / 4%), 0 12px 30px rgb(2 6 23 / 8%);
@@ -59,7 +59,7 @@
   border: 1px solid #e2e8f0;
   border-radius: 12px;
   padding: 1.25rem;
-  margin-bottom: 1.25rem;
+  margin-bottom: 0rem;
   width: 100%;
 }
 
@@ -108,6 +108,37 @@
 .filter-select {
   resize: vertical;
   overflow-y: auto;
+}
+
+.checkbox-fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.checkbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.5rem 0;
+}
+
+.checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #334155;
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkbox-item input[type='checkbox'] {
+  width: 15px;
+  height: 15px;
+  cursor: pointer;
+  accent-color: #3b82f6;
+  flex-shrink: 0;
 }
 
 .filter-input:hover,
@@ -167,6 +198,19 @@
   transform: translateY(-1px);
 }
 
+.btn.ghost-active {
+  background: #fff1f2;
+  color: #dc2626;
+  border-color: #fca5a5;
+}
+
+.btn.ghost-active:hover {
+  background: #ffe4e6;
+  border-color: #f87171;
+  box-shadow: 0 6px 20px rgb(220 38 38 / 15%);
+  transform: translateY(-1px);
+}
+
 /* --- Normalize native date inputs across browsers --- */
 .filter-input[type='date'] {
   height: 44px;
@@ -213,8 +257,6 @@
   justify-content: center;
   width: 100%;
   max-width: 680px;
-  aspect-ratio: 1 / 1;
-  min-height: 400px;
   margin: 0 auto;
   overflow: visible;
 }
@@ -226,6 +268,7 @@
 .recharts-wrapper,
 .recharts-surface {
   display: block;
+  overflow: visible !important;
 }
 
 .chart-canvas,
@@ -336,6 +379,7 @@
   background: #232d53;
   color: #e5e7eb;
   border-color: #3b4a75;
+  color-scheme: dark;
 }
 
 .experience-donut-chart-dark-mode .filter-input:hover,
@@ -351,6 +395,10 @@
 
 .experience-donut-chart-dark-mode .filter-input[type='date']::-webkit-calendar-picker-indicator {
   filter: invert(1) opacity(0.9);
+}
+
+.experience-donut-chart-dark-mode .checkbox-item {
+  color: #dbe3ff;
 }
 
 /* ===================== Buttons (dark) ===================== */
@@ -375,6 +423,18 @@
 
 .experience-donut-chart-dark-mode .btn.ghost:hover {
   box-shadow: 0 6px 20px rgb(0 0 0 / 35%);
+}
+
+.experience-donut-chart-dark-mode .btn.ghost-active {
+  background: #3b1f28;
+  color: #fca5a5;
+  border-color: #7f2a3a;
+}
+
+.experience-donut-chart-dark-mode .btn.ghost-active:hover {
+  background: #4c2030;
+  border-color: #f87171;
+  box-shadow: 0 6px 20px rgb(220 38 38 / 25%);
 }
 
 /* ===================== Chart canvas (dark) ===================== */
@@ -418,8 +478,7 @@
   }
 
   .chart-canvas {
-    max-width: 360px;
-    min-height: 260px;
+    max-width: 100%;
   }
 }
 
@@ -446,4 +505,43 @@
   .pie-cell {
     transition: none;
   }
+}
+
+/* ===================== Mobile legend (shown instead of outside labels) ===================== */
+.mobile-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem 1rem;
+  padding: 0.75rem 0.5rem 0.25rem;
+  width: 100%;
+}
+
+.mobile-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.mobile-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.mobile-legend-pct {
+  color: #2563eb;
+  font-weight: 700;
+}
+
+.experience-donut-chart-dark-mode .mobile-legend-item {
+  color: #e2e8f0;
+}
+
+.experience-donut-chart-dark-mode .mobile-legend-pct {
+  color: #93c5fd;
 }

--- a/src/components/ExperienceDonutChart/ExperienceDonutChart.module.css
+++ b/src/components/ExperienceDonutChart/ExperienceDonutChart.module.css
@@ -1,4 +1,4 @@
-/* stylelint-disable  */
+﻿/* stylelint-disable  */
 /* ===================== Global reset ===================== */
 *,
 *::before,
@@ -10,7 +10,7 @@
 .experience-chart-container {
   position: relative;
   width: 100%;
-  max-width: 960px;
+  max-width: 1100px;
   margin: 2rem auto;
   padding: 1.75rem;
   background: #fff;
@@ -78,7 +78,7 @@
 .filter-actions {
   flex: 1 1 220px; /* grow/shrink; base width ~220px */
   max-width: 320px; /* avoid overly wide inputs */
-  min-width: 200px; /* don’t get too tiny */
+  min-width: 200px; /* don't get too tiny */
   text-align: left; /* labels/inputs left-aligned inside */
 }
 
@@ -200,23 +200,27 @@
 .chart-area {
   width: 100%;
   min-width: 0;
-  display: flex; /* ← was commented out; enable flex centering */
+  display: flex;
   flex-direction: column;
-  align-items: center; /* center horizontally */
-  justify-content: center; /* center vertically within area */
+  align-items: center;
+  justify-content: center;
   text-align: center;
-  padding-right: 100px !important;
 }
 
 .chart-canvas {
   display: flex;
   align-items: center;
-  justify-content: center; /* center the inner wrapper */
+  justify-content: center;
   width: 100%;
-  max-width: 520px;
-  aspect-ratio: 1 / 1; /* keeps donut perfectly square */
-  min-height: 240px; /* fallback for older browsers */
+  max-width: 680px;
+  aspect-ratio: 1 / 1;
+  min-height: 400px;
   margin: 0 auto;
+  overflow: visible;
+}
+
+.recharts-wrapper {
+  overflow: visible !important;
 }
 
 .recharts-wrapper,
@@ -232,144 +236,6 @@
 /* Recharts wrappers: enforce centering */
 .chart-canvas .recharts-wrapper {
   margin: 0 auto !important;
-}
-
-/* ===================== Details (below donut) ===================== */
-.chart-details {
-  max-width: 960px; /* match .experience-chart-container */
-  width: 100%;
-  margin: 1rem auto 0;
-  padding-inline: 0.5rem;
-  display: grid;
-  gap: 0.8rem;
-
-  /* single strategy: fluid columns that never force overflow */
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  place-items: stretch stretch;
-  overflow-x: hidden; /* safety net */
-}
-
-/* 2) Let cards fill the grid cell on desktop (remove narrow cap) */
-.detail-item {
-  display: grid;
-  grid-template-columns: 12px 1fr auto auto; /* dot | name | count | pct */
-  column-gap: 8px;
-  align-items: center;
-  width: 100%;
-  max-width: none; /* fill grid column, don't cap */
-  padding: 0.6rem 0.75rem;
-
-  /* text-align: left; */
-
-  /* prevent overflow on long role names / unbroken strings */
-  overflow-wrap: anywhere;
-  text-align: center;
-  justify-content: center;
-}
-
-.detail-item:hover,
-.detail-item.active {
-  background: #111827;
-  border-color: #0b1220;
-  box-shadow: 0 8px 18px rgb(2 6 23 / 12%);
-  transform: translateY(-1px);
-}
-
-.detail-item:hover span,
-.detail-item.active span {
-  color: #fff !important;
-}
-
-/* Map children into the grid */
-.detail-dot {
-  grid-column: 1;
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  box-shadow: 0 0 0 2px rgb(255 255 255 / 70%);
-}
-
-.detail-name {
-  grid-column: 2;
-  font-weight: 800;
-  color: #0f172a;
-  font-size: 0.9rem;
-}
-
-.detail-sep {
-  display: none;
-} /* we don’t need the bullet in a grid layout */
-.detail-count {
-  grid-column: 3;
-  font-weight: 800;
-  color: #0f172a;
-}
-
-.detail-sub {
-  display: none;
-} /* optional: hide to keep cards compact; show if you prefer */
-.detail-pct {
-  grid-column: 4;
-  margin-left: 0;
-  font-weight: 800;
-  color: #2563eb;
-}
-
-/* .detail-item:hover,
-.detail-item.active {
-  background: #111827;
-  border-color: #0b1220;
-  box-shadow: 0 8px 18px rgba(2,6,23,.12);
-  transform: translateY(-1px);
-} */
-
-/* .detail-item:hover span,
-.detail-item.active span { color: #ffffff !important; } */
-.detail-item:hover .detail-pct,
-.detail-item.active .detail-pct {
-  color: #93c5fd !important;
-} /* keep contrast on hover */
-
-@media (width <= 640px) {
-  .chart-details {
-    grid-template-columns: 1fr;
-  }
-
-  .detail-item {
-    display: flex; /* simpler on mobile */
-    flex-wrap: wrap;
-    justify-content: center;
-    text-align: center;
-    gap: 0.45rem 0.6rem;
-  }
-
-  .detail-dot {
-    order: 1;
-  }
-
-  .detail-name {
-    order: 2;
-    width: 100%;
-    font-size: 1rem;
-  }
-
-  .detail-sep {
-    display: none;
-  }
-
-  .detail-count {
-    order: 3;
-  }
-
-  .detail-sub {
-    order: 4;
-    display: inline;
-    color: #475569;
-  }
-
-  .detail-pct {
-    order: 5;
-  }
 }
 
 /* ===================== States ===================== */
@@ -403,200 +269,25 @@
   margin: 0;
 }
 
-.error-container {
-  padding: 2rem;
-  text-align: center;
-}
-
-.error-message {
-  color: #dc2626;
-  font-weight: 700;
-  font-size: 0.95rem;
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  border-radius: 10px;
-  padding: 1.1rem 1.25rem;
-  display: inline-block;
-}
-
-.no-data-container {
-  padding: 3rem 2rem;
-  text-align: center;
-}
-
-.no-data-message {
-  font-size: 1.15rem;
-  font-weight: 800;
-  color: #6b7280;
-  margin: 0 0 0.4rem;
-}
-
-.no-data-subtitle {
-  font-size: 0.95rem;
-  color: #9ca3af;
-  margin: 0;
-  font-style: italic;
-}
-
-/* ===================== Tooltip ===================== */
-
-/* Adjusted tooltip for Light Mode: Light background with dark text for contrast */
-.custom-tooltip {
-  background: rgb(255 255 255 / 96%) !important;
-  border: 1px solid #e2e8f0 !important;
-  border-radius: 10px !important;
-  padding: 0.9rem 1rem !important;
-  box-shadow: 0 12px 28px rgb(2 6 23 / 15%) !important;
-  backdrop-filter: blur(10px);
-  color: #0f172a !important;
-}
-
-.tooltip-content {
-  color: #fff !important;
-  margin: 0 !important;
-  font-size: 0.875rem !important;
-  line-height: 1.5 !important;
-}
-
-/* ===================== Slices ===================== */
-.pie-cell {
-  transition: opacity 0.15s ease, filter 0.15s ease, transform 0.15s ease;
-  cursor: pointer;
-}
-
-.pie-cell:hover {
-  opacity: 0.9;
-  filter: brightness(1.05);
-}
-
-/* .detail-item { text-align: center; justify-content: center; } */
-
-/* ===================== Responsive tweaks ===================== */
-@media (width <= 640px) {
-  .filter-group,
-  .filter-actions {
-    max-width: 320px;
-    min-width: 220px;
-  }
-
-  .chart-canvas {
-    max-width: 360px;
-    min-height: 220px;
-  }
-
-  .chart-details {
-    grid-template-columns: 1fr;
-  } /* single column for clarity */
-}
-
-/* ===================== Print & Accessibility ===================== */
+/* ===================== Print & prefers-color-scheme ===================== */
 @media print {
-  .experience-chart-container {
+  .experience-donut-chart-dark-mode .experience-chart-container {
+    background: #fff;
+    color: #0f172a;
     box-shadow: none;
     border: 1px solid #cbd5e1;
   }
+}
 
-  .filter-section {
-    display: none;
+/* Keep prefers-color-scheme consistent with your chosen dark */
+@media (prefers-color-scheme: dark) {
+  .experience-donut-chart-dark-mode .experience-chart-container {
+    background: #1c2441;
   }
 }
-
-@media (prefers-contrast: more) {
-  .experience-chart-container {
-    border: 2px solid #000;
-  }
-
-  .filter-input,
-  .filter-select {
-    border: 2px solid #000;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .spinner {
-    animation: none;
-  }
-
-  .pie-cell,
-  .btn,
-  .filter-input,
-  .filter-select {
-    transition: none;
-  }
-}
-
-@media (width <= 640px) {
-  .chart-details {
-    grid-template-columns: 1fr;
-  }
-
-  .detail-item {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    text-align: center;
-    gap: 0.45rem 0.6rem;
-  }
-
-  .detail-name {
-    width: 100%;
-    font-size: 1rem;
-  }
-}
-
-/* --- Ensure detail cards always show a visible background --- */
-.chart-details .detail-item {
-  background-color: #f1f5f9; /* stronger than #f8fafc, more visible */
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  box-shadow: 0 2px 8px rgb(2 6 23 / 6%);
-  background-clip: padding-box;
-  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.2s ease,
-    transform 0.15s ease;
-}
-
-/* Keep dark hover/active but ensure contrast is clear */
-.chart-details .detail-item:hover,
-.chart-details .detail-item.active {
-  background-color: #111827;
-  border-color: #0b1220;
-  box-shadow: 0 8px 18px rgb(2 6 23 / 12%);
-}
-
-/* If your app has global card or utility classes that might strip bg,
-   this raises specificity a bit further without !important. */
-.experience-chart-container .chart-details .detail-item {
-  background-color: #f1f5f9;
-}
-
-/* Optional: high-contrast users still get borders */
-@media (prefers-contrast: more) {
-  .chart-details .detail-item {
-    border-color: #0f172a;
-  }
-}
-
-/* --- Make chart-driven active state win over base card styles --- */
-.chart-details .detail-item.active {
-  background-color: #111827 !important; /* win against base bg */
-  border-color: #0b1220 !important;
-  box-shadow: 0 8px 18px rgb(2 6 23 / 12%);
-  color: #fff;
-}
-
-.chart-details .detail-item.active span {
-  color: #fff !important; /* keep text readable */
-}
-
-/* Optional: smooth the state change */
-
-/* .chart-details .detail-item {
-  transition: background-color .15s ease, border-color .15s ease, box-shadow .2s ease, transform .15s ease;
-} */
 
 /* ===================== DARK MODE (scoped to wrapper) ===================== */
 
-/* Ensure every surface flips dark */
 .experience-donut-chart.experience-donut-chart-dark-mode,
 .experience-donut-chart-dark-mode,
 .experience-donut-chart-dark-mode .experience-chart-container,
@@ -610,7 +301,6 @@
   margin-top: -35px;
 }
 
-/* Top gradient bar */
 .experience-donut-chart-dark-mode .experience-chart-container::before {
   background: linear-gradient(
     90deg,
@@ -622,16 +312,15 @@
   );
 }
 
-/* Title & header */
 .experience-donut-chart-dark-mode .chart-title {
-  color: #fff !important; /* “Applicants by Experience” */
+  color: #fff !important;
 }
 
 .experience-donut-chart-dark-mode .chart-header {
   color: #f1f5f9;
 }
 
-/* ===================== Filters ===================== */
+/* ===================== Filters (dark) ===================== */
 .experience-donut-chart-dark-mode .filter-section {
   background: #232d53;
   border-color: #3b4a75;
@@ -660,12 +349,11 @@
   box-shadow: 0 0 0 4px rgb(96 165 250 / 25%);
 }
 
-/* Date input icons */
 .experience-donut-chart-dark-mode .filter-input[type='date']::-webkit-calendar-picker-indicator {
   filter: invert(1) opacity(0.9);
 }
 
-/* ===================== Buttons ===================== */
+/* ===================== Buttons (dark) ===================== */
 .experience-donut-chart-dark-mode .btn {
   color: #e5e7eb;
 }
@@ -689,70 +377,18 @@
   box-shadow: 0 6px 20px rgb(0 0 0 / 35%);
 }
 
-/* ===================== Chart canvas & Recharts ===================== */
+/* ===================== Chart canvas (dark) ===================== */
 .experience-donut-chart-dark-mode .chart-canvas {
   background: transparent;
 }
 
-/* Default Recharts labels/ticks/legend */
 .experience-donut-chart-dark-mode .recharts-text,
-.experience-donut-chart-dark-mode .recharts-label,
-.experience-donut-chart-dark-mode .recharts-legend-item-text {
+.experience-donut-chart-dark-mode .recharts-label {
   fill: #e5e7eb !important;
   color: #e5e7eb !important;
 }
 
-/* Grid lines if any */
-.experience-donut-chart-dark-mode .recharts-cartesian-grid-horizontal line,
-.experience-donut-chart-dark-mode .recharts-cartesian-grid-vertical line {
-  stroke: #3b4a75 !important;
-}
-
-/* Strong contrast on hover/active (details + svg labels) */
-.experience-donut-chart-dark-mode .chart-details .detail-item:hover span,
-.experience-donut-chart-dark-mode .chart-details .detail-item.active span {
-  color: #fff !important;
-}
-
-.experience-donut-chart-dark-mode .recharts-sector:hover text,
-.experience-donut-chart-dark-mode .recharts-pie-sector:hover text {
-  fill: #fff !important;
-}
-
-/* ===================== Details (cards under chart) ===================== */
-.experience-donut-chart-dark-mode .chart-details {
-  color: #e5e7eb;
-}
-
-.experience-donut-chart-dark-mode .chart-details .detail-item {
-  background-color: #2a355f;
-  border: 1px solid #3b4a75;
-  color: #e2e8f0;
-  box-shadow: 0 2px 8px rgb(0 0 0 / 35%);
-}
-
-.experience-donut-chart-dark-mode .detail-name,
-.experience-donut-chart-dark-mode .detail-count {
-  color: #e5e7eb;
-}
-
-.experience-donut-chart-dark-mode .detail-item .detail-pct {
-  color: #93c5fd;
-}
-
-.experience-donut-chart-dark-mode .detail-dot {
-  box-shadow: 0 0 0 2px rgb(28 36 65 / 70%);
-}
-
-/* Hover/active state harmonized with palette */
-.experience-donut-chart-dark-mode .chart-details .detail-item:hover,
-.experience-donut-chart-dark-mode .chart-details .detail-item.active {
-  background-color: #232d53;
-  border-color: #1c2441;
-  box-shadow: 0 8px 18px rgb(0 0 0 / 45%);
-}
-
-/* ===================== States (loading, error, empty) ===================== */
+/* ===================== States (dark) ===================== */
 .experience-donut-chart-dark-mode .spinner {
   border-color: #2a355f;
   border-top-color: #60a5fa;
@@ -768,41 +404,46 @@
   border-color: #7f2a3a;
 }
 
-.experience-donut-chart-dark-mode .no-data-message {
-  color: #dbe3ff;
+/* ===================== Slices ===================== */
+.pie-cell {
+  transition: opacity 0.15s ease, filter 0.15s ease;
 }
 
-.experience-donut-chart-dark-mode .no-data-subtitle {
-  color: #b8c2ea;
-}
+/* ===================== Responsive ===================== */
+@media (width <= 640px) {
+  .filter-group,
+  .filter-actions {
+    max-width: 320px;
+    min-width: 220px;
+  }
 
-/* ===================== Tooltip ===================== */
-
-/* Adjusted tooltip for Dark Mode: Scoped to .experience-donut-chart-dark-mode */
-.experience-donut-chart-dark-mode .custom-tooltip {
-  background-color: rgb(42 53 95 / 96%) !important;
-  color: #f1f5f9 !important;
-  border: 1px solid #3b4a75 !important;
-  box-shadow: 0 12px 28px rgb(0 0 0 / 45%) !important;
-}
-
-.experience-donut-chart-dark-mode .custom-tooltip strong {
-  color: #fff !important;
-}
-
-/* ===================== Print & prefers-color-scheme ===================== */
-@media print {
-  .experience-donut-chart-dark-mode .experience-chart-container {
-    background: #fff;
-    color: #0f172a;
-    box-shadow: none;
-    border: 1px solid #cbd5e1;
+  .chart-canvas {
+    max-width: 360px;
+    min-height: 260px;
   }
 }
 
-/* Keep prefers-color-scheme consistent with your chosen dark */
-@media (prefers-color-scheme: dark) {
-  .experience-donut-chart-dark-mode .experience-chart-container {
-    background: #1c2441;
+/* ===================== Accessibility ===================== */
+@media (prefers-contrast: more) {
+  .experience-chart-container {
+    border: 2px solid #000;
+  }
+
+  .filter-input,
+  .filter-select {
+    border: 2px solid #000;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+
+  .btn,
+  .filter-input,
+  .filter-select,
+  .pie-cell {
+    transition: none;
   }
 }


### PR DESCRIPTION
## Description

This PR is a follow-up to #4961 and delivers a full visual overhaul of the "Applicants by Experience" donut chart, addressing post-merge feedback on chart readability, label rendering, and data validation.
<img width="685" height="729" alt="image" src="https://github.com/user-attachments/assets/6c730360-60a8-4cb7-b66c-f86dc3ac97cc" />

## Main Changes Explained

### Chart Labels & Layout
- Removed the legend/details panel below the chart — all information is now shown directly on the chart
- Added custom elbow label lines with full geometry control (diagonal + horizontal segment) so labels never clip
- Each segment now shows the count at its visual centroid, computed via `midAngle`/`innerRadius`/`outerRadius`
- Label lines show the experience label on the top line and percentage below it
- Removed tooltip — no hover popover needed since all data is always visible

### Animation & Hover
- Sweep animation plays on initial load and on every filter apply/reset
- Counts, labels, and center total are hidden during animation and revealed only when it completes, preventing bleed-through
- Respects `prefers-reduced-motion` — animation is skipped and values shown immediately for users who have it enabled
- Hover over a segment expands the arc outward, thickens the label line, and increases font sizes for the label and inside count

### Date Filter Validation
- Both date inputs are capped at today via `max` attribute — future dates are greyed out in the native picker
- `applyFilters` validates manually typed future dates and shows a clear error message

### Bug Fixes
- Invalid date range previously cleared the chart silently — now shows `"Start date must be before end date"`
- `TODAY` and `PREFERS_REDUCED_MOTION` moved to module-level constants to prevent recalculation on every render
- `animationDone` effect dependency changed from `visibleChartData` (unstable array reference) to `chartData` to prevent unnecessary resets
- Removed ~3,000 chars of dead CSS from the removed legend, tooltip, and details panel

## How to Test

1. Checkout the current branch
2. Run `npm install` followed by `npm run start:local`
3. Clear site data/cache to ensure fresh configuration
4. Log in as an Owner user and navigate to `/ExperienceDonutChart`
5. Verify the donut chart renders with:
   - Counts inside each segment
   - Label lines with experience name and percentage
   - Total count in the center hole
6. Hover over each segment and verify it expands with larger text and a thicker line
7. Verify counts and labels are **hidden during the sweep animation** and appear only once it finishes
8. Apply date filters — verify future dates are greyed out in the picker and manually typed future dates show an error
9. Apply an invalid date range (start after end) and verify the error message appears
10. Click **Reset** and verify the error clears and the chart reloads with unfiltered data
11. Switch between **Light Mode** and **Dark Mode** and verify labels, lines, and segment colors remain legible in both

## Screenshots of changes
<img width="1098" height="830" alt="image" src="https://github.com/user-attachments/assets/bce1313b-8555-4f5e-823c-3bc4fbbeae4a" />


Updated UI:
<img width="1130" height="524" alt="Screenshot 2026-06-07 113720" src="https://github.com/user-attachments/assets/72998775-5598-4bc9-956b-bf9f0b34e143" />
<img width="1140" height="820" alt="Screenshot 2026-06-07 113704" src="https://github.com/user-attachments/assets/24710baa-3e29-4d3c-bde8-32c3d13239a1" />
<img width="970" height="678" alt="image" src="https://github.com/user-attachments/assets/045fdf0e-3604-47bb-baea-48033e618a67" />
