### PR TITLE
Diya 🔥 fix(ui): Fixed User management page UI

### DIFF
--- a/src/components/UserManagement/UserSearchPanel.jsx
+++ b/src/components/UserManagement/UserSearchPanel.jsx
@@ -35,7 +35,7 @@ function UserSearchPanel({
       <button
         type="button"
         disabled={!canCreateUsers}
-        className="btn btn-info mr-2 mb-2"
+        className="btn btn-info mr-2"
         onClick={handleNewUserSetupPopup}
         style={darkMode ? boxStyleDark : boxStyle}
       >
@@ -44,7 +44,7 @@ function UserSearchPanel({
       <OverlayTrigger placement="bottom" overlay={setupHistoryTooltip}>
         <button
           type="button"
-          className="btn btn-info mr-2 mb-2"
+          className="btn btn-info mr-2"
           onClick={handleSetupHistoryPopup}
           style={darkMode ? boxStyleDark : boxStyle}
           aria-label="Setup History"
@@ -69,7 +69,7 @@ function UserSearchPanel({
       <button
         type="button"
         disabled={!canCreateUsers}
-        className="btn btn-info mr-2 mb-2"
+        className="btn btn-info mr-2"
         onClick={() => {
           onNewUserClick();
         }}


### PR DESCRIPTION
# Description
Fixes misaligned buttons in the User Management search panel where the Send Setup Link, bell icon, and Create User buttons were vertically offset from the search input and Show dropdown.

## Related PRS (if any):
None

## Main changes explained:
- Removed mb-2 from all three buttons which was causing the vertical offset

## How to test:
1. Check out current branch
2. Run npm install and npm start
3. Log in as any user
4. Go to Other Links → User Management
5. Verify the Send Setup Link, bell icon, and Create User buttons are vertically aligned with the Search input and Show dropdown

## Screenshots or videos of changes:
Before: 
<img width="1568" height="66" alt="preview" src="https://github.com/user-attachments/assets/8be55bb9-ed66-4857-bb6b-ea934f3dc313" />
After:
<img width="1891" height="74" alt="Screenshot 2026-05-25 at 11 21 38 PM" src="https://github.com/user-attachments/assets/cff164d4-ba0a-414a-b6d1-2bf61cb43a27" />

## Note:
The mb-2 margin-bottom on the buttons was pushing them down relative to the other inline elements. 
