### PR TITLE
Abhishek 🔥: hide project comparison change value when No Comparison is selected

### DIFF
--- a/src/components/TotalOrgSummary/HoursCompleted/HoursCompletedBarChart.jsx
+++ b/src/components/TotalOrgSummary/HoursCompleted/HoursCompletedBarChart.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import TinyBarChart from '../TinyBarChart';
 import Loading from '../../common/Loading';
 
-export default function HoursCompletedBarChart({ isLoading, data, darkMode }) {
+export default function HoursCompletedBarChart({ isLoading, data, darkMode, comparisonType }) {
   const initialCardSize = () => {
     if (window.innerWidth <= 680) {
       return { height: '240px' };
@@ -86,7 +86,10 @@ export default function HoursCompletedBarChart({ isLoading, data, darkMode }) {
     color: ['rgba(76,75,245,255)', 'rgba(0,175,244,255)'],
   }));
   const projectBarInfo = {
-    ifcompare: projectChangePercentage !== undefined && projectChangePercentage !== null,
+    ifcompare:
+      comparisonType !== 'No Comparison' &&
+      projectChangePercentage !== undefined &&
+      projectChangePercentage !== null,
     amount: projectHours.count,
     percentage: `${(projectPercentage * 100).toFixed(2)}%`,
     change:


### PR DESCRIPTION
## What's Working Well
- Fixes a bug on the "Hours Completed" chart (Total Org Summary) where the "Projects" summary box would show a spurious green change percentage (e.g. "0%") even when the comparison dropdown was set to "No Comparison."

## Root Cause
- `HoursCompletedBarChart.jsx` did not receive the `comparisonType` prop despite it being passed in from the parent (`TotalOrgSummary.jsx`).
- The `ifcompare` flag controlling whether the change value renders only checked whether `projectChangePercentage` was `undefined`/`null`, not whether the user had actually selected a comparison option. Since the backend can return `0` as a default value even in "No Comparison" mode, the change value rendered regardless of the selected comparison type.

## Changes
- Added `comparisonType` to the component's destructured props.
- Updated `ifcompare` to also require `comparisonType !== 'No Comparison'` before rendering a change percentage, matching the pattern already used elsewhere (e.g. Mentor Status chart).

## Testing
- Checkout the `Abhishek_FixHoursCompletedNoComparisonBug` branch in the frontend repo and use development for the backend
- Login as admin and navigate to Dashboard → Reports → Total Org Summary → Hours Completed
Verified locally:
- With "No Comparison" selected: the Projects box now shows only the amount and percentage, with no change value.

<img width="698" height="796" alt="Screenshot 2026-07-16 204540" src="https://github.com/user-attachments/assets/b476b3d7-aa38-42ad-8b80-83c659eaea5c" />
<img width="766" height="824" alt="Screenshot 2026-07-16 204320" src="https://github.com/user-attachments/assets/940948ab-9b7b-4360-9127-e3503f961d50" />
