### PR TITLE
Sayali: 🔥 fix dashboard layout and UserProfile page - badges, QST tags, basic info alignment

### DIFF
--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -1,23 +1,20 @@
-import React, { useState, useEffect } from 'react';
-import { Row, Col, Container } from 'reactstrap';
-import { connect, useSelector, useDispatch } from 'react-redux';
-import { cantUpdateDevAdminDetails } from '~/utils/permissions';
+import { useEffect, useState } from 'react';
+import { connect, useDispatch, useSelector } from 'react-redux';
+import { toast } from 'react-toastify';
+import { Col, Container, Row } from 'reactstrap';
+import { updateSummaryBarData } from '~/actions/dashboardActions';
 import {
-  DEV_ADMIN_ACCOUNT_EMAIL_DEV_ENV_ONLY,
   DEV_ADMIN_ACCOUNT_CUSTOM_WARNING_MESSAGE_DEV_ENV_ONLY,
+  DEV_ADMIN_ACCOUNT_EMAIL_DEV_ENV_ONLY,
   PROTECTED_ACCOUNT_MODIFICATION_WARNING_MESSAGE,
 } from '~/utils/constants';
-import { updateSummaryBarData } from '~/actions/dashboardActions';
-import Leaderboard from '../LeaderBoard';
-import WeeklySummary from '../WeeklySummary/WeeklySummary';
-import Badge from '../Badge';
-import Timelog from '../Timelog/Timelog';
-import SummaryBar from '../SummaryBar/SummaryBar';
-import styles from './Dashboard.module.css';
+import { cantUpdateDevAdminDetails } from '~/utils/permissions';
 import '../../App.module.css';
+import Leaderboard from '../LeaderBoard';
+import SummaryBar from '../SummaryBar/SummaryBar';
+import Timelog from '../Timelog/Timelog';
+import WeeklySummary from '../WeeklySummary/WeeklySummary';
 import TimeOffRequestDetailModal from './TimeOffRequestDetailModal';
