### PR TITLE
Abhishek_Fix: SonarQube contrast issue in no-show status badge (follow-up to #5188)

### DIFF
--- a/src/components/AttendanceSystem/AttendanceNoShowCharts.module.css
+++ b/src/components/AttendanceSystem/AttendanceNoShowCharts.module.css
@@ -496,7 +496,7 @@
 
 .noShowStatus {
   background: #fee2e2;
-  color: #dc2626;
+  color: #991b1b;
 }
 
 .noRows {


### PR DESCRIPTION
## Description

Small follow-up to #5188 (Attendance Tracking System). SonarQube's Quality Gate flagged a contrast accessibility issue after that PR merged.

## Issue Fixed

**Text does not meet minimal contrast requirement (css:S7924)**
- File: `AttendanceNoShowCharts.module.css`, line 499
- The `.noShowStatus` badge had insufficient contrast between its background (`#fee2e2`) and text (`#dc2626`) — ratio was ~3.95:1, below the WCAG AA minimum of 4.5:1.
- Fixed by darkening the text color to `#991b1b`, bringing the ratio to ~6.8:1 while keeping the red "no-show" visual meaning intact.

## How to test

1. Check out this branch and run locally
2. Navigate to `/logattendance`
3. Select any event, go to the Participates tab
4. Any participant with "No-Show" status will show the badge — verify it's clearly legible in both light and dark mode