### PR TITLE
Diya 🔥 fix(blueSq): Fixed Blue Square Bulk Issues

### DIFF
--- a/src/components/BlueSquareEmailManagement/BlueSquareEmailManagement.jsx
+++ b/src/components/BlueSquareEmailManagement/BlueSquareEmailManagement.jsx
@@ -11,6 +11,7 @@ import styles from './BlueSquareEmailManagement.module.css';
 const BlueSquareEmailManagement = ({
   auth,
   darkMode,
+  roles,
   resendBlueSquareEmails,
   resendWeeklySummaryEmails,
 }) => {
@@ -20,7 +21,15 @@ const BlueSquareEmailManagement = ({
 
   // Check if user has the required permission
   const userPermissions = auth.user?.permissions?.frontPermissions || [];
-  const hasEmailPermission = userPermissions.includes('resendBlueSquareAndSummaryEmails');
+  const removedPermissions = auth.user?.permissions?.removedDefaultPermissions || [];
+  const userRole = auth.user?.role;
+
+  const userRoleData = roles?.find(r => r.roleName === userRole);
+  const roleDefaultPermissions = userRoleData?.permissions || [];
+  const hasEmailPermission =
+    (roleDefaultPermissions.includes('resendBlueSquareAndSummaryEmails') &&
+      !removedPermissions.includes('resendBlueSquareAndSummaryEmails')) ||
+    userPermissions.includes('resendBlueSquareAndSummaryEmails');
 
   const handleBlueSquareResend = async () => {
     setIsLoading(true);
@@ -223,6 +232,7 @@ const BlueSquareEmailManagement = ({
 const mapStateToProps = state => ({
   auth: state.auth,
   darkMode: state.theme.darkMode,
+  roles: state.role.roles,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/UserManagement/setupNewUserPopup.jsx
+++ b/src/components/UserManagement/setupNewUserPopup.jsx
@@ -20,7 +20,7 @@ const SetupNewUserPopupComponent = (props) => {
     props.onClose();
   };
 
-  const handelSendLink = () => {
+  const handleSendLink = () => {
     setAlert({ visibility: 'hidden', message: '', state: 'success' });
     if (!email.match(patt)) {
       setAlert({ visibility: 'visible', message: 'Please enter a valid email.', state: 'error' });
@@ -138,7 +138,7 @@ const SetupNewUserPopupComponent = (props) => {
               type="button"
               className="btn btn-primary"
               id="setup-new-user-popup-btn"
-              onClick={handelSendLink}
+              onClick={handleSendLink}
             >
               Send Link
             </button>

--- a/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
+++ b/src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx
@@ -48,6 +48,7 @@ const ScheduleReasonModal = ({
     dateOfLeave: nextSunday,
     numberOfWeeks: 1,
     reasonForLeave: '',
+    reasonType: 'vacationTime',
   };
 
   const initialRequestDataErrors = {
@@ -323,10 +324,11 @@ const ScheduleReasonModal = ({
     }
   };
 
-  const handelConfirmReason = () => {
+  const handleConfirmReason = () => {
     const data = {
       requestFor: userId,
       reason: requestData.reasonForLeave,
+      reasonType: requestData.reasonType,
       startingDate: getDateWithoutTimeZone(requestData.dateOfLeave),
       duration: requestData.numberOfWeeks,
     };
@@ -351,7 +353,7 @@ const ScheduleReasonModal = ({
     setRequestTodelete(id);
   };
 
-  const handelDeleteConfirmReason = () => {
+  const handleDeleteConfirmReason = () => {
     dispatch(deleteTimeOffRequestThunk(requestTodelete));
     setRequestTodelete('');
     toggleDeleteConfirmationModal();
@@ -369,6 +371,7 @@ const ScheduleReasonModal = ({
       dateOfLeave: new Date(request.startingDate),
       numberOfWeeks: Number(request.duration),
       reasonForLeave: request.reason || '',
+      reasonType: request.reasonType || '',
     });
   };
 
@@ -414,13 +417,13 @@ const ScheduleReasonModal = ({
           <Form onSubmit={handleSaveReason}>
             <Modal.Body className={darkMode ? 'bg-yinmn-blue' : ''}>
               <Form.Group className="mb-0" controlId="exampleForm.ControlTextarea1">
-                <Form.Label className={`mb-3 ${darkMode ? 'text-light' : ''}`}>
+                <Form.Label className={`mb-3 ${darkMode ? 'text-light' : 'text-dark bg-white'}`}>
                   {` Need to take time off for an emergency or vacation? That's no problem. The system
                   will still issue you a blue square but scheduling here will note this reason on it
                   so it's clear you chose to use one (vs receiving one for missing something) and
                   let us know in advance. Blue squares are meant for situations like this and we allow the use and scheduling of 4 a year.`}
                 </Form.Label>
-                <Form.Label className={darkMode ? 'text-light' : ''}>
+                <Form.Label className={darkMode ? 'text-light' : 'text-dark bg-white'}>
                   {`Select the Sunday of the week you'll be leaving (If you'll be absent this week,
                   choose the Sunday of current week):`}
                 </Form.Label>
@@ -442,7 +445,7 @@ const ScheduleReasonModal = ({
                 <Form.Text className="text-danger pl-1">
                   {requestDataErrors.dateOfLeaveError}
                 </Form.Text>
-                <Form.Label className={darkMode ? 'text-light' : ''}>
+                <Form.Label className={darkMode ? 'text-light' : 'text-dark bg-white'}>
                   Enter the duration of your absence (In Weeks):
                 </Form.Label>
                 <Form.Control
@@ -459,10 +462,23 @@ const ScheduleReasonModal = ({
                     }
                   }}
                 />
+                <Form.Label className={`mt-1 ${darkMode ? 'text-light' : 'text-dark bg-white'}`}>
+                    Select the type of your absence:
+                </Form.Label>
+                <Form.Control
+                  as="select"
+                  name="reasonType"
+                  value={requestData.reasonType}
+                  onChange={e => handleAddRequestDataChange(e)}
+                  className={darkMode ? 'bg-darkmode-liblack text-light' : ''}
+                >
+                  <option value="vacationTime">Vacation Time</option>
+                  <option value="other">Other</option>
+                </Form.Control>
                 <Form.Text className="text-danger pl-1">
                   {requestDataErrors.numberOfWeeksError}
                 </Form.Text>
-                <Form.Label className={`mt-1 ${darkMode ? 'text-light' : ''}`}>
+                <Form.Label className={`mt-1 ${darkMode ? 'text-light' : 'text-dark bg-white'}`}>
                   What is your reason for requesting this time off?
                 </Form.Label>
                 <span className="red-asterisk">* </span>
@@ -471,7 +487,6 @@ const ScheduleReasonModal = ({
                   rows={2}
                   name="reasonForLeave"
                   className="w-100 user-time-off-scheduler-reason-input"
-                  // controlId=""
                   placeholder="Please be detailed in describing your reason and, if it is different than your scheduled Sunday, include the expected date you’ll return to work."
                   value={requestData.reasonForLeave}
                   onChange={e => handleAddRequestDataChange(e)}
@@ -556,7 +571,7 @@ const ScheduleReasonModal = ({
                 <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
                   <Button variant="primary" onClick={()=>{
                     handleStartWeekConfirmationModal()
-                    handelConfirmReason()
+                    handleConfirmReason()
                     handleClose()
                   }}>
                     Confirm
@@ -665,7 +680,7 @@ const ScheduleReasonModal = ({
                 </Container>
               </ModalBody>
               <ModalFooter>
-                <Button variant="primary" onClick={handelDeleteConfirmReason}>
+                <Button variant="primary" onClick={handleDeleteConfirmReason}>
                   Confirm
                 </Button>
                 <Button variant="secondary" onClick={toggleDeleteConfirmationModal}>

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -766,8 +766,8 @@ setUpdatedTasks(prev => {
           date: dateStamp,
           description: summary,
           createdDate: moment().format('YYYY-MM-DD'),
-          manullyAssigned: true,
-          manullyAssignedBy: requestorId,
+          manuallyAssigned: true,
+          manuallyAssignedBy: requestorId,
         };
         setModalTitle('Blue Square');
         axios

--- a/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
+++ b/src/components/UserProfile/UserProfileModal/UserProfileModal.jsx
@@ -26,26 +26,28 @@ import PropTypes from 'prop-types';
 
 // Helper component to render blue square metadata (manual assignment and edit history)
 const BlueSquareMetadata = ({ blueSquareData, fontColor, darkMode }) => {
-  const hasManualAssignment = blueSquareData?.manullyAssigned;
   const hasEditHistory = blueSquareData?.editedBy && blueSquareData.editedBy.length > 0;
-  
-  if (!hasManualAssignment && !hasEditHistory) return null;
+
+  // Determine who assigned the blue square
+  const getAssignedBy = () => {
+    if (blueSquareData?.manuallyAssigned && blueSquareData?.manuallyAssignedBy?.firstName) {
+      return `${blueSquareData.manuallyAssignedBy.firstName} ${blueSquareData.manuallyAssignedBy.lastName}`;
+    }
+    if (!blueSquareData?.manuallyAssigned) {
+      return 'HGN System';
+    }
+    return 'Admin User';
+  };
 
   return (
     <>
-      {hasManualAssignment && (
-        <FormGroup>
-          <Label className={fontColor} for="manullyAssigned">
-            <strong>Manual Assignment</strong>
-          </Label>
-          <div className={fontColor}>
-            {blueSquareData?.manullyAssignedBy?.firstName && blueSquareData?.manullyAssignedBy?.lastName
-              ? `${blueSquareData.manullyAssignedBy.firstName} ${blueSquareData.manullyAssignedBy.lastName}`
-              : 'Admin User'}
-          </div>
-        </FormGroup>
-      )}
-      
+      <FormGroup>
+        <Label className={fontColor}>
+          <strong>Assigned by:</strong>
+        </Label>
+        <div className={fontColor}>{getAssignedBy()}</div>
+      </FormGroup>
+
       {hasEditHistory && (
         <FormGroup>
           <div style={{ textAlign: 'right', fontSize: '0.9em', color: darkMode ? '#ccc' : '#666' }}>
@@ -67,8 +69,8 @@ const BlueSquareMetadata = ({ blueSquareData, fontColor, darkMode }) => {
 
 BlueSquareMetadata.propTypes = {
   blueSquareData: PropTypes.shape({
-    manullyAssigned: PropTypes.bool,
-    manullyAssignedBy: PropTypes.shape({
+    manuallyAssigned: PropTypes.bool,
+    manuallyAssignedBy: PropTypes.shape({
       firstName: PropTypes.string,
       lastName: PropTypes.string,
     }),


### PR DESCRIPTION
# Description

Adds `reasonType` support to time-off request scheduling, improves the "Assigned by" display logic for blue squares, and fixes a permission check in `BlueSquareEmailManagement` to account for role-based default permissions.

Fixes # (High) Blue square infringements deleted incorrectly by the weekly cron job
Implements # Time-off request reason type categorization

## Related PRs (if any):
This frontend PR is related to the backend [PR #2239](https://github.com/OneCommunityGlobal/HGNRest/pull/2239)

## Main changes explained:

- **`src/components/BlueSquareEmailManagement/BlueSquareEmailManagement.jsx`** — Added `roles` prop via `mapStateToProps`; updated `hasEmailPermission` logic to check role-based default permissions and removed permissions, not just front permissions directly, so users with the permission granted via their role (and not explicitly removed) are also correctly allowed
- **`src/components/UserManagement/setupNewUserPopup.jsx`** — Fixed typo: renamed `handelSendLink` → `handleSendLink` for consistency
- **`src/components/UserProfile/ScheduleReasonModal/ScheduleReasonModal.jsx`** — Added `reasonType` field to request data state (defaulting to `'vacationTime'`), included it in `handleConfirmReason` payload and edit pre-fill logic; added a new "Type of absence" dropdown in the form UI with options `Vacation Time` and `Other`; fixed dark mode label classNames for better contrast
- **`src/components/UserProfile/UserProfile.jsx`** — Included `manuallyAssignedBy: requestorId` when constructing the blue square object on manual assignment
- **`src/components/UserProfile/UserProfileModal/UserProfileModal.jsx`** — Refactored `BlueSquareMetadata` helper component: replaced the old ternary-based "Manual Assignment" display with a cleaner `getAssignedBy()` function that returns the assigner's full name if manually assigned, `'HGN System'` if not, or `'Admin User'` as fallback; label changed from "Manual Assignment" to "Assigned by"

## How to test:

1. Check out this branch and the corresponding backend branch
2. Run `npm install` and start the dev server
3. Clear site data/cache
4. **Time-off request:**
   - Log in as any active user
   - Navigate to the schedule/time-off request modal
   - Confirm a new "Type of absence" dropdown appears with options `Vacation Time` and `Other`
   - Submit a request and verify `reasonType` is saved correctly in the DB
   - Edit an existing request and confirm `reasonType` pre-fills correctly
5. **Blue square "Assigned by" display:**
   - Log in as an admin/owner
   - Manually assign a blue square to a user
   - Open the user's profile modal and verify the blue square shows "Assigned by: [Your Name]"
   - Find a system-auto-assigned blue square and verify it shows "Assigned by: HGN System"
6. **Email permission:**
   - Log in as a user whose role has `resendBlueSquareAndSummaryEmails` as a default permission (not explicitly granted via front permissions)
   - Verify they can still access the BlueSquareEmailManagement component correctly

## Screenshots or videos of changes:
[BlueSquareReasonTypes - UI](https://www.dropbox.com/scl/fi/44uwuw428hx3tfyev29hc/BlueSquareReasonTypes-UI.png?rlkey=tyv32vfc7o2hhfumytjkgqk9s&st=u26nckhn&dl=0)


## Note:
The `reasonType` dropdown defaults to `'vacationTime'` to maintain backward compatibility with existing time-off requests that were created without this field.