-import FeedbackModal from '../FeedbackModal/FeedbackModal';
-import { toast } from 'react-toastify';
 
 export function Dashboard(props) {
   const [popup, setPopup] = useState(false);
@@ -82,8 +79,7 @@ export function Dashboard(props) {
         isNotAllowedToEdit={isNotAllowedToEdit}
       />
       <Row className="w-100 ml-1">
-        <Col lg={7}></Col>
-        <Col lg={5}>
+        <Col lg={5} className="order-lg-2 order-2">
           <div className="row justify-content-center">
             <div
               role="button"
@@ -103,10 +99,6 @@ export function Dashboard(props) {
               />
             </div>
           </div>
-        </Col>
-      </Row>
-      <Row className="w-100 ml-1">
-        <Col lg={5} className="order-lg-2 order-2">
           <Leaderboard
             displayUserId={displayUserId}
             isNotAllowedToEdit={isNotAllowedToEdit}

--- a/src/components/UserProfile/BadgeImage/BadgeImage.jsx
+++ b/src/components/UserProfile/BadgeImage/BadgeImage.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from 'react';
-import { Card, CardTitle, CardBody, CardImg, CardText, Popover } from 'reactstrap';
+import { useEffect, useState } from 'react';
+import { Card, CardBody, CardImg, CardText, CardTitle, Popover } from 'reactstrap';
+import styles from '../Badge.module.css';
 
 const BadgeImage = props => {
   const [isOpen, setOpen] = useState(false);
@@ -29,8 +30,8 @@ const BadgeImage = props => {
 
   return (
     <>
-      <div className="badge_md_image_container">
-        <div className="badge_image_md" data-testid="badge-image-wrapper">
+      <div className={styles.badge_md_image_container}>
+        <div className={styles.badge_image_md} data-testid="badge-image-wrapper">
           <img
             data-testid={`badge-image-${props.index}`}
             src={props?.badgeData?.imageUrl}
@@ -39,13 +40,13 @@ const BadgeImage = props => {
           />
 
           {props.badgeData.type == 'Personal Max' ? (
-            <span data-testid="badge_featured_count_personalmax" className={'badge_featured_count_personalmax'}>
+            <span data-testid="badge_featured_count_personalmax" className={styles.badge_featured_count_personalmax}>
               {`${Math.floor(badgeValue)} ${Math.floor(badgeValue) <= 1 ? ' hr' : ' hrs'}`}
             </span>
           ) : props.count < 100 ? (
-            <span data-testid="badge_featured_count" className={'badge_featured_count'}>{Math.round(badgeValue)}</span>
+            <span data-testid="badge_featured_count" className={styles.badge_featured_count}>{Math.round(badgeValue)}</span>
           ) : (
-            <span data-testid="badge_featured_count_3_digit" className="badge_featured_count_3_digit">{Math.round(badgeValue)}</span>
+            <span data-testid="badge_featured_count_3_digit"className={styles.badge_featured_count_3_digit}>{Math.round(badgeValue)}</span>
           )}
         </div>
       </div>
@@ -55,8 +56,8 @@ const BadgeImage = props => {
         toggle={toggle}
         target={'popover_' + props.time + props.index.toString()}
       >
-        <Card className="text-center">
-          <CardImg className="badge_image_lg" src={props?.badgeData?.imageUrl} />
+        <Card className="text-center" style={{maxWidth: '220px'}}>
+          <CardImg style={{width: '120px', height: '120px', margin: '0 auto', display: 'block'}} src={props?.badgeData?.imageUrl} />
           <CardBody>
             <CardTitle
               style={{

--- a/src/components/UserProfile/BadgeImage/BadgeImage.jsx
+++ b/src/components/UserProfile/BadgeImage/BadgeImage.jsx
@@ -1,6 +1,8 @@
+import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import { Card, CardBody, CardImg, CardText, CardTitle, Popover } from 'reactstrap';
 import styles from '../Badge.module.css';
+
 
 const BadgeImage = props => {
   const [isOpen, setOpen] = useState(false);
@@ -75,6 +77,20 @@ const BadgeImage = props => {
       </Popover>
     </>
   );
+};
+
+BadgeImage.propTypes = {
+  badgeData: PropTypes.shape({
+    imageUrl: PropTypes.string,
+    type: PropTypes.string,
+    badgeName: PropTypes.string,
+    description: PropTypes.string,
+    ranking: PropTypes.number,
+  }),
+  count: PropTypes.number,
+  index: PropTypes.number,
+  time: PropTypes.string,
+  personalBestMaxHrs: PropTypes.number,
 };
 
 export default BadgeImage;

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -1,26 +1,25 @@
-import React, { useState, useEffect, useRef } from 'react';
-import PropTypes from 'prop-types';
-import { Row, Label, Input, Col, FormFeedback, FormGroup, Button } from 'reactstrap';
-import ToggleSwitch from '../UserProfileEdit/ToggleSwitch';
-import moment from 'moment';
-import PhoneInput from 'react-phone-input-2';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import PropTypes from 'prop-types';
+import { useEffect, useRef, useState } from 'react';
+import PhoneInput from 'react-phone-input-2';
+import { Button, Col, FormFeedback, FormGroup, Input, Label, Row } from 'reactstrap';
+import ToggleSwitch from '../UserProfileEdit/ToggleSwitch';
 
 //// import 'react-phone-input-2/lib/style.css';
-import PauseAndResumeButton from '~/components/UserManagement/PauseAndResumeButton';
-import TimeZoneDropDown from '../TimeZoneDropDown';
-import { connect , useDispatch } from 'react-redux';
-import hasPermission from '~/utils/permissions';
-import SetUpFinalDayButton from '~/components/UserManagement/SetUpFinalDayButton';
-import styles from './BasicInformationTab.module.css';
-import { boxStyle, boxStyleDark } from '~/styles';
-import EditableInfoModal from '~/components/UserProfile/EditableModal/EditableInfoModal';
-import { formatDateLocal, formatDateCompany } from '~/utils/formatDate';
-import { ENDPOINTS } from '~/utils/URL';
 import axios from 'axios';
 import { isString } from 'lodash';
+import { connect, useDispatch } from 'react-redux';
 import { toast } from 'react-toastify';
+import PauseAndResumeButton from '~/components/UserManagement/PauseAndResumeButton';
+import SetUpFinalDayButton from '~/components/UserManagement/SetUpFinalDayButton';
+import EditableInfoModal from '~/components/UserProfile/EditableModal/EditableInfoModal';
+import { boxStyle, boxStyleDark } from '~/styles';
+import { formatDateCompany, formatDateLocal } from '~/utils/formatDate';
+import hasPermission from '~/utils/permissions';
+import { ENDPOINTS } from '~/utils/URL';
+import TimeZoneDropDown from '../TimeZoneDropDown';
+import styles from './BasicInformationTab.module.css';
 
 
 export const Name = props => {
@@ -561,7 +560,7 @@ const BasicInformationTab = props => {
 
   const nameComponent = (
     <>
-      <Col className={darkMode ? styles['dark-label-col'] : ''}>
+      <Col md="5" className={darkMode ? styles['dark-label-col'] : ''}>
         <span className={styles['label-icon-container']}>
           <Label className={darkMode ? 'text-light label-with-icon' : 'label-with-icon'}>
             Name
@@ -594,7 +593,7 @@ const BasicInformationTab = props => {
 
   const titleComponent = (
     <>
-      <Col className={darkMode ? styles['dark-label-col'] : ''}>
+      <Col md="5" className={darkMode ? styles['dark-label-col'] : ''}>
         <span className={styles['label-icon-container']}>
           <Label className={darkMode ? 'text-light label-with-icon' : 'label-with-icon'}>
             Title
@@ -626,7 +625,7 @@ const BasicInformationTab = props => {
 
   const emailComponent = (
     <>
-      <Col className={darkMode ? styles['dark-label-col'] : ''}>
+      <Col md="5" className={darkMode ? styles['dark-label-col'] : ''}>
         <span className={styles['label-icon-container']}>
           <Label className={darkMode ? 'text-light label-with-icon' : ' label-with-icon'}>
             Email
@@ -659,7 +658,7 @@ const BasicInformationTab = props => {
 
   const phoneComponent = (
     <>
-      <Col className={darkMode ? styles['dark-label-col'] : ''}>
+      <Col md="5" className={darkMode ? styles['dark-label-col'] : ''}>
         <span className={styles['label-icon-container']}>
           <Label className={darkMode ? 'text-light label-with-icon' : 'label-with-icon'}>
             Phone
@@ -691,7 +690,7 @@ const BasicInformationTab = props => {
 
   const videoCallPreferenceComponent = (
     <>
-      <Col className={darkMode ? styles['dark-label-col'] : ''}>
+      <Col md="5" className={darkMode ? styles['dark-label-col'] : ''}>
         <Label className={darkMode ? 'text-light' : ''}>Video Call Preference</Label>
       </Col>
       <Col md={desktopDisplay ? '6' : ''} className={darkMode ? 'bg-yinmn-blue' : ''}>
@@ -711,7 +710,7 @@ const BasicInformationTab = props => {
             />
           </FormGroup>
         ) : (
-          `${userProfile.collaborationPreference}`
+          <p className={`text-right ${darkMode ? 'text-light' : ''}`}>{userProfile.collaborationPreference}</p>
         )}
       </Col>
     </>
@@ -719,7 +718,7 @@ const BasicInformationTab = props => {
 
   const roleComponent = (
     <>
-      <Col className={darkMode ? styles['dark-label-col'] : ''}>
+      <Col md="5" className={darkMode ? styles['dark-label-col'] : ''}>
         <Label className={darkMode ? 'text-light' : ''}>Role</Label>
       </Col>
       <Col md={desktopDisplay ? '6' : ''} className={darkMode ? 'bg-yinmn-blue' : ''}>
@@ -762,7 +761,7 @@ const BasicInformationTab = props => {
             </select>
           </FormGroup>
         ) : (
-          `${userProfile.role}`
+          <p className={`text-right ${darkMode ? 'text-light' : ''}`}>{userProfile.role}</p>
         )}
       </Col>
       {desktopDisplay ? (
@@ -838,11 +837,11 @@ const BasicInformationTab = props => {
 
   const timeZoneComponent = (
     <>
-      <Col className={darkMode ? styles['dark-label-col'] : ''}>
+      <Col md="5" className={darkMode ? styles['dark-label-col'] : ''}>
         <Label className={darkMode ? 'text-light' : ''}>Time Zone</Label>
       </Col>
       <Col md={desktopDisplay ? '6' : ''} className={darkMode ? 'bg-yinmn-blue' : ''}>
-        {!canEdit && <p className={darkMode ? 'text-light' : ''}>{userProfile.timeZone}</p>}
+        <p className={`text-right ${darkMode ? 'text-light' : ''}`}>{userProfile.timeZone}</p>
         {canEdit && (
           <TimeZoneDropDown
             filter={timeZoneFilter}
@@ -885,18 +884,11 @@ const BasicInformationTab = props => {
           Status
         </Label>
       </Col>
-      <Col md={desktopDisplay ? '7' : ''} className={darkMode ? 'bg-yinmn-blue' : ''}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Label
-            style={{ margin: '0' }}
-            className={darkMode ? 'text-light label-with-icon' : 'label-with-icon'}
-          >
-            {userProfile.isActive
-              ? 'Active'
-              : userProfile.reactivationDate
-              ? 'Paused until ' + formatDateCompany(userProfile.reactivationDate)
-              : 'Inactive'}
-          </Label>
+      <Col md={desktopDisplay ? '6' : ''} className={darkMode ? 'bg-yinmn-blue' : ''}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
+          <p className={`text-right ${darkMode ? 'text-light' : ''}`} style={{ margin: '0' }}>
+            {userProfile.isActive ? 'Active' : userProfile.reactivationDate ? 'Paused until ' + formatDateCompany(userProfile.reactivationDate) : 'Inactive'}
+          </p>
           {canEdit && canEditStatus && (
             <PauseAndResumeButton
               setUserProfile={setUserProfile}
@@ -918,13 +910,11 @@ const BasicInformationTab = props => {
           End Date
         </Label>
       </Col>
-      <Col md={desktopDisplay ? '7' : ''} className={darkMode ? 'bg-yinmn-blue' : ''}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Label className={darkMode ? 'text-light' : ''} style={{ margin: '0' }}>
-            {userProfile.endDate
-              ? formatDateLocal(userProfile.endDate)
-              : 'N/A'}
-          </Label>
+      <Col md={desktopDisplay ? '6' : ''} className={darkMode ? 'bg-yinmn-blue' : ''}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
+          <p className={`text-right ${darkMode ? 'text-light' : ''}`} style={{ margin: '0' }}>
+            {userProfile.endDate ? formatDateLocal(userProfile.endDate) : 'N/A'}
+          </p>
           {canEdit && canEditEndDate && (
             <SetUpFinalDayButton
               loadUserProfile={loadUserProfile}
@@ -1016,7 +1006,10 @@ const BasicInformationTab = props => {
               {videoCallPreferenceComponent}
               <Col md="1" lg="1"></Col>
             </Row>
-            <Row style={{ marginBottom: '10px' }}>{roleComponent}</Row>
+            <Row style={{ marginBottom: '10px' }}>
+              {roleComponent}
+              <Col md="1" lg="1"></Col>
+            </Row>
             <Row style={{  marginBottom: '10px' }}>
               {locationComponent}
               <Col md="1"></Col>
@@ -1025,9 +1018,9 @@ const BasicInformationTab = props => {
               {timeZoneComponent}
               <Col md="1"></Col>
             </Row>
-            <Row style={{ marginBottom: '10px' }}>{timeZoneDifferenceComponent}</Row>
-            <Row style={{ marginBottom: '10px' }}>{statusComponent}</Row>
-            <Row style={{ marginBottom: '10px' }}>{endDateComponent}</Row>
+            <Row style={{ marginBottom: '10px' }}>{timeZoneDifferenceComponent}<Col md="1"></Col></Row>
+            <Row style={{ marginBottom: '10px' }}>{statusComponent}<Col md="1"></Col></Row>
+            <Row style={{ marginBottom: '10px' }}>{endDateComponent}<Col md="1"></Col></Row>
           </>
         ) : (
           <>

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -887,7 +887,11 @@ const BasicInformationTab = props => {
       <Col md={desktopDisplay ? '6' : ''} className={darkMode ? 'bg-yinmn-blue' : ''}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
           <p className={`text-right ${darkMode ? 'text-light' : ''}`} style={{ margin: '0' }}>
-            {userProfile.isActive ? 'Active' : userProfile.reactivationDate ? 'Paused until ' + formatDateCompany(userProfile.reactivationDate) : 'Inactive'}
+            {(() => {
+              if (userProfile.isActive) return 'Active';
+              if (userProfile.reactivationDate) return 'Paused until ' + formatDateCompany(userProfile.reactivationDate);
+              return 'Inactive';
+            })()}
           </p>
           {canEdit && canEditStatus && (
             <PauseAndResumeButton

--- a/src/components/UserProfile/FeaturedBadges/FeaturedBadges.jsx
+++ b/src/components/UserProfile/FeaturedBadges/FeaturedBadges.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import styles from '../Badge.module.css';
 import BadgeImage from '../BadgeImage';
 
 const FeaturedBadges = props => {
@@ -32,7 +33,7 @@ const FeaturedBadges = props => {
   }, [props.badges]);
 
   return (
-    <div data-testid="badge_featured_container" className="badge_featured_container">
+    <div data-testid="badge_featured_container" className={styles.badge_featured_container}>
       {filteredBadges.map((value, index) => (
         <BadgeImage 
           personalBestMaxHrs={props.personalBestMaxHrs} 

--- a/src/components/UserProfile/QuickSetupModal/QuickSetupCodes.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupCodes.jsx
@@ -1,5 +1,5 @@
-import { useSelector } from 'react-redux';
-import styles from '../BlueSquares/BlueSquare.module.css'
+
+import modalStyles from './QuickSetupModal.module.css';
 
 function QuickSetupCodes({
   titles,
@@ -12,7 +12,7 @@ function QuickSetupCodes({
 }) {
 
   return (
-    <div className={`${styles.blueSquares} mt-3`} id="qsc-outer-wrapper">
+    <div className="mt-3" id="qsc-outer-wrapper" style={{display: 'flex', flexWrap: 'wrap', gap: '6px', padding: '4px'}}>
       {titles.map(title => {
         const isTeamCodeInList = teamCodes.some(code => code.value === title.teamCode);
         return (
@@ -21,7 +21,7 @@ function QuickSetupCodes({
             key={title._id}
             role="button"
             id="wrapper"
-            className={`role-button ${isTeamCodeInList ? 'bg-warning' : 'bg-danger'}`}
+            className={`${modalStyles['role-button']} ${isTeamCodeInList ? 'bg-warning' : 'bg-danger'}`}
             onClick={() => {
               if (editMode) {
                 setShowAddTitle(true);
@@ -33,8 +33,8 @@ function QuickSetupCodes({
             value={title.titleName}
           >
             {title?.titleCode ? title.titleCode : title?.titleName?.substring(0, 7)}
-            <div className={styles.title}>
-              <span className="setup-title-name">{title?.titleName}</span>
+            <div style={{display: 'none'}}>
+              <span className={modalStyles['setup-title-name']}>{title?.titleName}</span>
             </div>
           </div>
         );

--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.module.css
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.module.css
@@ -1,15 +1,22 @@
 #qsc-outer-wrapper {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px; 
+  gap: 4px;
+  align-items: flex-start;
+  align-content: flex-start;
 }
 
 .role-button {
-    border-radius: 10%;
-    padding: 4px;
-    background-color: #117a8b;
-    color: white;
-  }
+  border-radius: 10%;
+  padding: 4px 8px;
+  color: white;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  font-size: 12px;
+  white-space: nowrap;
+  position: relative;
+}
 
   .titles-list {
     display: flex;


### PR DESCRIPTION
Fixes layout issues on the UserProfile page and Dashboard that were caused by the CSS modules migration in PR #5194.

## Changes:
- Fixed Featured Badges displaying vertically instead of horizontally by adding styles import to FeaturedBadges.jsx and BadgeImage.jsx
- Fixed QST tags overlapping by removing incorrect blueSquares grid class from QuickSetupCodes.jsx
- Fixed Basic Information tab layout - all values now properly right-aligned in two-column layout
- Fixed Dashboard gap between header and Tasks/Timelogs section by moving WeeklySummary into the correct column

## How to test:
1. Check out this branch
2. Run `yarn install` and `npm run start:local`
3. Log in as admin user
4. Go to any user profile page
5. Verify QST tags display as small inline pills
6. Verify Featured Badges display horizontally with correct size
7. Verify Basic Information tab shows two-column layout with right-aligned values
8. Go to Dashboard and verify no gap between header and Tasks/Timelogs section

## Screenshots:
<img width="1919" height="863" alt="image" src="https://github.com/user-attachments/assets/73201040-ce00-4db1-b00a-01e3113bcd47" />
<img width="1598" height="865" alt="image" src="https://github.com/user-attachments/assets/4b91d085-67b9-4e77-b3b7-ddbb6444a36c" />
