### PR TITLE
Abhishek 🔥: clear pending user edits after save and sort by signup date

### DIFF
--- a/src/actions/userManagement.js
+++ b/src/actions/userManagement.js
@@ -14,6 +14,7 @@ import {
   DISABLE_USER_PROFILE_EDIT,
   CHANGE_USER_PROFILE_PAGE,
   START_USER_INFO_UPDATE,
+  FINISH_USER_INFO_UPDATE,
 } from '../constants/userManagement';
 import { ENDPOINTS } from '~/utils/URL';
 import { UserStatus, UserStatusOperations, InactiveReason } from '~/utils/enums';
@@ -139,18 +140,18 @@ const resolveEndDate = (user) => {
 
   //2) if no lastActivityAt, use createdDate (if present)
   // format createdDate to real datetime in COMPANY_TZ
-  if(!user?.lastActivityAt && user?.createdDate) {
+  if (!user?.lastActivityAt && user?.createdDate) {
     const created = moment.tz(user.createdDate, 'YYYY-MM-DD', COMPANY_TZ).startOf('day');
     return created.toISOString();
   }
 
   //3) if no createdDate -> endDate will be set as passed
-  if(user?.endDate) {
+  if (user?.endDate) {
     return moment(user.endDate).toISOString();
   }
 
   // optional: if lastActivityAt is present, use that
-  if(user?.lastActivityAt) {
+  if (user?.lastActivityAt) {
     return moment(user.lastActivityAt).toISOString();
   }
 
@@ -159,7 +160,7 @@ const resolveEndDate = (user) => {
 }
 
 export const buildUpdatedUserLifecycleDetails = (user, payload) => {
-  const {action, endDate, reactivationDate} = payload;
+  const { action, endDate, reactivationDate } = payload;
   switch (action) {
     case UserStatusOperations.ACTIVATE:
       return {
@@ -445,4 +446,15 @@ export const changePagination = value => dispatch => {
 
 export const updateUserInfomation = value => dispatch => {
   dispatch({ type: START_USER_INFO_UPDATE, payload: value });
+};
+
+/**
+ * Clears the queue of pending user info edits (newUserData) after they have
+ * been successfully saved to the backend. Without this, previously-saved
+ * edits remain in the queue and get resubmitted (replayed) the next time any
+ * user's info is saved, silently overwriting that user's data with stale
+ * values. See hotfix: User Management stale date replay bug.
+ */
+export const finishUserInfoUpdate = () => dispatch => {
+  dispatch({ type: FINISH_USER_INFO_UPDATE });
 };

--- a/src/components/UserManagement/UserManagement.jsx
+++ b/src/components/UserManagement/UserManagement.jsx
@@ -228,9 +228,22 @@ class UserManagement extends React.PureComponent {
 
       return usersSearchData
         .sort((a, b) => {
-          if (a.startDate >= b.startDate) return -1;
-          if (a.startDate < b.startDate) return 1;
-          return 0;
+          // Sort by signup date (createdDate), most recent signups first.
+          // Previously this sorted by startDate, which is intended to track
+          // when a user actually begins logging time (and can be updated
+          // later), not when they signed up - using it here produced an
+          // incorrect and unstable ordering on the User Management page.
+          // See hotfix: User Management stale date replay bug.
+          const aTime = new Date(a.createdDate).getTime();
+          const bTime = new Date(b.createdDate).getTime();
+          const aValid = !Number.isNaN(aTime);
+          const bValid = !Number.isNaN(bTime);
+
+          if (!aValid && !bValid) return 0;
+          if (!aValid) return 1;
+          if (!bValid) return -1;
+
+          return bTime - aTime;
         })
         .slice(
           (this.state.selectedPage - 1) * this.state.pageSize,

--- a/src/components/UserManagement/UserTableHeader.jsx
+++ b/src/components/UserManagement/UserTableHeader.jsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEdit, faSave } from '@fortawesome/free-solid-svg-icons';
 import axios from 'axios';
 import { toast } from 'react-toastify';
-import { getAllUserProfile } from '../../actions/userManagement';
+import { getAllUserProfile, finishUserInfoUpdate } from '../../actions/userManagement';
 import { ENDPOINTS } from '~/utils/URL';
 import userTableDataPermissions from '../../utils/userTableDataPermissions';
 import PropTypes from 'prop-types';
@@ -36,6 +36,11 @@ const UserTableHeaderComponent = ({ authRole, roleSearchText, darkMode, editUser
         const response = await axios.patch(ENDPOINTS.USER_PROFILE_UPDATE, updatedData);
         if (response.status === 200) {
           const toastId = toast.success(' Saving Data...', { autoClose: false });
+          // Clear the pending edit queue now that it has been saved successfully.
+          // Without this, these edits would remain queued and get resubmitted
+          // (replayed) the next time any user's info is saved, silently
+          // overwriting that user's data with stale values.
+          dispatch(finishUserInfoUpdate());
           await dispatch(getAllUserProfile());
           toast.update(toastId, {
             render: 'Data Updated successfully !',

--- a/src/reducers/allUserProfilesReducer.js
+++ b/src/reducers/allUserProfilesReducer.js
@@ -85,6 +85,11 @@ export const enableUserInfoEditReducer = (userProfile = userProfilesInitial, act
       return updateObject(userProfile, { editable: action.payload });
     case 'START_USER_INFO_UPDATE':
       return { ...userProfile, newUserData: userProfile.newUserData.concat(action.payload) };
+    // Clears the pending edit queue after a successful save so that stale
+    // edits from a previous save are never resubmitted on a later save.
+    // See hotfix: User Management stale date replay bug.
+    case types.FINISH_USER_INFO_UPDATE:
+      return { ...userProfile, newUserData: [] };
     default:
       return userProfile;
   }


### PR DESCRIPTION
## Summary
Fixes two related User Management bugs reported by Jae: (1) user signup/start/end dates appearing incorrect for accounts that were never intentionally edited, and (2) the User Management table not sorting by signup date as intended.

## Problem 1: Stale edits silently replayed onto unrelated users
Each column in the User Management table (Start Date, End Date, First Name, etc.) has its own independent Edit/Save toggle. Every edit made while in edit mode gets appended to a single global Redux array (`newUserData`), tagged with the target user's `_id`. When any column's Save button is clicked, the *entire* accumulated array is sent to the backend in one PATCH request — not just the edit for that column/user.

Critically, this array was **never cleared** after a successful save. This meant that once an edit was queued and saved, it stayed in the array indefinitely and got resubmitted every time *any other* edit was saved afterward — even for a completely different user and field. This explains the reported symptom: a user who was never directly edited showing corrupted dates, because a stale edit from a previous, unrelated save session was silently replayed onto her account.

## Problem 2: Incorrect sort field
The table sorted by `startDate` (intended to reflect when a user actually begins logging time, and which can legitimately change after signup) instead of `createdDate` (the actual signup date). This produced an unstable, incorrect ordering on the User Management page, independent of Problem 1.

## Fix
- Added a `finishUserInfoUpdate()` action (using the existing but previously unused `FINISH_USER_INFO_UPDATE` constant) that clears `newUserData` back to `[]`.
- Dispatched this action immediately after a successful save in `UserTableHeader.jsx`, before refetching profiles.
- Added the corresponding reducer case in `allUserProfilesReducer.js`.
- Changed the sort comparator in `UserManagement.jsx` to sort by `createdDate` descending (most recent signups first), with safe fallback handling for missing/invalid dates.

## Files changed
- `src/actions/userManagement.js`
- `src/reducers/allUserProfilesReducer.js`
- `src/components/UserManagement/UserTableHeader.jsx`
- `src/components/UserManagement/UserManagement.jsx`

## Testing performed
- Use `Abhishek_FixUserManagementDates` branch for frontend and development for backend
- Confirmed a new signup now appears at the top of the User Management list regardless of `startDate`.
- Reproduced the stale-replay bug pre-fix: edited User A's start date, saved, then edited User B's unrelated end date and saved — confirmed via Network tab that the second PATCH request included User A's stale entry alongside User B's new one.
- Applied the fix and repeated the same steps: confirmed the second PATCH request contains only User B's edit, and User A's data remains unchanged after the second save.
- Verified normal single-user, single-field edits still save and display correctly (no regression).

## Notes
This PR intentionally scopes to what Jae reported. During investigation I also found an unrelated bug in the backend signup flow (`profileInitialSetupController.js` in HGNRest) where a missing `return` causes a duplicate user-creation code path to execute after the response is already sent. This doesn't corrupt saved data (email has a unique index), but produces an unhandled error on every signup. Flagging separately rather than including here, since it's a different repo and outside this hotfix's scope. Will address this in another PR.