### PR TITLE
Diya 🔥 fix(toggle): Fixed Toggles on Weekly Summary Report

### DIFF
--- a/src/components/UserProfile/UserProfileEdit/ToggleSwitch/TriStateToggleSwitch.jsx
+++ b/src/components/UserProfile/UserProfileEdit/ToggleSwitch/TriStateToggleSwitch.jsx
@@ -1,52 +1,39 @@
-import './TriStateToggleSwitch.module.css';
+import styles from './TriStateToggleSwitch.module.css';
 import React, { useState, useEffect } from 'react';
 
 function TriStateToggleSwitch({ pos, onChange }) {
-  const [position, setPosition] = useState(pos);
+  const [position, setPosition] = useState(pos || 'default');
   const [bgColor, setBgColor] = useState('');
 
-  const handleClick = pos => {
-    setPosition(pos);
-
-    if (onChange) {
-      onChange(pos);
-    }
-
-    if (pos === 'posted') {
-      setBgColor('blue');
-    } else if (pos === 'default') {
-      setBgColor('darkgray');
-    } else {
-      setBgColor('green');
-    }
+  const handleClick = newPos => {
+    setPosition(newPos);
+    if (onChange) onChange(newPos);
+    if (newPos === 'posted') setBgColor('blue');
+    else if (newPos === 'default') setBgColor('darkgray');
+    else setBgColor('green');
   };
 
   useEffect(() => {
-    if (pos) {
-      setPosition(pos);
-    }
-
-    if (pos === 'posted') {
-      setBgColor('blue');
-    } else if (pos === 'default') {
-      setBgColor('darkgray');
-    } else {
-      setBgColor('green');
-    }
+    if (pos) setPosition(pos);
+    if (pos === 'posted') setBgColor('blue');
+    else if (pos === 'default') setBgColor('darkgray');
+    else setBgColor('green');
   }, [pos]);
 
-  return (
-    <div className={`toggle-switch bg-${bgColor}`}>
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-      <div className="knob-area">
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-        <div onClick={() => handleClick('posted')}></div>
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-        <div onClick={() => handleClick('default')}></div>
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-        <div onClick={() => handleClick('requested')}></div>  
+    return (
+    <div className={`${styles['toggle-switch']} ${styles[`bg-${bgColor}`]}`}>
+      <div className={styles['knob-area']} style={{ position: 'relative', zIndex: 1 }}>
+        {['posted', 'default', 'requested'].map(p => (
+          <div
+            key={p}
+            role="button"
+            tabIndex={0}
+            onClick={() => handleClick(p)}
+            onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && handleClick(p)}
+          />
+        ))}
       </div>
-      <div className={`knob ${position}`}></div>
+      <div className={`${styles.knob} ${styles[position]}`} />
     </div>
   );
 }

--- a/src/components/UserProfile/UserProfileEdit/ToggleSwitch/TriStateToggleSwitch.jsx
+++ b/src/components/UserProfile/UserProfileEdit/ToggleSwitch/TriStateToggleSwitch.jsx
@@ -21,11 +21,12 @@ function TriStateToggleSwitch({ pos, onChange }) {
   }, [pos]);
 
     return (
-    <div className={`${styles['toggle-switch']} ${styles[`bg-${bgColor}`]}`}>
-      <div className={styles['knob-area']} style={{ position: 'relative', zIndex: 1 }}>
+    <div data-testid="toggle-switch" className={`${styles['toggle-switch']} ${styles[`bg-${bgColor}`]}`}>
+      <div data-testid="knob-area" className={styles['knob-area']} style={{ position: 'relative', zIndex: 1 }}>
         {['posted', 'default', 'requested'].map(p => (
           <div
             key={p}
+            data-testid={`option-${p}`}
             role="button"
             tabIndex={0}
             onClick={() => handleClick(p)}
@@ -33,7 +34,7 @@ function TriStateToggleSwitch({ pos, onChange }) {
           />
         ))}
       </div>
-      <div className={`${styles.knob} ${styles[position]}`} />
+      <div data-testid="knob" className={`${styles.knob} ${styles[position]}`} />
     </div>
   );
 }

