### PR TITLE
Mahitha taking over: complete server date protection for timelog and weekly summary

### DIFF
--- a/src/actions/__tests__/timeEntries.js.test.js
+++ b/src/actions/__tests__/timeEntries.js.test.js
@@ -15,11 +15,17 @@ import {
 import { GET_TIME_ENTRIES_PERIOD, GET_TIME_ENTRIES_WEEK } from '../../constants/timeEntries';
 // Import ENDPOINTS
 import { ENDPOINTS } from '~/utils/URL';
+import { fetchServerTime, getServerMoment } from '~/utils/serverTime';
 // Import moment for date manipulation
 // Mock axios for HTTP requests
 
 // Mock axios module
 vi.mock('axios');
+
+vi.mock('~/utils/serverTime', () => ({
+  fetchServerTime: vi.fn(() => Promise.resolve()),
+  getServerMoment: vi.fn(() => moment()),
+}));
 
 describe('timeEntries action creators', () => {
   // Mock console.error to suppress error output during tests
@@ -164,7 +170,7 @@ describe('timeEntries action creators', () => {
     // Test case to ensure the response status is returned
     it('should return the response status', async () => {
       const dispatchMock = vi.fn(); // Mock dispatch function
-      const timeEntry = { entryType: 'default', dateOfWork: moment().toISOString() }; // Sample time entry
+      const timeEntry = { entryType: 'default', dateOfWork: moment().format('YYYY-MM-DD') }; // Sample time entry
       axios.post.mockResolvedValue({ status: 200 }); // Mock axios post response
 
       const status = await postTimeEntry(timeEntry)(dispatchMock); // Call postTimeEntry
@@ -175,7 +181,7 @@ describe('timeEntries action creators', () => {
     // Test case to handle errors and return the error response status
     it('should handle errors and return the error response status', async () => {
       const dispatchMock = vi.fn(); // Mock dispatch function
-      const timeEntry = { entryType: 'default', dateOfWork: moment().toISOString() }; // Sample time entry
+      const timeEntry = { entryType: 'default', dateOfWork: moment().format('YYYY-MM-DD') }; // Sample time entry
       axios.post.mockRejectedValue({ response: { status: 500 } }); // Mock axios post error response
 
       const status = await postTimeEntry(timeEntry)(dispatchMock); // Call postTimeEntry

--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -10,6 +10,7 @@ import {
   GET_TIME_ENTRIES_PERIOD_BULK,
 } from '../constants/timeEntries';
 import { ENDPOINTS } from '~/utils/URL';
+import { fetchServerTime, getServerMoment } from '../utils/serverTime';
 
 export const setTimeEntriesForWeek = (data, offset) => ({
   type: GET_TIME_ENTRIES_WEEK,
@@ -47,6 +48,7 @@ export const getTimeEntriesForWeek = (userId, offset) => {
     .format('YYYY-MM-DDTHH:mm:ss');
 
   const url = ENDPOINTS.TIME_ENTRIES_PERIOD(userId, fromDate, toDate);
+  
   return async dispatch => {
     let loggedOut = false;
     const res = await axios.get(url).catch(error => {
@@ -197,6 +199,8 @@ export const getTimeStartDateEntriesByPeriod = (userId, fromDate, toDate) => {
     }
   };
 };
+
+/*
 export const postTimeEntry = (timeEntry, { displayedUserId } = {}) => {
   const url = ENDPOINTS.TIME_ENTRY();
   return async dispatch => {
@@ -211,6 +215,50 @@ export const postTimeEntry = (timeEntry, { displayedUserId } = {}) => {
     }
   };
 };
+*/
+
+
+export const postTimeEntry = (timeEntry, { displayedUserId } = {}) => {
+  const url = ENDPOINTS.TIME_ENTRY();
+
+  return async dispatch => {
+    try {
+      // Get backend server time
+      await fetchServerTime();
+
+      const serverNow = moment(getServerMoment());
+
+      const selectedDate = moment(timeEntry.dateOfWork);
+
+      console.log('Server time:', serverNow.format());
+      console.log('Selected time entry date:', selectedDate.format());
+
+      // // Prevent future date/time logging
+      // if (selectedDate.isAfter(serverNow)) {
+      //   toast.error('You cannot log time for a future date or time.');
+      //   return 400;
+      // }
+
+      // Prevent logging on previous or future dates
+      if (!selectedDate.isSame(serverNow, 'day')) {
+        toast.error('You can only log time for today.');
+        return 400;
+      }
+
+      const res = await axios.post(url, timeEntry);
+
+      if (timeEntry.entryType === 'default' || timeEntry.entryType === 'person') {
+        dispatch(updateTimeEntries(timeEntry, undefined, displayedUserId));
+      }
+
+      return res.status;
+
+    } catch (e) {
+      return e.response.status;
+    }
+  };
+};
+
 
 export const editTimeEntry = (timeEntryId, timeEntry, oldDateOfWork, { displayedUserId } = {}) => {
   const url = ENDPOINTS.TIME_ENTRY_CHANGE(timeEntryId);

--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -230,8 +230,8 @@ export const postTimeEntry = (timeEntry, { displayedUserId } = {}) => {
 
       const selectedDate = moment(timeEntry.dateOfWork);
 
-      console.log('Server time:', serverNow.format());
-      console.log('Selected time entry date:', selectedDate.format());
+      // console.log('Server time:', serverNow.format());
+      // console.log('Selected time entry date:', selectedDate.format());
 
       // // Prevent future date/time logging
       // if (selectedDate.isAfter(serverNow)) {

--- a/src/actions/timeEntries.js
+++ b/src/actions/timeEntries.js
@@ -254,7 +254,8 @@ export const postTimeEntry = (timeEntry, { displayedUserId } = {}) => {
       return res.status;
 
     } catch (e) {
-      return e.response.status;
+      toast.error('Unable to verify server time. Please try again.');
+      return e.response?.status ?? 500;
     }
   };
 };

--- a/src/utils/serverTime.js
+++ b/src/utils/serverTime.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+let serverTime = null;
+
+export const fetchServerTime = async () => {
+  const response = await axios.get('/api/servertime');
+  serverTime = response.data.serverTime;
+  return serverTime;
+};
+
+export const getServerMoment = () => {
+  return serverTime ? serverTime : new Date();
+};


### PR DESCRIPTION
# Description

**Implements:** #4312 (Priority: High)
<img width="803" height="145" alt="Screenshot 2026-07-15 at 2 49 20 PM" src="https://github.com/user-attachments/assets/98814408-80f4-4c04-8319-c01fa5ca4532" />

This PR resolves the issue where users could bypass time entry validation by changing their local system date. Previously, the frontend relied on the client's local time, allowing users to log time for incorrect dates by modifying their device clock.

This implementation updates the frontend to fetch the current server time before creating a time entry. Time entry validation now uses the server date instead of the local system date, preventing users from logging time on dates other than the current server date.

**Related Issue**

* Priority High: Finish abandoned PR #5129 – Resolved Server Date Issue Frontend (#4312)

---

## Related PRs

* **Frontend PR:** This PR
* **Backend PR:** [PR #2271<backend PR number>](https://github.com/OneCommunityGlobal/HGNRest/pull/2271)

To test this feature, check out both the frontend and backend PRs.

---

## Main changes explained

* Added a new `serverTime` utility to retrieve the current backend server time.
* Updated `postTimeEntry()` to fetch the latest server time before submitting a time entry.
* Replaced local system date validation with server-based date validation.
* Prevented users from logging time for any date other than the current server date.
* Displayed an error message when attempting to log time for a different day.

---

## How to test

1. Check out both the frontend and backend branches.
2. Run:

   ```bash
   npm install
   npm start
   ```
3. Clear the browser cache/site data.
4. Log in as an admin user.
5. Navigate to **Dashboard → Tasks → Select a task → Log Time**.
6. Verify that logging time for the current server date succeeds.
7. Change your computer's system date to a previous or future day.
8. Attempt to log time again.
9. Verify that:

   * The application displays **"You can only log time for today."**
   * No time entry is created.
10. Reset your system clock and verify that logging time for the current date works as expected.

---

## Screenshots or Videos

Video demonstration:
https://youtu.be/ziEJpHzcmX8

---

## Note

This PR depends on the corresponding backend PR, which introduces the `/api/servertime` endpoint used for server-based date validation.
