### PR TITLE
Abhishek 🔥: Team Stats section text wrapping, dropdown sizing, and dark mode issues

### DIFF
--- a/src/components/TotalOrgSummary/TeamStats/TeamStats.module.css
+++ b/src/components/TotalOrgSummary/TeamStats/TeamStats.module.css
@@ -1,7 +1,81 @@
-.team-stats-active-members-dropdown {
-  border: 1px solid #e0e0e0;
+.teamStatsActiveMembers {
+  margin-top: 1rem;
+}
+
+.teamStatsBarChartSummary {
+  display: flex;
+  align-items: center;
+}
+
+.teamStatsSummaryText {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  color: inherit;
+  font-size: 1rem;
+}
+
+.customDropdown {
+  position: relative;
+  display: inline-flex;
+}
+
+.dropdownButton {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 3.5rem;
+  padding: 0.3rem 0.75rem;
   border-radius: 5px;
-  color: #828282;
-  margin: 0 0.3rem;
-  font-size: 1.2em;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+.dropdownArrow {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid currentcolor;
+  transition: transform 0.15s ease;
+}
+
+.dropdownArrowOpen {
+  transform: rotate(180deg);
+}
+
+.dropdownMenu {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  z-index: 10;
+  min-width: 5.5rem;
+  width: max-content;
+  margin: 0 0 0.25rem;
+  padding: 0.25rem 0.15rem 0.25rem 0;
+  list-style: none;
+  border-radius: 5px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+  max-height: 9rem;
+  overflow-y: auto;
+}
+
+.dropdownItem {
+  display: block;
+  width: 100%;
+  padding: 0.4rem 1rem;
+  text-align: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  white-space: nowrap;
+}
+
+.dropdownItem:hover {
+  background-color: rgb(0 0 0 / 5%);
 }

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -906,6 +906,7 @@ function TotalOrgSummary(props) {
                   usersInTeamStats={volunteerStats?.usersInTeamStats}
                   endDate={currentToDate}
                   comparisonType={selectedComparison}
+                  darkMode={darkMode}
                 />
               </div>
             </Col>


### PR DESCRIPTION
## Bug
Multiple issues in the "Team Stats" section under Teams and Blue Squares:
1. "207 teams with [X] + active members" always wrapped across 3 separate lines instead of flowing on one line
2. The active-members dropdown showed incorrectly in light mode (rendered as if dark mode were active)
3. Dropdown menu list was cramped/too narrow for two-digit numbers
4. Dropdown menu, when opened, was clipped by the card's overflow: hidden boundary since it opened downward into an area
   with no remaining visible space

## Root Cause
- TeamStats.module.css defined an unused, differently-named class that didn't match any class actually referenced in TeamStats.jsx, meaning the summary text and dropdown had no layout styling at all and fell back to default block-level stacking
- TotalOrgSummary.jsx never passed the darkMode prop into <TeamStats />, so it relied on a document.body fallback check that was misfiring
- Dropdown menu had no explicit width, sizing to the narrow button
- Dropdown menu opened downward (position: absolute; top: 100%) into the card's clipped overflow area

## Fix
- Added proper flex layout CSS so the summary text and dropdown sit on one line (wrapping only if the container is genuinely too narrow)
- Passed darkMode explicitly into <TeamStats />, consistent with every other chart component on this page
- Widened the dropdown button and menu, added padding, and added a proper dropdown arrow indicator
- Changed the dropdown menu to open upward (bottom: 100%) instead of downward, since there's no clipped space above the button within the card

## Testing
- Run the front-end repo on `Abhishek_FixTeamStatsSingleLineText` branch and backend on development
- Login as admin and navigate to Dashboard → Total Org Summary → Teams and Blue Squares → Team Stats.
- Verified in light mode and dark mode
- Verified the dropdown opens fully without clipping and shows all 13 options with a working scrollbar
- Verified text stays on one line at normal desktop width

<img width="1366" height="812" alt="Screenshot 2026-07-14 133347" src="https://github.com/user-attachments/assets/2166db36-c65b-44c3-b85a-c0f7ab4e0bca" />
<img width="1374" height="812" alt="Screenshot 2026-07-14 133403" src="https://github.com/user-attachments/assets/41241b2c-f904-497d-bf30-c7453ff86ad0" />