### PR TITLE
Neeraj Implement Inventory Search Functionality

### DIFF
--- a/src/components/KitchenandInventory/KIInventory/KIInventory.jsx
+++ b/src/components/KitchenandInventory/KIInventory/KIInventory.jsx
@@ -66,11 +66,21 @@ const KIInventory = () => {
   // Onsite grown — computed from all items
   const onsiteGrown = items.filter(i => i.onsite).length;
 
-  // Items for active tab filtered by category and search term
+  // Search helper
+  const filterItems = itemsToFilter => {
+    if (!searchTerm.trim()) {
+      return itemsToFilter;
+    }
+
+    return itemsToFilter.filter(item => item.name.toLowerCase().includes(searchTerm.toLowerCase()));
+  };
+
+  // Items for active tab
   const activeCategory = CATEGORY_MAP[activeTab];
-  const tabItems = items
-    .filter(i => i.category === activeCategory)
-    .filter(i => !searchTerm || i.name.toLowerCase().includes(searchTerm.toLowerCase()));
+
+  const categoryItems = items.filter(i => i.category === activeCategory);
+
+  const tabItems = filterItems(categoryItems);
 
   // Preserved items description for notification banner
   const preservedDesc =
@@ -91,7 +101,9 @@ const KIInventory = () => {
     }
     if (searchTerm) {
       return (
-        <p style={{ padding: '1rem', opacity: 0.6 }}>No results for &quot;{searchTerm}&quot;</p>
+        <p className={`${styles.noResults} ${darkMode ? styles.darkNoResults : ''}`}>
+          No results for "{searchTerm}"
+        </p>
       );
     }
     return <p style={{ padding: '1rem', opacity: 0.6 }}>No items in {tabName} yet.</p>;
@@ -188,12 +200,20 @@ const KIInventory = () => {
               value={searchTerm}
               onChange={e => setSearchTerm(e.target.value)}
             />
-            <button
-              className={`${styles.clearSearch} ${darkMode ? styles.darkClearSearch : ''}`}
-              onClick={() => setSearchTerm('')}
-            >
-              x
-            </button>
+            {searchTerm && (
+              <button
+                className={`${styles.clearSearch} ${darkMode ? styles.darkClearSearch : ''}`}
+                onClick={() => setSearchTerm('')}
+                style={{
+                  backgroundColor: 'red',
+                  color: 'white',
+                  padding: '4px 8px',
+                  marginLeft: '5px',
+                }}
+              >
+                CLEAR
+              </button>
+            )}
           </div>
           <div>
             <button className={classnames(styles.button, styles.addItemButton)}>
@@ -213,7 +233,7 @@ const KIInventory = () => {
           <TabPane key={tab} tabId={tab}>
             <div className={styles.tabContainer}>
               {/* Preserved items notification — only on the Ingredients tab */}
-              {index === 0 && preservedItems.length > 0 && (
+              {index === 0 && preservedItems.length > 0 && !searchTerm && (
                 <div
                   className={`${styles.notificationContainer} ${
                     darkMode ? styles.darkModeNotification : ''

--- a/src/components/KitchenandInventory/KIInventory/KIInventory.module.css
+++ b/src/components/KitchenandInventory/KIInventory/KIInventory.module.css
@@ -311,6 +311,18 @@
   }
 }
 
+.noResults {
+  padding: 1rem;
+  opacity: 0.6;
+  text-align: center;
+  width: 100%;
+  font-size: 1rem;
+}
+
+.darkNoResults {
+  color: #d1d5db;
+}
+
 @media screen and (width <= 768px){
   .inventoryContainer {
     padding: 5px;


### PR DESCRIPTION
# Description
<img width="1634" height="1410" alt="image" src="https://github.com/user-attachments/assets/2b1a3afe-cc02-4bce-9a39-58cde5cf06aa" />

## Related PRS (if any):
This frontend PR is related to the Development Backend PR.
…

## Main changes explained:
- Updated KIInventory.jsx to add a reusable filterItems() helper for inventory item filtering.
- Enhanced inventory search functionality to perform case-insensitive item name matching within the currently selected inventory category.
- Added search reset behavior when switching between inventory tabs.
- Updated the preserved stock notification logic to hide the notification banner during active searches, improving search result visibility.
- Added new CSS styling for the no-results state, including dark mode support.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Navigate to: http://localhost:5173/kitchenandinventory/inventory
6. Enter a valid inventory item name in the search bar and verify matching items are displayed.
7. Verify search is case-insensitive (e.g., search using lowercase and uppercase variations of the same item name).
8. Enter a non-existent item name and verify the "No results found" message is displayed.
9. Verify the Preserved Stock notification banner is hidden while a search term is active and reappears when the search is cleared.
10. Verify inventory items continue to render correctly after clearing the search. 

## Screenshots or videos of changes:
<img width="2914" height="1774" alt="image" src="https://github.com/user-attachments/assets/de6eae92-9e0f-4059-afa9-e76a51150f98" />

<img width="2872" height="1298" alt="image" src="https://github.com/user-attachments/assets/53c128e7-2b70-4639-addb-470d8a39c180" />

<img width="2940" height="1358" alt="image" src="https://github.com/user-attachments/assets/8b1ed573-f313-4c42-9145-05f509c63a97" />

## Note:
N/A