### PR TITLE
Abhishek 🔥: left-align team member name, tracking button, and stats in Team Member Tasks viewfix: left-align team member name, tracking button, and stats in Team Member Tasks view

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -412,7 +412,7 @@ const TeamMemberTask = React.memo(
                           <td
                             colSpan={2}
                             className={styles['team-member-tasks-user-name']}
-                            style={{ textAlign: 'center' }}
+                            style={{ textAlign: 'left', alignItems: 'flex-start' }}
                           >
                             <Link
                               className={styles['team-member-tasks-user-name-link']}


### PR DESCRIPTION
## What's Working Well
Fixes a hotfix reported by Jae: the "Team Member Tasks" dashboard view (per team member row) was rendering with the name, Tracking button, and hours stats all center-aligned, instead of left-aligned as they correctly appear in production.

## Root Cause
The `<td>` containing each team member's name link, role, Tracking/+/- buttons, and hours stats had an inline `style={{ textAlign: 'center' }}` explicitly forcing centered text. Its parent CSS class (`.team-member-tasks-user-name`) is also a flex column container with `align-items: center`, which independently centers its flex children (the Tracking button and stats numbers) regardless of `text-align`. Together, both properties caused the entire per-row content block to appear centered instead of left-aligned.

## Changes
`TeamMemberTask.jsx`: updated the inline style on the team member name `<td>` from `{ textAlign: 'center' }` to `{ textAlign: 'left', alignItems: 'flex-start' }`, so both the text content and the flex-positioned children (Tracking button, stats) align left.

This is scoped to the per-row `<td>` only via inline style, so it doesn't affect the shared `.team-member-tasks-user-name` class used elsewhere (e.g. the column header, which also uses this class but combined with different centering rules intentionally).

## Testing
Verified locally on the Team Member Tasks dashboard: (use the `Abhishek_FixTeamMemberTasksAlignment` branch for frontend and development for backend)
- Team member name, role, Tracking/+/- buttons, and hours stats (e.g. "10 / 0 / 29.0") now render left-aligned, matching production on the dashboard
- No regressions to the column header row or other rows

<img width="1628" height="1720" alt="Screenshot 2026-07-20 050632" src="https://github.com/user-attachments/assets/01c57869-f5f3-422c-8935-2665e30bf09e" />
