### PR TITLE
Sai Sandeep - 🔥 Fix reusable and materials route in bmdashboard that have been broken by missing darkMode import and children prop

### DIFF
--- a/src/components/BMDashboard/ItemList/ItemListView.jsx
+++ b/src/components/BMDashboard/ItemList/ItemListView.jsx
@@ -2,14 +2,21 @@ import { useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
-
 import BMError from '../shared/BMError';
 import SelectForm from './SelectForm';
 import SelectItem from './SelectItem';
 import ItemsTable from './ItemsTable';
 import styles from './ItemListView.module.css';
+import { useSelector } from 'react-redux';
 
-export function ItemListView({ itemType, items, errors, UpdateItemModal, dynamicColumns }) {
+export function ItemListView({
+  itemType,
+  items,
+  errors,
+  UpdateItemModal,
+  dynamicColumns,
+  children,
+}) {
   const [filteredItems, setFilteredItems] = useState([]);
   const [selectedProject, setSelectedProject] = useState([]); // Array of strings
   const [selectedItem, setSelectedItem] = useState([]); // Array of strings
@@ -20,6 +27,8 @@ export function ItemListView({ itemType, items, errors, UpdateItemModal, dynamic
   const [sortConfig, setSortConfig] = useState({ key: null, direction: 'asc' });
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(25);
+
+  const darkMode = useSelector(state => state.theme.darkMode);
 
   // Sync initial items load
   useEffect(() => {


### PR DESCRIPTION
# Description
When user's navigate to bmdashboard/reusables or bmdashboard/materials we see an error page and can't see anything on  screen. This PR aims to fix it. Below are the routes that are having errors and this PR aims to fix them.

<img width="1800" height="930" alt="Screenshot 2026-07-11 130054" src="https://github.com/user-attachments/assets/73186a79-f78e-4b07-8545-c49b8ed8fe91" />
<img width="1752" height="918" alt="Screenshot 2026-07-11 130044" src="https://github.com/user-attachments/assets/c64e42f6-d76a-4f33-bb82-2698ca0a3453" />


## Related PRS (if any):
This PR is related [4537 ](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4537)

## Main changes explained:
1. Imported darkMode from redux store.
2. Destructured missing children prop as we are using it in component.

## How to test:
1. check into current branch
3. do `npm install` and `npm start` to run this PR locally
4. Clear site data/cache
5. log as admin user
6. go to bmdashboard/reusables ,bmdashboard/materials and bmdashboard/tools 
7. now everything should work and nothing should be  broken
8. Please find the mock video that i have recorded explaining the changes.

## Note
1. Styling needs to changed according to the component. As we cant style same on all pages and routes as each component styles the imported components differently.

## Screenshots or videos of changes:
<img width="1861" height="1080" alt="Screenshot 2026-07-11 124444" src="https://github.com/user-attachments/assets/154244ea-24ef-4213-a2c2-8626f0581bda" />
<img width="1872" height="1077" alt="Screenshot 2026-07-11 124434" src="https://github.com/user-attachments/assets/3aa8fcd6-626c-4ae7-a058-6451cb119fed" />
<img width="1877" height="1112" alt="Screenshot 2026-07-11 124423" src="https://github.com/user-attachments/assets/fde4383f-fab2-4936-a0af-399c40cac330" />

## Video of changes

https://github.com/user-attachments/assets/07f46b0a-8ee8-4798-b17d-29c1c0d8793a


