### PR TITLE
Diya 🔥 fix(bsFlow): Fixed Blue Square flow

### DIFF
--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -758,97 +758,65 @@ setUpdatedTasks(prev => {
   const modifyBlueSquares = async (id, dateStamp, summary, operation) => {
     setShowModal(false);
     if (operation === 'add') {
-      /* peizhou: check that the date of the blue square is not future or empty. */
       if (moment(dateStamp).isAfter(moment().format('YYYY-MM-DD')) || dateStamp === '') {
         if (moment(dateStamp).isAfter(moment().format('YYYY-MM-DD'))) {
-          // eslint-disable-next-line no-console
           console.log('WARNING: Future Blue Square');
-          // eslint-disable-next-line no-alert
           alert('WARNING: Cannot Assign Blue Square with a Future Date');
         }
         if (dateStamp === '') {
-          // eslint-disable-next-line no-console
           console.log('WARNING: Empty Date');
-          // eslint-disable-next-line no-alert
           alert('WARNING: Cannot Assign Blue Square with an Empty Date');
         }
       } else {
         const newBlueSquare = {
           date: dateStamp,
           description: summary,
-          // createdDate: moment
-          //   .tz('America/Los_Angeles')
-          //   .toISOString()
-          //   .split('T')[0],
           createdDate: moment().format('YYYY-MM-DD'),
-          // Track manual assignment - note: backend uses 'manullyAssigned' (typo in field name)
           manullyAssigned: true,
           manullyAssignedBy: requestorId,
         };
         setModalTitle('Blue Square');
         axios
-          .post(ENDPOINTS.ADD_BLUE_SQUARE(userProfile._id), {
-            blueSquare: newBlueSquare,
-          })
+          .post(ENDPOINTS.ADD_BLUE_SQUARE(userProfile._id), { blueSquare: newBlueSquare })
           .then(res => {
-
-            const updatedInfringements = [
-              ...userProfile.infringements,
-              {
-                _id: res.data._id,
-                ...newBlueSquare,
-              }
-            ];
-
-            setOriginalUserProfile(prev => ({
-              ...prev,
-              infringements: updatedInfringements,
-            }));
-
-            setUserProfile(prev => ({
-              ...prev,
-              infringements: updatedInfringements,
-            }));
+            // Use API response as source of truth
+            setUserProfile(prev => ({ ...prev, infringements: res.data.infringements }));
+            setOriginalUserProfile(prev => ({ ...prev, infringements: res.data.infringements }));
           })
           .catch(error => {
-            // eslint-disable-next-line no-console
             console.log('error in modifying bluesquare', error);
             toast.error('Failed to add Blue Square!');
           });
       }
     } else if (operation === 'update') {
-      const currentBlueSquares = [...userProfile?.infringements] || [];
-      if (dateStamp != null && currentBlueSquares.length !== 0) {
-        currentBlueSquares.find(blueSquare => blueSquare._id === id).date = dateStamp;
-      }
-      if (summary != null && currentBlueSquares.length !== 0) {
-        currentBlueSquares.find(blueSquare => blueSquare._id === id).description = summary;
-      }
-      await axios
-        .put(ENDPOINTS.MODIFY_BLUE_SQUARE(userProfile._id, id), {
+      try {
+        const res = await axios.put(ENDPOINTS.MODIFY_BLUE_SQUARE(userProfile._id, id), {
           dateStamp,
           summary,
           editedBy: requestorId,
-        })
-        .catch(error => {
-          toast.error('Failed to update Blue Square!');
         });
-      toast.success('Blue Square Updated!');
-      setUserProfile({ ...userProfile, infringements: currentBlueSquares });
-      setOriginalUserProfile({ ...userProfile, infringements: currentBlueSquares });
+        toast.success('Blue Square Updated!');
+        // Use API response as source of truth
+        setUserProfile(prev => ({ ...prev, infringements: res.data.infringements }));
+        setOriginalUserProfile(prev => ({ ...prev, infringements: res.data.infringements }));
+      } catch (error) {
+        toast.error('Failed to update Blue Square!');
+      }
     } else if (operation === 'delete') {
-      let newInfringements = [...userProfile?.infringements] || [];
-      if (newInfringements.length !== 0) {
-        newInfringements = newInfringements.filter(infringement => infringement._id !== id);
-        await axios.delete(ENDPOINTS.MODIFY_BLUE_SQUARE(userProfile._id, id)).catch(error => {
+      if (userProfile?.infringements?.length !== 0) {
+        try {
+          const res = await axios.delete(ENDPOINTS.MODIFY_BLUE_SQUARE(userProfile._id, id));
+          toast.success('Blue Square Deleted!');
+          // Use API response as source of truth
+          setUserProfile(prev => ({ ...prev, infringements: res.data.infringements }));
+          setOriginalUserProfile(prev => ({ ...prev, infringements: res.data.infringements }));
+        } catch (error) {
           toast.error('Failed to delete Blue Square!');
-        });
-        toast.success('Blue Square Deleted!');
-        setUserProfile({ ...userProfile, infringements: newInfringements });
-        setOriginalUserProfile({ ...userProfile, infringements: newInfringements });
+        }
       }
     }
   };
+  
   const fetchSpecialWarnings = async () => {
     const userId = props?.match?.params?.userId;
     try {

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -800,6 +800,7 @@ setUpdatedTasks(prev => {
         setUserProfile(prev => ({ ...prev, infringements: res.data.infringements }));
         setOriginalUserProfile(prev => ({ ...prev, infringements: res.data.infringements }));
       } catch (error) {
+        console.error('Failed to update Blue Square:', error);
         toast.error('Failed to update Blue Square!');
       }
     } else if (operation === 'delete') {
@@ -811,12 +812,13 @@ setUpdatedTasks(prev => {
           setUserProfile(prev => ({ ...prev, infringements: res.data.infringements }));
           setOriginalUserProfile(prev => ({ ...prev, infringements: res.data.infringements }));
         } catch (error) {
+          console.error('Failed to delete Blue Square:', error);
           toast.error('Failed to delete Blue Square!');
         }
       }
     }
   };
-  
+
   const fetchSpecialWarnings = async () => {
     const userId = props?.match?.params?.userId;
     try {


### PR DESCRIPTION
# Description

Fixes the Blue Square UI showing stale infringement data after add, edit, and delete operations by using the API response as the source of truth instead of constructing local state manually.

**Fixes:** Blue Square UI showing incorrect count and stale infringements after mutations (High)

## Related PRs (if any):
This frontend PR is related to the backend [PR #2230](https://github.com/OneCommunityGlobal/HGNRest/pull/2230)

## Main changes explained:
- Updated `modifyBlueSquares` in `UserProfile.jsx` for the `add` operation to use `res.data.infringements` from the API response to update local state, instead of spreading stale `userProfile.infringements` and appending a locally constructed object with the wrong `_id`
- Updated `modifyBlueSquares` for the `update` operation to use `res.data.infringements` from the API response instead of manually patching the local array
- Updated `modifyBlueSquares` for the `delete` operation to use `res.data.infringements` from the API response instead of filtering the local array

## How to test:
1. Check out current branch
2. Run `npm install` and `npm start`
3. Log in as an admin user
4. Navigate to any user profile
5. Add a blue square — verify the UI immediately shows the correct count without refresh
6. Edit the blue square — verify the updated description shows immediately and persists after hard refresh
7. Delete the blue square — verify it disappears immediately and the count updates correctly
8. Hard refresh after each operation — verify UI matches DB state exactly

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/009f9994-4043-4842-a90f-f1e42209701f


## Note:
The previous `add` implementation was spreading `userProfile.infringements` (stale local state) and appending a new object using `res.data._id` which is the user's `_id`, not the new infringement's `_id`. This caused the UI to show an incorrect count (stale count + 1) and made it impossible to interact with the newly added blue square by ID. All three operations now rely entirely on the backend response which reflects the true DB state.