### PR TITLE
Sphurthy-added dark mode

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -26,9 +26,13 @@ button {
 
 
 
-/* Dark mode override for #root */
-body.dark-mode #root,
-body.bm-dashboard-dark #root {
+/* Dark mode override for #root (wrapped in :global so the scoped CSS module
+   does not hash the body class / #root id and break the real-DOM match).
+   body is darkened too so no white shows below #root when content is short. */
+:global(body.dark-mode),
+:global(body.bm-dashboard-dark),
+:global(body.dark-mode #root),
+:global(body.bm-dashboard-dark #root) {
   background-color: #1a1d23 !important;
 }
 

--- a/src/components/BMDashboard/AddConsumable/AddConsumable.jsx
+++ b/src/components/BMDashboard/AddConsumable/AddConsumable.jsx
@@ -150,9 +150,12 @@ function AddConsumable({ toggle }) {
   }
 
   return (
-    <Container fluid className={`${styles.consumableContainer}`}>
+    <Container
+      fluid
+      className={`${styles.consumableContainer} ${darkMode ? styles.consumableContainerDark : ''}`}
+    >
       <div className={`${styles.consumablePage} ${darkMode ? styles.darkBg : ''}`}>
-        <div className={`${styles.consumable} ${darkMode ? styles.lightBg : ''}`}>
+        <div className={`${styles.consumable} ${darkMode ? styles.consumableCardDark : ''}`}>
           <div className={`${styles.consumableTitle}`}>ADD CONSUMABLES FORM</div>
           <Card>
             <CardBody>

--- a/src/components/BMDashboard/AddConsumable/AddConsumable.module.css
+++ b/src/components/BMDashboard/AddConsumable/AddConsumable.module.css
@@ -62,11 +62,53 @@
 }
 
 .darkBg{
-  background-color: #2E5061;
+  background-color: #1b2a41;
 }
 
 .lightBg{
   background-color: #607D8B;
+}
+
+.consumableContainerDark {
+  background-color: #1b2a41;
+}
+
+.consumableCardDark {
+  background-color: #2e5061;
+  color: #fff;
+}
+
+.consumableCardDark .consumableTitle {
+  color: #fff;
+}
+
+.consumableCardDark :global(.card) {
+  background-color: #2e5061;
+  border-color: #3a506b;
+}
+
+.consumableCardDark :global(.card-body) {
+  background-color: #2e5061;
+  color: #fff;
+}
+
+.consumableCardDark :global(.form-control) {
+  background-color: #2a3f5f;
+  border-color: #3a506b;
+  color: #fff;
+}
+
+.consumableCardDark :global(.form-control):disabled {
+  background-color: #14233a;
+  color: #b0b8c4;
+}
+
+.consumableCardDark :global(.form-control)::placeholder {
+  color: #b0b8c4;
+}
+
+.consumableCardDark :global(.form-check-label) {
+  color: #fff;
 }
 
 .select :global(.rs__control) {

--- a/src/components/BMDashboard/AddMaterial/AddMaterial.module.css
+++ b/src/components/BMDashboard/AddMaterial/AddMaterial.module.css
@@ -67,7 +67,18 @@ font-size: .8em;
   gap: 0.5rem;
   width: 100%;
   margin-top: 1rem;
-  
+
+}
+
+/* The uploaded-image preview had no bounds and rendered at full natural size;
+   cap it to a thumbnail. (.file-preview is a plain global class on each item.) */
+.filePreviewContainer :global(.file-preview) img {
+  width: auto;
+  height: auto;
+  max-width: 120px;
+  max-height: 120px;
+  object-fit: contain;
+  border-radius: 4px;
 }
 
 .materialFormError {

--- a/src/components/BMDashboard/AddTeamMember/AddTeamMember.jsx
+++ b/src/components/BMDashboard/AddTeamMember/AddTeamMember.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import Select from 'react-select';
 import { MdOutlinePersonAddAlt1 } from 'react-icons/md';
 import { toast } from 'react-toastify';
@@ -7,6 +8,7 @@ import { ENDPOINTS } from '~/utils/URL';
 import styles from './AddTeamMember.module.css';
 
 function AddTeamMember() {
+  const darkMode = useSelector(state => state.theme.darkMode);
   const initialState = {
     firstName: '',
     lastName: '',
@@ -21,6 +23,42 @@ function AddTeamMember() {
   };
 
   const [formData, setFormData] = useState(initialState);
+
+  const darkSelectStyles = darkMode
+    ? {
+        control: base => ({
+          ...base,
+          backgroundColor: '#2a3f5f',
+          borderColor: '#3a506b',
+          color: '#fff',
+        }),
+        menu: base => ({
+          ...base,
+          backgroundColor: '#2a3f5f',
+        }),
+        menuList: base => ({
+          ...base,
+          backgroundColor: '#2a3f5f',
+        }),
+        option: (base, state) => ({
+          ...base,
+          backgroundColor: state.isSelected || state.isFocused ? '#3a506b' : '#2a3f5f',
+          color: '#fff',
+        }),
+        singleValue: base => ({
+          ...base,
+          color: '#fff',
+        }),
+        input: base => ({
+          ...base,
+          color: '#fff',
+        }),
+        placeholder: base => ({
+          ...base,
+          color: '#b0b8c4',
+        }),
+      }
+    : undefined;
 
   const optionsRole = [
     { value: 'carpenter', label: 'Carpenter' },
@@ -138,7 +176,7 @@ function AddTeamMember() {
   };
 
   return (
-    <div className={`${styles.containerAdd}`}>
+    <div className={`${styles.containerAdd} ${darkMode ? styles.containerAddDark : ''}`}>
       <div className={`${styles.iconAddPerson}`}>
         <MdOutlinePersonAddAlt1 size={90} />
         <h1 className={`${styles.titleMember}`}>Create new team member</h1>
@@ -192,6 +230,7 @@ function AddTeamMember() {
               value={formData.role}
               onChange={option => handleSelectChange(option, 'role')}
               className={formData.errors.role ? 'error' : ''}
+              styles={darkSelectStyles}
             />
             Roles
           </label>
@@ -231,6 +270,7 @@ function AddTeamMember() {
               value={formData.team}
               onChange={option => handleSelectChange(option, 'team')}
               className={formData.errors.team ? 'error' : ''}
+              styles={darkSelectStyles}
             />
             Teams
           </label>
@@ -280,6 +320,7 @@ function AddTeamMember() {
             value={countryCodes.find(code => code.value === formData.countryCode)}
             onChange={option => handleSelectChange(option, 'countryCode')}
             className={`${styles.countryCodeSelect}`}
+            styles={darkSelectStyles}
           />
           <input
             type="tel"

--- a/src/components/BMDashboard/AddTeamMember/AddTeamMember.module.css
+++ b/src/components/BMDashboard/AddTeamMember/AddTeamMember.module.css
@@ -164,3 +164,34 @@
     font-size: 12px;
     margin-top: 5px;
 }
+
+/* Dark Mode */
+.containerAddDark {
+    background-color: #1b2a41;
+    color: #fff;
+}
+
+.containerAddDark .iconAddPerson,
+.containerAddDark label,
+.containerAddDark .inputName label,
+.containerAddDark .roleInput label,
+.containerAddDark .teamInput label,
+.containerAddDark .contactInfo label {
+    color: #fff;
+}
+
+.containerAddDark input {
+    background-color: #2a3f5f;
+    border: 1px solid #3a506b;
+    color: #fff;
+}
+
+.containerAddDark input::placeholder {
+    color: #b0b8c4;
+}
+
+.containerAddDark .cancelButton {
+    background-color: #2e5061;
+    border-color: #3a506b;
+    color: #fff;
+}

--- a/src/components/BMDashboard/BMTimeLogger/BMTimeLogCard.jsx
+++ b/src/components/BMDashboard/BMTimeLogger/BMTimeLogCard.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { Container, Row, Col, InputGroup, Input } from 'reactstrap';
 import { useSelector, useDispatch } from 'react-redux';
 import BMError from '../shared/BMError';
@@ -145,5 +146,15 @@ function BMTimeLogCard(props) {
     </Container>
   );
 }
+
+BMTimeLogCard.propTypes = {
+  darkMode: PropTypes.bool,
+  selectedProject: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+BMTimeLogCard.defaultProps = {
+  darkMode: false,
+  selectedProject: null,
+};
 
 export default BMTimeLogCard;

--- a/src/components/BMDashboard/BMTimeLogger/BMTimeLogCard.jsx
+++ b/src/components/BMDashboard/BMTimeLogger/BMTimeLogCard.jsx
@@ -5,8 +5,10 @@ import BMError from '../shared/BMError';
 import { fetchBMProjectMembers } from '../../../actions/bmdashboard/projectMemberAction';
 import BMTimeLogDisplayMember from './BMTimeLogDisplayMember';
 import BMTimeLogSummary from './BMTimeLogSummary';
+import styles from './BMTimeLogCard.module.css';
 
 function BMTimeLogCard(props) {
+  const darkMode = props.darkMode ?? false;
   const [isError, setIsError] = useState(false);
   const [memberList, setMemberList] = useState([]);
   const [isMemberFetched, setIsMemberFetched] = useState(false);
@@ -87,9 +89,9 @@ function BMTimeLogCard(props) {
   };
 
   return (
-    <Container fluid>
+    <Container fluid className={darkMode ? styles.darkMode : ''}>
       {/* Time Log Summary Section */}
-      <BMTimeLogSummary projectId={props.selectedProject} />
+      <BMTimeLogSummary projectId={props.selectedProject} darkMode={darkMode} />
 
       {isMemberFetched && (
         <>

--- a/src/components/BMDashboard/BMTimeLogger/BMTimeLogCard.module.css
+++ b/src/components/BMDashboard/BMTimeLogger/BMTimeLogCard.module.css
@@ -213,3 +213,95 @@
 font-size: 0.875em;
 margin-top:3px;
 }
+
+/* Dark mode via Redux-driven conditional class on the card container */
+.darkMode {
+  background-color: #1b2a41;
+  color: #fff;
+}
+
+/* Search input inside the card in dark mode */
+.darkMode :global(input.form-control) {
+  background-color: #2a3f5f;
+  border-color: #3a506b;
+  color: #fff;
+}
+
+.darkMode :global(input.form-control)::placeholder {
+  color: #b7c4d4;
+}
+
+/* Muted helper text (e.g. "Found X out of Y members") on the dark container */
+.darkMode :global(.text-muted) {
+  color: #b7c4d4 !important;
+}
+
+/* Member card in dark mode (header keeps its role color; body goes dark) */
+.memberCardDark {
+  background-color: #2e5061;
+  color: #fff;
+}
+
+.memberCardDark :global(.card-body) {
+  background-color: #2e5061;
+  color: #fff;
+}
+
+/* "Start at:" time text (default gray) needs lightening on dark card */
+.memberCardDark .fontColorGray {
+  color: #cdd8e6;
+}
+
+/* Time Log Summary card + table in dark mode */
+.summaryCardDark {
+  background-color: #2e5061;
+  color: #fff;
+  border-color: #3a506b;
+}
+
+.summaryCardDark :global(.card-body) {
+  background-color: #2e5061;
+  color: #fff;
+}
+
+.summaryCardDark :global(table) {
+  color: #e0eaf5;
+}
+
+.summaryCardDark :global(table) th,
+.summaryCardDark :global(table) td {
+  color: #e0eaf5;
+  border-color: #3a506b;
+}
+
+/* Table header row: dark background + light text so the column labels
+   ("Member, Role, Start Time, ...") stay readable in dark mode.
+   Override bootstrap's --bs-table-color which otherwise forces dark header text. */
+.summaryCardDark :global(table) thead th {
+  background-color: #2f4157;
+  color: #e8edf4;
+  border-color: #3a506b;
+
+  --bs-table-color: #e8edf4;
+  --bs-table-bg: #2f4157;
+}
+
+/* Override bootstrap striped row background so rows stay dark */
+.summaryCardDark :global(.table-striped) > tbody > tr:nth-of-type(odd) > * {
+  background-color: #355a6e;
+  color: #e0eaf5;
+}
+
+.summaryCardDark :global(.table-striped) > tbody > tr:nth-of-type(even) > * {
+  background-color: #2e5061;
+  color: #e0eaf5;
+}
+
+.summaryCardDark :global(.table-hover) > tbody > tr:hover > * {
+  background-color: #3d6479;
+  color: #fff;
+}
+
+.summaryCardDark :global(.text-muted) {
+  color: #b7c4d4 !important;
+}

--- a/src/components/BMDashboard/BMTimeLogger/BMTimeLogDisplayMember.jsx
+++ b/src/components/BMDashboard/BMTimeLogger/BMTimeLogDisplayMember.jsx
@@ -1,9 +1,11 @@
+import { useSelector } from 'react-redux';
 import { CardHeader, Card } from 'reactstrap';
 import BMTimeLogStopWatch from './BMTimeLogStopWatch';
 import styles from './BMTimeLogCard.module.css';
 
 // function BMTimeLogCard({ selectedProject }) {
 function BMTimeLogDisplayMember({ firstName, lastName, role, memberId, projectId }) {
+  const darkMode = useSelector(state => state.theme.darkMode);
   const roleColors = {
     volunteer: '#78bdda', // light blue
     core: '#ecb16c', // light orange
@@ -19,7 +21,9 @@ function BMTimeLogDisplayMember({ firstName, lastName, role, memberId, projectId
   return (
     <div>
       <Card
-        className={`${styles.memberCard} rounded-8 mr-3 my-3`}
+        className={`${styles.memberCard} ${
+          darkMode ? styles.memberCardDark : ''
+        } rounded-8 mr-3 my-3`}
         style={{ border: borderProperty }}
       >
         <CardHeader className={`${styles.memberCardHeader}`} style={{ backgroundColor: cardColor }}>

--- a/src/components/BMDashboard/BMTimeLogger/BMTimeLogSummary.jsx
+++ b/src/components/BMDashboard/BMTimeLogger/BMTimeLogSummary.jsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { getAllProjectTimeLogs } from '../../../actions/bmdashboard/timeLoggerActions';
 import styles from './BMTimeLogCard.module.css';
 
-function BMTimeLogSummary({ projectId }) {
+function BMTimeLogSummary({ projectId, darkMode = false }) {
   const dispatch = useDispatch();
   const allProjectTimeLogs = useSelector(
     state => state.bmTimeLogger?.allProjectTimeLogs?.[projectId] || [],
@@ -74,7 +74,7 @@ function BMTimeLogSummary({ projectId }) {
 
   if (completedTimeLogs.length === 0) {
     return (
-      <Card className="my-4">
+      <Card className={`my-4 ${darkMode ? styles.summaryCardDark : ''}`}>
         <CardHeader className="bg-primary text-white">
           <h5 className="mb-0">Time Log Summary</h5>
         </CardHeader>
@@ -88,7 +88,7 @@ function BMTimeLogSummary({ projectId }) {
   }
 
   return (
-    <Card className="my-4">
+    <Card className={`my-4 ${darkMode ? styles.summaryCardDark : ''}`}>
       <CardHeader className="bg-primary text-white">
         <h5 className="mb-0">Time Log Summary</h5>
       </CardHeader>

--- a/src/components/BMDashboard/BMTimeLogger/BMTimeLogSummary.jsx
+++ b/src/components/BMDashboard/BMTimeLogger/BMTimeLogSummary.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import { Card, CardHeader, CardBody, Table } from 'reactstrap';
 import moment from 'moment';
@@ -127,5 +128,15 @@ function BMTimeLogSummary({ projectId, darkMode = false }) {
     </Card>
   );
 }
+
+BMTimeLogSummary.propTypes = {
+  projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  darkMode: PropTypes.bool,
+};
+
+BMTimeLogSummary.defaultProps = {
+  projectId: null,
+  darkMode: false,
+};
 
 export default BMTimeLogSummary;

--- a/src/components/BMDashboard/BMTimeLogger/BMTimeLogger.jsx
+++ b/src/components/BMDashboard/BMTimeLogger/BMTimeLogger.jsx
@@ -13,6 +13,7 @@ function BMTimeLogger() {
   const [selectedProject, setselectedProject] = useState(null);
 
   const dispatch = useDispatch();
+  const darkMode = useSelector(state => state.theme.darkMode);
   const errors = useSelector(state => state.errors);
   const projects = useSelector(state => state.bmProjects);
   // fetch projects data on pageload
@@ -28,7 +29,7 @@ function BMTimeLogger() {
   }, [errors]);
 
   return (
-    <Container className="justify-content-center">
+    <Container className={`justify-content-center ${darkMode ? styles.darkMode : ''}`}>
       <header className={`${styles.bmTimelogger_header}`}>
         <Row className="mx-auto">
           <h1>Member Group Check In</h1>
@@ -62,7 +63,7 @@ function BMTimeLogger() {
         </Col>
       </Row>
 
-      {selectedProject && <BMTimeLogCard selectedProject={selectedProject} />}
+      {selectedProject && <BMTimeLogCard selectedProject={selectedProject} darkMode={darkMode} />}
       {isError && <BMError errors={errors} />}
     </Container>
   );

--- a/src/components/BMDashboard/BMTimeLogger/BMTimeLogger.module.css
+++ b/src/components/BMDashboard/BMTimeLogger/BMTimeLogger.module.css
@@ -5,6 +5,32 @@
   margin-top: 2em;
 }
 
+/* Dark mode via Redux-driven conditional class on the root container */
+.darkMode {
+  background-color: #1b2a41;
+  color: #fff;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.darkMode .bmTimelogger_header h1 {
+  color: #fff;
+}
+
+/* Plain text labels (e.g. "Date:", "Project:") that otherwise keep a dark color */
+.darkMode p,
+.darkMode :global(.col),
+.darkMode label {
+  color: #e8edf4;
+}
+
+/* Project select dropdown in dark mode */
+.darkMode :global(#projectSelect) {
+  background-color: #2a3f5f;
+  border-color: #3a506b;
+  color: #fff;
+}
+
 .bmDashboard_button.btn.btnSecondary {
   background-color: #2e5061;
 }

--- a/src/components/BMDashboard/ConsumablePurchaseRequest/PurchaseConsumable.jsx
+++ b/src/components/BMDashboard/ConsumablePurchaseRequest/PurchaseConsumable.jsx
@@ -10,6 +10,7 @@ import styles from './PurchaseConsumable.module.css';
 export default function PurchaseConsumable() {
   const dispatch = useDispatch();
   const errors = useSelector(state => state.errors);
+  const darkMode = useSelector(state => state.theme.darkMode);
   const [isError, setIsError] = useState(false);
 
   useEffect(() => {
@@ -35,7 +36,7 @@ export default function PurchaseConsumable() {
   }
 
   return (
-    <main className={`${styles.purchaseConsumableContainer}`}>
+    <main className={`${styles.purchaseConsumableContainer} ${darkMode ? styles.darkMode : ''}`}>
       <header className={`${styles.purchaseConsumableHeader}`}>
         <h2>Purchase Request: Consumables</h2>
         <div className="inv-form-info">

--- a/src/components/BMDashboard/ConsumablePurchaseRequest/PurchaseConsumable.module.css
+++ b/src/components/BMDashboard/ConsumablePurchaseRequest/PurchaseConsumable.module.css
@@ -17,3 +17,42 @@
         width: 95%;
     }
 }
+
+/* Dark mode container/header backgrounds */
+.darkMode.purchaseConsumableContainer {
+    background-color: #1b2a41;
+    border-color: #3a506b;
+    color: #ffffff;
+}
+
+.darkMode .purchaseConsumableHeader {
+    background-color: #1b2a41;
+    color: #ffffff;
+}
+
+.darkMode .purchaseConsumableHeader h2,
+.darkMode :global(.inv-form-info),
+.darkMode :global(label) {
+    color: #e0eaf5;
+}
+
+/* Inner PurchaseForm uses global/bootstrap classes (no module classes),
+   so reach its controls via descendant :global selectors. */
+.darkMode :global(.form-control) {
+    background-color: #2a3f5f;
+    border-color: #3a506b;
+    color: #ffffff;
+}
+
+.darkMode :global(.form-control)::placeholder {
+    color: #b8c5d1;
+}
+
+.darkMode :global(select.form-control) {
+    appearance: none;
+}
+
+.darkMode :global(option) {
+    background-color: #2a3f5f;
+    color: #ffffff;
+}

--- a/src/components/BMDashboard/Equipment/Add/AddEquipmentType.jsx
+++ b/src/components/BMDashboard/Equipment/Add/AddEquipmentType.jsx
@@ -9,6 +9,7 @@ import AddTypeForm from './AddTypeForm';
 
 export default function AddEquipmentType() {
   const errors = useSelector(state => state.errors);
+  const darkMode = useSelector(state => state.theme.darkMode);
   const [isError, setIsError] = useState(false);
   const [modal, setModal] = useState(false);
 
@@ -32,7 +33,10 @@ export default function AddEquipmentType() {
       <CheckTypesModal modal={modal} setModal={setModal} type="Equipments" />
       <header>
         <h2>Add Type: Equipment</h2>
-        <div className={`${styles.invFormInfo}`}>
+        <div
+          className={`${styles.invFormInfo}`}
+          style={darkMode ? { color: '#b7c4d4' } : undefined}
+        >
           <BsInfoCircle />
           Add a new type of equipment so it can be purchased and used in projects
         </div>

--- a/src/components/BMDashboard/Equipment/Detail/EquipmentDetail.jsx
+++ b/src/components/BMDashboard/Equipment/Detail/EquipmentDetail.jsx
@@ -112,6 +112,7 @@ function EquipmentDetail() {
   const { equipmentId } = useParams();
   const dispatch = useDispatch();
 
+  const darkMode = useSelector(state => state.theme.darkMode);
   const equipment = useSelector(state => state.bmEquipments.singleEquipment);
   const { loading: updateLoading } = useSelector(state => state.bmEquipments.updateEquipment);
   const projects = useSelector(state => state.bmProjects);
@@ -430,7 +431,9 @@ function EquipmentDetail() {
 
   return (
     <Container
-      className={`${styles.equipmentDetailPage} justify-content-center align-items-center mw-80 px-4`}
+      className={`${styles.equipmentDetailPage} ${
+        darkMode ? styles.darkMode : ''
+      } justify-content-center align-items-center mw-80 px-4`}
     >
       <header className={styles.equipmentDetailPageHeader}>
         <h1>Equipment Detail Page</h1>

--- a/src/components/BMDashboard/Equipment/Detail/EquipmentDetailPage.module.css
+++ b/src/components/BMDashboard/Equipment/Detail/EquipmentDetailPage.module.css
@@ -246,3 +246,66 @@ button.descriptionItem_button:hover {
   color: #e0eaf5 !important;
   border-color: #e0eaf5 !important;
 }
+
+/* Dark mode via Redux-driven conditional class on the root container */
+.darkMode {
+  background-color: #1b2a41;
+  color: #e0eaf5;
+}
+
+.darkMode .equipmentDetailPageHeader h1 {
+  color: #fff;
+}
+
+.darkMode .equipmentDetailPageContent {
+  background-color: #2e5061;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.darkMode :global(.EquipmentDetailPage__detail_item) {
+  color: #e0eaf5;
+}
+
+.darkMode :global(.EquipmentDetailPage__span) {
+  background-color: #2a3f5f;
+  border-color: #3a506b;
+  color: #fff;
+}
+
+.darkMode :global(.EquipmentDetailPage__dashed_line) {
+  border-color: #5a6d7a;
+}
+
+.darkMode button.descriptionItem_button {
+  color: #74c0fc;
+}
+
+.darkMode .editableSection {
+  background-color: #14233a;
+  border-color: #3a506b;
+}
+
+.darkMode .editableFieldLabel,
+.darkMode .radioLabel {
+  color: #d0dbe8;
+}
+
+.darkMode .editableFieldInput,
+.darkMode .editableField select {
+  background-color: #2a3f5f;
+  border-color: #3a506b;
+  color: #e0eaf5;
+}
+
+.darkMode .editableField select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='%23e0eaf5'%3E%3Cpath d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+}
+
+.darkMode .backBtn {
+  color: #e0eaf5 !important;
+  border-color: #e0eaf5 !important;
+}

--- a/src/components/BMDashboard/Equipment/List/EquipmentListModal.jsx
+++ b/src/components/BMDashboard/Equipment/List/EquipmentListModal.jsx
@@ -1,9 +1,27 @@
 import { Modal, ModalHeader, ModalBody, ModalFooter, Button, Table } from 'reactstrap';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import styles from './Equipments.module.css';
 
+/* Dark-mode styling for the (portal-rendered) modal. Neutralizes the global
+   theme's "body.bm-dashboard-dark .modal-title { filter: invert(1) }" and gives
+   the table light cell text (bootstrap's --bs-table-color otherwise forces dark). */
+const DARK_MODAL_STYLE = `
+  .dark-oxford-modal { background-color: #1b2a41 !important; color: #ffffff !important; }
+  .dark-oxford-modal .modal-header,
+  .dark-oxford-modal .modal-body,
+  .dark-oxford-modal .modal-footer { background-color: #1b2a41 !important; color: #ffffff !important; border-color: rgba(255,255,255,0.08) !important; }
+  .dark-oxford-modal .modal-title { color: #ffffff !important; filter: none !important; }
+  .dark-oxford-modal table { --bs-table-color: #e8edf4; --bs-table-bg: transparent; }
+  .dark-oxford-modal thead th { background-color: #24344d !important; color: #ffffff !important; border-color: #334155 !important; }
+  .dark-oxford-modal tbody td, .dark-oxford-modal tbody th { color: #e8edf4 !important; border-color: #334155 !important; }
+  .dark-oxford-modal a:not(.btn) { color: #74b6ff !important; }
+`;
+
 function EquipmentListModal({ modal, setModal, record, recordType }) {
+  const darkMode = useSelector(state => state.theme.darkMode);
+
   if (!record) return null;
 
   const toggle = () => setModal(false);
@@ -16,7 +34,13 @@ function EquipmentListModal({ modal, setModal, record, recordType }) {
     }[recordType] || '';
 
   return (
-    <Modal isOpen={modal} size="xl" className={styles.ModalViewContainer}>
+    <Modal
+      isOpen={modal}
+      size="xl"
+      className={styles.ModalViewContainer}
+      contentClassName={darkMode ? 'dark-oxford-modal' : ''}
+    >
+      {darkMode && <style>{DARK_MODAL_STYLE}</style>}
       <ModalHeader>Equipments &nbsp;{headerTitle}</ModalHeader>
 
       <ModalBody>

--- a/src/components/BMDashboard/Equipment/List/Equipments.module.css
+++ b/src/components/BMDashboard/Equipment/List/Equipments.module.css
@@ -452,6 +452,39 @@ body.bm-dashboard-dark .PageViewContainer {
   background-color: #0a0a0a;
 }
 
+/* ---------------------------------------------------------------------------
+   WORKING dark-mode overrides.
+   useTheme() adds `dark-mode` / `bm-dashboard-dark` to <body>. The bare
+   `body.dark-mode` / `body.bm-dashboard-dark` selectors above are SCOPED/HASHED
+   by the CSS-module pipeline (the `.dark-mode` part gets a hash appended), so
+   they never match the real body class and are DEAD. The `:global(...)`
+   selectors below keep the body class literal while still hashing the local
+   class names, so they actually apply.
+--------------------------------------------------------------------------- */
+
+/* Page heading "EQUIPMENTS" -> light text */
+:global(.dark-mode) .BuildingTitle,
+:global(.bm-dashboard-dark) .BuildingTitle {
+  color: #e8edf4;
+  border-bottom-color: #4dabf7;
+}
+
+/* reactstrap <Table> sets --bs-table-color (#212529) on cells, which overrides
+   the inherited light text and makes body rows dark-on-dark. Override the
+   Bootstrap table CSS vars so every cell renders light. */
+:global(.dark-mode) .tableWrapper table,
+:global(.bm-dashboard-dark) .tableWrapper table {
+  --bs-table-color: #e8edf4;
+  --bs-table-bg: transparent;
+  --bs-table-border-color: #2f4157;
+}
+
+/* Defensive explicit cell text color (header row stays styled by its own th rule) */
+:global(.dark-mode) .tableWrapper tbody td,
+:global(.bm-dashboard-dark) .tableWrapper tbody td {
+  color: #e8edf4;
+}
+
 /* Responsive Design */
 @media (width <= 768px) {
   .PageViewContainer {

--- a/src/components/BMDashboard/Issue/Issue.module.css
+++ b/src/components/BMDashboard/Issue/Issue.module.css
@@ -7,7 +7,53 @@
 }
 
 .darkModeIssueFormContainer{
+  margin: 0 auto;
+  width: 100%;
+  padding: 5px;
+  background-color: #1b2a41;
   color: white;
+}
+
+.darkModeIssueFormContainer .subTitleText {
+  color: #9fc3d6;
+}
+
+.darkModeIssueFormContainer .issueTitleText {
+  color: #fff;
+}
+
+/* Form controls (select, date, textarea, text inputs) in dark mode */
+.darkModeIssueFormContainer .issueFormOverrideCss {
+  background-color: #2a3f5f;
+  border-color: #3a506b;
+  color: #fff;
+}
+
+.darkModeIssueFormContainer .issueFormOverrideCss::placeholder {
+  color: #b7c4d4;
+}
+
+/* Brighten native date-picker indicator so it is visible on dark input */
+.darkModeIssueFormContainer .issueDateInput::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}
+
+/* Disabled "Other" textarea stays legible */
+.darkModeIssueFormContainer .issueFormOverrideCss:disabled {
+  background-color: #22344f;
+  color: #8fa3bd;
+}
+
+/* Character counter readable on dark background */
+.darkModeIssueFormContainer .characterCounterText {
+  color: #b7c4d4;
+}
+
+/* Cancel button: dark surface with light text in dark mode */
+.darkModeIssueFormContainer button.issueFormButtonCancel {
+  background-color: #14233a !important;
+  color: #9fc3d6 !important;
+  border-color: #9fc3d6 !important;
 }
 
 .redText {

--- a/src/components/BMDashboard/ItemList/ItemListView.module.css
+++ b/src/components/BMDashboard/ItemList/ItemListView.module.css
@@ -250,8 +250,20 @@ table td {
   padding-bottom: 2rem;
 }
 
+/* Bootstrap drives cell text via --bs-table-color (defaults to dark #212529),
+   which overrode the inherited light color and made rows unreadable in dark
+   mode. Override the table CSS variables so all cells render light. */
+.darkTable {
+  --bs-table-color: #e8edf4;
+  --bs-table-bg: transparent;
+  --bs-table-border-color: #2f4157;
+
+  color: #e8edf4;
+}
+
 .darkTable tbody td,
 .darkTable tbody th {
+  color: #e8edf4;
   border-color: #2f4157 !important;
 }
 

--- a/src/components/BMDashboard/ItemList/ItemListView.module.css
+++ b/src/components/BMDashboard/ItemList/ItemListView.module.css
@@ -53,6 +53,16 @@ table td {
   color: black;
 }
 
+/* The Usage Record / Updates / Purchases columns looked cramped: keep their
+   headers on one line and space the edit/view controls apart. */
+.itemsTableContainer thead th {
+  white-space: nowrap;
+}
+
+.itemsCell :global(.btn) {
+  margin-left: 8px;
+}
+
 
 .searchRow {
   display: flex;

--- a/src/components/BMDashboard/ItemList/RecordsModal.jsx
+++ b/src/components/BMDashboard/ItemList/RecordsModal.jsx
@@ -63,7 +63,7 @@ export default function RecordsModal({ modal, setModal, record, setRecord, recor
         contentClassName={darkMode ? 'dark-oxford-modal' : ''}
       >
         <ModalHeader className={darkMode ? 'dark-modal-header bg-space-cadet text-white' : ''}>
-          {recordType} Record
+          {recordType === 'UsageRecord' ? 'Usage' : recordType} Record
         </ModalHeader>
 
         <ModalBody className={darkMode ? 'dark-modal-body bg-yinmn-blue text-light' : ''}>
@@ -160,7 +160,7 @@ export function Record({ record, recordType, setRecord, itemType }) {
     }
   };
 
-  if (recordType === 'Update') {
+  if (recordType === 'Update' || recordType === 'UsageRecord') {
     return (
       <>
         <thead className={darkMode ? 'dark-thead bg-space-cadet text-white' : ''}>

--- a/src/components/BMDashboard/ItemList/RecordsModal.jsx
+++ b/src/components/BMDashboard/ItemList/RecordsModal.jsx
@@ -36,6 +36,23 @@ export default function RecordsModal({ modal, setModal, record, setRecord, recor
               color: #ffffff !important;
               border-color: rgba(255,255,255,0.08) !important;
             }
+            .dark-oxford-modal .modal-title {
+              color: #ffffff !important;
+              /* Neutralize the global theme's "body.bm-dashboard-dark .modal-title
+                 { filter: invert(1) }" which would flip this white title to black. */
+              filter: none !important;
+            }
+            .dark-oxford-modal .close {
+              color: #ffffff !important;
+              opacity: 1 !important;
+            }
+            .dark-oxford-modal,
+            .dark-oxford-modal table,
+            .dark-oxford-modal th,
+            .dark-oxford-modal td,
+            .dark-oxford-modal a:not(.btn) {
+              color: #ffffff !important;
+            }
           `}
         </style>
       )}

--- a/src/components/BMDashboard/ItemList/RecordsModal.module.css
+++ b/src/components/BMDashboard/ItemList/RecordsModal.module.css
@@ -129,6 +129,19 @@
   font-weight: bold;
 }
 
+/* Dark mode: the default status colors are too dark on the dark modal surface. */
+:global(.bm-dashboard-dark) .statusApproved {
+  color: #4ade80;
+}
+
+:global(.bm-dashboard-dark) .statusRejected {
+  color: #f87171;
+}
+
+:global(.bm-dashboard-dark) .statusPending {
+  color: #fbbf24;
+}
+
 .darkTable .stickyThead th {
   background-color: #2f4157;
   border-bottom: 1px solid #3f5269;

--- a/src/components/BMDashboard/ItemList/SelectForm.jsx
+++ b/src/components/BMDashboard/ItemList/SelectForm.jsx
@@ -4,6 +4,15 @@ import { useSelector } from 'react-redux';
 export default function SelectForm({ items, setSelectedProject, setSelectedItem }) {
   const darkMode = useSelector(state => state.theme.darkMode);
 
+  // In dark mode the native <select>/<option> default to a white background, which
+  // left the white option text invisible. Give them an explicit dark surface.
+  const darkControlStyle = darkMode
+    ? { color: 'white', backgroundColor: '#1e2632' }
+    : { color: 'inherit' };
+  const darkOptionStyle = darkMode
+    ? { color: 'white', backgroundColor: '#1e2632' }
+    : { color: 'inherit' };
+
   let projectsSet = [];
   if (items.length) {
     projectsSet = [...new Set(items.map(el => el.project?.name))];
@@ -26,21 +35,21 @@ export default function SelectForm({ items, setSelectedProject, setSelectedItem 
           type="select"
           onChange={handleChange}
           disabled={!items.length}
-          style={{ color: darkMode ? 'white' : 'inherit' }}
+          style={darkControlStyle}
         >
           {items.length ? (
             <>
-              <option value="all" style={{ color: darkMode ? 'white' : 'inherit' }}>
+              <option value="all" style={darkOptionStyle}>
                 All
               </option>
               {projectsSet.map(name => (
-                <option key={name} value={name} style={{ color: darkMode ? 'white' : 'inherit' }}>
+                <option key={name} value={name} style={darkOptionStyle}>
                   {name}
                 </option>
               ))}
             </>
           ) : (
-            <option style={{ color: darkMode ? 'white' : 'inherit' }}>No data</option>
+            <option style={darkOptionStyle}>No data</option>
           )}
         </Input>
       </FormGroup>

--- a/src/components/BMDashboard/LessonList/LessonCard.jsx
+++ b/src/components/BMDashboard/LessonList/LessonCard.jsx
@@ -79,7 +79,7 @@ function LessonCard({ filteredLessons, onEditLessonSummary, onDeliteLessonCard, 
     const { isLiked, totalLikes } = getLikeStatus(lesson._id);
 
     return (
-      <Card key={lesson._id} className={styles.lessonCard}>
+      <Card key={lesson._id} className={`${styles.lessonCard} ${darkMode ? styles.darkCard : ''}`}>
         <Card.Header
           onClick={() => toggleCardExpansion(lesson._id)}
           style={{ cursor: 'pointer' }}

--- a/src/components/BMDashboard/LessonList/LessonCard.module.css
+++ b/src/components/BMDashboard/LessonList/LessonCard.module.css
@@ -140,47 +140,48 @@
   color: #a00;
 }
 
-/* Responsive Layouts */
-@media (width <= 768px) {
-/* ================= DARK MODE (AFTER BASE) ================= */
+/* ================= DARK MODE (AFTER BASE) =================
+   These rules were previously trapped inside an `@media (width <= 768px)`
+   block (so they only applied on mobile) AND `.darkCard` was never put on the
+   card in the JSX. The card body/footer therefore used var(--module-text)
+   which resolves dark -> dark-on-dark. Now applied via a conditional class on
+   all screen sizes. The light-blue brand header is intentionally left intact. */
 
 .darkCard {
-  background-color: #1e1e1e !important;
-  color: #f5f5f5 !important;
-  border-color: #333 !important;
-}
-
-.darkCard .lessonCardHeader {
-  background-color: #2a2a2a !important;
-  color: #fff !important;
-  border-bottom: 1px solid #333 !important;
+  background-color: #1b2a41 !important;
+  border-color: #3a506b !important;
 }
 
 .darkCard .scrollableCardBody {
-  background-color: #1e1e1e !important;
-  color: #e6e6e6 !important;
+  background-color: #1b2a41 !important;
+  color: #e8edf4 !important;
 }
 
-.darkCard span,
-.darkCard p,
-.darkCard div {
-  color: #e6e6e6 !important;
+.darkCard .scrollableCardBody span,
+.darkCard .scrollableCardBody p,
+.darkCard .scrollableCardBody div {
+  color: #e8edf4 !important;
 }
 
-.darkCard .tagItem {
-  color: #bfbfbf !important;
+.darkCard .scrollableCardBody .tagItem {
+  color: #b7c4d4 !important;
 }
 
 .darkCard .lessonCardFooter {
-  background-color: #2a2a2a !important;
-  color: #ccc !important;
-  border-top: 1px solid #333 !important;
+  background-color: #14233a !important;
+  color: #cdd8e6 !important;
+  border-top: 1px solid #3a506b !important;
+}
+
+.darkCard .lessonCardFooter span,
+.darkCard .lessonCardFooter button {
+  color: #cdd8e6 !important;
 }
 
 .darkCard textarea.editable-lesson-summary {
-  background-color: #2a2a2a !important;
+  background-color: #2a3f5f !important;
   color: #fff !important;
-  border: 1px solid #555 !important;
+  border: 1px solid #3a506b !important;
 }
 
 .darkExpandLessons {
@@ -206,6 +207,7 @@
     height: auto;
     flex-direction: column;
   }
+
   .lessonCardFooterItems {
     justify-content: flex-start;
   }
@@ -215,6 +217,7 @@
   .formSelectContainer {
     flex-direction: column;
   }
+
   .cardFooter {
     font-size: small;
   }
@@ -238,6 +241,7 @@
   .nav {
     height: auto;
   }
+
   .tagItem {
     display: block;
     margin-top: 5px;
@@ -249,6 +253,7 @@
     flex-direction: column;
     align-items: flex-start;
   }
+
   .footerItemsActions {
     justify-content: flex-start;
   }
@@ -287,5 +292,4 @@
     display: block;
     margin-top: 5px;
   }
-}
 }

--- a/src/components/BMDashboard/PurchaseRequests/PurchaseForm.jsx
+++ b/src/components/BMDashboard/PurchaseRequests/PurchaseForm.jsx
@@ -413,7 +413,9 @@ function PurchaseForm({
         className={darkMode ? styles.darkModeModal : ''}
       >
         <ModalHeader toggle={() => setShowSuccessModal(false)}>
-          Request Submitted Successfully
+          <span style={darkMode ? { color: '#f1f5f9' } : undefined}>
+            Request Submitted Successfully
+          </span>
         </ModalHeader>
         <ModalBody>
           {submittedData && (

--- a/src/components/BMDashboard/PurchaseRequests/PurchaseForm.jsx
+++ b/src/components/BMDashboard/PurchaseRequests/PurchaseForm.jsx
@@ -29,6 +29,7 @@ function PurchaseForm({
 }) {
   const dispatch = useDispatch();
   const history = useHistory();
+  const darkMode = useSelector(state => state.theme.darkMode);
   const primaryData = useSelector(primaryDataSelector);
   const secondaryData = useSelector(secondaryDataSelector);
   const errors = useSelector(errorSelector);
@@ -233,7 +234,7 @@ function PurchaseForm({
   }
 
   return (
-    <main className={`${styles.purchaseRequestContainer}`}>
+    <main className={`${styles.purchaseRequestContainer} ${darkMode ? styles.darkMode : ''}`}>
       <header className={`${styles.purchaseHeader}`}>
         <h2>{formLabels.headerText}</h2>
         <p>{formLabels.headerSubText}</p>
@@ -406,7 +407,11 @@ function PurchaseForm({
       </Form>
 
       {/* Success Modal */}
-      <Modal isOpen={showSuccessModal} toggle={() => setShowSuccessModal(false)}>
+      <Modal
+        isOpen={showSuccessModal}
+        toggle={() => setShowSuccessModal(false)}
+        className={darkMode ? styles.darkModeModal : ''}
+      >
         <ModalHeader toggle={() => setShowSuccessModal(false)}>
           Request Submitted Successfully
         </ModalHeader>

--- a/src/components/BMDashboard/PurchaseRequests/PurchaseForm.module.css
+++ b/src/components/BMDashboard/PurchaseRequests/PurchaseForm.module.css
@@ -113,9 +113,58 @@
   }
 }
 
-:global(body.dark-mode) .purchaseRequestContainer select,
-:global(body.bm-dashboard-dark) .purchaseRequestContainer select {
+/* Dark mode container/panel backgrounds */
+.darkMode.purchaseRequestContainer {
+  background-color: #1b2a41;
+  border-color: #3a506b;
+  color: #ffffff;
+}
+
+.darkMode .purchaseHeader h2,
+.darkMode .purchaseHeader p,
+.darkMode label {
+  color: #e0eaf5;
+}
+
+.darkMode .purchaseForm input,
+.darkMode .purchaseForm textarea,
+.darkMode .purchaseForm select {
+  background-color: #2a3f5f;
+  border-color: #3a506b;
+  color: #ffffff;
+}
+
+.darkMode .purchaseForm input::placeholder,
+.darkMode .purchaseForm textarea::placeholder {
+  color: #b8c5d1;
+}
+
+.darkMode .purchaseForm option {
+  background-color: #2a3f5f;
+  color: #ffffff;
+}
+
+.darkMode .purchaseForm select {
   appearance: none;
 }
 
+/* Success modal (rendered in a portal, styled via its className prop) */
+.darkModeModal :global(.modal-content) {
+  background-color: #2e5061;
+  border-color: #3a506b;
+  color: #e0eaf5;
+}
+
+.darkModeModal :global(.modal-header),
+.darkModeModal :global(.modal-body),
+.darkModeModal :global(.modal-footer) {
+  background-color: #2e5061;
+  border-color: #3a506b;
+  color: #e0eaf5;
+}
+
+.darkModeModal :global(.modal-header) :global(.close) {
+  color: #e0eaf5;
+  text-shadow: none;
+}
 

--- a/src/components/BMDashboard/PurchaseRequests/PurchaseForm.module.css
+++ b/src/components/BMDashboard/PurchaseRequests/PurchaseForm.module.css
@@ -168,3 +168,27 @@
   text-shadow: none;
 }
 
+/* Force light text throughout the success popup so the body copy isn't dark-on-dark */
+.darkModeModal :global(.modal-body),
+.darkModeModal :global(.modal-body) p,
+.darkModeModal :global(.modal-body) strong {
+  color: #f1f5f9 !important;
+}
+
+/* The title is an <h5>; the global theme's `body.bm-dashboard-dark h5` rule
+   (with !important + a text-shadow) outranks a plain .modal-title selector and
+   left the heading dim/blurred. Scope through .modal-header to win on
+   specificity and drop the shadow so it matches the body text. */
+.darkModeModal :global(.modal-header) :global(.modal-title) {
+  color: #f1f5f9 !important;
+  text-shadow: none !important;
+}
+
+/* Pure red (#dc3545) is hard to read on the dark navy surface; brighten the
+   required-asterisk and error text in dark mode for adequate contrast. */
+.darkMode .requiredIndicator,
+.darkMode .fieldError,
+.darkMode .purchaseErrorMessage {
+  color: #f87171;
+}
+

--- a/src/components/BMDashboard/ToolItemList/ToolItemListView.module.css
+++ b/src/components/BMDashboard/ToolItemList/ToolItemListView.module.css
@@ -237,6 +237,19 @@
 /* DARK theme table */
 .darkTheme .itemsTableContainer {
   border: 1px solid #374151;
+
+  /* reactstrap <Table> sets --bs-table-color (#212529) on cells, which overrides
+     the inherited light text. Override the Bootstrap table CSS vars so all
+     body/header cell text is light and readable in dark mode. */
+  --bs-table-color: #e8edf4;
+  --bs-table-bg: transparent;
+  --bs-table-border-color: #374151;
+}
+
+/* Ensure cell text itself is light (defensive against --bs-table-color cascade) */
+.darkTheme .itemsTableContainer tbody td,
+.darkTheme .itemsTableContainer thead th {
+  color: #e8edf4;
 }
 
 .darkTheme .itemsTableContainer thead th {

--- a/src/components/BMDashboard/ToolItemList/ToolRecordsModal.jsx
+++ b/src/components/BMDashboard/ToolItemList/ToolRecordsModal.jsx
@@ -1,9 +1,27 @@
 import { Modal, ModalHeader, ModalBody, ModalFooter, Button, Table } from 'reactstrap';
+import { useSelector } from 'react-redux';
 import moment from 'moment';
 
 import styles from './ToolRecordsModal.module.css';
 
+/* Dark-mode styling for the (portal-rendered) modal. Neutralizes the global
+   theme's "body.bm-dashboard-dark .modal-title { filter: invert(1) }" and gives
+   the table light cell text (bootstrap's --bs-table-color otherwise forces dark). */
+const DARK_MODAL_STYLE = `
+  .dark-oxford-modal { background-color: #1b2a41 !important; color: #ffffff !important; }
+  .dark-oxford-modal .modal-header,
+  .dark-oxford-modal .modal-body,
+  .dark-oxford-modal .modal-footer { background-color: #1b2a41 !important; color: #ffffff !important; border-color: rgba(255,255,255,0.08) !important; }
+  .dark-oxford-modal .modal-title { color: #ffffff !important; filter: none !important; }
+  .dark-oxford-modal table { --bs-table-color: #e8edf4; --bs-table-bg: transparent; }
+  .dark-oxford-modal thead th { background-color: #24344d !important; color: #ffffff !important; border-color: #334155 !important; }
+  .dark-oxford-modal tbody td, .dark-oxford-modal tbody th { color: #e8edf4 !important; border-color: #334155 !important; }
+  .dark-oxford-modal a:not(.btn) { color: #74b6ff !important; }
+`;
+
 export default function RecordsModal({ modal, setModal, record, setRecord, recordType }) {
+  const darkMode = useSelector(state => state.theme.darkMode);
+
   if (record) {
     const toggle = () => {
       setModal(false);
@@ -11,19 +29,22 @@ export default function RecordsModal({ modal, setModal, record, setRecord, recor
     };
 
     return (
-      <Modal isOpen={modal} size="xl">
-        <ModalHeader>{recordType} Record</ModalHeader>
-        <ModalBody>
-          <div className={`${styles.recordsModalTableContainer}`}>
-            <Table>
-              <Record record={record} recordType={recordType} />
-            </Table>
-          </div>
-        </ModalBody>
-        <ModalFooter>
-          <Button onClick={toggle}>Close</Button>
-        </ModalFooter>
-      </Modal>
+      <>
+        {darkMode && <style>{DARK_MODAL_STYLE}</style>}
+        <Modal isOpen={modal} size="xl" contentClassName={darkMode ? 'dark-oxford-modal' : ''}>
+          <ModalHeader>{recordType} Record</ModalHeader>
+          <ModalBody>
+            <div className={`${styles.recordsModalTableContainer}`}>
+              <Table>
+                <Record record={record} recordType={recordType} />
+              </Table>
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <Button onClick={toggle}>Close</Button>
+          </ModalFooter>
+        </Modal>
+      </>
     );
   }
   return null;

--- a/src/components/BMDashboard/ToolPurchaseRequest/PurchaseForm.module.css
+++ b/src/components/BMDashboard/ToolPurchaseRequest/PurchaseForm.module.css
@@ -118,6 +118,44 @@
   margin: 0.5rem 0 0;
 }
 
+/* Form labels/help text (global elements inside module form) in dark mode */
+:global(body.dark-mode) .purchaseToolForm :global(label),
+:global(body.dark-mode) .purchaseToolForm :global(.form-text),
+:global(body.bm-dashboard-dark) .purchaseToolForm :global(label),
+:global(body.bm-dashboard-dark) .purchaseToolForm :global(.form-text) {
+  color: #e0eaf5;
+}
+
+/* Form inputs/selects (module classes) in dark mode */
+:global(body.dark-mode) .purchaseToolForm input,
+:global(body.dark-mode) .purchaseToolForm textarea,
+:global(body.dark-mode) .purchaseToolForm select,
+:global(body.bm-dashboard-dark) .purchaseToolForm input,
+:global(body.bm-dashboard-dark) .purchaseToolForm textarea,
+:global(body.bm-dashboard-dark) .purchaseToolForm select {
+  background-color: #2a3f5f;
+  border-color: #3a506b;
+  color: #ffffff;
+}
+
+:global(body.dark-mode) .purchaseToolForm input::placeholder,
+:global(body.dark-mode) .purchaseToolForm textarea::placeholder,
+:global(body.bm-dashboard-dark) .purchaseToolForm input::placeholder,
+:global(body.bm-dashboard-dark) .purchaseToolForm textarea::placeholder {
+  color: #b8c5d1;
+}
+
+:global(body.dark-mode) .purchaseToolForm select,
+:global(body.bm-dashboard-dark) .purchaseToolForm select {
+  appearance: none;
+}
+
+:global(body.dark-mode) .purchaseToolForm option,
+:global(body.bm-dashboard-dark) .purchaseToolForm option {
+  background-color: #2a3f5f;
+  color: #ffffff;
+}
+
 :global(body.dark-mode) .toolInsightPanel,
 :global(body.bm-dashboard-dark) .toolInsightPanel {
   border-color: rgb(71 85 105);

--- a/src/components/BMDashboard/ToolPurchaseRequest/PurchaseTool.jsx
+++ b/src/components/BMDashboard/ToolPurchaseRequest/PurchaseTool.jsx
@@ -13,6 +13,7 @@ import styles from './PurchaseTool.module.css';
 export default function PurchaseTool() {
   const dispatch = useDispatch();
   const errors = useSelector(state => state.errors);
+  const darkMode = useSelector(state => state.theme.darkMode);
   const [isError, setIsError] = useState(false);
 
   useEffect(() => {
@@ -39,7 +40,7 @@ export default function PurchaseTool() {
   }
 
   return (
-    <main className={`${styles.purchaseToolContainer}`}>
+    <main className={`${styles.purchaseToolContainer} ${darkMode ? styles.darkMode : ''}`}>
       <header className={`${styles.purchaseToolHeader}`}>
         <h2>Purchase Request: Tools</h2>
         <div className="inv-form-info">

--- a/src/components/BMDashboard/ToolPurchaseRequest/PurchaseTool.module.css
+++ b/src/components/BMDashboard/ToolPurchaseRequest/PurchaseTool.module.css
@@ -17,3 +17,20 @@
       width: 95%;
     }
   }
+
+  /* Dark mode container/header backgrounds */
+  .darkMode.purchaseToolContainer {
+    background-color: #1b2a41;
+    border-color: #3a506b;
+    color: #ffffff;
+  }
+
+  .darkMode .purchaseToolHeader {
+    background-color: #1b2a41;
+    color: #ffffff;
+  }
+
+  .darkMode .purchaseToolHeader h2,
+  .darkMode :global(.inv-form-info) {
+    color: #e0eaf5;
+  }

--- a/src/components/BMDashboard/Tools/AddTool.jsx
+++ b/src/components/BMDashboard/Tools/AddTool.jsx
@@ -1,9 +1,12 @@
+import { useSelector } from 'react-redux';
 import AddToolForm from './AddToolForm';
 import styles from './AddTool.module.css';
 
 export default function AddTool() {
+  const darkMode = useSelector(state => state.theme.darkMode);
+
   return (
-    <main className={`${styles.addToolContainer}`}>
+    <main className={`${styles.addToolContainer} ${darkMode ? styles.addToolContainerDark : ''}`}>
       <header className={`${styles.addToolHeader}`}>
         <h2>ADD TYPE: TOOL</h2>
       </header>

--- a/src/components/BMDashboard/Tools/AddTool.module.css
+++ b/src/components/BMDashboard/Tools/AddTool.module.css
@@ -8,6 +8,16 @@
   border-radius: 20px;
 }
 
+.addToolContainerDark {
+  border-color: #3a506b;
+  background-color: #1b2a41;
+  color: #fff;
+}
+
+.addToolContainerDark h2 {
+  color: #fff;
+}
+
 .addToolHeader h2{
  font-size: clamp(1.5rem, 2.5vw, 2.5rem);
  margin-left: 1rem;

--- a/src/components/BMDashboard/Tools/EquipmentUpdateForm.jsx
+++ b/src/components/BMDashboard/Tools/EquipmentUpdateForm.jsx
@@ -19,6 +19,7 @@ export default function EquipmentUpdateForm() {
   const [formData, setFormData] = useState(initialFormState);
   const [isFormValid, setIsFormValid] = useState(false);
   const dispatch = useDispatch();
+  const darkMode = useSelector(state => state.theme.darkMode);
   // Fetch dropdown data
   const projects = useSelector(state => state.bmProjects || []);
   const tools = useSelector(state => state.bmTools.toolslist || []);
@@ -99,7 +100,7 @@ export default function EquipmentUpdateForm() {
   };
 
   return (
-    <div className={styles.addToolForm}>
+    <div className={`${styles.addToolForm} ${darkMode ? styles.addToolFormDark : ''}`}>
       <Form onSubmit={handleSubmit}>
         <FormGroup>
           <Label for="project">

--- a/src/components/BMDashboard/Tools/EquipmentUpdateForm.module.css
+++ b/src/components/BMDashboard/Tools/EquipmentUpdateForm.module.css
@@ -13,6 +13,11 @@
   margin-bottom: 0.5rem;
 }
 
+.addToolFormDark {
+  background-color: #2e5061;
+  border-radius: 10px;
+}
+
 .addToolButtons {
   display: flex;
   justify-content: space-between;

--- a/src/components/BMDashboard/Tools/ToolDetailPage.jsx
+++ b/src/components/BMDashboard/Tools/ToolDetailPage.jsx
@@ -56,6 +56,7 @@ function ToolDetailPage() {
   const history = useHistory();
   const { toolId } = useParams();
 
+  const darkMode = useSelector(state => state.theme.darkMode);
   const tool = useSelector(state => state.tool);
 
   const dispatch = useDispatch();
@@ -164,7 +165,9 @@ function ToolDetailPage() {
 
   return (
     <Container
-      className={`${styles.toolDetailPage} justify-content-center align-items-center mw-80 px-4`}
+      className={`${styles.toolDetailPage} ${
+        darkMode ? styles.darkMode : ''
+      } justify-content-center align-items-center mw-80 px-4`}
     >
       <header className={`${styles.toolDetailPage_header}`}>
         <h1>Tool Detail Page</h1>

--- a/src/components/BMDashboard/Tools/ToolDetailPage.module.css
+++ b/src/components/BMDashboard/Tools/ToolDetailPage.module.css
@@ -38,8 +38,53 @@ button.descriptionItemButton:hover{
 }
 
 .toolDetailPage_dashedLine{
-  border-top: 1px dashed #000; 
+  border-top: 1px dashed #000;
   width: 50%;
   margin-top: 10px;
   margin-bottom: 10px;
+}
+
+/* Dark mode via Redux-driven conditional class on the root container */
+.darkMode {
+  background-color: #1b2a41;
+  color: #fff;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.darkMode .toolDetailPage_header h1 {
+  color: #fff;
+}
+
+.darkMode .toolDetailPage_dashedLine {
+  border-top-color: #5a6d7a;
+}
+
+.darkMode button.descriptionItemButton {
+  color: #74c0fc;
+}
+
+/* Content area becomes a readable card on the dark page */
+.darkMode :global(.ToolDetailPage__content) {
+  background-color: #2e5061;
+  border-radius: 8px;
+  padding: 1rem;
+  color: #fff;
+}
+
+.darkMode .toolDetailPage_detailItem {
+  color: #fff;
+}
+
+/* Span sits on the #2e5061 card; deepen it for contrast */
+.darkMode .toolDetailPage_span {
+  background-color: #14233a;
+  border-color: #3a506b;
+  color: #fff;
+}
+
+/* Back to List button readable on dark */
+.darkMode :global(.btn) {
+  color: #e0eaf5;
+  border-color: #e0eaf5;
 }

--- a/src/components/BMDashboard/Tools/ToolDetailPage.module.css
+++ b/src/components/BMDashboard/Tools/ToolDetailPage.module.css
@@ -19,9 +19,13 @@ margin-left: 1em;
 
 .toolDetailPage_image{
   border: 1px solid #e5e5e6;
-  border-radius: 5px; 
+  border-radius: 5px;
   width: 150px;
   height: auto;
+  /* Bound the rendered size so tall/large source images can't blow up the layout */
+  max-width: 150px;
+  max-height: 150px;
+  object-fit: contain;
 }
 
 .toolDetailPage_detailItem{

--- a/src/components/BMDashboard/UpdateMaterials/UpdateMaterialsBulk/UpdateMaterialsBulk.jsx
+++ b/src/components/BMDashboard/UpdateMaterials/UpdateMaterialsBulk/UpdateMaterialsBulk.jsx
@@ -1,5 +1,6 @@
 import { Container } from 'reactstrap';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import moment from 'moment';
 import UpdateMaterialsBulkTable from './UpdateMaterialsBulkTable';
 import UpdateMaterialsBulkInputs from './UpdateMaterialsBulkInputs';
@@ -8,10 +9,11 @@ import styles from './UpdateMaterialsBulk.module.css';
 function UpdateMaterialsBulk() {
   const [date, setDate] = useState(moment(new Date()).format('YYYY-MM-DD'));
   const [project, setProject] = useState('All Projects');
+  const darkMode = useSelector(state => state.theme.darkMode);
   return (
     <Container fluid className={`${styles.logMaterialContainer}`}>
-      <div className={`${styles.logMaterialPage}`}>
-        <div className={`${styles.logMaterial}`}>
+      <div className={`${styles.logMaterialPage} ${darkMode ? styles.logMaterialPageDark : ''}`}>
+        <div className={`${styles.logMaterial} ${darkMode ? styles.logMaterialDark : ''}`}>
           <div className={`${styles.logMaterialTitle}`}>MATERIAL DAILY ACTIVITIES UPDATE FORM</div>
           <UpdateMaterialsBulkInputs
             project={project}

--- a/src/components/BMDashboard/UpdateMaterials/UpdateMaterialsBulk/UpdateMaterialsBulk.module.css
+++ b/src/components/BMDashboard/UpdateMaterials/UpdateMaterialsBulk/UpdateMaterialsBulk.module.css
@@ -94,6 +94,20 @@
   color: #fff;
 }
 
+/* Bootstrap's row hover uses a light background; with white cell text that made
+   the hovered row unreadable. Force a dark highlight in dark mode. */
+.logMaterialDark .logMaterialTable {
+  --bs-table-hover-bg: #14233a;
+  --bs-table-hover-color: #fff;
+}
+
+.logMaterialDark .logMaterialTable tbody tr:hover > td,
+.logMaterialDark .logMaterialTable tbody tr:hover > th,
+.logMaterialDark .logMaterialTable tbody tr:focus-within > td {
+  background-color: #14233a !important;
+  color: #fff !important;
+}
+
 .logMaterialDark .logMTableHeaderLine {
   background-color: #14233a;
   border-bottom-color: #3a506b;

--- a/src/components/BMDashboard/UpdateMaterials/UpdateMaterialsBulk/UpdateMaterialsBulk.module.css
+++ b/src/components/BMDashboard/UpdateMaterials/UpdateMaterialsBulk/UpdateMaterialsBulk.module.css
@@ -60,6 +60,68 @@
   height: auto;
 }
 
+.logMaterialPageDark {
+  background-color: #1b2a41;
+}
+
+.logMaterialDark {
+  background-color: #2e5061;
+  color: #fff;
+}
+
+.logMaterialDark .logMaterialTitle {
+  color: #fff;
+}
+
+/* Outline "Cancel" button: bootstrap's grey text (#6c757d) is unreadable on the dark card */
+.logMaterialDark :global(.logMButtons.btn-outline-secondary) {
+  color: #cdd8e6;
+  border-color: #5a7a9b;
+}
+
+/* Inputs row (Date / Project labels) */
+.logMaterialDark :global(label) {
+  color: #fff;
+}
+
+/* Table text light, header bands darkened */
+.logMaterialDark .logMaterialTable {
+  color: #fff !important;
+}
+
+.logMaterialDark .logMaterialTable td,
+.logMaterialDark .logMaterialTable th {
+  color: #fff;
+}
+
+.logMaterialDark .logMTableHeaderLine {
+  background-color: #14233a;
+  border-bottom-color: #3a506b;
+  border-top-color: #3a506b;
+}
+
+.logMaterialDark .logMaterialTable :global(.table-light),
+.logMaterialDark .logMaterialTable :global(.table-light) > th,
+.logMaterialDark .logMaterialTable :global(.table-light) > td {
+  background-color: #14233a;
+  color: #fff;
+}
+
+.logMaterialDark .logMTableHead {
+  color: #4da8da;
+}
+
+/* Inputs/selects inside table & form */
+.logMaterialDark :global(.form-control) {
+  background-color: #2a3f5f;
+  border-color: #3a506b;
+  color: #fff;
+}
+
+.logMaterialDark :global(.form-control)::placeholder {
+  color: #b0b8c4;
+}
+
 
 .logMaterialTable {
   color: #a2a5aa !important;

--- a/src/components/BMDashboard/UpdateReusables/UpdateReusablesBulk/UpdateReusablesBulk.jsx
+++ b/src/components/BMDashboard/UpdateReusables/UpdateReusablesBulk/UpdateReusablesBulk.jsx
@@ -1,5 +1,6 @@
 import { Container } from 'reactstrap';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import moment from 'moment';
 import UpdateReusablesBulkTable from './UpdateReusablesBulkTable';
 import UpdateReusablesBulkInputs from './UpdateReusablesBulkInputs';
@@ -8,10 +9,11 @@ import styles from './UpdateReusablesBulk.module.css';
 function UpdateReusablesBulk() {
   const [date, setDate] = useState(moment(new Date()).format('YYYY-MM-DD'));
   const [project, setProject] = useState('All Projects');
+  const darkMode = useSelector(state => state.theme.darkMode);
   return (
     <Container fluid className={`${styles.logReusableContainer}`}>
-      <div className={`${styles.logReusablePage}`}>
-        <div className={`${styles.logReusable}`}>
+      <div className={`${styles.logReusablePage} ${darkMode ? styles.logReusablePageDark : ''}`}>
+        <div className={`${styles.logReusable} ${darkMode ? styles.logReusableDark : ''}`}>
           <div className={`${styles.logReusableTitle}`}>MATERIAL DAILY ACTIVITIES UPDATE FORM</div>
           <UpdateReusablesBulkInputs
             project={project}

--- a/src/components/BMDashboard/UpdateReusables/UpdateReusablesBulk/UpdateReusablesBulk.module.css
+++ b/src/components/BMDashboard/UpdateReusables/UpdateReusablesBulk/UpdateReusablesBulk.module.css
@@ -60,6 +60,68 @@
   height: auto;
 }
 
+.logReusablePageDark {
+  background-color: #1b2a41;
+}
+
+.logReusableDark {
+  background-color: #2e5061;
+  color: #fff;
+}
+
+.logReusableDark .logReusableTitle {
+  color: #fff;
+}
+
+/* Outline "Cancel" button: bootstrap's grey text (#6c757d) is unreadable on the dark card */
+.logReusableDark :global(.logMButtons.btn-outline-secondary) {
+  color: #cdd8e6;
+  border-color: #5a7a9b;
+}
+
+/* Inputs row (Date / Project labels) */
+.logReusableDark :global(label) {
+  color: #fff;
+}
+
+/* Table text light, header bands darkened */
+.logReusableDark .logReusableTable {
+  color: #fff !important;
+}
+
+.logReusableDark .logReusableTable td,
+.logReusableDark .logReusableTable th {
+  color: #fff;
+}
+
+.logReusableDark .logMTableHeaderLine {
+  background-color: #14233a;
+  border-bottom-color: #3a506b;
+  border-top-color: #3a506b;
+}
+
+.logReusableDark .logReusableTable :global(.table-light),
+.logReusableDark .logReusableTable :global(.table-light) > th,
+.logReusableDark .logReusableTable :global(.table-light) > td {
+  background-color: #14233a;
+  color: #fff;
+}
+
+.logReusableDark .logMTableHead {
+  color: #4da8da;
+}
+
+/* Inputs/selects inside table & form */
+.logReusableDark :global(.form-control) {
+  background-color: #2a3f5f;
+  border-color: #3a506b;
+  color: #fff;
+}
+
+.logReusableDark :global(.form-control)::placeholder {
+  color: #b0b8c4;
+}
+
 
 .logReusableTable {
   color: #a2a5aa !important;

--- a/src/components/BMDashboard/_tests_/AddTeamMember.test.jsx
+++ b/src/components/BMDashboard/_tests_/AddTeamMember.test.jsx
@@ -6,6 +6,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import axios from 'axios';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
 import AddTeamMember from '../AddTeamMember/AddTeamMember';
 import { ENDPOINTS } from '../../../utils/URL';
 
@@ -37,6 +39,12 @@ vi.mock('react-toastify', () => ({
 
 const mockedAxios = axios;
 
+// AddTeamMember reads `state.theme.darkMode` via useSelector, so it must be
+// rendered inside a Redux Provider with a theme slice.
+const mockStore = configureMockStore([]);
+const renderWithStore = ui =>
+  render(<Provider store={mockStore({ theme: { darkMode: false } })}>{ui}</Provider>);
+
 describe('AddTeamMember Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -46,35 +54,35 @@ describe('AddTeamMember Component', () => {
 
   describe('Component Rendering', () => {
     it('renders the person add icon', () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       expect(screen.getByText('Create new team member')).toBeInTheDocument();
     });
   });
 
   describe('Form Input Changes', () => {
     it('updates first name field when typed', async () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       const firstNameInput = screen.getByLabelText('First Name');
       await userEvent.type(firstNameInput, 'John');
       expect(firstNameInput).toHaveValue('John');
     });
 
     it('updates last name field when typed', async () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       const lastNameInput = screen.getByLabelText('Last Name');
       await userEvent.type(lastNameInput, 'Doe');
       expect(lastNameInput).toHaveValue('Doe');
     });
 
     it('updates email field when typed', async () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       const emailInput = screen.getByLabelText('Email Address');
       await userEvent.type(emailInput, 'john.doe@example.com');
       expect(emailInput).toHaveValue('john.doe@example.com');
     });
 
     it('updates teamSpecify field when typed', async () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       // Assumes second empty input corresponds to teamSpecify in your UI
       const teamSpecifyInput = screen.getAllByDisplayValue('')[1];
       await userEvent.type(teamSpecifyInput, 'Custom Team');
@@ -84,21 +92,21 @@ describe('AddTeamMember Component', () => {
 
   describe('Phone Number Formatting', () => {
     it('formats phone number correctly as user types', async () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       const phoneInput = screen.getByPlaceholderText('123-456-7890');
       await userEvent.type(phoneInput, '1234567890');
       expect(phoneInput).toHaveValue('123-456-7890');
     });
 
     it('formats partial phone numbers correctly', async () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       const phoneInput = screen.getByPlaceholderText('123-456-7890');
       await userEvent.type(phoneInput, '123456');
       expect(phoneInput).toHaveValue('123-456');
     });
 
     it('handles short phone numbers correctly', async () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       const phoneInput = screen.getByPlaceholderText('123-456-7890');
       await userEvent.type(phoneInput, '123');
       expect(phoneInput).toHaveValue('123');
@@ -107,7 +115,7 @@ describe('AddTeamMember Component', () => {
 
   describe('Form Validation', () => {
     it('shows validation errors for empty required fields', async () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       await userEvent.click(screen.getByText('Submit'));
       await waitFor(() => {
         expect(screen.getByText('First name is required')).toBeInTheDocument();
@@ -119,14 +127,14 @@ describe('AddTeamMember Component', () => {
     });
 
     it('shows validation error for invalid email format', async () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       await userEvent.type(screen.getByLabelText('Email Address'), 'invalid-email');
       await userEvent.click(screen.getByText('Submit'));
       expect(await screen.findByText('Please enter a valid email address')).toBeInTheDocument();
     });
 
     it('shows validation error for invalid phone number', async () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       await userEvent.type(screen.getByPlaceholderText('123-456-7890'), '123');
       await userEvent.click(screen.getByText('Submit'));
       expect(
@@ -141,7 +149,7 @@ describe('AddTeamMember Component', () => {
       // you can specialize responses here. Otherwise, the default GET mock above is fine.
       mockedAxios.post.mockResolvedValue({ data: { success: true } });
 
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
 
       // Fill required fields
       await userEvent.type(screen.getByLabelText('First Name'), 'John');
@@ -185,7 +193,7 @@ describe('AddTeamMember Component', () => {
 
     it('handles submission error correctly', async () => {
       mockedAxios.post.mockRejectedValue(new Error('Network error'));
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
 
       await userEvent.type(screen.getByLabelText('First Name'), 'John');
       await userEvent.type(screen.getByLabelText('Last Name'), 'Doe');
@@ -210,7 +218,7 @@ describe('AddTeamMember Component', () => {
 
   describe('Cancel Functionality', () => {
     it('resets form when cancel button is clicked', async () => {
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
       await userEvent.type(screen.getByLabelText('First Name'), 'John');
       await userEvent.type(screen.getByLabelText('Last Name'), 'Doe');
       await userEvent.type(screen.getByLabelText('Email Address'), 'john@example.com');
@@ -226,7 +234,7 @@ describe('AddTeamMember Component', () => {
   describe('Form Reset After Successful Submission', () => {
     it('resets form after successful submission', async () => {
       mockedAxios.post.mockResolvedValue({ data: { success: true } });
-      render(<AddTeamMember />);
+      renderWithStore(<AddTeamMember />);
 
       await userEvent.type(screen.getByLabelText('First Name'), 'John');
       await userEvent.type(screen.getByLabelText('Last Name'), 'Doe');

--- a/src/components/BMDashboard/shared/BMError.jsx
+++ b/src/components/BMDashboard/shared/BMError.jsx
@@ -13,7 +13,7 @@ import styles from './BMError.module.css';
 
 export default function BMError({ errors }) {
   return (
-    <section>
+    <section className={`${styles.bmError}`}>
       <p className={`${styles.errorText}`}>
         <BiErrorCircle />
         There was an error processing your request:{' '}

--- a/src/components/BMDashboard/shared/BMError.module.css
+++ b/src/components/BMDashboard/shared/BMError.module.css
@@ -4,3 +4,10 @@
   align-items: center;
   column-gap: 4px;
 }
+
+/* Dark mode: BMError text inherits bootstrap's dark default (#212529) and
+   becomes unreadable on the dark bmdashboard surfaces. Force a light color. */
+:global(body.bm-dashboard-dark) .bmError,
+:global(body.bm-dashboard-dark) .bmError p {
+  color: #e0eaf5;
+}


### PR DESCRIPTION
# Description
<img width="733" height="514" alt="image" src="https://github.com/user-attachments/assets/e2b01e23-0cb8-4a50-8182-672a612bd10d" />


## Related PRS (if any):
None

## Main changes explained:

- No files deleted or created — this PR only adds dark-mode styling to existing BMDashboard Phase 2 pages (43 files touched, all under src/components/BMDashboard/ plus one root fix).
- Fix src/App.module.css to make the intended dark #root/body background actually apply (it was a CSS-module that hashed body.dark-mode #root, leaving a white gutter behind every page) — wrapped in :global().
- Update list/table pages (ItemListView, Equipment/List, ToolItemListView) to give table cells light text in dark mode by overriding Bootstrap's --bs-table-color (cells were dark-on-dark).
- Update form pages (purchase/add/update for materials, reusables, tools, consumables, equipment; AddTeamMember, AddTool, EquipmentUpdateForm) with dark backgrounds, readable labels, dark inputs, and dark react-select dropdowns.
- Update detail/misc pages (EquipmentDetail, ToolDetailPage, Issue, BMTimeLogger/BMTimeLogCard, LessonCard) for dark surfaces + readable text.
- Update modals (RecordsModal, ToolRecordsModal, EquipmentListModal, BMError) — neutralized a global filter: invert(1) that flipped white modal titles to black, and gave modal tables light cell text.


## How to test:

1. Check out this branch.
2. Run npm install and npm start to run locally.
3. Clear site data/cache.
4. Log in as an admin user with BM Portal access.
5. Toggle dark mode on (header dark-mode button).
6. Visit each Phase 2 page under /bmdashboard/... (materials, consumables, reusables, equipment, tools, inventorytypes, the add/purchase/update forms, equipment & tool detail, lessonlist, lessonform, timelog, AddTeamMember).
7. On the list pages (materials/tools/equipment), click View / Updates / Purchases and View Update History to open the modals.
8. Verify everything is readable: no white background outside the page, no dark-on-dark or black-on-dark text, modal titles/tables/dropdowns all legible.
9. Toggle back to light mode and confirm nothing regressed.
10. Confirm it follows the dark mode guidelines.

## Screenshots or videos of changes:
<img width="1357" height="672" alt="image" src="https://github.com/user-attachments/assets/5187aa72-747b-4bfa-b41c-e878beb69c67" />
<img width="1349" height="672" alt="image" src="https://github.com/user-attachments/assets/8dc22ffd-3488-4240-9a69-3ed4d5d9c877" />
<img width="1357" height="683" alt="image" src="https://github.com/user-attachments/assets/f495cb47-3854-4295-ad62-439542ceeb19" />
<img width="1365" height="698" alt="image" src="https://github.com/user-attachments/assets/aaf11769-3cf7-4bd5-af78-10c763eff1e0" />
<img width="1347" height="678" alt="image" src="https://github.com/user-attachments/assets/f801f5f7-9db2-4f3e-af8c-17384955dfe5" />

