### PR TITLE
Sayali 🔥 fix: add desktop/tablet media query to UserProfile.scss for reliable CSS build

### DIFF
--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -496,3 +496,21 @@ button.btn.btn-outline-primary {
   }
 }
 }
+
+.desktop {
+  display: block;
+}
+
+.tablet {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .desktop {
+    display: none;
+  }
+
+  .tablet {
+    display: block;
+  }
+}


### PR DESCRIPTION
# Description
The previous fix used :global() syntax in TeamsAndProjects.module.css to hide/show 
desktop and tablet layouts. This worked locally but not on the dev server build. 
This PR moves the .desktop and .tablet media query styles to UserProfile.scss which 
is guaranteed to be compiled and loaded correctly in all environments.

## Changes Made
- Added .desktop and .tablet media query classes to UserProfile.scss
- These classes control which layout (desktop or tablet) is shown based on screen width

## How to Test
1. Check into fix/userprofile-layout-fixes-v3 branch
2. Run `npm install` and `npm run start:local`
3. Go to any User Profile → Projects tab
4. Verify only ONE Projects + Tasks section is visible (no duplicates)
5. Resize browser below 768px and verify tablet layout renders correctly

##Sreenshot
<img width="1304" height="859" alt="image" src="https://github.com/user-attachments/assets/5e372193-4f34-4440-9a62-9e407e6a8ccd" />

## Note
The :global() fix in TeamsAndProjects.module.css is kept as a fallback.