--- a/src/components/UserProfile/UserProfileEdit/__tests__/TriStateToggleSwitch.test.jsx
+++ b/src/components/UserProfile/UserProfileEdit/__tests__/TriStateToggleSwitch.test.jsx
@@ -1,135 +1,96 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import TriStateToggleSwitch from '../ToggleSwitch/TriStateToggleSwitch';
 
 describe('TriStateToggleSwitch Component', () => {
   it('initializes state based on pos prop and applies correct background color', () => {
-    const { container, rerender } = render(<TriStateToggleSwitch pos="posted" />);
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const wrapper = container.querySelector('.toggle-switch');
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const knob = container.querySelector('.knob');
-    
-    expect(wrapper).toHaveClass('toggle-switch', 'bg-blue');
-    expect(knob).toHaveClass('posted');
+    const { rerender } = render(<TriStateToggleSwitch pos="posted" />);
+
+    expect(screen.getByTestId('toggle-switch').className).toMatch(/bg-blue/);
+    expect(screen.getByTestId('knob').className).toMatch(/posted/);
 
     rerender(<TriStateToggleSwitch pos="default" />);
-    expect(wrapper).toHaveClass('toggle-switch', 'bg-darkgray');
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    expect(container.querySelector('.knob')).toHaveClass('default');
+    expect(screen.getByTestId('toggle-switch').className).toMatch(/bg-darkgray/);
+    expect(screen.getByTestId('knob').className).toMatch(/default/);
 
-    
     rerender(<TriStateToggleSwitch pos="requested" />);
-    expect(wrapper).toHaveClass('toggle-switch', 'bg-green');
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    expect(container.querySelector('.knob')).toHaveClass('requested');
+    expect(screen.getByTestId('toggle-switch').className).toMatch(/bg-green/);
+    expect(screen.getByTestId('knob').className).toMatch(/requested/);
   });
 
   it('calls onChange and updates state and bgColor on click for all states', () => {
     const handleChange = vi.fn();
-    const { container } = render(<TriStateToggleSwitch pos="default" onChange={handleChange} />);
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const wrapper = container.querySelector('.toggle-switch');
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const options = container.querySelectorAll('.knob-area div');
+    render(<TriStateToggleSwitch pos="default" onChange={handleChange} />);
 
-    
-    fireEvent.click(options[0]);
+    fireEvent.click(screen.getByTestId('option-posted'));
     expect(handleChange).toHaveBeenCalledWith('posted');
-    expect(wrapper).toHaveClass('bg-blue');
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    expect(container.querySelector('.knob')).toHaveClass('posted');
+    expect(screen.getByTestId('toggle-switch').className).toMatch(/bg-blue/);
+    expect(screen.getByTestId('knob').className).toMatch(/posted/);
 
-    
     handleChange.mockClear();
-    fireEvent.click(options[1]);
+    fireEvent.click(screen.getByTestId('option-default'));
     expect(handleChange).toHaveBeenCalledWith('default');
-    expect(wrapper).toHaveClass('bg-darkgray');
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    expect(container.querySelector('.knob')).toHaveClass('default');
+    expect(screen.getByTestId('toggle-switch').className).toMatch(/bg-darkgray/);
+    expect(screen.getByTestId('knob').className).toMatch(/default/);
 
-   
     handleChange.mockClear();
-    fireEvent.click(options[2]);
+    fireEvent.click(screen.getByTestId('option-requested'));
     expect(handleChange).toHaveBeenCalledWith('requested');
-    expect(wrapper).toHaveClass('bg-green');
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    expect(container.querySelector('.knob')).toHaveClass('requested');
+    expect(screen.getByTestId('toggle-switch').className).toMatch(/bg-green/);
+    expect(screen.getByTestId('knob').className).toMatch(/requested/);
   });
 
   it('does not throw if onChange is not provided', () => {
-    const { container } = render(<TriStateToggleSwitch pos="default" />);
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const options = container.querySelectorAll('.knob-area div');
-
-    expect(() => fireEvent.click(options[0])).not.toThrow();
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const wrapper = container.querySelector('.toggle-switch');
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    expect(wrapper).toHaveClass('bg-blue');
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    expect(container.querySelector('.knob')).toHaveClass('posted');
+    render(<TriStateToggleSwitch pos="default" />);
+    expect(() => fireEvent.click(screen.getByTestId('option-posted'))).not.toThrow();
+    expect(screen.getByTestId('toggle-switch').className).toMatch(/bg-blue/);
+    expect(screen.getByTestId('knob').className).toMatch(/posted/);
   });
 
   it('does not call onChange on mount or prop change', () => {
     const handleChange = vi.fn();
     const { rerender } = render(<TriStateToggleSwitch pos="posted" onChange={handleChange} />);
-    
     expect(handleChange).not.toHaveBeenCalled();
 
-    
     rerender(<TriStateToggleSwitch pos="default" onChange={handleChange} />);
     expect(handleChange).not.toHaveBeenCalled();
   });
 
   it('renders exactly three clickable areas for each state option', () => {
-    const { container } = render(<TriStateToggleSwitch pos="requested" />);
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const options = container.querySelectorAll('.knob-area div');
-    expect(options.length).toBe(3);
+    render(<TriStateToggleSwitch pos="requested" />);
+    expect(screen.getByTestId('knob-area').children.length).toBe(3);
   });
 
   it('wrapper always includes the toggle-switch class', () => {
-    const { container } = render(<TriStateToggleSwitch pos="default" />);
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const wrapper = container.querySelector('.toggle-switch');
-    expect(wrapper).toBeInTheDocument();
+    render(<TriStateToggleSwitch pos="default" />);
+    expect(screen.getByTestId('toggle-switch')).toBeInTheDocument();
   });
 
   it('wrapper has exactly two classes (toggle-switch and bg-color) for each state', () => {
-    const { container, rerender } = render(<TriStateToggleSwitch pos="default" />);
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const wrapper = container.querySelector('.toggle-switch');
-    
-    expect(wrapper.classList.length).toBe(2);
-    expect(wrapper.classList.contains('toggle-switch')).toBe(true);
-    expect(wrapper.classList.contains('bg-darkgray')).toBe(true);
+    const { rerender } = render(<TriStateToggleSwitch pos="default" />);
 
-    
+    expect(screen.getByTestId('toggle-switch').classList.length).toBe(2);
+    expect(screen.getByTestId('toggle-switch').className).toMatch(/toggle-switch/);
+    expect(screen.getByTestId('toggle-switch').className).toMatch(/bg-darkgray/);
+
     rerender(<TriStateToggleSwitch pos="posted" />);
-    expect(wrapper.classList.length).toBe(2);
-    expect(wrapper.classList.contains('bg-blue')).toBe(true);
+    expect(screen.getByTestId('toggle-switch').classList.length).toBe(2);
+    expect(screen.getByTestId('toggle-switch').className).toMatch(/bg-blue/);
 
-    
     rerender(<TriStateToggleSwitch pos="requested" />);
-    expect(wrapper.classList.length).toBe(2);
-    expect(wrapper.classList.contains('bg-green')).toBe(true);
+    expect(screen.getByTestId('toggle-switch').classList.length).toBe(2);
+    expect(screen.getByTestId('toggle-switch').className).toMatch(/bg-green/);
   });
 
   it('allows sequential clicking through all states', () => {
     const handleChange = vi.fn();
-    const { container } = render(<TriStateToggleSwitch pos="default" onChange={handleChange} />);
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const options = container.querySelectorAll('.knob-area div');
+    render(<TriStateToggleSwitch pos="default" onChange={handleChange} />);
 
-    options.forEach((option, idx) => {
-      fireEvent.click(option);
-      const expected = ['posted', 'default', 'requested'][idx];
-      expect(handleChange).toHaveBeenLastCalledWith(expected);
-      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-      expect(container.querySelector('.knob')).toHaveClass(expected);
+    ['posted', 'default', 'requested'].forEach(state => {
+      fireEvent.click(screen.getByTestId(`option-${state}`));
+      expect(handleChange).toHaveBeenLastCalledWith(state);
+      expect(screen.getByTestId('knob').className).toMatch(new RegExp(state));
     });
   });
-
 });

--- a/src/components/WeeklySummariesReport/components/SlideToggle.module.scss
+++ b/src/components/WeeklySummariesReport/components/SlideToggle.module.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable  */
 .default {
-  --checked-bg-color: #6c757d;
+  --checked-bg-color: #adb5bd;
   --slider-color: #6c757d;
   --slider-checked-color: #FFF;
 }


### PR DESCRIPTION
# Description
Fixes two UI regressions on the Weekly Summaries Report page: the Bio announcement toggle was rendering as raw text "postedrequested" with no interactive control visible, and the Bio Status filter toggle had no visual distinction between its on/off states.

## Related PRS (if any):
None

## Main changes explained:
- Fix ToggleSwitch.jsx — restored the missing import TriStateToggleSwitch from './TriStateToggleSwitch' component import, which had been incorrectly replaced with a CSS file import, causing the bio toggle to render as invisible empty divs.
- Fix TriStateToggleSwitch.jsx — corrected the CSS module import from a broken side-effect import (import './TriStateToggleSwitch.module.css') to a proper named import (import styles from './TriStateToggleSwitch.module.css'), and updated all className references to use the scoped styles.xxx syntax so CSS module hashing is applied correctly.
- Fix click interactivity in TriStateToggleSwitch.jsx — added zIndex: 1 to the knob-area so click zones are not obscured by the absolutely-positioned knob element. Also added role="button", tabIndex={0}, and onKeyDown handlers to satisfy accessibility (jsx-a11y) requirements. Refactored the three identical clickable divs into a single .map().
- Fix TriStateToggleSwitch.test.jsx — updated all class-based selectors to use data-testid attributes and screen.getByTestId queries, since CSS module hashing breaks plain .className queries.
- Fix SlideToggle.module.scss — updated the default color variant's --checked-bg-color from #6c757d to #adb5bd so the Bio Status, Trophies, and Over Hours filter toggles show a visible lighter gray when active, distinguishable from their off state.

## How to test:
1. Check out this branch
2. Run npm install and start the dev server
3. Clear site data/cache
4. Log in as an Administrator or Owner
5. Go to Reports → Weekly Summaries Report
6. Verify that the Bio announcement row shows a tri-state toggle (not the text "postedrequested")
7. Click each of the three toggle zones and verify the knob moves to posted (blue), default (gray), or requested (green)
8. Verify the change persists and the success toast appears
9. Verify the Filter by: Bio Status / Trophies / Over Hours toggles at the top show a lighter gray when toggled on vs. off

## Screenshots or videos of changes:
Before:
<img width="320" height="48" alt="Screenshot 2026-06-11 at 6 01 30 PM" src="https://github.com/user-attachments/assets/a0667030-4be6-4e84-aa69-f035b35f5d40" />
<img width="220" height="46" alt="Screenshot 2026-06-11 at 6 40 41 PM" src="https://github.com/user-attachments/assets/0d42d094-78e6-4575-8439-e9b69e3d1977" />

After:
<img width="396" height="60" alt="Screenshot 2026-06-11 at 5 56 11 PM" src="https://github.com/user-attachments/assets/c4f7ed9a-4f80-4324-b5e2-4b1dfe81a26e" />
<img width="213" height="45" alt="Screenshot 2026-06-11 at 6 40 12 PM" src="https://github.com/user-attachments/assets/df21def2-1ff7-4ff8-b21e-2ff2fd2c11cd" />


## Note:
The root cause of the bio toggle regression was a bad import that replaced the TriStateToggleSwitch React component import with a CSS file import — likely introduced during a refactor or merge conflict resolution. No backend changes required.