### PR TITLE
Abhishek 🔥: correct chart sizing mismatch and calendar dark mode theming in Longest Open Issues

### DIFF
--- a/src/components/BMDashboard/Issues/CustomDateComponent.jsx
+++ b/src/components/BMDashboard/Issues/CustomDateComponent.jsx
@@ -19,7 +19,15 @@ export const CustomDateComponent = ({
         ◀
       </button>
 
-      <span style={{ flex: 1, textAlign: 'center', fontWeight: 'bold', fontSize: '16px' }}>
+      <span
+        style={{
+          flex: 1,
+          textAlign: 'center',
+          fontWeight: 'bold',
+          fontSize: '16px',
+          color: darkMode ? 'white' : 'black',
+        }}
+      >
         {date.toLocaleString('default', {
           month: 'long',
           year: 'numeric',

--- a/src/components/BMDashboard/Issues/issueCharts.module.css
+++ b/src/components/BMDashboard/Issues/issueCharts.module.css
@@ -241,11 +241,10 @@ Issue Charts Module CSS
 
 .chartContainerDark {
   width: 100%;
-  max-width: 900px; /* centers the chart while panel stays 100% */
   background: #1a1c20;
   padding: 25px;
   border-radius: 12px;
-  margin: 0 auto;
+  margin: 20px;
   box-shadow: 0 2px 6px rgb(0 0 0 / 60%);
   color: #cfd7e3;
 }
@@ -311,4 +310,99 @@ Issue Charts Module CSS
   .filter {
     width: 100%;
   }
+}
+
+/* ----- React DatePicker calendar overrides -----
+   calendarClassName is passed as a plain string ('darkCalendar' / 'lightCalendar'),
+   not a CSS-module-scoped class, so these must be :global to actually apply. */
+:global(.lightCalendar) {
+  font-family: inherit;
+  border: 1px solid #e2e8f0 !important;
+  background-color: #fff !important;
+  color: #333 !important;
+}
+
+:global(.lightCalendar) :global(.react-datepicker__header) {
+  background-color: #f0f0f0 !important;
+  border-bottom: 1px solid #e0e0e0 !important;
+}
+
+:global(.lightCalendar) :global(.react-datepicker__current-month),
+:global(.lightCalendar) :global(.react-datepicker__day-name) {
+  color: #333 !important;
+}
+
+:global(.lightCalendar) :global(.react-datepicker__day) {
+  color: #333 !important;
+}
+
+:global(.lightCalendar) :global(.react-datepicker__day:hover) {
+  background-color: #e0e0e0 !important;
+}
+
+:global(.lightCalendar) :global(.react-datepicker__day--in-range) {
+  background-color: #d6e9ff !important;
+  color: #333 !important;
+}
+
+:global(.lightCalendar) :global(.react-datepicker__day--range-start),
+:global(.lightCalendar) :global(.react-datepicker__day--range-end),
+:global(.lightCalendar) :global(.react-datepicker__day--selected) {
+  background-color: #007bff !important;
+  color: #fff !important;
+}
+
+:global(.darkCalendar) {
+  font-family: inherit;
+  border: 1px solid #4a5568 !important;
+  background-color: #1c2541 !important;
+  color: #fff !important;
+}
+
+:global(.darkCalendar) :global(.react-datepicker__header) {
+  background-color: #0f1729 !important;
+  border-bottom: 1px solid #4a5568 !important;
+}
+
+:global(.darkCalendar) :global(.react-datepicker__current-month),
+:global(.darkCalendar) :global(.react-datepicker__day-name) {
+  color: #fff !important;
+}
+
+:global(.darkCalendar) :global(.react-datepicker__day) {
+  color: #e2e8f0 !important;
+}
+
+:global(.darkCalendar) :global(.react-datepicker__day:hover) {
+  background-color: #2d3748 !important;
+  color: #fff !important;
+}
+
+:global(.darkCalendar) :global(.react-datepicker__day--selected),
+:global(.darkCalendar) :global(.react-datepicker__day--keyboard-selected),
+:global(.darkCalendar) :global(.react-datepicker__day--in-range) {
+  background-color: #007bff !important;
+  color: #fff !important;
+}
+
+:global(.darkCalendar) :global(.react-datepicker__day--disabled) {
+  color: #6c757d !important;
+}
+
+:global(.lightCalendar) :global(.react-datepicker__navigation),
+:global(.darkCalendar) :global(.react-datepicker__navigation) {
+  top: 8px !important;
+}
+
+:global(.lightCalendar) :global(.react-datepicker__navigation-icon::before) {
+  border-color: #333 !important;
+}
+
+:global(.darkCalendar) :global(.react-datepicker__navigation-icon::before) {
+  border-color: #fff !important;
+}
+
+:global(.lightCalendar) :global(.react-datepicker__triangle),
+:global(.darkCalendar) :global(.react-datepicker__triangle) {
+  display: none !important;
 }

--- a/src/components/BMDashboard/Issues/issueCharts.module.css
+++ b/src/components/BMDashboard/Issues/issueCharts.module.css
@@ -348,7 +348,7 @@ Issue Charts Module CSS
 :global(.lightCalendar) :global(.react-datepicker__day--range-start),
 :global(.lightCalendar) :global(.react-datepicker__day--range-end),
 :global(.lightCalendar) :global(.react-datepicker__day--selected) {
-  background-color: #007bff !important;
+  background-color: #0056b3 !important;
   color: #fff !important;
 }
 
@@ -381,7 +381,7 @@ Issue Charts Module CSS
 :global(.darkCalendar) :global(.react-datepicker__day--selected),
 :global(.darkCalendar) :global(.react-datepicker__day--keyboard-selected),
 :global(.darkCalendar) :global(.react-datepicker__day--in-range) {
-  background-color: #007bff !important;
+  background-color: #0056b3 !important;
   color: #fff !important;
 }
 


### PR DESCRIPTION
## What's Working Well
 
Fixes two dark mode theming issues in the "Longest Open Issues" chart (BM Dashboard → Issue Tracking). Paired with a backend fix (HGNRest PR, same branch name) that corrects the underlying data (an "undefined" row, all-zero durations, and missing sort by duration).
 
## Root Cause & Changes
 
### 1. Chart size mismatch between light and dark mode
 
`.chartContainer` (light mode) has no `max-width`, filling all available space. `.chartContainerDark` had an extra `max-width: 900px; margin: 0 auto;`, causing the chart to render visibly smaller and centered in dark mode only.
 
**Fix:** removed the mismatched constraint so both modes render at the same width.
 
### 2. Calendar (date range picker) not respecting dark mode
 
`openIssueCharts.jsx` passes `calendarClassName={darkMode ? 'darkCalendar' : 'lightCalendar'}` as a plain string to `react-datepicker`. However, `.darkCalendar`/`.lightCalendar` rules only existed in a completely unrelated component's CSS Module (`SimpleToolChart.module.css`), scoped locally to that module — they never actually applied here. As a result, only the custom header's arrow icons respected dark mode; the calendar body (day grid, weekday labels, selection highlighting) and even the month/year label text stayed unstyled/incorrect in dark mode.
 
**Fix:**
- Added `:global(.darkCalendar)` / `:global(.lightCalendar)` rules to `issueCharts.module.css`, adapted from the working implementation in `SimpleToolChart.module.css`, covering the header, day cells, hover/selected states, and navigation arrows.
- Fixed `CustomDateComponent.jsx`'s month/year label, which had no `color` set at all (previously always rendering in default/black text regardless of theme).

## Files Changed
 
- `src/components/BMDashboard/Issues/issueCharts.module.css`
- `src/components/BMDashboard/Issues/CustomDateComponent.jsx`
## Testing
Verified via the frontend (Use this branch for frontend and backend: Abhishek_FixLongestOpenIssuesDataAndTheming): Reports → Total Construction Summary → Issue Tracking → Longest Open Issues
- Chart now renders at consistent width in both modes
- Date range picker calendar (both Start Date and End Date) correctly themed in dark mode — background, header, day cells, hover state, and selected-range highlighting all readable
- No regressions to light mode calendar appearance
## Related PRs
 
This frontend PR pairs with a backend PR (https://github.com/OneCommunityGlobal/HGNRest/pull/2278) that fixes the underlying data issues:
- "undefined" row appearing due to a missing fallback for array-typed issue titles
- All bars showing "0 months" due to a response shape mismatch between backend and frontend
- Results not being sorted by duration before truncation
Both PRs should be reviewed/merged together for the fix to be complete, since the frontend chart sizing/calendar fixes are independent of the data fixes but the full bug report (incorrect data + poor dark mode theming) requires both.

<img width="2660" height="1158" alt="Screenshot 2026-07-20 020706" src="https://github.com/user-attachments/assets/6ef9bf04-a9ea-44c0-8676-6ca5cfe50602" />
<img width="2728" height="1192" alt="Screenshot 2026-07-20 020635" src="https://github.com/user-attachments/assets/ddf8413b-16b0-4e44-bb07-e269fa0c98c8" />
<img width="2702" height="1176" alt="Screenshot 2026-07-20 020646" src="https://github.com/user-attachments/assets/93837c32-b88c-4155-856e-d882f66c9d9a" />