### PR TITLE
Jaden Taking Over For Peterson: Implement No Teams Found Message - Teams Page (DONE)

### DIFF
--- a/src/components/Teams/Team.module.css
+++ b/src/components/Teams/Team.module.css
@@ -134,3 +134,11 @@ tr.darkModeRow:hover {
   display: flex !important;
   gap: 10px;
 }
+
+.teamNotFoundContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+}

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -30,6 +30,7 @@ import DeleteTeamPopup from './DeleteTeamPopup';
 import TeamStatusPopup from './TeamStatusPopup';
 import AddTeamPopup from '../UserProfile/TeamsAndProjects/AddTeamPopup';
 import CreateNewTeamPopup from './CreateNewTeamPopup';
+import styles from './Team.module.css';
 // constants
 const FILTER_ALL = 'all';
 const FILTER_ACTIVE = 'active';
@@ -241,15 +242,32 @@ class Teams extends React.PureComponent {
     }
 
     if (this.state.teams.length === 0) {
+      const { wildCardSearchText } = this.state;
       return (
         <div
           className={`d-flex justify-content-center align-items-center py-5 ${
             darkMode ? 'dark-mode' : ''
           }`}
         >
-          <h1 className="warning-text">
-            <strong>Team Not Found</strong>
-          </h1>
+          {wildCardSearchText ? (
+            <div className={styles.teamNotFoundContainer}>
+              <p className={darkMode ? 'text-light' : 'text-dark'}>
+                No team found matching &quot;{wildCardSearchText}&quot;, but you can create it by
+                clicking the button below.
+              </p>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={this.onCreateNewTeamFromSearch}
+              >
+                Create Team
+              </button>
+            </div>
+          ) : (
+            <h1 className="warning-text">
+              <strong>Team Not Found</strong>
+            </h1>
+          )}
         </div>
       );
     }
@@ -363,6 +381,7 @@ class Teams extends React.PureComponent {
           open={this.state.createNewTeamPopupOpen}
           onClose={this.onCreateNewTeamPopupClose}
           onOkClick={this.onCreateNewTeamOkClick}
+          teamName={this.state.createNewTeamName}
         />
       </>
     );
@@ -435,11 +454,18 @@ class Teams extends React.PureComponent {
   };
 
   onCreateNewTeamShow = () => {
-    this.setState({ createNewTeamPopupOpen: true });
+    this.setState({ createNewTeamPopupOpen: true, createNewTeamName: '' });
+  };
+
+  onCreateNewTeamFromSearch = () => {
+    this.setState({
+      createNewTeamPopupOpen: true,
+      createNewTeamName: this.state.wildCardSearchText,
+    });
   };
 
   onCreateNewTeamPopupClose = () => {
-    this.setState({ createNewTeamPopupOpen: false });
+    this.setState({ createNewTeamPopupOpen: false, createNewTeamName: '' });
   };
 
   onCreateNewTeamOkClick = async teamName => {


### PR DESCRIPTION
## Description
Implements a \"no team found\" message with a Create Team button on the Teams page when a search yields no results.

## Main changes
- When a wildcard search returns no results, shows a message and a \"Create Team\" button instead of a plain \"Team Not Found\" heading
- Clicking \"Create Team\" opens the modal with the search text pre-filled
- Normal \"Create Team\" button (top right) still opens the modal empty as before

## How to test
1. Check out branch and run locally
2. Log in as admin or owner
3. Go to Other Links - Teams
4. Type a team name that does not exist in the search box
5. A message and \"Create Team\" button should appear
6. Click \"Create Team\" - modal opens with the search text pre-filled
7. Verify normal Create Team button still opens modal empty
8. Verify light and dark mode both work

## Related PRs
Resolves conflicts from #3928 (peterson337's original PR)