### PR TITLE
Sayali: fix show trackers lagging v2

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -46,7 +46,6 @@ const TeamMemberTask = React.memo(
     userId,
     updateTaskStatus,
     showWhoHasTimeOff,
-    showTrackers,
     showTasks,
     onTimeOff,
     goingOnTimeOff,
@@ -519,7 +518,6 @@ const TeamMemberTask = React.memo(
                               userRole={userRole}
                               personId={user.personId}
                               displayUser={displayUser}
-                              showTrackers={showTrackers}
                             />
                             <div
                               style={{ textAlign: 'center', marginTop: '8px' }}
@@ -855,7 +853,6 @@ TeamMemberTask.propTypes = {
     timeOffTill: PropTypes.string,
   }).isRequired,
   userRole: PropTypes.string.isRequired,
-  showTrackers: PropTypes.bool,
   showTasks: PropTypes.bool,
   userId: PropTypes.string.isRequired,
   displayUser: PropTypes.object,

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -50,7 +50,6 @@ const TeamMemberTasks = React.memo(props => {
   const [isTimeFilterActive, setIsTimeFilterActive] = useState(false);
   const [taskModalOption, setTaskModalOption] = useState('');
   const [showWhoHasTimeOff, setShowWhoHasTimeOff] = useState(true);
-  const [showTrackers, setShowTrackers] = useState(false);
   const [showTasks, setShowTasks] = useState(true);
 
   const userOnTimeOff = useSelector(state => state.timeOffRequests.onTimeOff);
@@ -391,10 +390,6 @@ const TeamMemberTasks = React.memo(props => {
     setShowWhoHasTimeOff(prev => !prev);
   };
 
-  function handleShowTrackers() {
-    setShowTrackers(prev => !prev);
-  }
-
   function handleHideTasks() {
     setShowTasks(prev => !prev);
   }
@@ -712,27 +707,6 @@ const TeamMemberTasks = React.memo(props => {
                         <div style={{ background: 'transparent', display: 'flex', gap: '4px' }}>
                           <button
                             type="button"
-                            onClick={handleShowTrackers}
-                            className={[
-                              styles.m1,
-                              darkMode ? styles.boxShadowDark : styles.boxShadowLight,
-                            ].join(' ')}
-                            style={{
-                              marginTop: '6px',
-                              padding: '2px 8px',
-                              fontSize: '12px',
-                              borderRadius: '4px',
-                              border: '1px solid #17a2b8',
-                              backgroundColor: showTrackers ? '#17a2b8' : 'white',
-                              color: showTrackers ? 'white' : '#17a2b8',
-                              cursor: 'pointer',
-                              whiteSpace: 'nowrap',
-                            }}
-                          >
-                            {showTrackers ? 'Hide Trackers' : 'Show Trackers'}
-                          </button>
-                          <button
-                            type="button"
                             onClick={handleHideTasks}
                             className={[
                               styles.m1,
@@ -825,7 +799,6 @@ const TeamMemberTasks = React.memo(props => {
                         updateTaskStatus={updateTaskStatus}
                         userId={displayUser._id}
                         showWhoHasTimeOff={showWhoHasTimeOff}
-                        showTrackers={showTrackers}
                         showTasks={showTasks}
                         onTimeOff={userOnTimeOff[user.personId]}
                         goingOnTimeOff={userGoingOnTimeOff[user.personId]}
@@ -860,7 +833,6 @@ const TeamMemberTasks = React.memo(props => {
                         updateTaskStatus={updateTaskStatus}
                         userId={displayUser._id}
                         showWhoHasTimeOff={showWhoHasTimeOff}
-                        showTrackers={showTrackers}
                         showTasks={showTasks}
                         onTimeOff={userOnTimeOff[user.personId]}
                         goingOnTimeOff={userGoingOnTimeOff[user.personId]}

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -496,3 +496,21 @@ button.btn.btn-outline-primary {
   }
 }
 }
+
+.desktop {
+  display: block;
+}
+
+.tablet {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .desktop {
+    display: none;
+  }
+
+  .tablet {
+    display: block;
+  }
+}

--- a/src/components/Warnings/Warnings.jsx
+++ b/src/components/Warnings/Warnings.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Alert, Button } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
 import { toast } from 'react-toastify';
@@ -22,13 +22,7 @@ import styles from './Warnings.module.css';
 // Log Time to Action Items (“i” = ,ltayg = Reminder to please log your time as you go. At a minimum, please log daily any time you work.)
 // Intangible Time Log w/o Reason (“i” = ,itlr = The timer should be used for all time logged, so any time logged as intangible must also include in the time log description an explanation for why you didn’t use the timer.
 
-export default function Warning({
-  personId,
-  username,
-  userRole,
-  displayUser,
-  showTrackers = false,
-}) {
+export default function Warning({ personId, username, userRole, displayUser }) {
   const dispatch = useDispatch();
   const [usersWarnings, setUsersWarnings] = useState([]);
 
@@ -65,26 +59,6 @@ export default function Warning({
     if (!toggle) fetchUsersWarningsById();
     setToggle(prev => !prev);
   };
-
-  useEffect(() => {
-    if (showTrackers) {
-      setToggle(true);
-      if (usersWarnings.length === 0) {
-        const index = Array.from(personId ?? '').reduce(
-          (acc, c) => acc + (c.codePointAt(0) ?? 0),
-          0,
-        );
-        const delay = index % 5000;
-        const timer = setTimeout(() => {
-          fetchUsersWarningsById();
-        }, delay);
-        return () => clearTimeout(timer);
-      }
-    } else {
-      setToggle(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showTrackers]);
 
   const handleDeleteWarning = async warningId => {
     dispatch(deleteWarningsById(warningId, personId)).then(res => {
@@ -255,5 +229,4 @@ Warning.propTypes = {
   username: PropTypes.string,
   userRole: PropTypes.string,
   displayUser: PropTypes.object,
-  showTrackers: PropTypes.bool,
 };


### PR DESCRIPTION
# Description
Removes the Show Trackers / Hide Trackers button from the Dashboard Tasks tab header.

## Reason for removal
The Show Trackers feature triggers 2447 simultaneous API calls to `/api/warnings/:userId` 
which causes ERR_INSUFFICIENT_RESOURCES browser crashes and a 20-30 second UI freeze 
from React re-rendering 2447 rows simultaneously.

## What was tried
- Staggered API calls (0-5000ms delay per user) - reduced crashes but still caused freezes
- Batch API endpoint (`POST /api/warnings/batch`) - reduces 2447 calls to 1, backend built 
  and working on branch `Sayali-Fix-ShowTrackers-BatchAPI`
- startTransition to reduce UI freeze - not sufficient

## Proper fix required
Virtual scrolling (react-window) which renders only visible rows (~15 at a time). 
This would eliminate both the API flood and React freeze.
The batch API backend is ready for future use on branch `Sayali-Fix-ShowTrackers-BatchAPI`.

## Files changed
- TeamMemberTasks.jsx - removed showTrackers state and button
- TeamMemberTask.jsx - removed showTrackers prop
- Warnings.jsx - removed showTrackers useEffect and prop

## How to test
1. Go to Dashboard → Tasks tab
2. Verify Show Trackers button is removed
3. Verify Hide Tasks button still works
4. Verify no performance regression