### PR TITLE
Abhishek 🔥: render Usage Record table instead of blank modal in Materials view

### DIFF
--- a/src/components/BMDashboard/ItemList/RecordsModal.jsx
+++ b/src/components/BMDashboard/ItemList/RecordsModal.jsx
@@ -178,7 +178,39 @@ export function Record({ record, recordType, setRecord, itemType }) {
       </>
     );
   }
+  if (recordType === 'UsageRecord') {
+    return (
+      <>
+        <thead className={darkMode ? 'dark-thead bg-space-cadet text-white' : ''}>
+          <tr className={darkMode ? 'dark-row text-white bg-yinmn-blue' : ''}>
+            <th>Date</th>
+            <th>Quantity Used</th>
+            <th>Logged By</th>
+            <th>Email</th>
+          </tr>
+        </thead>
 
+        <tbody className={darkMode ? 'dark-tbody bg-yinmn-blue text-light' : ''}>
+          {record?.usageRecord?.length ? (
+            record.usageRecord.map(data => (
+              <tr key={data._id} className={darkMode ? 'dark-row text-white bg-yinmn-blue' : ''}>
+                <td>{data.date ? moment.utc(data.date).format('LL') : '-'}</td>
+                <td>{formatQuantity(data.quantityUsed, record.itemType?.unit)}</td>
+                <td>{renderUser(data.createdBy)}</td>
+                <td>{data?.createdBy?.email || '-'}</td>
+              </tr>
+            ))
+          ) : (
+            <tr className={darkMode ? 'text-light bg-space-cadet' : ''}>
+              <td colSpan={4} style={{ fontWeight: 'bold' }}>
+                There are no usage records for this item.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </>
+    );
+  }
   if (recordType === 'Purchase') {
     return (
       <>


### PR DESCRIPTION
## What's Working Well
- Fixes a bug on the BM Dashboard's Materials page where clicking "View" under the **Usage Record** column opened a completely blank modal (title only, no content, no error).

## Root Cause
`RecordsModal.jsx`'s internal `Record` component explicitly handles rendering for `recordType === 'Update'` and `recordType === 'Purchase'`, each with their own table. There was no corresponding branch for `recordType === 'UsageRecord'`, so it fell through to the function's final `return null;`, rendering nothing inside the modal shell.

The backend schema (`inventoryItemMaterial.js`) already defines a `usageRecord` field (`date`, `createdBy`, `quantityUsed`) parallel to `updateRecord` and `purchaseRecord`, so no backend changes are needed for this fix — the frontend just needed the missing rendering branch.

Note: while investigating, we found that no current backend code path actually writes to `usageRecord` (stock usage is tracked via `updateRecord` instead), so this table will currently always show "no usage records" in practice. That's a separate, pre-existing backend gap outside the scope of this fix, and is being tracked separately.

## Changes
- `RecordsModal.jsx`: added a `recordType === 'UsageRecord'` branch to the `Record` component, rendering a table with Date, Quantity Used, Logged By, and Email columns — following the same structure, styling, and dark-mode handling already used by the `Update` and `Purchase` branches.

## Testing
Verified locally in both light and dark mode: (use `Abhishek_FixMaterialUsageRecordModal` branch for frontend and run backend on development)
- Clicking "View" under Usage Record no longer shows a blank modal — it now renders a proper table.
- For materials with no usage records, it correctly shows "There are no usage records for this item." instead of a blank screen.
- No regressions to the existing "Update" and "Purchase" record views.

<img width="1694" height="1454" alt="Screenshot 2026-07-17 195742" src="https://github.com/user-attachments/assets/44add20c-c08b-488f-956d-887bae15cbbd" />
