### PR TITLE
Yingshu/contributors report comparison

### DIFF
--- a/src/components/Reports/Reports.jsx
+++ b/src/components/Reports/Reports.jsx
@@ -708,7 +708,7 @@ endDate: moment()
                           fontSize={15}
                           isPermissionPage
                           darkMode={darkMode}
-                          defaultText="Click this to see only people who logged/contributed a minimum of 10 tangible hours. This is used for identifying actual contributors vs. people who never started, were immediately terminated, etc."
+                          defaultText="This report only shows Team Members who have contributed more than 10 Hours."
                         />
                       </div>
                     </div>

--- a/src/components/Reports/TotalReport/TotalContributorsReport.jsx
+++ b/src/components/Reports/TotalReport/TotalContributorsReport.jsx
@@ -1,218 +1,34 @@
-import axios from 'axios';
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ENDPOINTS } from '~/utils/URL';
+import { useState } from 'react';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
 import Loading from '../../common/Loading';
 import EditableInfoModal from '../../UserProfile/EditableModal/EditableInfoModal';
-import {
-  getCachedData,
-  logApiRequest,
-  logApiResponse,
-  setCachedData,
-  validateUserList,
-} from './cacheUtils';
-import { generateBarData as generateBarDataUtil } from './generateBarData';
+import useContributorsData from './useContributorsData';
 import styles from './TotalReport.module.css';
 import TotalReportBarGraph from './TotalReportBarGraph';
 
-function TotalContributorsReport({ startDate, endDate, userProfiles, darkMode, userRole }) {
-  const [contributors, setContributors] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [timeEntries, setTimeEntries] = useState([]);
-  const [showMonthly, setShowMonthly] = useState(false);
-  const [showYearly, setShowYearly] = useState(false);
-  const [contributorsInMonth, setContributorsInMonth] = useState([]);
-  const [contributorsInYear, setContributorsInYear] = useState([]);
+const MIN_DATE = new Date('01/01/2010');
 
-  const fromDate = useMemo(() => startDate.toLocaleDateString('en-CA'), [startDate]);
-  const toDate = useMemo(() => endDate.toLocaleDateString('en-CA'), [endDate]);
-  const userList = useMemo(() => {
-    return userProfiles?.map(({ _id }) => _id) || [];
-  }, [userProfiles]);
+const formatDate = date =>
+  date.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' });
 
-  // Fetch time entries for the selected period
-  const loadTimeEntriesForPeriod = useCallback(async (controller) => {
-    const reportName = 'TotalContributorsReport';
-    const url = ENDPOINTS.TIME_ENTRIES_REPORTS;
-
-    if (!url) {
-      return;
-    }
-
-    // Validate userList
-    if (!validateUserList(userList, userProfiles, reportName)) {
-      setTimeEntries([]);
-      setLoading(false);
-      return;
-    }
-
-    // Check cache with date range key
-    const cacheKey = `${reportName}_${fromDate}_${toDate}`;
-    const cached = getCachedData(cacheKey, reportName);
-    if (cached.data) {
-      setTimeEntries(cached.data);
-      setLoading(false);
-      return;
-    }
-
-    try {
-      logApiRequest(reportName, url, { users: userList, fromDate, toDate }, {
-        usersCount: userList?.length,
-      });
-
-      const response = await axios.post(
-        url,
-        { users: userList, fromDate, toDate },
-        { signal: controller.signal }
-      );
-
-      logApiResponse(reportName, response.data?.length);
-
-      const mappedTimeEntries = response.data.map(entry => ({
-        userId: entry.personId,
-        hours: entry.hours,
-        minutes: entry.minutes,
-        isTangible: entry.isTangible,
-        date: entry.dateOfWork,
-      }));
-
-      setTimeEntries(mappedTimeEntries);
-      setCachedData(cacheKey, mappedTimeEntries, reportName);
-    } catch (error) {
-      // eslint-disable-next-line import/no-named-as-default-member
-      if (!axios.isCancel(error)) {
-        // eslint-disable-next-line no-console
-        console.error(`${reportName} API Error:`, error);
-        setTimeEntries([]);
-      }
-    }
-  }, [fromDate, toDate, userList, userProfiles]);
-
-  // Group time entries by user and calculate total hours
-  const sumByUser = useCallback((entries) => {
-    return entries.reduce((acc, { userId, hours = 0, minutes = 0, isTangible = false }) => {
-      if (!acc[userId]) {
-        acc[userId] = {
-          userId,
-          hours: 0,
-          minutes: 0,
-          tangibleTime: 0,
-        };
-      }
-      const numHours = parseFloat(hours) || 0;
-      const numMinutes = parseFloat(minutes) || 0;
-      acc[userId].hours += numHours;
-      acc[userId].minutes += numMinutes;
-      if (isTangible) {
-        acc[userId].tangibleTime += numHours + numMinutes / 60;
-      }
-      return acc;
-    }, {});
-  }, []);
-
-  // Filter users who have contributed more than 10 hours
-  const filterContributors = useCallback((users) => {
-    return users.filter(user => 
-      (user.hours + user.minutes/60) >= 10
-    );
-  }, []);
-
-  // Group entries by time range (month/year)
-  const groupByTimeRange = useCallback((entries, timeRange) => {
-    return entries.reduce((acc, entry) => {
-      const date = new Date(entry.date);
-      const key = timeRange === 'month' 
-        ? `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
-        : `${date.getFullYear()}`;
-      
-      if (!acc[key]) {
-        acc[key] = [];
-      }
-      acc[key].push(entry);
-      return acc;
-    }, {});
-  }, []);
-
-  // Generate summary data for the specified time range
-  const summaryOfTimeRange = useCallback((timeRange) => {
-    const groupedEntries = Object.entries(groupByTimeRange(timeEntries, timeRange));
-    return groupedEntries.map(([key, entries]) => {
-      const groupedUsers = Object.values(sumByUser(entries));
-      const contributedUsers = filterContributors(groupedUsers);
-      return { timeRange: key, usersOfTime: contributedUsers };
-    });
-  }, [timeEntries, groupByTimeRange, sumByUser, filterContributors]);
-
-  // Generate bar chart data
-  const generateBarData = useCallback((groupedDate, isYear = false) => {
-    return generateBarDataUtil(groupedDate, isYear, startDate, endDate, 'usersOfTime');
-  }, [startDate, endDate]);
-
-  // Check if we should show monthly/yearly summaries
-  const checkPeriodForSummary = useCallback(() => {
-    const oneMonth = 1000 * 60 * 60 * 24 * 31;
-    const diffDate = endDate - startDate;
-    if (diffDate > oneMonth) {
-      setContributorsInMonth(generateBarData(summaryOfTimeRange('month')));
-      setContributorsInYear(generateBarData(summaryOfTimeRange('year'), true));
-      if (diffDate <= oneMonth * 12) {
-        setShowMonthly(true);
-      }
-      if (startDate.getFullYear() !== endDate.getFullYear()) {
-        setShowYearly(true);
-      }
-    }
-  }, [endDate, startDate, generateBarData, summaryOfTimeRange]);
-
-  // Load data when date range changes
-  useEffect(() => {
-    // Only make API call if userList has data
-    if (!userList || userList.length === 0) {
-      return;
-    }
-
-    setLoading(true);
-    const controller = new AbortController();
-    loadTimeEntriesForPeriod(controller).then(() => {
-      setLoading(false);
-    });
-    return () => controller.abort();
-  }, [loadTimeEntriesForPeriod, userList]);
-
-  // Process data when time entries are loaded
-  useEffect(() => {
-    if (!loading && timeEntries.length > 0) {
-      setShowMonthly(false);
-      setShowYearly(false);
-      const groupedUsers = Object.values(sumByUser(timeEntries));
-      const contributedUsers = filterContributors(groupedUsers);
-      setContributors(contributedUsers);
-      checkPeriodForSummary();
-    }
-  }, [loading, timeEntries, sumByUser, filterContributors, checkPeriodForSummary]);
-
-  if (loading) {
-    return <Loading darkMode={darkMode} />;
-  }
-
-  const totalTangibleTime = contributors.reduce((acc, obj) => acc + Number(obj.tangibleTime), 0);
+// Renders the summary stats and charts for a single period.
+function ContributorsPeriodPanel({ startDate, endDate, data, idSuffix, title }) {
+  const {
+    contributors,
+    totalTangibleTime,
+    showMonthly,
+    showYearly,
+    contributorsInMonth,
+    contributorsInYear,
+  } = data;
 
   return (
-    <div className={`${styles.totalContainer} ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}>
-      <div className="d-flex align-items-center">
-        <h2 className={`${styles.totalTitle} ${darkMode ? 'text-azure' : ''}`}>Contributors Report</h2>
-        <EditableInfoModal
-          areaName="contributorsReportInfo"
-          areaTitle="Contributors Report"
-          role={userRole}
-          fontSize={15}
-          defaultText="Click this to see only people who logged/contributed a minimum of 10 tangible hours..."
-          isPermissionPage
-          darkMode={darkMode}
-        />
-      </div>
+    <div className={styles.comparisonPanel}>
+      {title && <div className={styles.panelTitle}>{title}</div>}
       <div className={styles.totalPeriod}>
-        In the period from {startDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })} to {endDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })}:
+        In the period from {formatDate(startDate)} to {formatDate(endDate)}:
       </div>
       <div className={styles.totalItem}>
         <div className={styles.totalNumber}>{contributors.length}</div>
