### PR TITLE
Abhishek 🔥: resolve overflow, contrast, and sizing issues in Project Status cards

### DIFF
--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
@@ -70,7 +70,7 @@ const projectStatusButtons = [
     change: '+13% week over week',
     bgColor: '#FFF6EE',
     buttonColor: '#FFD8A5',
-    textColor: '#FFD8A5',
+    textColor: '#328D1B',
   },
   {
     title: 'Total Material Cost',

--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.module.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.module.css
@@ -229,7 +229,7 @@
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
-  overflow: hidden visible;
+  overflow: visible;
 }
 
 .darkMode .weeklyProjectSummaryCard {
@@ -518,7 +518,8 @@
   border-radius: 25px;
   width: 100%;
   max-width: 284px;
-  height: 190px;
+  min-height: 190px;
+  height: auto;
   text-align: center;
   box-shadow: 0 4px 8px rgb(0 0 0 / 15%);
   padding: 20px;
@@ -615,7 +616,7 @@
   grid-template-columns: repeat(5, 1fr);
   gap: 20px;
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
   width: 100%;
   max-width: 1600px;
   margin: auto;


### PR DESCRIPTION
## What's Working Well
- Fixes the vertical scrollbar/clip artifact on the "Total Labor Hours Invested" and "Total Labor Cost" cards, caused by an ambiguous `overflow: hidden visible` shorthand combined with a fixed card height that couldn't accommodate a two-line title.
- Fixes the "Avg Project Duration" card's "+13% week over week" text, which was previously set to the same color as its own accent button (`#FFD8A5` on `#FFD8A5`), making it nearly invisible in light mode.
- Fixes inconsistent card heights across the Project Status grid caused by `align-items: center` in the grid container, so all cards in a row now stretch to match height.

## Changes
- `WeeklyProjectSummary.module.css`: changed `.weeklyProjectSummaryCard` overflow to `visible`; changed `.statusCard` from fixed `height: 190px` to `min-height: 190px; height: auto`; changed `.projectStatusGrid` `align-items` from `center` to `stretch`.
- `WeeklyProjectSummary.jsx`: corrected `textColor` for the "Avg Project Duration" card entry from `#FFD8A5` to `#328D1B`.

## Testing
- Run the front-end repo on `Abhishek_FixProjectStatusCardOverflow` branch and backend on development
- Login as admin and navigate to Dashboard → Reports → Total Construction Summary

Verified locally in both light and dark mode:
- No scrollbar/clip artifact on any Project Status card
- Two-line title wraps cleanly without cutting off content
- All cards in each row now render at equal height
- "+13% week over week" text is legible (green) in light mode

<img width="2680" height="784" alt="Screenshot 2026-07-14 160704" src="https://github.com/user-attachments/assets/1e4e4dbe-9ddd-4245-93f2-80739673c557" />
<img width="2680" height="800" alt="Screenshot 2026-07-14 160721" src="https://github.com/user-attachments/assets/78c4227f-0ac9-4c3a-8f12-0255c7f9294a" />