### PR TITLE
Diya 🔥 fix(props): Added PropTypes to Blue Square Email Management

### DIFF
--- a/src/components/BlueSquareEmailManagement/BlueSquareEmailManagement.jsx
+++ b/src/components/BlueSquareEmailManagement/BlueSquareEmailManagement.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import ReactTooltip from 'react-tooltip';
@@ -239,5 +240,26 @@ const mapDispatchToProps = dispatch => ({
   resendBlueSquareEmails: () => dispatch(resendBlueSquareEmails()),
   resendWeeklySummaryEmails: () => dispatch(resendWeeklySummaryEmails()),
 });
+
+BlueSquareEmailManagement.propTypes = {
+  auth: PropTypes.shape({
+    user: PropTypes.shape({
+      permissions: PropTypes.shape({
+        frontPermissions: PropTypes.arrayOf(PropTypes.string),
+        removedDefaultPermissions: PropTypes.arrayOf(PropTypes.string),
+      }),
+      role: PropTypes.string,
+    }),
+  }),
+  darkMode: PropTypes.bool,
+  roles: PropTypes.arrayOf(
+    PropTypes.shape({
+      roleName: PropTypes.string,
+      permissions: PropTypes.arrayOf(PropTypes.string),
+    }),
+  ),
+  resendBlueSquareEmails: PropTypes.func.isRequired,
+  resendWeeklySummaryEmails: PropTypes.func.isRequired,
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(BlueSquareEmailManagement);


### PR DESCRIPTION
# Description

Fixes SonarQube quality gate failures in `BlueSquareEmailManagement.jsx` by adding missing PropTypes validation. These were flagged as Major code smells and accepted during the previous PR but Jae has requested they be resolved.

Fixes # (Low) SonarQube quality gate — 7 missing PropTypes violations in BlueSquareEmailManagement

## Related PRs (if any):
This is a follow-up to frontend PR #5323 (Blue Square system overhaul).
No backend changes required.

## Main changes explained:

- **`src/components/BlueSquareEmailManagement/BlueSquareEmailManagement.jsx`** — Added `PropTypes` import and defined `BlueSquareEmailManagement.propTypes` to cover all 7 flagged violations: `roles`, `auth.user`, `auth.user.permissions`, `auth.user.permissions.frontPermissions`, `auth.user.permissions.removedDefaultPermissions`, `auth.user.role`, and `roles[].roleName` / `roles[].permissions`

## How to test:

1. Check out this branch
2. Run `npm install` and start the dev server
3. Clear site data/cache
4. Log in as an Owner or admin user
5. Navigate to the Blue Square Email Management page
6. Verify the page loads correctly and the resend buttons are visible and functional
7. Log in as a user without the `resendBlueSquareAndSummaryEmails` permission and verify the Access Denied card is shown
8. Verify the above works correctly in [[dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)
9. Confirm SonarQube no longer flags the 7 issues on this file

## Screenshots or videos of changes:

_No visual changes — this is a code quality fix only._

## Note:

No functional behavior has changed. This PR purely adds PropTypes to satisfy SonarQube's consistency rules. The 7 issues were previously marked "Accepted" but are being resolved per Jae's request.