### PR TITLE
Sayali: add Show/Hide Trackers button to Dashboard Tasks tab header

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -46,6 +46,7 @@ const TeamMemberTask = React.memo(
     userId,
     updateTaskStatus,
     showWhoHasTimeOff,
+    showTrackers,
     showTasks,
     onTimeOff,
     goingOnTimeOff,
@@ -518,6 +519,7 @@ const TeamMemberTask = React.memo(
                               userRole={userRole}
                               personId={user.personId}
                               displayUser={displayUser}
+                              showTrackers={showTrackers}
                             />
                             <div
                               style={{ textAlign: 'center', marginTop: '8px' }}
@@ -853,6 +855,7 @@ TeamMemberTask.propTypes = {
     timeOffTill: PropTypes.string,
   }).isRequired,
   userRole: PropTypes.string.isRequired,
+  showTrackers: PropTypes.bool,
   showTasks: PropTypes.bool,
   userId: PropTypes.string.isRequired,
   displayUser: PropTypes.object,

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -50,6 +50,7 @@ const TeamMemberTasks = React.memo(props => {
   const [isTimeFilterActive, setIsTimeFilterActive] = useState(false);
   const [taskModalOption, setTaskModalOption] = useState('');
   const [showWhoHasTimeOff, setShowWhoHasTimeOff] = useState(true);
+  const [showTrackers, setShowTrackers] = useState(false);
   const [showTasks, setShowTasks] = useState(true);
 
   const userOnTimeOff = useSelector(state => state.timeOffRequests.onTimeOff);
@@ -390,6 +391,10 @@ const TeamMemberTasks = React.memo(props => {
     setShowWhoHasTimeOff(prev => !prev);
   };
 
+  function handleShowTrackers() {
+    setShowTrackers(prev => !prev);
+  }
+
   function handleHideTasks() {
     setShowTasks(prev => !prev);
   }
@@ -707,6 +712,27 @@ const TeamMemberTasks = React.memo(props => {
                         <div style={{ background: 'transparent', display: 'flex', gap: '4px' }}>
                           <button
                             type="button"
+                            onClick={handleShowTrackers}
+                            className={[
+                              styles.m1,
+                              darkMode ? styles.boxShadowDark : styles.boxShadowLight,
+                            ].join(' ')}
+                            style={{
+                              marginTop: '6px',
+                              padding: '2px 8px',
+                              fontSize: '12px',
+                              borderRadius: '4px',
+                              border: '1px solid #17a2b8',
+                              backgroundColor: showTrackers ? '#17a2b8' : 'white',
+                              color: showTrackers ? 'white' : '#17a2b8',
+                              cursor: 'pointer',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {showTrackers ? 'Hide Trackers' : 'Show Trackers'}
+                          </button>
+                          <button
+                            type="button"
                             onClick={handleHideTasks}
                             className={[
                               styles.m1,
@@ -799,6 +825,7 @@ const TeamMemberTasks = React.memo(props => {
                         updateTaskStatus={updateTaskStatus}
                         userId={displayUser._id}
                         showWhoHasTimeOff={showWhoHasTimeOff}
+                        showTrackers={showTrackers}
                         showTasks={showTasks}
                         onTimeOff={userOnTimeOff[user.personId]}
                         goingOnTimeOff={userGoingOnTimeOff[user.personId]}
@@ -833,6 +860,7 @@ const TeamMemberTasks = React.memo(props => {
                         updateTaskStatus={updateTaskStatus}
                         userId={displayUser._id}
                         showWhoHasTimeOff={showWhoHasTimeOff}
+                        showTrackers={showTrackers}
                         showTasks={showTasks}
                         onTimeOff={userOnTimeOff[user.personId]}
                         goingOnTimeOff={userGoingOnTimeOff[user.personId]}

--- a/src/components/TeamMemberTasks/TeamMemberTasks.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTasks.jsx
@@ -804,74 +804,46 @@ const TeamMemberTasks = React.memo(props => {
               teamList
                 .filter(user => filterByUserFeatures(user))
                 .map(user => {
+                  const taskNode = (
+                    <TeamMemberTask
+                      key={!isTimeFilterActive ? user.personId : undefined}
+                      user={user}
+                      userPermission={props?.auth?.user?.permissions?.frontPermissions?.includes(
+                        'putReviewStatus',
+                      )}
+                      teamRoles={
+                        user.teams !== undefined && user.teams.length > 0
+                          ? filteredTeamRoles(user.teams)
+                          : ''
+                      }
+                      handleOpenTaskNotificationModal={handleOpenTaskNotificationModal}
+                      handleMarkAsDoneModal={handleMarkAsDoneModal}
+                      handleRemoveFromTaskModal={handleRemoveFromTaskModal}
+                      handleTaskModalOption={handleTaskModalOption}
+                      userRole={displayUser.role}
+                      updateTaskStatus={updateTaskStatus}
+                      userId={displayUser._id}
+                      showWhoHasTimeOff={showWhoHasTimeOff}
+                      showTrackers={showTrackers}
+                      showTasks={showTasks}
+                      onTimeOff={userOnTimeOff[user.personId]}
+                      goingOnTimeOff={userGoingOnTimeOff[user.personId]}
+                      displayUser={displayUser}
+                      userStateCatalog={userStateCatalog}
+                      onCatalogChange={setUserStateCatalog}
+                      userStateSelection={userStateSelections[user.personId] || []}
+                      onSelectionChange={(uid, updated) =>
+                        setUserStateSelections(prev => ({ ...prev, [uid]: updated }))
+                      }
+                      expandAll={expandAll}
+                    />
+                  );
                   if (!isTimeFilterActive) {
-                    return (
-                      <TeamMemberTask
-                        key={user.personId}
-                        user={user}
-                        userPermission={props?.auth?.user?.permissions?.frontPermissions?.includes(
-                          'putReviewStatus',
-                        )}
-                        teamRoles={
-                          user.teams !== undefined && user.teams.length > 0
-                            ? filteredTeamRoles(user.teams)
-                            : ''
-                        }
-                        handleOpenTaskNotificationModal={handleOpenTaskNotificationModal}
-                        handleMarkAsDoneModal={handleMarkAsDoneModal}
-                        handleRemoveFromTaskModal={handleRemoveFromTaskModal}
-                        handleTaskModalOption={handleTaskModalOption}
-                        userRole={displayUser.role}
-                        updateTaskStatus={updateTaskStatus}
-                        userId={displayUser._id}
-                        showWhoHasTimeOff={showWhoHasTimeOff}
-                        showTrackers={showTrackers}
-                        showTasks={showTasks}
-                        onTimeOff={userOnTimeOff[user.personId]}
-                        goingOnTimeOff={userGoingOnTimeOff[user.personId]}
-                        displayUser={displayUser}
-                        userStateCatalog={userStateCatalog}
-                        onCatalogChange={setUserStateCatalog}
-                        userStateSelection={userStateSelections[user.personId] || []}
-                        onSelectionChange={(uid, updated) =>
-                          setUserStateSelections(prev => ({ ...prev, [uid]: updated }))
-                        }
-                        expandAll={expandAll}
-                      />
-                    );
+                    return taskNode;
                   }
                   return (
                     <Fragment key={user.personId}>
-                      <TeamMemberTask
-                        user={user}
-                        userPermission={props?.auth?.user?.permissions?.frontPermissions?.includes(
-                          'putReviewStatus',
-                        )}
-                        teamRoles={
-                          user.teams !== undefined && user.teams.length > 0
-                            ? filteredTeamRoles(user.teams)
-                            : ''
-                        }
-                        handleOpenTaskNotificationModal={handleOpenTaskNotificationModal}
-                        handleMarkAsDoneModal={handleMarkAsDoneModal}
-                        handleRemoveFromTaskModal={handleRemoveFromTaskModal}
-                        handleTaskModalOption={handleTaskModalOption}
-                        userRole={displayUser.role}
-                        updateTaskStatus={updateTaskStatus}
-                        userId={displayUser._id}
-                        showWhoHasTimeOff={showWhoHasTimeOff}
-                        showTrackers={showTrackers}
-                        showTasks={showTasks}
-                        onTimeOff={userOnTimeOff[user.personId]}
-                        goingOnTimeOff={userGoingOnTimeOff[user.personId]}
-                        userStateCatalog={userStateCatalog}
-                        onCatalogChange={setUserStateCatalog}
-                        userStateSelection={userStateSelections[user.personId] || []}
-                        onSelectionChange={(uid, updated) =>
-                          setUserStateSelections(prev => ({ ...prev, [uid]: updated }))
-                        }
-                        expandAll={expandAll}
-                      />
+                      {taskNode}
 
                       {timeEntriesList.length > 0 &&
                         timeEntriesList

--- a/src/components/Warnings/Warnings.jsx
+++ b/src/components/Warnings/Warnings.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Alert, Button } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
 import { toast } from 'react-toastify';
@@ -22,7 +22,13 @@ import styles from './Warnings.module.css';
 // Log Time to Action Items (“i” = ,ltayg = Reminder to please log your time as you go. At a minimum, please log daily any time you work.)
 // Intangible Time Log w/o Reason (“i” = ,itlr = The timer should be used for all time logged, so any time logged as intangible must also include in the time log description an explanation for why you didn’t use the timer.
 
-export default function Warning({ personId, username, userRole, displayUser }) {
+export default function Warning({
+  personId,
+  username,
+  userRole,
+  displayUser,
+  showTrackers = false,
+}) {
   const dispatch = useDispatch();
   const [usersWarnings, setUsersWarnings] = useState([]);
 
@@ -59,6 +65,26 @@ export default function Warning({ personId, username, userRole, displayUser }) {
     if (!toggle) fetchUsersWarningsById();
     setToggle(prev => !prev);
   };
+
+  useEffect(() => {
+    if (showTrackers) {
+      setToggle(true);
+      if (usersWarnings.length === 0) {
+        const index = Array.from(personId ?? '').reduce(
+          (acc, c) => acc + (c.codePointAt(0) ?? 0),
+          0,
+        );
+        const delay = index % 5000;
+        const timer = setTimeout(() => {
+          fetchUsersWarningsById();
+        }, delay);
+        return () => clearTimeout(timer);
+      }
+    } else {
+      setToggle(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showTrackers]);
 
   const handleDeleteWarning = async warningId => {
     dispatch(deleteWarningsById(warningId, personId)).then(res => {
@@ -229,4 +255,5 @@ Warning.propTypes = {
   username: PropTypes.string,
   userRole: PropTypes.string,
   displayUser: PropTypes.object,
+  showTrackers: PropTypes.bool,
 };


### PR DESCRIPTION
## Description
Implements the Show Trackers and Hide Tasks buttons in the Dashboard Tasks Tab header as requested.
Implements #2 (Priority Medium)

##Main changes explained:
Added "Show Trackers" button to the left of "Hide Tasks" in the Tasks Tab header — trackers hidden by default, clicking expands all users' tracker lists at once
Added "Hide Tasks" button — tasks shown by default, clicking hides the task list for all users
Both buttons toggle their label based on current state (Show Trackers ↔ Hide Trackers, Hide Tasks ↔ Show Tasks)
Updated Warnings.jsx to accept showTrackers prop and sync internal toggle state with the global button

##How to test:
Check into current branch
Do npm install and npm run start to run this PR locally
Clear site data/cache
Log in as admin user
Go to Dashboard → Tasks tab
Verify "Show Trackers" button appears to the left of "Hide Tasks" button below the clock icons
Click "Show Trackers" — all users' tracker lists should expand and button should change to "Hide Trackers"
Click "Hide Trackers" — all tracker lists should collapse
Click "Hide Tasks" — all task lists should hide and button should change to "Show Tasks"
Click "Show Tasks" — all task lists should reappear
Verify this new feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9IOH0BsfnaHx01h1NZZXfl)

##Screenshots or videos of changes:
<img width="1847" height="860" alt="image" src="https://github.com/user-attachments/assets/0523a483-0a7c-4eca-83c6-5de162935a2a" />
<img width="1918" height="869" alt="image" src="https://github.com/user-attachments/assets/5429923e-7589-42c8-9d04-f995b8488225" />
<img width="1402" height="869" alt="image" src="https://github.com/user-attachments/assets/cea56cf5-93fb-4988-a267-448292afabf4" />
<img width="1754" height="729" alt="image" src="https://github.com/user-attachments/assets/9cfd6581-d4b5-4e91-9753-16b7d4386c20" />

##Note:
Both buttons are placed below the clock icons in the Tasks Tab header. "Show Trackers" is on the left, "Hide Tasks" is on the right.

##Additional Notes (Performance Investigation)
Tried  to fix the lag with 2447 users. Approaches tried:
Staggered API calls (0-5000ms delay per user) — reduced crashes but still caused freezes
Batch API to reduce 2447 calls to 1 — backend built and working but React re-render freeze remained
React startTransition to prevent UI freeze — not sufficient
The proper fix requires virtual scrolling (react-window) which renders only visible rows (~15 at a time). This would eliminate both the API flood and React freeze but would take 10+ hours to implement.
If this PR causes lag on production, the recommended fix is virtual scrolling. The staggered delay (index % 5000) spreads API calls over 5 seconds to prevent browser crashes.