### PR TITLE
Mahitha - Fix badges earned notification logic and restore badges UI layout

### DIFF
--- a/src/components/Badge/Badge.module.css
+++ b/src/components/Badge/Badge.module.css
@@ -93,8 +93,8 @@
 .new_badges {
   display: flex;
   flex-wrap: wrap;
-  overflow-y: auto;
-  height: 70px;
+  overflow-y: scroll;
+  height: 120px;
 }
 
 .old_badges {

--- a/src/components/Badge/BadgeHistory.jsx
+++ b/src/components/Badge/BadgeHistory.jsx
@@ -1,5 +1,6 @@
 import BadgeImage from './BadgeImage';
 import { WEEK_DIFF } from '../../constants/badge';
+import styles from './Badge.module.css';
 
 function BadgeHistory({ badges, personalBestMaxHrs }) {
   const filterBadges = allBadges => {
@@ -31,7 +32,7 @@ function BadgeHistory({ badges, personalBestMaxHrs }) {
   const filteredBadges = filterBadges(badges);
 
   return (
-    <div className="badge_history_container">
+    <div className={styles.badge_history_container}>
       {filteredBadges.map((value, index) =>
         value && value.badge ? (
           <BadgeImage

--- a/src/components/Badge/NewBadges.jsx
+++ b/src/components/Badge/NewBadges.jsx
@@ -1,7 +1,7 @@
 import { Card, CardTitle, CardBody, UncontrolledTooltip } from 'reactstrap';
 import BadgeImage from './BadgeImage';
 import { WEEK_DIFF } from '../../constants/badge';
-import './Badge.module.css';
+import styles from './Badge.module.css';
 
 function NewBadges(props) {
   const filterBadges = allBadges => {
@@ -50,7 +50,8 @@ function NewBadges(props) {
           >
             New Badges Earned <i className="fa fa-info-circle" id="NewBadgeInfo" />
           </CardTitle>
-          <div className={`new_badges ${props.darkMode ? 'text-light' : ''}`}>
+
+          <div className={`${styles.new_badges} ${props.darkMode ? 'text-light' : ''}`}>
             {filteredBadges.length === 0 ? (
               <strong
                 style={{ opacity: 0.7 }}
@@ -76,6 +77,7 @@ function NewBadges(props) {
           </div>
         </CardBody>
       </Card>
+
       <UncontrolledTooltip
         placement="right"
         target="NewBadgeInfo"

--- a/src/components/UserProfile/Badge.module.css
+++ b/src/components/UserProfile/Badge.module.css
@@ -84,7 +84,10 @@
 }
 
 .old_badges {
-  height: 220px;
+  display: flex;
+  flex-wrap: wrap;
+  overflow-y: scroll;
+  height: 70px;
 }
 
 .badge_featured_container {


### PR DESCRIPTION

<img width="783" height="319" alt="Screenshot 2026-06-24 at 11 08 30 PM" src="https://github.com/user-attachments/assets/3b58aee7-fa21-44d8-93f5-aed306121173" />
<img width="830" height="657" alt="Screenshot 2026-06-24 at 11 08 41 PM" src="https://github.com/user-attachments/assets/c7eaaa59-ef01-400f-8eb0-d098edd90a18" />

# Description
Fix Badges Earned notification behavior and restore Badges section formatting.

## Related PRs (if any):

N/A

## Main changes explained:

* Fixed badge notification count behavior.
* Added notification dismissal and persistence after refresh.
* Restored badge layout and count positioning in the Badges section.

## How to test:

1. Checkout this branch.
2. Run the application locally.
3. Clear browser cache/site data.
4. Log in as an admin user.
5. Navigate to User Profile.
6. Assign yourself a badge and click **Confirm**.
7. Go to the Dashboard and verify the badge icon displays a notification count.
8. Click the badge icon and verify it navigates to the Badges tab.
9. Verify the notification count is cleared.
10. Refresh the page and verify the notification count remains cleared.
11. Verify the badge layout matches the expected design.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/58786d19-fc85-4271-9f25-4c30cbedbfce

## Note:

* Clicking the badge notification clears the dashboard notification count.
* Badge counts and formatting in the Badges section remain visible and are displayed in the restored layout.