@@ -224,12 +40,176 @@ function TotalContributorsReport({ startDate, endDate, userProfiles, darkMode, u
       </div>
       <div>
         {showMonthly && contributorsInMonth.length > 0 && (
-          <TotalReportBarGraph barData={contributorsInMonth} range="month" />
+          <TotalReportBarGraph barData={contributorsInMonth} range="month" idSuffix={idSuffix} />
         )}
         {showYearly && contributorsInYear.length > 0 && (
-          <TotalReportBarGraph barData={contributorsInYear} range="year" />
+          <TotalReportBarGraph barData={contributorsInYear} range="year" idSuffix={idSuffix} />
         )}
       </div>
+    </div>
+  );
+}
+
+ContributorsPeriodPanel.propTypes = {
+  startDate: PropTypes.instanceOf(Date).isRequired,
+  endDate: PropTypes.instanceOf(Date).isRequired,
+  data: PropTypes.shape({
+    contributors: PropTypes.arrayOf(PropTypes.shape({})),
+    totalTangibleTime: PropTypes.number,
+    showMonthly: PropTypes.bool,
+    showYearly: PropTypes.bool,
+    contributorsInMonth: PropTypes.arrayOf(PropTypes.shape({})),
+    contributorsInYear: PropTypes.arrayOf(PropTypes.shape({})),
+  }).isRequired,
+  idSuffix: PropTypes.string,
+  title: PropTypes.string,
+};
+
+ContributorsPeriodPanel.defaultProps = {
+  idSuffix: '',
+  title: '',
+};
+
+function TotalContributorsReport({ startDate, endDate, userProfiles, darkMode, userRole }) {
+  const [comparisonEnabled, setComparisonEnabled] = useState(false);
+  // Default the comparison window to the equal-length period immediately
+  // preceding the primary start date (e.g. 2023-2024 vs 2024-2025).
+  const [compareStartDate, setCompareStartDate] = useState(() => {
+    const length = endDate - startDate;
+    const start = new Date(startDate.getTime() - length);
+    return start < MIN_DATE ? MIN_DATE : start;
+  });
+  const [compareEndDate, setCompareEndDate] = useState(() => new Date(startDate));
+
+  const primary = useContributorsData({ startDate, endDate, userProfiles, enabled: true });
+  const comparison = useContributorsData({
+    startDate: compareStartDate,
+    endDate: compareEndDate,
+    userProfiles,
+    enabled: comparisonEnabled,
+  });
+
+  const onToggleComparison = e => {
+    const enabled = e.target.checked;
+    if (enabled) {
+      // Default the comparison to the equal-length period immediately preceding
+      // the currently-selected primary range.
+      const length = endDate - startDate;
+      const start = new Date(startDate.getTime() - length);
+      setCompareStartDate(start < MIN_DATE ? MIN_DATE : start);
+      setCompareEndDate(new Date(startDate));
+    }
+    setComparisonEnabled(enabled);
+  };
+
+  const onCompareStartDateChange = date => {
+    if (date && date <= compareEndDate) {
+      setCompareStartDate(date);
+    }
+  };
+
+  const onCompareEndDateChange = date => {
+    if (date && date >= compareStartDate) {
+      setCompareEndDate(date);
+    }
+  };
+
+  if (primary.loading) {
+    return <Loading darkMode={darkMode} />;
+  }
+
+  const today = new Date();
+
+  return (
+    <div className={`${styles.totalContainer} ${darkMode ? 'bg-yinmn-blue text-light' : ''}`}>
+      <div className="d-flex align-items-center">
+        <h2 className={`${styles.totalTitle} ${darkMode ? 'text-azure' : ''}`}>
+          Contributors Report
+        </h2>
+        <EditableInfoModal
+          areaName="contributorsReportInfo"
+          areaTitle="Contributors Report"
+          role={userRole}
+          fontSize={15}
+          defaultText="Click this to see only people who logged/contributed a minimum of 10 tangible hours..."
+          isPermissionPage
+          darkMode={darkMode}
+        />
+      </div>
+
+      <div className={styles.comparisonControls}>
+        <label className={styles.comparisonToggle} htmlFor="contributors-compare-toggle">
+          <input
+            id="contributors-compare-toggle"
+            type="checkbox"
+            checked={comparisonEnabled}
+            onChange={onToggleComparison}
+          />
+          <span>Compare to another period</span>
+        </label>
+        {comparisonEnabled && (
+          <div className={styles.comparePickers}>
+            <div className={styles.comparePickerItem}>
+              <label htmlFor="contributors-compare-start">Compare Start Date</label>
+              <DatePicker
+                id="contributors-compare-start"
+                selected={compareStartDate}
+                minDate={MIN_DATE}
+                maxDate={today}
+                onChange={onCompareStartDateChange}
+                className={`form-control ${
+                  darkMode ? 'bg-darkmode-liblack text-light border-0' : ''
+                }`}
+              />
+            </div>
+            <div className={styles.comparePickerItem}>
+              <label htmlFor="contributors-compare-end">Compare End Date</label>
+              <DatePicker
+                id="contributors-compare-end"
+                selected={compareEndDate}
+                minDate={MIN_DATE}
+                maxDate={today}
+                onChange={onCompareEndDateChange}
+                className={`form-control ${
+                  darkMode ? 'bg-darkmode-liblack text-light border-0' : ''
+                }`}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {comparisonEnabled ? (
+        <div className={styles.comparisonGrid}>
+          <ContributorsPeriodPanel
+            startDate={startDate}
+            endDate={endDate}
+            data={primary}
+            idSuffix="-primary"
+            title="Selected period"
+          />
+          {comparison.loading ? (
+            <div className={styles.comparisonPanel}>
+              <Loading darkMode={darkMode} />
+            </div>
+          ) : (
+            <ContributorsPeriodPanel
+              startDate={compareStartDate}
+              endDate={compareEndDate}
+              data={comparison}
+              idSuffix="-compare"
+              title="Comparison period"
+            />
+          )}
+        </div>
+      ) : (
+        <ContributorsPeriodPanel
+          startDate={startDate}
+          endDate={endDate}
+          data={primary}
+          idSuffix="-primary"
+        />
+      )}
     </div>
   );
 }
@@ -237,9 +217,11 @@ function TotalContributorsReport({ startDate, endDate, userProfiles, darkMode, u
 TotalContributorsReport.propTypes = {
   startDate: PropTypes.instanceOf(Date).isRequired,
   endDate: PropTypes.instanceOf(Date).isRequired,
-  userProfiles: PropTypes.arrayOf(PropTypes.shape({
-    _id: PropTypes.string,
-  })),
+  userProfiles: PropTypes.arrayOf(
+    PropTypes.shape({
+      _id: PropTypes.string,
+    }),
+  ),
   darkMode: PropTypes.bool,
   userRole: PropTypes.string,
 };

--- a/src/components/Reports/TotalReport/TotalContributorsReport.jsx
+++ b/src/components/Reports/TotalReport/TotalContributorsReport.jsx
@@ -13,6 +13,8 @@ const MIN_DATE = new Date('01/01/2010');
 const formatDate = date =>
   date.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' });
 
+const getDateRangeLabel = (startDate, endDate) => `${formatDate(startDate)} to ${formatDate(endDate)}`;
+
 // Renders the summary stats and charts for a single period.
 function ContributorsPeriodPanel({ startDate, endDate, data, idSuffix, title }) {
   const {
@@ -23,27 +25,48 @@ function ContributorsPeriodPanel({ startDate, endDate, data, idSuffix, title }) 
     contributorsInMonth,
     contributorsInYear,
   } = data;
+  const dateRangeLabel = getDateRangeLabel(startDate, endDate);
 
   return (
     <div className={styles.comparisonPanel}>
       {title && <div className={styles.panelTitle}>{title}</div>}
-      <div className={styles.totalPeriod}>
-        In the period from {formatDate(startDate)} to {formatDate(endDate)}:
+      <div className={`${styles.totalPeriod} ${styles.contributorPeriodLabel}`}>
+        In the period from {dateRangeLabel}:
       </div>
-      <div className={styles.totalItem}>
-        <div className={styles.totalNumber}>{contributors.length}</div>
-        <div className={styles.totalText}>members have contributed more than 10 hours.</div>
-      </div>
-      <div className={styles.totalItem}>
-        <div className={styles.totalNumber}>{totalTangibleTime.toFixed(2)}</div>
-        <div className={styles.totalText}>hours of tangible time have been logged.</div>
+      <div className={styles.contributorSummaryMetrics}>
+        <div className={`${styles.totalItem} ${styles.contributorSummaryItem}`}>
+          <div className={`${styles.totalNumber} ${styles.contributorSummaryNumber}`}>
+            {contributors.length}
+          </div>
+          <div className={`${styles.totalText} ${styles.contributorSummaryText}`}>
+            Members have contributed more than 10 Hours.
+          </div>
+        </div>
+        <div className={`${styles.totalItem} ${styles.contributorSummaryItem}`}>
+          <div className={`${styles.totalNumber} ${styles.contributorSummaryNumber}`}>
+            {totalTangibleTime.toFixed(2)}
+          </div>
+          <div className={`${styles.totalText} ${styles.contributorSummaryText}`}>
+            Hours of tangible time have been logged.
+          </div>
+        </div>
       </div>
       <div>
         {showMonthly && contributorsInMonth.length > 0 && (
-          <TotalReportBarGraph barData={contributorsInMonth} range="month" idSuffix={idSuffix} />
+          <TotalReportBarGraph
+            barData={contributorsInMonth}
+            range="month"
+            idSuffix={idSuffix}
+            fallbackLabel={dateRangeLabel}
+          />
         )}
         {showYearly && contributorsInYear.length > 0 && (
-          <TotalReportBarGraph barData={contributorsInYear} range="year" idSuffix={idSuffix} />
+          <TotalReportBarGraph
+            barData={contributorsInYear}
+            range="year"
+            idSuffix={idSuffix}
+            fallbackLabel={dateRangeLabel}
+          />
         )}
       </div>
     </div>
@@ -88,7 +111,6 @@ function TotalContributorsReport({ startDate, endDate, userProfiles, darkMode, u
     userProfiles,
     enabled: comparisonEnabled,
   });
-
   const onToggleComparison = e => {
     const enabled = e.target.checked;
     if (enabled) {
@@ -131,7 +153,7 @@ function TotalContributorsReport({ startDate, endDate, userProfiles, darkMode, u
           areaTitle="Contributors Report"
           role={userRole}
           fontSize={15}
-          defaultText="Click this to see only people who logged/contributed a minimum of 10 tangible hours..."
+          defaultText="This report only shows Team Members who have contributed more than 10 Hours."
           isPermissionPage
           darkMode={darkMode}
         />

--- a/src/components/Reports/TotalReport/TotalReport.module.css
+++ b/src/components/Reports/TotalReport/TotalReport.module.css
@@ -39,6 +39,61 @@
   font-weight: 400;
 }
 
+.comparisonControls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 12px 0 8px;
+}
+
+.comparisonToggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  margin: 0;
+}
+
+.comparePickers {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 16px;
+}
+
+.comparePickerItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.comparisonGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.comparisonPanel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.panelTitle {
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: steelblue;
+}
+
+@media screen and (width <= 700px) {
+  .comparisonGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .totalDetail {
   margin-top: 20px;
 }
@@ -102,6 +157,10 @@
 }
 
 :global(.dark-mode) .totalTitle {
+  color: #60a5fa;
+}
+
+:global(.dark-mode) .panelTitle {
   color: #60a5fa;
 }
 

--- a/src/components/Reports/TotalReport/TotalReport.module.css
+++ b/src/components/Reports/TotalReport/TotalReport.module.css
@@ -71,20 +71,22 @@
 .comparisonGrid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 24px;
+  gap: 28px;
   align-items: start;
 }
 
 .comparisonPanel {
   display: flex;
   flex-direction: column;
+  gap: 12px;
   min-width: 0;
 }
 
 .panelTitle {
   font-size: 20px;
   font-weight: 600;
-  margin-bottom: 8px;
+  line-height: 1.3;
+  margin-bottom: 0;
   color: steelblue;
 }
 
@@ -120,6 +122,39 @@
   font-size: inherit;
 }
 
+.contributorPeriodLabel {
+  font-size: 17px;
+  line-height: 1.45;
+}
+
+.contributorSummaryMetrics {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.contributorSummaryItem {
+  display: grid;
+  grid-template-columns: 112px minmax(0, 1fr);
+  align-items: center;
+  column-gap: 14px;
+  min-height: 44px;
+}
+
+.contributorSummaryNumber {
+  margin-right: 0;
+  font-size: 30px;
+  line-height: 1.15;
+  text-align: right;
+}
+
+.contributorSummaryText {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 18px;
+  line-height: 1.45;
+}
+
 @media screen and (width <= 1100px) {
   .totalTitle,
   .totalNumber,
@@ -129,6 +164,24 @@
 
   .totalText {
     font-size: 12px;
+  }
+
+  .contributorPeriodLabel {
+    font-size: 16px;
+  }
+
+  .contributorSummaryItem {
+    grid-template-columns: 96px minmax(0, 1fr);
+    column-gap: 12px;
+  }
+
+  .contributorSummaryNumber {
+    font-size: 26px;
+  }
+
+  .contributorSummaryText {
+    font-size: 16px;
+    line-height: 1.45;
   }
 }
 
@@ -142,11 +195,41 @@
   .totalText {
     font-size: 14px;
   }
+
+  .comparisonPanel {
+    gap: 12px;
+  }
+
+  .contributorPeriodLabel {
+    font-size: 16px;
+  }
+
+  .contributorSummaryItem {
+    grid-template-columns: 104px minmax(0, 1fr);
+  }
+
+  .contributorSummaryNumber {
+    font-size: 28px;
+  }
+
+  .contributorSummaryText {
+    font-size: 16px;
+    line-height: 1.45;
+  }
 }
 
 @media screen and (width <= 550px) {
   .totalContainer {
     padding: 15px;
+  }
+
+  .contributorSummaryItem {
+    grid-template-columns: 88px minmax(0, 1fr);
+    column-gap: 10px;
+  }
+
+  .contributorSummaryNumber {
+    font-size: 24px;
   }
 }
 
@@ -193,4 +276,3 @@
 :global(.dark-mode) .totalWarning {
   color: #fbbf24;
 }
-

--- a/src/components/Reports/TotalReport/TotalReportBarGraph.jsx
+++ b/src/components/Reports/TotalReport/TotalReportBarGraph.jsx
@@ -3,8 +3,8 @@ import * as d3 from 'd3';
 import styles from './TotalReportBarGraph.module.css';
 import { useSelector } from 'react-redux';
 
-function TotalReportBarGraph({ barData, range }) {
-  const svgId = `svg-container-${range}`;
+function TotalReportBarGraph({ barData, range, idSuffix = '' }) {
+  const svgId = `svg-container-${range}${idSuffix}`;
   const darkMode = useSelector(state => state.theme.darkMode);
   const containerRef = useRef(null);
 

--- a/src/components/Reports/TotalReport/TotalReportBarGraph.jsx
+++ b/src/components/Reports/TotalReport/TotalReportBarGraph.jsx
@@ -3,23 +3,52 @@ import * as d3 from 'd3';
 import styles from './TotalReportBarGraph.module.css';
 import { useSelector } from 'react-redux';
 
-function TotalReportBarGraph({ barData, range, idSuffix = '' }) {
+function TotalReportBarGraph({
+  barData,
+  range,
+  idSuffix = '',
+  fallbackLabel = '',
+}) {
   const svgId = `svg-container-${range}${idSuffix}`;
   const darkMode = useSelector(state => state.theme.darkMode);
   const containerRef = useRef(null);
+  const isComparisonChart = idSuffix.includes('compare');
+  const barColor = isComparisonChart
+    ? darkMode
+      ? '#f59e0b'
+      : '#d97706'
+    : darkMode
+      ? '#4a90e2'
+      : '#5b6ee1';
+  const aboveBarLabelColor = darkMode ? '#f8fafc' : '#1f2937';
+  const insideLabelMinHeight = 34;
+
+  const getReadableLabel = label => {
+    const text = label === null || label === undefined ? '' : String(label);
+    if (!text || text.includes('NaN') || text === 'Invalid Date') {
+      return fallbackLabel || 'Selected date range';
+    }
+    return text;
+  };
 
   const drawChart = (data, darkmode) => {
-    data.sort((a, b) => (a.label > b.label ? 1 : -1));
+    const normalizedData = data
+      .map(item => ({
+        ...item,
+        label: getReadableLabel(item.label),
+        value: Number.isNaN(Number(item.value)) ? 0 : Number(item.value),
+      }))
+      .sort((a, b) => (a.label > b.label ? 1 : -1));
 
     const container = containerRef.current;
-    const { width: containerWidth } = container.getBoundingClientRect(); 
-    const containerHeight = containerWidth;
+    const { width: containerWidth } = container.getBoundingClientRect();
+    const containerHeight = Math.max(containerWidth * 0.75, 320);
 
     const margin = { top: 10, right: 8, bottom: 100, left: 20 };
     const width = containerWidth - margin.left - margin.right;
     const height = containerHeight - margin.top - margin.bottom;
 
-    const maxValue = Math.max(...data.map(d => d.value));
+    const maxValue = Math.max(...normalizedData.map(d => d.value), 1);
 
     const svg = d3
       // eslint-disable-next-line testing-library/no-node-access
@@ -37,7 +66,7 @@ function TotalReportBarGraph({ barData, range, idSuffix = '' }) {
 
     const xScale = d3
       .scaleBand()
-      .domain(data.map(d => d.label))
+      .domain(normalizedData.map(d => d.label))
       .range([0, width])
       .padding(0.4);
 
@@ -46,43 +75,32 @@ function TotalReportBarGraph({ barData, range, idSuffix = '' }) {
       .domain([0, maxValue])
       .range([height, 0]);
 
-      const colorScale = d3
-      .scaleLinear()
-      .domain([0, maxValue])
-      .range(darkMode ? ['#4a90e2', '#003366'] : ['#f5a3a3', '#c3b6f7']);
-    data.forEach(d => {
+    normalizedData.forEach(d => {
       const x = xScale(d.label);
       const barHeight = height - yScale(d.value);
       const y = yScale(d.value);
+      const labelFitsInside = barHeight >= insideLabelMinHeight;
 
-     
       chart
         .append('rect')
         .attr('x', x)
         .attr('y', y)
         .attr('width', xScale.bandwidth())
         .attr('height', barHeight)
-        .attr('fill', colorScale(d.value));
-
-    
-      const yText =
-        barHeight >= 30
-          ? y + barHeight / 2
-          : 
-            y - 10;
+        .attr('fill', barColor);
 
       chart
         .append('text')
         .attr('x', x + xScale.bandwidth() / 2)
-        .attr('y', yText)
+        .attr('y', labelFitsInside ? y + barHeight / 2 : Math.max(y - 8, 14))
         .attr('text-anchor', 'middle')
-        .style('fill', darkmode ? 'white' : 'black')
-        .style('font-size', '20px')
+        .attr('dominant-baseline', labelFitsInside ? 'middle' : 'baseline')
+        .style('fill', labelFitsInside ? 'white' : aboveBarLabelColor)
+        .style('font-size', '24px')
         .style('font-weight', 'bold')
-        .text(Number.isNaN(d.value) ? '' : d.value);
+        .text(d.value > 0 ? d.value : '');
     });
 
-   
     chart
       .append('g')
       .attr('transform', `translate(0, ${height})`)
@@ -92,7 +110,7 @@ function TotalReportBarGraph({ barData, range, idSuffix = '' }) {
       .style('text-anchor', 'middle')
       .style('font-size', '14px')
       .style('fill', 'black')
-      .style('fill', darkmode ? 'white' : 'black'); 
+      .style('fill', darkmode ? 'white' : 'black');
   };
 
   useEffect(() => {

--- a/src/components/Reports/TotalReport/useContributorsData.js
+++ b/src/components/Reports/TotalReport/useContributorsData.js
@@ -1,0 +1,227 @@
+import axios from 'axios';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ENDPOINTS } from '~/utils/URL';
+import {
+  getCachedData,
+  logApiRequest,
+  logApiResponse,
+  setCachedData,
+  validateUserList,
+} from './cacheUtils';
+import { generateBarData as generateBarDataUtil } from './generateBarData';
+
+const REPORT_NAME = 'TotalContributorsReport';
+const ONE_MONTH = 1000 * 60 * 60 * 24 * 31;
+
+// Group time entries by user and calculate total hours
+const sumByUser = entries => {
+  return entries.reduce((acc, { userId, hours = 0, minutes = 0, isTangible = false }) => {
+    if (!acc[userId]) {
+      acc[userId] = { userId, hours: 0, minutes: 0, tangibleTime: 0 };
+    }
+    const numHours = parseFloat(hours) || 0;
+    const numMinutes = parseFloat(minutes) || 0;
+    acc[userId].hours += numHours;
+    acc[userId].minutes += numMinutes;
+    if (isTangible) {
+      acc[userId].tangibleTime += numHours + numMinutes / 60;
+    }
+    return acc;
+  }, {});
+};
+
+// Filter users who have contributed more than 10 hours
+const filterContributors = users => users.filter(user => user.hours + user.minutes / 60 >= 10);
+
+// Group entries by time range (month/year)
+const groupByTimeRange = (entries, timeRange) => {
+  return entries.reduce((acc, entry) => {
+    const date = new Date(entry.date);
+    const key =
+      timeRange === 'month'
+        ? `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
+        : `${date.getFullYear()}`;
+    if (!acc[key]) {
+      acc[key] = [];
+    }
+    acc[key].push(entry);
+    return acc;
+  }, {});
+};
+
+// Generate summary data for the specified time range
+const summaryOfTimeRange = (entries, timeRange) => {
+  const groupedEntries = Object.entries(groupByTimeRange(entries, timeRange));
+  return groupedEntries.map(([key, rangeEntries]) => {
+    const groupedUsers = Object.values(sumByUser(rangeEntries));
+    const contributedUsers = filterContributors(groupedUsers);
+    return { timeRange: key, usersOfTime: contributedUsers };
+  });
+};
+
+/**
+ * Encapsulates fetching + processing the Contributors Report data for a single
+ * date range. Returns the computed summary so it can be rendered for both the
+ * primary period and an optional comparison period.
+ *
+ * @param {Object} params
+ * @param {Date} params.startDate
+ * @param {Date} params.endDate
+ * @param {Array} params.userProfiles
+ * @param {boolean} params.enabled - When false, no fetching/processing happens
+ *   (used to skip work for the comparison period until the user enables it).
+ */
+export default function useContributorsData({ startDate, endDate, userProfiles, enabled = true }) {
+  const [loading, setLoading] = useState(true);
+  const [timeEntries, setTimeEntries] = useState([]);
+  const [contributors, setContributors] = useState([]);
+  const [showMonthly, setShowMonthly] = useState(false);
+  const [showYearly, setShowYearly] = useState(false);
+  const [contributorsInMonth, setContributorsInMonth] = useState([]);
+  const [contributorsInYear, setContributorsInYear] = useState([]);
+
+  const fromDate = useMemo(() => startDate.toLocaleDateString('en-CA'), [startDate]);
+  const toDate = useMemo(() => endDate.toLocaleDateString('en-CA'), [endDate]);
+  const userList = useMemo(() => userProfiles?.map(({ _id }) => _id) || [], [userProfiles]);
+
+  // Fetch time entries for the selected period
+  const loadTimeEntriesForPeriod = useCallback(
+    async controller => {
+      const url = ENDPOINTS.TIME_ENTRIES_REPORTS;
+      if (!url) {
+        return;
+      }
+
+      if (!validateUserList(userList, userProfiles, REPORT_NAME)) {
+        setTimeEntries([]);
+        setLoading(false);
+        return;
+      }
+
+      const cacheKey = `${REPORT_NAME}_${fromDate}_${toDate}`;
+      const cached = getCachedData(cacheKey, REPORT_NAME);
+      if (cached.data) {
+        setTimeEntries(cached.data);
+        setLoading(false);
+        return;
+      }
+
+      try {
+        logApiRequest(
+          REPORT_NAME,
+          url,
+          { users: userList, fromDate, toDate },
+          { usersCount: userList?.length },
+        );
+
+        const response = await axios.post(
+          url,
+          { users: userList, fromDate, toDate },
+          { signal: controller.signal },
+        );
+
+        logApiResponse(REPORT_NAME, response.data?.length);
+
+        const mappedTimeEntries = response.data.map(entry => ({
+          userId: entry.personId,
+          hours: entry.hours,
+          minutes: entry.minutes,
+          isTangible: entry.isTangible,
+          date: entry.dateOfWork,
+        }));
+
+        setTimeEntries(mappedTimeEntries);
+        setCachedData(cacheKey, mappedTimeEntries, REPORT_NAME);
+      } catch (error) {
+        // eslint-disable-next-line import/no-named-as-default-member
+        if (!axios.isCancel(error)) {
+          // eslint-disable-next-line no-console
+          console.error(`${REPORT_NAME} API Error:`, error);
+          setTimeEntries([]);
+        }
+      }
+    },
+    [fromDate, toDate, userList, userProfiles],
+  );
+
+  // Load data when the date range changes
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return undefined;
+    }
+    if (!userList || userList.length === 0) {
+      return undefined;
+    }
+
+    setLoading(true);
+    const controller = new AbortController();
+    loadTimeEntriesForPeriod(controller).then(() => {
+      setLoading(false);
+    });
+    return () => controller.abort();
+  }, [enabled, loadTimeEntriesForPeriod, userList]);
+
+  // Process data when time entries are loaded
+  useEffect(() => {
+    if (!enabled || loading) {
+      return;
+    }
+
+    if (timeEntries.length === 0) {
+      setContributors([]);
+      setShowMonthly(false);
+      setShowYearly(false);
+      setContributorsInMonth([]);
+      setContributorsInYear([]);
+      return;
+    }
+
+    const groupedUsers = Object.values(sumByUser(timeEntries));
+    setContributors(filterContributors(groupedUsers));
+
+    const diffDate = endDate - startDate;
+    let monthly = false;
+    let yearly = false;
+    let monthData = [];
+    let yearData = [];
+    if (diffDate > ONE_MONTH) {
+      monthData = generateBarDataUtil(
+        summaryOfTimeRange(timeEntries, 'month'),
+        false,
+        startDate,
+        endDate,
+        'usersOfTime',
+      );
+      yearData = generateBarDataUtil(
+        summaryOfTimeRange(timeEntries, 'year'),
+        true,
+        startDate,
+        endDate,
+        'usersOfTime',
+      );
+      if (diffDate <= ONE_MONTH * 12) {
+        monthly = true;
+      }
+      if (startDate.getFullYear() !== endDate.getFullYear()) {
+        yearly = true;
+      }
+    }
+    setShowMonthly(monthly);
+    setShowYearly(yearly);
+    setContributorsInMonth(monthData);
+    setContributorsInYear(yearData);
+  }, [enabled, loading, timeEntries, startDate, endDate]);
+
+  const totalTangibleTime = contributors.reduce((acc, obj) => acc + Number(obj.tangibleTime), 0);
+
+  return {
+    loading,
+    contributors,
+    totalTangibleTime,
+    showMonthly,
+    showYearly,
+    contributorsInMonth,
+    contributorsInYear,
+  };
+}

--- a/src/components/Reports/TotalReport/useContributorsData.js
+++ b/src/components/Reports/TotalReport/useContributorsData.js
@@ -73,7 +73,6 @@ const summaryOfTimeRange = (entries, timeRange) => {
  */
 export default function useContributorsData({ startDate, endDate, userProfiles, enabled = true }) {
   const [loading, setLoading] = useState(true);
-  const [timeEntries, setTimeEntries] = useState([]);
   const [contributors, setContributors] = useState([]);
   const [showMonthly, setShowMonthly] = useState(false);
   const [showYearly, setShowYearly] = useState(false);
@@ -84,6 +83,60 @@ export default function useContributorsData({ startDate, endDate, userProfiles, 
   const toDate = useMemo(() => endDate.toLocaleDateString('en-CA'), [endDate]);
   const userList = useMemo(() => userProfiles?.map(({ _id }) => _id) || [], [userProfiles]);
 
+  const resetReportData = useCallback(() => {
+    setContributors([]);
+    setShowMonthly(false);
+    setShowYearly(false);
+    setContributorsInMonth([]);
+    setContributorsInYear([]);
+  }, []);
+
+  const processTimeEntries = useCallback(
+    entries => {
+      if (entries.length === 0) {
+        resetReportData();
+        return;
+      }
+
+      const groupedUsers = Object.values(sumByUser(entries));
+      setContributors(filterContributors(groupedUsers));
+
+      const diffDate = endDate - startDate;
+      let monthly = false;
+      let yearly = false;
+      let monthData = [];
+      let yearData = [];
+      if (diffDate > ONE_MONTH) {
+        monthData = generateBarDataUtil(
+          summaryOfTimeRange(entries, 'month'),
+          false,
+          startDate,
+          endDate,
+          'usersOfTime',
+        );
+        yearData = generateBarDataUtil(
+          summaryOfTimeRange(entries, 'year'),
+          true,
+          startDate,
+          endDate,
+          'usersOfTime',
+        );
+        if (diffDate <= ONE_MONTH * 12) {
+          monthly = true;
+        }
+        if (startDate.getFullYear() !== endDate.getFullYear()) {
+          yearly = true;
+        }
+      }
+
+      setShowMonthly(monthly);
+      setShowYearly(yearly);
+      setContributorsInMonth(monthData);
+      setContributorsInYear(yearData);
+    },
+    [endDate, resetReportData, startDate],
+  );
+
   // Fetch time entries for the selected period
   const loadTimeEntriesForPeriod = useCallback(
     async controller => {
@@ -93,7 +146,7 @@ export default function useContributorsData({ startDate, endDate, userProfiles, 
       }
 
       if (!validateUserList(userList, userProfiles, REPORT_NAME)) {
-        setTimeEntries([]);
+        resetReportData();
         setLoading(false);
         return;
       }
@@ -101,7 +154,7 @@ export default function useContributorsData({ startDate, endDate, userProfiles, 
       const cacheKey = `${REPORT_NAME}_${fromDate}_${toDate}`;
       const cached = getCachedData(cacheKey, REPORT_NAME);
       if (cached.data) {
-        setTimeEntries(cached.data);
+        processTimeEntries(cached.data);
         setLoading(false);
         return;
       }
@@ -130,18 +183,18 @@ export default function useContributorsData({ startDate, endDate, userProfiles, 
           date: entry.dateOfWork,
         }));
 
-        setTimeEntries(mappedTimeEntries);
+        processTimeEntries(mappedTimeEntries);
         setCachedData(cacheKey, mappedTimeEntries, REPORT_NAME);
       } catch (error) {
         // eslint-disable-next-line import/no-named-as-default-member
         if (!axios.isCancel(error)) {
           // eslint-disable-next-line no-console
           console.error(`${REPORT_NAME} API Error:`, error);
-          setTimeEntries([]);
+          resetReportData();
         }
       }
     },
-    [fromDate, toDate, userList, userProfiles],
+    [fromDate, processTimeEntries, resetReportData, toDate, userList, userProfiles],
   );
 
   // Load data when the date range changes
@@ -161,57 +214,6 @@ export default function useContributorsData({ startDate, endDate, userProfiles, 
     });
     return () => controller.abort();
   }, [enabled, loadTimeEntriesForPeriod, userList]);
-
-  // Process data when time entries are loaded
-  useEffect(() => {
-    if (!enabled || loading) {
-      return;
-    }
-
-    if (timeEntries.length === 0) {
-      setContributors([]);
-      setShowMonthly(false);
-      setShowYearly(false);
-      setContributorsInMonth([]);
-      setContributorsInYear([]);
-      return;
-    }
-
-    const groupedUsers = Object.values(sumByUser(timeEntries));
-    setContributors(filterContributors(groupedUsers));
-
-    const diffDate = endDate - startDate;
-    let monthly = false;
-    let yearly = false;
-    let monthData = [];
-    let yearData = [];
-    if (diffDate > ONE_MONTH) {
-      monthData = generateBarDataUtil(
-        summaryOfTimeRange(timeEntries, 'month'),
-        false,
-        startDate,
-        endDate,
-        'usersOfTime',
-      );
-      yearData = generateBarDataUtil(
-        summaryOfTimeRange(timeEntries, 'year'),
-        true,
-        startDate,
-        endDate,
-        'usersOfTime',
-      );
-      if (diffDate <= ONE_MONTH * 12) {
-        monthly = true;
-      }
-      if (startDate.getFullYear() !== endDate.getFullYear()) {
-        yearly = true;
-      }
-    }
-    setShowMonthly(monthly);
-    setShowYearly(yearly);
-    setContributorsInMonth(monthData);
-    setContributorsInYear(yearData);
-  }, [enabled, loading, timeEntries, startDate, endDate]);
 
   const totalTangibleTime = contributors.reduce((acc, obj) => acc + Number(obj.tangibleTime), 0);
 


### PR DESCRIPTION
# Description

Implements comparison support for the Contributors Report and improves the overall report UI.
<img width="693" height="273" alt="Screenshot 2026-06-27 at 5 59 19 PM" src="https://github.com/user-attachments/assets/6919a336-bb09-412a-876e-bb51eb5543ab" />


## Related PRs (if any)

[[PR #3378](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3378)] → [[PR #3423](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3423)]

No backend PR is required.

## Main changes

* Added comparison mode for the Contributors Report.
* Updated the report layout to display the Selected Period and Comparison Period side by side.
* Created `useContributorsData.js` to encapsulate Contributors Report data fetching and processing for a single date range.
* Improved the Contributors Report summary layout, typography, spacing, and alignment.
* Updated the Contributors Report tooltip text to clarify that the report only shows Team Members who have contributed more than 10 Hours.
* Verified the new functionality in both light mode and dark mode.

## How to test

1. Checkout this branch.
2. Install dependencies and start the application.
3. Open the Reports page.
4. Verify the original Contributors Report.
5. Enable "Compare to another period".
6. Verify the Selected Period and Comparison Period are displayed side by side.
7. Verify the updated summary layout, tooltip, and dark mode support.

## Screenshots / Video

Demo Video:
https://github.com/user-attachments/assets/f6cb5a59-1132-445a-8764-29405eb5ccb8