### PR TITLE
Manoj 🔥 profile and people

### DIFF
--- a/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
+++ b/src/components/UserProfile/TeamsAndProjects/UserTeamsTable.jsx
@@ -273,8 +273,8 @@ const UserTeamsTable = props => {
           </Col>
         )}
       </div>
-      <div style={{ maxHeight: '300px', overflow: 'auto' }}>
-        <table className={`table table-bordered ${darkMode ? 'text-light' : ''}`}>
+      <div>
+        <table className={`table table-bordered table-responsive-sm ${darkMode ? 'text-light' : ''}`}>
           <thead className="user-team-head">
             {props.role && (
               <tr>

--- a/src/components/common/PieChart/PieChart.jsx
+++ b/src/components/common/PieChart/PieChart.jsx
@@ -225,8 +225,14 @@ export function PieChart({
             </tbody>
           </table>
         </div>
-        <div className={styles['data-total-value']} style={{ marginTop: 8 }}>
-          <strong className={styles['strong-text']}>Total Hours:</strong> {totalHours.toFixed(2)}
+        <div
+          className={`${styles['data-total-value']} ${darkMode ? styles['text-light'] : ''}`}
+          style={{ marginTop: 8, color: darkMode ? '#f5f5f5' : 'inherit' }}
+        >
+          <strong className={`${styles['strong-text']} ${darkMode ? styles['text-light'] : ''}`}>
+            Total Hours:
+          </strong>{' '}
+          {totalHours.toFixed(2)}
         </div>
       </div>
     </div>

--- a/src/components/common/PieChart/PieChart.module.css
+++ b/src/components/common/PieChart/PieChart.module.css
@@ -167,3 +167,13 @@ div.pie-chart-legend-container {
 .pie-chart-legend-table td {
   padding: 8px 0;
 }
+
+.data-total-value {
+  font-weight: bold;
+  margin-top: 10px;
+  color: inherit;
+}
+
+.strong-text.text-light,
+.text-light strong,
+.text-light .strong-text { color:#f5f5f5 !important; }

--- a/src/components/common/PieChart/ProjectPieChart.jsx
+++ b/src/components/common/PieChart/ProjectPieChart.jsx
@@ -189,7 +189,7 @@ export default function UserProjectD3PieChart({ projectsData, darkMode }) {
           className={`${styles['data-total-value']} ${darkMode ? styles['text-light'] : ''}`}
           style={{ marginTop: 8, color: darkMode ? '#f5f5f5' : 'inherit' }}
         >
-          <strong className={`strong-text ${darkMode ? styles['text-light'] : ''}`}>
+          <strong className={`${styles['strong-text']} ${darkMode ? styles['text-light'] : ''}`}>
             Total Hours:
           </strong>{' '}
           {total.toFixed(2)}

--- a/src/components/common/PieChart/UserProjectPieChart.module.css
+++ b/src/components/common/PieChart/UserProjectPieChart.module.css
@@ -220,10 +220,6 @@
   color: inherit;
 }
 
-.strong-text {
-  font-weight: bold;
-}
-
 .strong-text.text-light,
 .text-light strong,
 .text-light .strong-text { color:#f5f5f5 !important; }

--- a/src/components/common/PieChart/UserProjectPieChart.module.css
+++ b/src/components/common/PieChart/UserProjectPieChart.module.css
@@ -220,6 +220,10 @@
   color: inherit;
 }
 
+.strong-text {
+  font-weight: bold;
+}
+
 .strong-text.text-light,
 .text-light strong,
 .text-light .strong-text { color:#f5f5f5 !important; }


### PR DESCRIPTION
# Description
Teams table no longer has a fixed height scroll area and now displays all rows consistently, matching the Projects table behavior 
Link: /userprofile/<userId>
"Total Hours:" label in the pie chart legend now correctly appears bold and renders in the proper light color when dark mode is enabled
Link: /peoplereport/<userId>

Video: https://www.loom.com/share/eeefbe9177f14c0f876616700476d895

## Related PRS (if any):
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ view Profile → Teams→check that scrolling effect is no longer there
6. go to dashboard→ other Links → User Management→people report→ Total hours on the Pie chart card is bold

## Screenshots or videos of changes:
<img width="1195" height="717" alt="02" src="https://github.com/user-attachments/assets/494303d8-5368-4cd2-962a-5f3a72329f87" />
<img width="1195" height="717" alt="Screenshot 2026-06-04 at 12 18 19 PM" src="https://github.com/user-attachments/assets/64b0cf1d-39d7-4de7-a067-792f1c775ca3" />

