### PR TITLE
Amaresh - Fix: task status checkbox not updating visually on subsequent clicks

### DIFF
--- a/src/reducers/followUpReducer.js
+++ b/src/reducers/followUpReducer.js
@@ -10,19 +10,27 @@ export const followUpReducer = (state = initialState, action) => {
   switch (action.type) {
     case types.FETCH_ALL_FOLLOWUPS:
       return { ...state, followUps: action.payload, error: null };
-    case types.SET_FOLLOWUP:
+    case types.SET_FOLLOWUP: {
+      const existingUserFollowUps = state.followUps[action.payload.userId];
+      let updatedFollowUps;
+      if (!existingUserFollowUps) {
+        updatedFollowUps = [action.payload];
+      } else if (existingUserFollowUps.some(ele => ele.taskId === action.payload.taskId)) {
+        updatedFollowUps = existingUserFollowUps.map(ele =>
+          ele.taskId === action.payload.taskId ? action.payload : ele,
+        );
+      } else {
+        updatedFollowUps = [...existingUserFollowUps, action.payload];
+      }
       return {
         ...state,
         followUps: {
           ...state.followUps,
-          [action.payload.userId]: state.followUps[action.payload.userId]
-            ? state.followUps[action.payload.userId].map(ele =>
-                ele.taskId === action.payload.taskId ? action.payload : ele,
-              )
-            : [action.payload],
+          [action.payload.userId]: updatedFollowUps,
         },
         error: null,
       };
+    }
     case types.SET_FOLLOWUP_ERROR:
       return { ...state, error: action.payload };
     default:


### PR DESCRIPTION
## Description
  Fixes Phase 1 bug: Fix task status checkbox inconsistency
<img width="756" height="316" alt="Screenshot 2026-06-25 at 8 00 45 PM" src="https://github.com/user-attachments/assets/82b27818-8c5b-4725-b852-418d88076aa8" />

  
  The follow-up checkbox on team member tasks was visually inconsistent — the first checkbox clicked would update correctly, but subsequent clicks on different tasks appeared to do nothing. Refreshing the page showed the changes were actually saved to the backend correctly. 
  
  
  ## Related PRs (if any):
  No related backend PR.
  
  ## Main changes explained:
  - Update src/reducers/followUpReducer.js to handle three cases in
    SET_FOLLOWUP: (1) user not in state → create new array, (2) user exists
    and task already in list → update with .map(), (3) user exists but task
    not in list → append new entry with spread operator
    
  ## How to test:
  1. Check into branch amaresh/fix-task-status-checkbox-inconsistency
  2. Run `npm install` and `npm start` to run locally
  3. Clear site data/cache 
  4. Log in as admin user
  5. Go to Dashboard → scroll to any user with multiple tasks
  6. Click the green follow-up checkbox on Task 1 — verify it updates visually
  7. Click the green follow-up checkbox on Task 2 of the same user — verify
     it also updates visually immediately without page refresh
  8. Repeat for Task 3, Task 4 — all should update instantly
  9. Verify same behavior works in dark mode
  10. Verify this same behavior in a different browser, like Firefox
  
  ## Screenshots or videos of changes:
  
<img width="736" height="439" alt="Screenshot 2026-06-25 at 8 03 16 PM" src="https://github.com/user-attachments/assets/4e166a54-0175-45c1-945c-ff13280cff77" />

  
  ## Note:
 