### PR TITLE
Abhishek_Fix: Add Search and Clear buttons to Resource Management page

### DIFF
--- a/src/components/ResourceManagement/ResourceManagement.jsx
+++ b/src/components/ResourceManagement/ResourceManagement.jsx
@@ -7,7 +7,7 @@ import * as XLSX from 'xlsx';
 import styles from './ResourceManagement.module.css';
 import { MOCK_RESOURCES } from './MockData';
 
-function SearchBar({ onSortToggle, darkMode, searchTerm, onSearchTermChange }) {
+function SearchBar({ onSortToggle, darkMode, searchTerm, onSearchTermChange, onClearSearch }) {
   return (
     <div
       className={`${styles.searchBarContainer} ${
@@ -35,6 +35,12 @@ function SearchBar({ onSortToggle, darkMode, searchTerm, onSearchTermChange }) {
           value={searchTerm}
           onChange={onSearchTermChange}
         />
+        <button type="button" className={styles.searchButton} onClick={() => {}}>
+          Search
+        </button>
+        <button type="button" className={styles.clearButton} onClick={onClearSearch}>
+          Clear
+        </button>
       </div>
     </div>
   );
@@ -248,6 +254,11 @@ function ResourceManagement() {
     setCurrentPage(1);
   };
 
+  const handleClearSearch = () => {
+    setSearchTerm('');
+    setCurrentPage(1);
+  };
+
   const filteredResources = useMemo(() => {
     const term = searchTerm.toLowerCase().trim();
 
@@ -416,6 +427,7 @@ function ResourceManagement() {
         darkMode={darkMode}
         searchTerm={searchTerm}
         onSearchTermChange={onSearchTermChange}
+        onClearSearch={handleClearSearch}
       />
 
       <div className={styles.resourceList}>
@@ -531,6 +543,7 @@ SearchBar.propTypes = {
   darkMode: PropTypes.bool,
   searchTerm: PropTypes.string.isRequired,
   onSearchTermChange: PropTypes.func.isRequired,
+  onClearSearch: PropTypes.func.isRequired,
 };
 
 SearchBar.defaultProps = {

--- a/src/components/ResourceManagement/ResourceManagement.module.css
+++ b/src/components/ResourceManagement/ResourceManagement.module.css
@@ -121,7 +121,7 @@
 
 .searchButton {
   padding: 8px 14px;
-  background-color: #007bff;
+  background-color: #0056b3;
   color: #fff;
   border: none;
   border-radius: 4px;

--- a/src/components/ResourceManagement/ResourceManagement.module.css
+++ b/src/components/ResourceManagement/ResourceManagement.module.css
@@ -119,6 +119,52 @@
   color: #fff;
 }
 
+.searchButton {
+  padding: 8px 14px;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s;
+}
+
+.searchButton:hover {
+  background-color: #0056b3;
+}
+
+.clearButton {
+  padding: 8px 14px;
+  background-color: #6c757d;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s;
+}
+
+.clearButton:hover {
+  background-color: #545b62;
+}
+
+.darkModeSearchBarContainer .searchButton {
+  background-color: #1a6fc4;
+}
+
+.darkModeSearchBarContainer .searchButton:hover {
+  background-color: #155da0;
+}
+
+.darkModeSearchBarContainer .clearButton {
+  background-color: #555e68;
+}
+
+.darkModeSearchBarContainer .clearButton:hover {
+  background-color: #434a52;
+}
+
 /* --- Table & Column Alignment --- */
 .resourceList {
   background-color: #fff;


### PR DESCRIPTION
Related PRs: Supersedes https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5068

### Reason for new branch:
The older branch had drifted significantly from development - it was missing ~6 months of merged features including column sorting, XLSX/CSV export, pagination, lucide-react icons, toast notifications, and PropTypes validation. Rebasing it would have caused major regressions. Instead, this PR implements the same feature (Search + Clear button) cleanly on top of the current development branch, preserving all existing functionality.

### What this PR does:
Implements the missing feature from issue (Phase 3 - Resource Management page Search Results Do Not Revert After Clearing Input; Missing Clear Filter Control) at `/communityportal/activity/:activityId/resources`:

- Adds a Clear button to the SearchBar that resets the search term and returns pagination to page 1
- Adds a Search button alongside the existing live-filter input
- Adds CSS for both buttons with full light and dark mode support
- All existing features preserved — sort toggle, column sorting, XLSX/CSV export, pagination, Add Log modal, form validation, dark mode

### How to test:

- Checkout branch `fix/resource-management-clear-button`
- Start the backend using the `development` branch
- Run `npm install` then `npm run start:local`
- Log in as admin
- Navigate to `/communityportal/activity/:activityId/resources`
- Verify the following:
  - Typing in the search box filters the list live 
  
<img width="2880" height="762" alt="PR5068_search_filtering_dark png" src="https://github.com/user-attachments/assets/e220c4c5-33a0-44e0-b0e1-52a227714d7c" />
<img width="2880" height="780" alt="PR5068_search_filtering_light png" src="https://github.com/user-attachments/assets/bd8e424b-1526-4b6c-a49b-9fbcedaa60a6" />

  - Clearing the input manually restores the full list 
  
<img width="2880" height="1054" alt="PR5068_search_autorestore_light png" src="https://github.com/user-attachments/assets/7fd0b8ed-d357-445f-841d-e871c260945a" />

  - Clicking Clear resets the list and pagination to page 1 
  
<img width="2880" height="1078" alt="PR5068_clear_button_dark png" src="https://github.com/user-attachments/assets/7713f698-2848-4da8-8ed5-7b785c253dde" />

  - Searching for a term with no matches shows an empty table 
  
<img width="2878" height="686" alt="PR5068_search_noresults_light png" src="https://github.com/user-attachments/assets/979548d2-2bb5-4348-98a6-e8b45857bc78" />

  - Submitting the Add New Log form empty shows inline validation errors on all fields 
  
<img width="684" height="1104" alt="PR5068_addlog_validation_empty_light png" src="https://github.com/user-attachments/assets/b46c281a-9836-457e-9f13-bc55e54f29ca" />

  - Entering invalid format in Time/Duration and numbers in Facilities shows field-level errors 
  
<img width="584" height="972" alt="PR5068_addlog_validation_format_light png" src="https://github.com/user-attachments/assets/dc402049-4d8f-40a5-ba76-40f318cfb59f" />


### Note:
The Add Log feature currently stores data in mock state only and does not persist to the backend — no backend endpoint exists in HGNRest for this feature. This is a pre-existing project-wide limitation and is out of scope for this PR. A separate backend PR would be needed to implement persistence.
