### PR TITLE
Abhishek 🔥: Tasks With Completed Hours dark mode background seam

### DIFF
--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -415,7 +415,7 @@ const Projects = function(props) {
         </div>
         <div>
         <table className="table table-bordered table-responsive-sm">
-          <thead>
+          <thead className={styles.projectsTableHead}>
             <ProjectTableHeader
               onChange={onChangeCategory}
               selectedValue={categorySelectedForSort}

--- a/src/components/Projects/projects.module.css
+++ b/src/components/Projects/projects.module.css
@@ -1,5 +1,5 @@
 /* stylelint-disable  */
-:global(thead) {
+.projectsTableHead {
   background: aliceblue;
 }
 

--- a/src/components/Teams/Team.module.css
+++ b/src/components/Teams/Team.module.css
@@ -1,5 +1,5 @@
 /* stylelint-disable  */
-thead {
+.teamsTableHead {
   background: aliceblue;
 }
 

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -3,6 +3,7 @@
 /* eslint-disable react/sort-comp */
 import React from 'react';
 import PropTypes from 'prop-types';
+import styles from './Team.module.css';
 import { connect } from 'react-redux';
 import { Container } from 'reactstrap';
 import { toast } from 'react-toastify';
@@ -257,7 +258,7 @@ class Teams extends React.PureComponent {
     return (
       <div className="table-responsive mt-3">
         <table className={tableClass}>
-          <thead>
+          <thead className={styles.teamsTableHead}>
             <TeamTableHeader
               onTeamNameSort={this.toggleTeamNameSort}
               onTeamActiveSort={this.toggleTeamActiveSort}

--- a/src/components/common/PieChart/PieChart.module.css
+++ b/src/components/common/PieChart/PieChart.module.css
@@ -166,7 +166,7 @@ div.pie-chart-legend-container {
 }
 
 .pie-chart-legend-table th {
-  background-color: white;
+  background-color: transparent;
 }
 
 .pie-chart-legend-table td,
@@ -175,7 +175,7 @@ div.pie-chart-legend-container {
 }
 
 .pie-chart-legend-table-dark th {
-  background-color: #1f2937;
+  background-color: transparent;
   color: #f9fafb;
 }
 


### PR DESCRIPTION
## Bug
On the People Report page, the "Tasks With Completed Hours" card showed a visible boundary/seam in dark mode — the area holding the table header ("Color", "Task Name", "Hours") had a different background than the rest of the card, making it look like two separate surfaces instead of one continuous card.
 
## Root Cause
The header background was actually being set by a completely unrelated, unscoped rule leaking in from elsewhere in the app:
 
```css
:global(thead) {
  background: aliceblue;
}
```
 
in `src/components/Projects/projects.module.css`, and an equivalent bare rule with the same effect:
 
```css
thead {
  background: aliceblue;
}
```
 
in `src/components/Teams/Team.module.css`.
 
CSS Modules only auto-scopes class selectors, not bare element selectors — so both of these `thead` rules applied globally to every `<thead>` in the entire app once bundled, including the one inside the shared `PieChart` component used by "Tasks With Completed Hours". In light mode this pale blue tint blended in with the mostly-white card background, so it went unnoticed; in dark mode it stood out as a visible seam.
 
## Fix
- Scoped the Projects header background to a real CSS Modules class (`.projectsTableHead`) instead of a bare `:global(thead)` selector, and applied that class directly to the `<thead>` in `Projects.jsx`.
- Scoped the Teams header background the same way (`.teamsTableHead`), applied to the `<thead>` in `Teams.jsx`.
- Removed the now-unnecessary hardcoded `background-color: white` / `#1f2937` on the `PieChart` component's own `th` rules, since the header now correctly inherits the card's actual background in both themes rather than being painted over.

## Testing
- Checkout the `Abhishek_FixPeopleTasksPieChartDarkModeSeam` branch in the frontend repo and use `development` for the backend
- Login as admin and navigate to Dashboard → Reports dropdown → Reports → People.
- Verified "Tasks With Completed Hours" (People Report → select a person) shows a single, unified card background in both light and dark mode, with no visible seam

<img width="2178" height="940" alt="Screenshot 2026-07-16 174115" src="https://github.com/user-attachments/assets/39079394-2b1b-42b6-82b6-ddbdfca903e3" />
<img width="2028" height="706" alt="Screenshot 2026-07-16 174044" src="https://github.com/user-attachments/assets/04a2d7e8-c5ef-4771-a72d-5d4977152b54" />
