### PR TITLE
Diya 🔥 fix(input): Fixed Input for Time Logging

### DIFF
--- a/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
+++ b/src/components/Timelog/TimeEntryForm/TimeEntryForm.jsx
@@ -92,6 +92,7 @@ function TimeEntryForm(props) {
   const viewingUser = JSON.parse(sessionStorage.getItem('viewingUser') ?? '{}');
   const userTimeZone = userProfile?.timeZone || 'America/Los_Angeles';
   const [actualDate, setActualDate] = useState('');
+  const [editorKey, setEditorKey] = useState(0);
 
   const initialFormValues = {
     dateOfWork: moment()
@@ -653,6 +654,7 @@ function TimeEntryForm(props) {
 
   useEffect(() => {
     if (isOpen) {
+      setEditorKey(prev => prev + 1);
       setActualDate(null);
       getActualDate();
     }
@@ -826,6 +828,7 @@ function TimeEntryForm(props) {
                   }}
                 >
                   <Editor
+                    key={editorKey}
                     tinymceScriptSrc="/tinymce/tinymce.min.js"
                     init={TINY_MCE_INIT_OPTIONS}
                     id="notes"


### PR DESCRIPTION
# Description
Fixes a production-only bug where the TinyMCE notes editor in the Time Entry modal becomes unresponsive after the modal is closed and reopened. The editor accepts input on first open but locks up on subsequent opens without a page refresh.

## Related PRS (if any):
None

## Main changes explained:
- Update TimeEntryForm.jsx to add an editorKey state that increments each time the modal opens, forcing TinyMCE to fully unmount and remount its editor instance on each open

## How to test:
1. Check out current branch
2. Run npm install and npm run start:local
3. Log in as any user
4. Open the Time Entry modal (e.g. via the Timer)
5. Select a project, attempt to type in the Notes field — verify it works
6. Close the modal and reopen it
7. Select a project again and attempt to type in the Notes field — verify it still works
8. Repeat steps 6–7 a few more times to confirm consistent behavior

## Note:
This bug was reported and verified on a specific user account in production. The root cause is TinyMCE's editor instance becoming stale after modal close — it reuses a detached DOM instance instead of reinitializing. The key prop fix is a standard React pattern for forcing clean remounts and is safe to ship.