### PR TITLE
Abhishek 🔥: resolve mentor status legend wrap misalignment

### DIFF
--- a/src/components/TotalOrgSummary/VolunteerStatus/MentorStatusPieChart.module.css
+++ b/src/components/TotalOrgSummary/VolunteerStatus/MentorStatusPieChart.module.css
@@ -81,7 +81,7 @@
   margin-bottom: 24px;
   flex-wrap: wrap;
   overflow-x: visible;
-  padding: 0 20px;
+  padding: 0 8px;
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;

--- a/src/components/TotalOrgSummary/VolunteerStatus/VolunteerStatusChart.module.css
+++ b/src/components/TotalOrgSummary/VolunteerStatus/VolunteerStatusChart.module.css
@@ -56,7 +56,8 @@
   }
 
   .mentorChartSection {
-    flex: 0 1 320px;
+    flex: 1 1 320px;
+    max-width: 400px;
   }
 }
 


### PR DESCRIPTION
## What's Working Well
- Fixes a legend alignment bug on the "Total Mentors" donut chart (Volunteer Status section, Total Org Summary), where the "Deactivated" legend item would wrap to its own line and misalign relative to the row above it, in both light and dark mode.

## Root Cause
- `.mentorChartSection` had `flex: 0 1 320px`, capping its width regardless of available space, while the sibling `.volunteerChartSection` could grow up to `400px` via `flex: 1 1 340px`.
- Combined with extra horizontal padding on the mentor legend (`padding: 0 20px` vs. the volunteer legend's `padding: 0 8px`), this left the mentor legend with less usable width than the volunteer legend, causing "Deactivated" to wrap even though the label text is identical on both charts.

## Changes
- `VolunteerStatusChart.module.css`: changed `.mentorChartSection` from `flex: 0 1 320px` to `flex: 1 1 320px; max-width: 400px`, letting it grow to match the volunteer section's available width.
- `MentorStatusPieChart.module.css`: aligned `.mentorStatusLabels` padding from `0 20px` to `0 8px` to match the volunteer legend.

## Testing
- Checkout the `Abhishek_FixVolunteerStatusLegendAlignment` branch in the frontend repo and use `development` for the backend
- Login as admin and navigate to Dashboard → Reports → Total Org Summary → Volunteer Status
Verified locally in both light and dark mode, across breakpoints:
- Desktop (1200px+): both legends render on a single row, matching alignment
- iPhone 14 Pro Max (430px): both legends single-row, no misalignment
- Samsung Galaxy S8+ (360px): both legends wrap gracefully and consistently when space is genuinely insufficient — confirming the fix addresses the alignment mismatch specifically, not general wrap behavior

<img width="1370" height="1026" alt="Screenshot 2026-07-16 191757" src="https://github.com/user-attachments/assets/7d2de4b3-14fc-48c9-9f42-386f687801d6" />
<img width="1364" height="1008" alt="Screenshot 2026-07-16 191816" src="https://github.com/user-attachments/assets/8eaa44f2-6fbf-473a-97e7-3bb34708c52f" />
<img width="1102" height="1620" alt="Screenshot 2026-07-16 191928" src="https://github.com/user-attachments/assets/d55eba4b-91d9-470a-a142-2f4813a7b3de" />
<img width="1104" height="1620" alt="Screenshot 2026-07-16 191953" src="https://github.com/user-attachments/assets/f1f9019e-fe34-4ac5-b210-fa068d60bc5a" />
