### PR TITLE
Abhishek 🔥: enable duplicate name detection when creating new users

### DIFF
--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -827,7 +827,7 @@ class UserProfileAdd extends Component {
     else return false;
   };
 
-  createUserProfile = () => {
+  createUserProfile = (skipDuplicateCheck = false) => {
     let that = this;
     const {
       firstName,
@@ -869,7 +869,7 @@ class UserProfileAdd extends Component {
       collaborationPreference: collaborationPreference,
       timeZone: timeZone,
       location: location,
-      allowsDuplicateName: true,
+      allowsDuplicateName: skipDuplicateCheck,
       createdDate: createdDate,
       teamCode: this.state.teamCode,
       actualEmail: role === 'Administrator' || role === 'Owner' ? actualEmail : '',
@@ -925,11 +925,16 @@ class UserProfileAdd extends Component {
       }
     }
     if (this.fieldsAreValid()) {
-      this.setState({ showphone: false });
       if (!email.match(patt)) {
         toast.error('Email is not valid. Please include @ followed by .com format');
-      } else {
-        createUser(userData)
+        return;
+      }
+      if (!skipDuplicateCheck && this.checkIfDuplicate(firstName, lastName)) {
+        this.setState({ popupOpen: true });
+        return;
+      }
+      this.setState({ showphone: false });
+      createUser(userData)
           .then(res => {
             if (res.data.warning) {
               toast.warn(
@@ -1005,7 +1010,6 @@ class UserProfileAdd extends Component {
             // Generic fallback
             toast.error(`Create failed${status ? ` (${status})` : ''}: ${data.error || 'Unknown error occurred.'}`);
           });
-      }
     }
   };
 

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -827,6 +827,108 @@ class UserProfileAdd extends Component {
     else return false;
   };
 
+  // Validates the Google Doc link (if provided) and appends it to userData.adminLinks.
+  // Returns true if creation should proceed, false if it should stop here.
+  validateAndAddGoogleDoc = (googleDoc, userData) => {
+    if (!googleDoc) return true;
+
+    if (isValidGoogleDocsUrl(googleDoc)) {
+      userData.adminLinks.push({ Name: 'Google Doc', Link: googleDoc.trim() });
+      return true;
+    }
+
+    toast.error('Invalid Google Doc link. Please provide a valid Google Doc URL.');
+    this.setState({
+      formValid: {
+        ...this.state.formValid,
+        googleDoc: false,
+      },
+      formErrors: {
+        ...this.state.formErrors,
+        googleDoc: 'Invalid Google Doc URL',
+      },
+    });
+    return false;
+  };
+
+  // Validates the Dropbox/media link (if provided) and appends it to userData.adminLinks.
+  // Returns true if creation should proceed, false if it should stop here.
+  validateAndAddDropboxDoc = (dropboxDoc, userData) => {
+    if (!dropboxDoc) return true;
+
+    if (isValidMediaUrl(dropboxDoc)) {
+      userData.adminLinks.push({ Name: 'Media Folder', Link: dropboxDoc.trim() });
+      return true;
+    }
+
+    toast.error('Invalid DropBox link. Please provide a valid Drop Box URL.');
+    this.setState({
+      formValid: {
+        ...this.state.formValid,
+        dropboxDoc: false,
+      },
+      formErrors: {
+        ...this.state.formErrors,
+        dropboxDoc: 'Invalid Dropbox Link URL',
+      },
+    });
+    return false;
+  };
+
+  // Centralized error handling for the createUser API call, extracted out of
+  // createUserProfile to keep that method's cognitive complexity in check.
+  handleCreateUserError = err => {
+    const res = err.response;
+    const status = res?.status;
+    const data = res?.data || {};
+
+    if (!res) {
+      toast.error(`Network error: ${err.message}`);
+      return;
+    }
+
+    // Handle Mongoose validation error cleanup
+    if (data?.errors && typeof data.errors === 'object') {
+      const firstErrorKey = Object.keys(data.errors)[0];
+      const firstError = data.errors[firstErrorKey];
+      const fieldName = firstError.path || firstErrorKey;
+      const message = firstError.message;
+
+      toast.error(`${fieldName.charAt(0).toUpperCase() + fieldName.slice(1)}: ${message}`);
+      return;
+    }
+
+    // Fallback to known type-based errors
+    if (data.type) {
+      switch (data.type) {
+        case 'email':
+          toast.error('Email already exists');
+          return;
+        case 'phoneNumber':
+          toast.error('Phone number already exists');
+          return;
+        case 'name':
+          toast.error('A user with this first and last name already exists');
+          return;
+        case 'credentials': {
+          // Prefer the backend’s explanation if available
+          const detail =
+            (typeof data.error === 'string' && data.error) ||
+            data?.error?.message ||
+            data?.message ||
+            '';
+          toast.error(`Admin credentials were not accepted${detail ? `: ${detail}` : ''}`);
+          return;
+        }
+        default:
+          break;
+      }
+    }
+
+    // Generic fallback
+    toast.error(`Create failed${status ? ` (${status})` : ''}: ${data.error || 'Unknown error occurred.'}`);
+  };
+
   createUserProfile = (skipDuplicateCheck = false) => {
     let that = this;
     const {
@@ -888,129 +990,51 @@ class UserProfileAdd extends Component {
       return;
     }
 
-    if (googleDoc) {
-      if (isValidGoogleDocsUrl(googleDoc)) {
-        userData.adminLinks.push({ Name: 'Google Doc', Link: googleDoc.trim() });
-      } else {
-        toast.error('Invalid Google Doc link. Please provide a valid Google Doc URL.');
-        this.setState({
-          formValid: {
-            ...that.state.formValid,
-            googleDoc: false,
-          },
-          formErrors: {
-            ...that.state.formErrors,
-            googleDoc: 'Invalid Google Doc URL',
-          },
-        });
-        return;
-      }
+    if (!this.validateAndAddGoogleDoc(googleDoc, userData)) {
+      return;
     }
-    if (dropboxDoc) {
-      if (isValidMediaUrl(dropboxDoc)) {
-        userData.adminLinks.push({ Name: 'Media Folder', Link: dropboxDoc.trim() });
-      } else {
-        toast.error('Invalid DropBox link. Please provide a valid Drop Box URL.');
-        this.setState({
-          formValid: {
-            ...that.state.formValid,
-            dropboxDoc: false,
-          },
-          formErrors: {
-            ...that.state.formErrors,
-            dropboxDoc: 'Invalid Dropbox Link URL',
-          },
-        });
-        return;
-      }
+    if (!this.validateAndAddDropboxDoc(dropboxDoc, userData)) {
+      return;
     }
-    if (this.fieldsAreValid()) {
-      if (!email.match(patt)) {
-        toast.error('Email is not valid. Please include @ followed by .com format');
-        return;
-      }
-      if (!skipDuplicateCheck && this.checkIfDuplicate(firstName, lastName)) {
-        this.setState({ popupOpen: true });
-        return;
-      }
-      this.setState({ showphone: false });
-      createUser(userData)
-          .then(res => {
-            if (res.data.warning) {
-              toast.warn(
-                typeof res.data.warning === 'string'
-                  ? res.data.warning
-                  : res.data.warning?.message || JSON.stringify(res.data.warning),
+    if (!this.fieldsAreValid()) {
+      return;
+    }
+    if (!email.match(patt)) {
+      toast.error('Email is not valid. Please include @ followed by .com format');
+      return;
+    }
+    if (!skipDuplicateCheck && this.checkIfDuplicate(firstName, lastName)) {
+      this.setState({ popupOpen: true });
+      return;
+    }
+
+    this.setState({ showphone: false });
+    createUser(userData)
+      .then(res => {
+        if (res.data.warning) {
+          toast.warn(
+            typeof res.data.warning === 'string'
+              ? res.data.warning
+              : res.data.warning?.message || JSON.stringify(res.data.warning),
+          );
+        } else {
+          toast.success('User profile created.');
+          // eslint-disable-next-line react/no-direct-mutation-state
+          this.state.userProfile._id = res.data._id;
+          if (this.state.teams.length > 0) {
+            this.state.teams.forEach(team => {
+              this.props.addTeamMember(
+                team._id,
+                res.data._id,
+                res.data.firstName,
+                res.data.lastName,
               );
-            } else {
-              toast.success('User profile created.');
-              // eslint-disable-next-line react/no-direct-mutation-state
-              this.state.userProfile._id = res.data._id;
-              if (this.state.teams.length > 0) {
-                this.state.teams.forEach(team => {
-                  this.props.addTeamMember(
-                    team._id,
-                    res.data._id,
-                    res.data.firstName,
-                    res.data.lastName,
-                  );
-                });
-              }
-            }
-            this.props.userCreated();
-          })
-          .catch(err => {
-            const res = err.response;
-            const status = res?.status;
-            const data = res?.data || {};
-
-            if (!res) {
-              toast.error(`Network error: ${err.message}`);
-              return;
-            }
-
-            // Handle Mongoose validation error cleanup
-            if (data?.errors && typeof data.errors === 'object') {
-              const firstErrorKey = Object.keys(data.errors)[0];
-              const firstError = data.errors[firstErrorKey];
-              const fieldName = firstError.path || firstErrorKey;
-              const message = firstError.message;
-          
-              toast.error(`${fieldName.charAt(0).toUpperCase() + fieldName.slice(1)}: ${message}`);
-              return;
-            }
-
-            // Fallback to known type-based errors
-            if (data.type) {
-              switch (data.type) {
-                case 'email':
-                  toast.error('Email already exists');
-                  return;
-                case 'phoneNumber':
-                  toast.error('Phone number already exists');
-                  return;
-                case 'name':
-                  toast.error('A user with this first and last name already exists');
-                  return;
-                case 'credentials': {
-                // Prefer the backend’s explanation if available
-                  const detail =
-                    (typeof data.error === 'string' && data.error) ||
-                    data?.error?.message ||
-                    data?.message ||
-                    '';
-                  toast.error(
-                    `Admin credentials were not accepted${detail ? `: ${detail}` : ''}`
-                  );
-                  return;
-                }
-              }
-            }
-
-            // Generic fallback
-            toast.error(`Create failed${status ? ` (${status})` : ''}: ${data.error || 'Unknown error occurred.'}`);
-          });
-    }
+            });
+          }
+        }
+        this.props.userCreated();
+      })
+      .catch(err => this.handleCreateUserError(err));
   };
 
   handleImageUpload = async e => {

--- a/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
+++ b/src/components/UserProfile/AddNewUserProfile/UserProfileAdd.jsx
@@ -838,16 +838,16 @@ class UserProfileAdd extends Component {
     }
 
     toast.error('Invalid Google Doc link. Please provide a valid Google Doc URL.');
-    this.setState({
+    this.setState(prevState => ({
       formValid: {
-        ...this.state.formValid,
+        ...prevState.formValid,
         googleDoc: false,
       },
       formErrors: {
-        ...this.state.formErrors,
+        ...prevState.formErrors,
         googleDoc: 'Invalid Google Doc URL',
       },
-    });
+    }));
     return false;
   };
 
@@ -862,16 +862,16 @@ class UserProfileAdd extends Component {
     }
 
     toast.error('Invalid DropBox link. Please provide a valid Drop Box URL.');
-    this.setState({
+    this.setState(prevState => ({
       formValid: {
-        ...this.state.formValid,
+        ...prevState.formValid,
         dropboxDoc: false,
       },
       formErrors: {
-        ...this.state.formErrors,
+        ...prevState.formErrors,
         dropboxDoc: 'Invalid Dropbox Link URL',
       },
-    });
+    }));
     return false;
   };
 
@@ -917,7 +917,8 @@ class UserProfileAdd extends Component {
             data?.error?.message ||
             data?.message ||
             '';
-          toast.error(`Admin credentials were not accepted${detail ? `: ${detail}` : ''}`);
+          const suffix = detail ? `: ${detail}` : '';
+          toast.error(`Admin credentials were not accepted${suffix}`);
           return;
         }
         default:


### PR DESCRIPTION
## What's Working Well
- Fixes a bug where the "Add User" form allowed creating a new user with a first and last name that already exists for another user, with no warning of any kind.

## Root Cause
The duplicate-name warning feature had been partially built but never wired up:
- `UserProfileAdd.jsx` already had a working `checkIfDuplicate(firstName, lastName)` method and a `DuplicateNamePopup` component already imported and rendered, but `checkIfDuplicate` was never actually called from `createUserProfile`, and `popupOpen` (which controls the popup's visibility) was only ever set to `false`, so the popup could never open.
- The submitted user payload also hardcoded `allowsDuplicateName: true`, unconditionally telling the backend to allow duplicates regardless of any check.
- `createUserProfile` ignored the boolean parameter that both the Create button (`createUserProfile(false)`) and the popup's Confirm button (`createUserProfile(true)`) were already designed to pass in, meaning the plumbing existed but the function itself never used it.

## Changes
`UserProfileAdd.jsx`:
- `createUserProfile` now accepts and uses a `skipDuplicateCheck` parameter.
- Before creating a user, it calls the existing `checkIfDuplicate` and opens the existing `DuplicateNamePopup` if a match is found (unless the check is explicitly skipped, e.g. after the user confirms via the popup).
- `allowsDuplicateName` in the submitted payload now reflects `skipDuplicateCheck` instead of being hardcoded to `true`.

## Testing
- Start the frontend and backend using `Abhishek_FixDuplicateNameValidation` and `development` branches respectively
- Login as admin and navigate to Other Links -> User Management and try creating a user for a duplicate case
Verified locally:
- Creating a user with a first/last name combo that already exists now triggers the "Duplicate Names" popup.
- "Change name" closes the popup without creating the user.
- "Confirm" proceeds to create the user despite the duplicate.
- Creating a user with a genuinely unique name proceeds normally with no popup interruption.

- Before: Duplicate users were getting created without warnings or notifications
<img width="1646" height="230" alt="Screenshot 2026-07-17 173821" src="https://github.com/user-attachments/assets/7ddeef66-afa6-4a26-bbf7-ccfe2c81dbf6" />

- After: Users are prompted a warning when a duplicate entry is detected
<img width="2880" height="1718" alt="Screenshot 2026-07-17 175621" src="https://github.com/user-attachments/assets/36fc51a9-4f2e-40c1-876d-68b1ed97b445" />

