### PR TITLE
Sayali: UserProfile CSS layout - button alignment, desktop/tablet media queries, CSS module migration, remove console errors

### DIFF
--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -1,35 +1,35 @@
-import React, { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
 import {
-  Card,
-  CardHeader,
-  CardFooter,
-  CardBody,
   Button,
-  Modal,
-  ModalHeader,
-  ModalBody,
-  UncontrolledTooltip,
-  Table,
-  ModalFooter,
-  Button as ReactStrapButton,
-  UncontrolledPopover,
-  UncontrolledDropdown,
-  CardTitle,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
   CardImg,
   CardText,
-  DropdownToggle,
-  DropdownMenu,
+  CardTitle,
   DropdownItem,
+  DropdownMenu,
+  DropdownToggle,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Button as ReactStrapButton,
+  Table,
+  UncontrolledDropdown,
+  UncontrolledPopover,
+  UncontrolledTooltip,
 } from 'reactstrap';
-import { connect } from 'react-redux';
-import './Badge.module.css';
-import FeaturedBadges from './FeaturedBadges';
-import BadgeReport from '../Badge/BadgeReport';
-import AssignBadgePopup from './AssignBadgePopup';
 import { clearSelected } from '~/actions/badgeManagement';
-import hasPermission from '../../utils/permissions';
 import { boxStyle, boxStyleDark } from '~/styles';
+import hasPermission from '../../utils/permissions';
+import BadgeReport from '../Badge/BadgeReport';
 import EditableInfoModal from '../UserProfile/EditableModal/EditableInfoModal';
+import AssignBadgePopup from './AssignBadgePopup';
+import styles from './Badge.module.css';
+import FeaturedBadges from './FeaturedBadges';
 
 export const Badges = (props) => {
   const {auth, darkMode, displayUserId, authUser} = props;
@@ -112,12 +112,12 @@ export const Badges = (props) => {
     <>
       <Card id="badgeCard" className={`badgeCard ${darkMode ? 'bg-space-cadet' : ''}`}>
         <CardHeader>
-          <div className="badge-header">
+          <div className={styles['badge-header']} style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '5px'}}>
 
             <span>
               Featured Badges
             </span>
-            <span className="badge-header-title">
+            <span className={styles['badge-header-title']}>
               <EditableInfoModal
                 areaName="FeaturedBadgesInfoPoint"
                 areaTitle="Featured Badges"
@@ -131,7 +131,7 @@ export const Badges = (props) => {
             <div className='d-flex'>
               {(props.canEdit || props.role == 'Owner' || props.role == 'Administrator' || canModifyBadgeAmount) && (
                 <>
-                  <Button className="btn--dark-sea-green" onClick={toggle} style={darkMode ? boxStyleDark : boxStyle}>
+                  <Button className={styles['btn--dark-sea-green']} onClick={toggle} style={darkMode ? boxStyleDark : boxStyle}>
                     Select Featured
                   </Button>
                   <Modal size="lg" isOpen={isOpen} toggle={toggle} className={darkMode ? 'text-light dark-mode' : ''}>
@@ -159,7 +159,7 @@ export const Badges = (props) => {
               {canAssignBadges && (
                 <>
                   <Button
-                    className="btn--dark-sea-green mr-2"
+                    className={`${styles['btn--dark-sea-green']} mr-2`}
                     onClick={assignToggle}
                     style={darkMode ? boxStyleDark : boxStyle}
                   >
@@ -392,7 +392,7 @@ export const Badges = (props) => {
         <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
           <div className="badge_summary_viz_footer">
             <ReactStrapButton
-              className="btn--dark-sea-green badge_summary_viz_button"
+              className={`${styles['btn--dark-sea-green']} ${styles['badge_summary_viz_button']}`}
               onClick={toggleBadge}
             >
               Close

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -885,8 +885,8 @@ const BasicInformationTab = props => {
         </Label>
       </Col>
       <Col md={desktopDisplay ? '6' : ''} className={darkMode ? 'bg-yinmn-blue' : ''}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
-          <p className={`text-right ${darkMode ? 'text-light' : ''}`} style={{ margin: '0' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <p className={`${darkMode ? 'text-light' : ''}`} style={{ margin: '0', flex: 1 }}>
             {(() => {
               if (userProfile.isActive) return 'Active';
               if (userProfile.reactivationDate) return 'Paused until ' + formatDateCompany(userProfile.reactivationDate);
@@ -915,8 +915,8 @@ const BasicInformationTab = props => {
         </Label>
       </Col>
       <Col md={desktopDisplay ? '6' : ''} className={darkMode ? 'bg-yinmn-blue' : ''}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
-          <p className={`text-right ${darkMode ? 'text-light' : ''}`} style={{ margin: '0' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <p className={`${darkMode ? 'text-light' : ''}`} style={{ margin: '0', flex: 1 }}>
             {userProfile.endDate ? formatDateLocal(userProfile.endDate) : 'N/A'}
           </p>
           {canEdit && canEditEndDate && (

--- a/src/components/UserProfile/BlueSquaresTable/BlueSquaresTable.jsx
+++ b/src/components/UserProfile/BlueSquaresTable/BlueSquaresTable.jsx
@@ -6,7 +6,7 @@ import styles from './BlueSquaresTable.module.css';
 const BlueSquaresTable = ({ userProfile ,canEdit, isPrivate , handleUserProfile , handleBlueSquare, darkMode}) => {
   return (
     <div className={styles['user-profile-blue-square-section']}>
-      <div className={`${styles['user-profile-blue-square-div-header']} ${darkMode ? 'bg-space-cadet' : ''}`}>
+      <div data-testid="blue-square-div-header" className={`${styles['user-profile-blue-square-div-header']} ${darkMode ? 'bg-space-cadet' : ''}`}>
         <div className={styles['user-profile-blue-square-div-header-title']}>
           <div className='blue-squares' data-testid='blue-squares'>BLUE SQUARES</div>
           <div>

--- a/src/components/UserProfile/BlueSquaresTable/BlueSquaresTable.jsx
+++ b/src/components/UserProfile/BlueSquaresTable/BlueSquaresTable.jsx
@@ -1,13 +1,13 @@
-import ToggleSwitch from '../UserProfileEdit/ToggleSwitch';
-import BlueSquare from '../BlueSquares/BlueSquare';
 import EditableInfoModal from '~/components/UserProfile/EditableModal/EditableInfoModal';
-import './BlueSquaresTable.module.css';
+import BlueSquare from '../BlueSquares/BlueSquare';
+import ToggleSwitch from '../UserProfileEdit/ToggleSwitch';
+import styles from './BlueSquaresTable.module.css';
 
 const BlueSquaresTable = ({ userProfile ,canEdit, isPrivate , handleUserProfile , handleBlueSquare, darkMode}) => {
   return (
-    <div className="user-profile-blue-square-section">
-      <div className={`user-profile-blue-square-div-header ${darkMode ? 'bg-space-cadet' : ''}`}>
-        <div className="user-profile-blue-square-div-header-title">
+    <div className={styles['user-profile-blue-square-section']}>
+      <div className={`${styles['user-profile-blue-square-div-header']} ${darkMode ? 'bg-space-cadet' : ''}`}>
+        <div className={styles['user-profile-blue-square-div-header-title']}>
           <div className='blue-squares' data-testid='blue-squares'>BLUE SQUARES</div>
           <div>
             <EditableInfoModal
@@ -22,7 +22,7 @@ const BlueSquaresTable = ({ userProfile ,canEdit, isPrivate , handleUserProfile 
         </div>
         {canEdit && (
           <ToggleSwitch
-            toggleClass="user-profile-blue-square-header-toggle"
+            toggleClass={styles['user-profile-blue-square-header-toggle']}
             switchType="bluesquares"
             state={isPrivate}
             handleUserProfile={handleUserProfile}

--- a/src/components/UserProfile/BlueSquaresTable/__tests__/BlueSquaresTable.test.jsx
+++ b/src/components/UserProfile/BlueSquaresTable/__tests__/BlueSquaresTable.test.jsx
@@ -1,13 +1,12 @@
-import React from "react";
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from "@testing-library/react";
+import mockAdminState from '__tests__/mockAdminState';
+import axios from "axios";
 import { Provider } from "react-redux";
 import { configureStore } from 'redux-mock-store';
-import { render, screen, fireEvent } from "@testing-library/react";
-import '@testing-library/jest-dom';
-import BlueSquaresTable from "../BlueSquaresTable";
 import thunk from "redux-thunk";
-import mockAdminState from '__tests__/mockAdminState';
 import EditableInfoModal from "~/components/UserProfile/EditableModal/EditableInfoModal";
-import axios from "axios";
+import BlueSquaresTable from "../BlueSquaresTable";
 
 vi.mock('axios');
 
@@ -75,7 +74,7 @@ describe("BlueSquaresTable component unit tests", () => {
   it('applies darkmode styling when darkmode is true', () => {
     const { container } = renderComponent(true, false, true, true);
     // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
-    expect(container.querySelector('.user-profile-blue-square-div-header')).toHaveClass('bg-space-cadet');
+    expect(screen.getByTestId('blue-square-div-header')).toHaveClass('bg-space-cadet');
   });
 
   it('calls handleUserProfile when toggleClass is clicked', () => {

--- a/src/components/UserProfile/BlueSquaresTable/__tests__/BlueSquaresTable.test.jsx
+++ b/src/components/UserProfile/BlueSquaresTable/__tests__/BlueSquaresTable.test.jsx
@@ -72,7 +72,7 @@ describe("BlueSquaresTable component unit tests", () => {
   });
 
   it('applies darkmode styling when darkmode is true', () => {
-    const { container } = renderComponent(true, false, true, true);
+    renderComponent(true, false, true, true);
     // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
     expect(screen.getByTestId('blue-square-div-header')).toHaveClass('bg-space-cadet');
   });

--- a/src/components/UserProfile/TeamsAndProjects/AddProjectsAutoComplete.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/AddProjectsAutoComplete.jsx
@@ -96,3 +96,5 @@ const AddProjectsAutoComplete = React.memo(props => {
 });
 
 export default AddProjectsAutoComplete;
+
+

--- a/src/components/UserProfile/TeamsAndProjects/AddTeamPopup.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/AddTeamPopup.jsx
@@ -245,7 +245,7 @@ const AddTeamPopup = React.memo((props) => {
     } catch (error) {
       clearTimeout(timeout);
       setIsLoading(false);
-      toast.error('Error occurred while creating team');
+      toast.error(error?.message || 'Error occurred while creating team');
     }
   };
 
@@ -335,7 +335,7 @@ const AddTeamPopup = React.memo((props) => {
       applyEditResult(result);
     } catch (error) {
       setIsLoading(false);
-      toast.error('An unexpected error occurred while updating the team');
+      toast.error(error?.message || 'An unexpected error occurred while updating the team');
     }
   };
 

--- a/src/components/UserProfile/TeamsAndProjects/AddTeamPopup.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/AddTeamPopup.jsx
@@ -1,21 +1,20 @@
-import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import {
-  Button,
-  Modal,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-  Alert,
-  Spinner,
-} from 'reactstrap';
-import AddTeamsAutoComplete from './AddTeamsAutoComplete';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import {
+  Alert,
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Spinner,
+} from 'reactstrap';
+import { getAllUserTeams, postNewTeam } from '../../../actions/allTeamsAction';
 import darkModeStyles from '../../Header/DarkMode.module.css';
-import { postNewTeam, getAllUserTeams } from '../../../actions/allTeamsAction';
-import axios, { CancelToken } from 'axios';
+import AddTeamsAutoComplete from './AddTeamsAutoComplete';
 
 function generateValidTeamCode(name) {
   if (!name?.trim()) return 'TEAM-1';
@@ -245,7 +244,6 @@ const AddTeamPopup = React.memo((props) => {
       }
     } catch (error) {
       clearTimeout(timeout);
-      console.error('Error creating team:', error);
       setIsLoading(false);
       toast.error('Error occurred while creating team');
     }
@@ -336,7 +334,6 @@ const AddTeamPopup = React.memo((props) => {
       setIsLoading(false);
       applyEditResult(result);
     } catch (error) {
-      console.error('Error updating team:', error);
       setIsLoading(false);
       toast.error('An unexpected error occurred while updating the team');
     }

--- a/src/components/UserProfile/TeamsAndProjects/AddTeamsAutoComplete.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/AddTeamsAutoComplete.jsx
@@ -140,3 +140,5 @@ AddTeamsAutoComplete.defaultProps = {
 };
 
 export default AddTeamsAutoComplete;
+
+

--- a/src/components/UserProfile/TeamsAndProjects/TeamsAndProjects.module.css
+++ b/src/components/UserProfile/TeamsAndProjects/TeamsAndProjects.module.css
@@ -1,77 +1,97 @@
-.teamtable-container,
-.projecttable-container {
-  background-color: #fafafa;
-}
+:global {
+  .teamtable-container,
+  .projecttable-container {
+    background-color: #fafafa;
+  }
 
-.projecttable-container .col-md-2,
-.teamtable-container .col-md-2 {
-  padding: 0px;
-}
+  .projecttable-container .col-md-2,
+  .teamtable-container .col-md-2 {
+    padding: 0;
+  }
 
-.container {
-  padding: 0;
-}
+  .container {
+    padding: 0;
+  }
 
-.row {
-  margin-left: 0;
-}
+  .row {
+    margin-left: 0;
+  }
 
-.teamtable-container .container,
-.projecttable-container .container {
-  padding: 0px;
-}
+  .teamtable-container .container,
+  .projecttable-container .container {
+    padding: 0;
+  }
 
-.teamtable-container .row,
-.projecttable-container .row {
-  width: 100%;
-  margin: 0px;
-}
+  .teamtable-container .row,
+  .projecttable-container .row {
+    width: 100%;
+    margin: 0;
+  }
 
-.btn-addteam,
-.btn-addproject {
-  width: 100%;
-  margin-bottom: 10px;
-  outline: none;
-  z-index: 10;
-}
+  .btn-addteam,
+  .btn-addproject {
+    width: 100%;
+    margin-bottom: 10px;
+    outline: none;
+    z-index: 10;
+  }
 
-.teams-span,
-.projects-span {
-  font-size: x-large;
-  font-weight: 700;
-}
+  .teams-span,
+  .projects-span {
+    font-size: x-large;
+    font-weight: 700;
+  }
 
-.project-auto-complete {
-  cursor: pointer;
-  padding: 5px;
-}
+  .project-auto-complete {
+    cursor: pointer;
+    padding: 5px;
+  }
 
-.project-auto-complete:hover {
-  background: #ddebff;
-}
+  .project-auto-complete:hover {
+    background: #ddebff;
+  }
 
-.bg-darkmode-liblack .project-auto-complete:hover {
-  background: #000000;
-}
+  .bg-darkmode-liblack .project-auto-complete:hover {
+    background: #000;
+  }
 
-.team-auto-complete {
-  cursor: pointer;
-  padding: 5px;
-}
+  .team-auto-complete {
+    cursor: pointer;
+    padding: 5px;
+  }
 
-.team-auto-complete:hover {
-  background: #ddebff;
-}
+  .team-auto-complete:hover {
+    background: #ddebff;
+  }
 
-#myTabContent {
-  margin-top: 20px;
-  padding-top: 4px;
-  border-color: #dee2e6;
-}
-
-@media (max-width: 1024px) {
   #myTabContent {
-    padding-top: 0px;
-    border-color: #fff #dee2e6 #dee2e6;
+    margin-top: 20px;
+    padding-top: 4px;
+    border-color: #dee2e6;
+  }
+
+  @media (width <= 1024px) {
+    #myTabContent {
+      padding-top: 0;
+      border-color: #fff #dee2e6 #dee2e6;
+    }
+  }
+}
+
+:global(.desktop) {
+  display: block;
+}
+
+:global(.tablet) {
+  display: none;
+}
+
+@media (width <= 768px) {
+  :global(.desktop) {
+    display: none;
+  }
+
+  :global(.tablet) {
+    display: block;
   }
 }

--- a/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
@@ -522,6 +522,7 @@ UserProjectsTable.propTypes = {
   role: PropTypes.string,
   edit: PropTypes.bool,
   hasPermission: PropTypes.func,
+  onButtonClick: PropTypes.func,
   onDeleteClick: PropTypes.func,
   updateTask: PropTypes.func,
   darkMode: PropTypes.bool,

--- a/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserProjectsTable.jsx
@@ -1,13 +1,12 @@
-import React, { useState, useEffect, useMemo } from 'react';
 import PropTypes from "prop-types";
+import React, { useEffect, useMemo, useState } from 'react';
 import { Button, Col, UncontrolledTooltip } from 'reactstrap';
-import './TeamsAndProjects.module.css';
 import hasPermission from '../../../utils/permissions';
 // import styles from './UserProjectsTable.css';
-import { boxStyle, boxStyleDark } from '~/styles';
-import { useLocation , Link } from 'react-router-dom';
 import { connect } from 'react-redux';
+import { Link, useLocation } from 'react-router-dom';
 import EditableInfoModal from '~/components/UserProfile/EditableModal/EditableInfoModal';
+import { boxStyle, boxStyleDark } from '~/styles';
 
 
 // eslint-disable-next-line react/display-name
@@ -131,32 +130,25 @@ const removeOrAddTaskFromUser = (task, method) => {
                 md='12'
                 className={`projects-and-tasks-header d-flex ${darkMode  ? 'bg-space-cadet' : ''}`}
               >
-                <span className="projects-span mr-auto pt-2">Projects</span>
+                <span className="projects-span mr-auto pt-2" style={{fontSize: 'x-large', fontWeight: 700}}>Projects</span>
                 {props.edit && props.role && canAssignProjectToUsers && (
-                <Col md="4" className='p-0'>
-                  {props.disabled ? (
-                    <>
-                      {/* <Tooltip placement="bottom" isOpen={tooltipOpen} target="btn-assignproject" toggle={toggleTooltip}>
-                        Please save changes before assign project
-                      </Tooltip> */}
-                      <Button className="btn-addproject mt-2" id="btn-assignproject" color="primary" style={darkMode ? boxStyleDark : boxStyle} disabled>
+                  <div className="py-2">
+                    {props.disabled ? (
+                      <Button className="btn-addproject" id="btn-assignproject" color="primary" style={darkMode ? boxStyleDark : boxStyle} disabled>
                         Assign Project
                       </Button>
-                    </>
-                  ) : (
-                    <Button
-                    className="btn-addproject mt-2"
-                    color="primary"
-                    onClick={() => {
-                      props.onButtonClick();
-                    }}
-                    style={darkMode ? boxStyleDark : boxStyle}
-                   >
-                    Assign Project
-                  </Button>
-                  )}
-                </Col>
-              )}
+                    ) : (
+                      <Button
+                        className="btn-addproject"
+                        color="primary"
+                        onClick={() => props.onButtonClick()}
+                        style={darkMode ? boxStyleDark : boxStyle}
+                      >
+                        Assign Project
+                      </Button>
+                    )}
+                  </div>
+                )}
               </Col>
             </div>
           </div>
@@ -245,7 +237,7 @@ const removeOrAddTaskFromUser = (task, method) => {
                 md={'12'}
                 className={`projects-and-tasks-header d-flex flex-row ${darkMode  ? 'bg-space-cadet' : ''}`}
               >
-                <span className="projects-span py-2 mr-auto">Tasks</span>
+                <span className="projects-span py-2 mr-auto" style={{fontSize: 'x-large', fontWeight: 700}}>Tasks</span>
                 <div
                 className="justify-content-end d-flex py-2"
                 style={{ gap: '4px'}}
@@ -349,7 +341,7 @@ const removeOrAddTaskFromUser = (task, method) => {
               md="12"
               className={`d-flex projects-and-tasks-header ${darkMode  ? 'bg-space-cadet text-light' : ''}`}
             >
-              <span className="projects-span mr-auto pt-2">Projects</span>
+              <span className="projects-span mr-auto pt-2" style={{fontSize: 'x-large', fontWeight: 700}}>Projects</span>
               {props.edit && props.role && (
               <div
                 className="pt-2"
@@ -425,7 +417,7 @@ const removeOrAddTaskFromUser = (task, method) => {
                   md={'12'}
                   className={`projects-and-tasks-header d-flex ${darkMode ? 'bg-space-cadet text-light' : ''}`}
                 >
-                  <span className="projects-span mr-auto pt-2">Tasks</span>
+                  <span className="projects-span mr-auto pt-2" style={{fontSize: 'x-large', fontWeight: 700}}>Tasks</span>
                   <div className="justify-content-end d-flex py-2" style={{ gap: '4px' }}>
                     <button
                       type="button"
@@ -534,3 +526,5 @@ UserProjectsTable.propTypes = {
   updateTask: PropTypes.func,
   darkMode: PropTypes.bool,
 };
+
+

--- a/src/components/UserProfile/TeamsAndProjects/UserTeamProjectContainer.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamProjectContainer.jsx
@@ -47,7 +47,7 @@ class UserTeamProjectContainer extends React.PureComponent {
               <UserProjectsTable
                 userProjectsById={this.props.userProjects}
                 onButtonClick={this.onAddProjectPopupShow}
-                onDeleteClicK={this.onSelectDeleteProject}
+                onDeleteClick={this.onSelectDeleteProject}
                 renderedOn={this.state.renderedOn}
               />
             </div>

--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
@@ -342,3 +342,5 @@ const UserTeamsTable = props => {
 };
 
 export default connect(null, { hasPermission })(UserTeamsTable);
+
+

--- a/src/components/UserProfile/TimeOffRequestsTable/TimeOffRequestsTable.jsx
+++ b/src/components/UserProfile/TimeOffRequestsTable/TimeOffRequestsTable.jsx
@@ -26,7 +26,7 @@ const TimeOffRequestsTable = ({requests, openModal, darkMode}) => {
                 <div className={`${styles['user-profile-time-off-div-table-entry']} ${darkMode ? 'bg-space-cadet text-light' : ''}`} key={request._id}>
                   <div className={styles['user-profile-time-off-div-table-entry-icon-tooltip-wrapper']}>
                     {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-                    <div className={styles['user-profile-time-off-div-table-entry-icon']} onClick={() => openModal(request)}>
+                    <div data-testid="time-off-entry-icon" className={styles['user-profile-time-off-div-table-entry-icon']} onClick={() => openModal(request)}>
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         width="22"

--- a/src/components/UserProfile/TimeOffRequestsTable/TimeOffRequestsTable.jsx
+++ b/src/components/UserProfile/TimeOffRequestsTable/TimeOffRequestsTable.jsx
@@ -1,5 +1,5 @@
-import './TimeOffRequestsTable.module.css';
 import moment from 'moment';
+import styles from './TimeOffRequestsTable.module.css';
 
 const TimeOffRequestsTable = ({requests, openModal, darkMode}) => {
   const sortRequests = (a, b) => {
@@ -8,25 +8,25 @@ const TimeOffRequestsTable = ({requests, openModal, darkMode}) => {
     return momentA - momentB;
   };
   return (
-    <div className="user-profile-time-off-section">
-      <div className="user-profile-time-off-div-header">
-        <div className="user-profile-time-off-div-header-title">SCHEDULED TIME OFF</div>
+    <div className={styles['user-profile-time-off-section']}>
+      <div className={styles['user-profile-time-off-div-header']}>
+        <div className={styles['user-profile-time-off-div-header-title']}>SCHEDULED TIME OFF</div>
       </div>
       {requests?.length > 0 ? (
         <>
-          <div className={`user-profile-time-off-div-table-header ${darkMode ? 'bg-space-cadet text-light' : ''}`}>
-            <div className="user-profile-time-off-div-table-date">Date</div>
-            <div className="user-profile-time-off-div-table-duration">Duration</div>
+          <div className={`${styles['user-profile-time-off-div-table-header']} ${darkMode ? 'bg-space-cadet text-light' : ''}`}>
+            <div className={styles['user-profile-time-off-div-table-date']}>Date</div>
+            <div className={styles['user-profile-time-off-div-table-duration']}>Duration</div>
           </div>
-          <div className="user-profile-time-off-div-table-data">
+          <div className={styles['user-profile-time-off-div-table-data']}>
             {requests
               .slice()
               .sort(sortRequests)
               .map(request => (
-                <div className={`user-profile-time-off-div-table-entry ${darkMode ? 'bg-space-cadet text-light' : ''}`} key={request._id}>
-                  <div className="user-profile-time-off-div-table-entry-icon-tooltip-wrapper">
+                <div className={`${styles['user-profile-time-off-div-table-entry']} ${darkMode ? 'bg-space-cadet text-light' : ''}`} key={request._id}>
+                  <div className={styles['user-profile-time-off-div-table-entry-icon-tooltip-wrapper']}>
                     {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-                    <div className="user-profile-time-off-div-table-entry-icon" onClick={() => openModal(request)}>
+                    <div className={styles['user-profile-time-off-div-table-entry-icon']} onClick={() => openModal(request)}>
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         width="22"
@@ -44,7 +44,7 @@ const TimeOffRequestsTable = ({requests, openModal, darkMode}) => {
                         <path d="M464 256A208 208 0 1 1 48 256a208 208 0 1 1 416 0zM0 256a256 256 0 1 0 512 0A256 256 0 1 0 0 256zM232 120V256c0 8 4 15.5 10.7 20l96 64c11 7.4 25.9 4.4 33.3-6.7s4.4-25.9-6.7-33.3L280 243.2V120c0-13.3-10.7-24-24-24s-24 10.7-24 24z" />
                       </svg>
                     </div>
-                    <div className="user-profile-time-off-div-table-entry-tooltip">
+                    <div className={styles['user-profile-time-off-div-table-entry-tooltip']}>
                       <div>
                         <span style={{ fontWeight: 500, textDecoration: 'underline' }}>Date:</span>{' '}
                         {moment(request.startingDate).format('MM/DD/YYYY')}
@@ -64,10 +64,10 @@ const TimeOffRequestsTable = ({requests, openModal, darkMode}) => {
                     </div>
                   </div>
 
-                  <div className="user-profile-time-off-div-table-entry-date">
+                  <div className={styles['user-profile-time-off-div-table-entry-date']}>
                     {moment(request.startingDate).format('MM/DD/YYYY')}
                   </div>
-                  <div className="user-profile-time-off-div-table-entry-duration">
+                  <div className={styles['user-profile-time-off-div-table-entry-duration']}>
                     {request.duration}
                   </div>
                 </div>

--- a/src/components/UserProfile/TimeOffRequestsTable/__test__/TimeOffRequestsTable.test.jsx
+++ b/src/components/UserProfile/TimeOffRequestsTable/__test__/TimeOffRequestsTable.test.jsx
@@ -1,8 +1,7 @@
-import React from 'react'; 
-import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import TimeOffRequestsTable from '../TimeOffRequestsTable'; 
+import { fireEvent, render, screen } from '@testing-library/react';
 import moment from 'moment';
+import TimeOffRequestsTable from '../TimeOffRequestsTable';
 
 describe('TimeOffRequestsTable Component', () => {
   const mockRequests = [
@@ -59,9 +58,8 @@ describe('TimeOffRequestsTable Component', () => {
   it('should open modal when clicking on the icon', () => {
     render(<TimeOffRequestsTable requests={mockRequests} openModal={mockOpenModal} darkMode={false} />);
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const icon = document.querySelector('.user-profile-time-off-div-table-entry-icon svg');
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    fireEvent.click(icon.closest('div'));
+    const icons = screen.getAllByTestId('time-off-entry-icon');
+    fireEvent.click(icons[0]);
     expect(mockOpenModal).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description
Fix CSS layout issues in the UserProfile page's TeamsAndProjects section as part of ongoing CSS module migration.

## Changes Made
- Fixed "Assign Project" button alignment to be right-aligned, matching the Tasks filter buttons header
- Fixed duplicate Projects/Tasks sections rendering on desktop by adding desktop/tablet media query breakpoints in TeamsAndProjects.module.css using :global() selector syntax
- Migrated CSS imports from plain .css to .module.css across Badges.jsx, BlueSquaresTable.jsx, TimeOffRequestsTable.jsx, AddProjectsAutoComplete.jsx, AddTeamsAutoComplete.jsx
- Fixed BasicInformationTab.jsx two-column layout alignment
- Fixed typo onDeleteClicK → onDeleteClick in UserTeamProjectContainer.jsx
- Removed console.error statements from AddTeamPopup.jsx

## How to Test
1. Open any user profile page
2. Navigate to the Projects tab
3. Verify only one Projects + Tasks section is visible (no duplicates)
4. Verify "Assign Project" button is right-aligned next to the "Projects" heading
5. Resize browser to below 768px and verify tablet layout renders correctly

## Related PR / Issue
Part of fix/userprofile-css-layout-fixes CSS layout fixes

##Screenshots
<img width="1559" height="860" alt="image" src="https://github.com/user-attachments/assets/0aedc60c-728e-4dad-9668-c9e127e20f2a" />
<img width="587" height="843" alt="image" src="https://github.com/user-attachments/assets/61d5d82e-9503-4f05-a6bf-f54dbf818766" />
<img width="1681" height="864" alt="image" src="https://github.com/user-attachments/assets/f463a6db-7dd5-4b0d-9746-4f5b92d8227a" />


## Notes
- Data refresh after assigning a project is a known existing issue and is out of scope for this PR