### PR TITLE
Abhishek 🔥: "Show Trackers" failing to load for most team members

### DIFF
--- a/src/components/Warnings/Warnings.jsx
+++ b/src/components/Warnings/Warnings.jsx
@@ -7,6 +7,7 @@ import { useDispatch } from 'react-redux';
 import { toast } from 'react-toastify';
 import hasPermission from '~/utils/permissions';
 import { ENDPOINTS } from '~/utils/URL';
+import { enqueueTask } from '~/utils/requestQueue';
 import {
   deleteWarningsById,
   getWarningsByUserId,
@@ -48,7 +49,7 @@ export default function Warning({
     dispatch(hasPermission('deleteWarningTracker'));
 
   const fetchUsersWarningsById = async () => {
-    dispatch(getWarningsByUserId(personId))
+    return dispatch(getWarningsByUserId(personId))
       .then(res => {
         if (!res || res.error) {
           setUsersWarnings([]);
@@ -70,15 +71,11 @@ export default function Warning({
     if (showTrackers) {
       setToggle(true);
       if (usersWarnings.length === 0) {
-        const index = Array.from(personId ?? '').reduce(
-          (acc, c) => acc + (c.codePointAt(0) ?? 0),
-          0,
-        );
-        const delay = index % 5000;
-        const timer = setTimeout(() => {
-          fetchUsersWarningsById();
-        }, delay);
-        return () => clearTimeout(timer);
+        let cancelled = false;
+        enqueueTask(() => (cancelled ? Promise.resolve() : fetchUsersWarningsById()));
+        return () => {
+          cancelled = true;
+        };
       }
     } else {
       setToggle(false);

--- a/src/utils/requestQueue.js
+++ b/src/utils/requestQueue.js
@@ -1,0 +1,37 @@
+// A simple shared concurrency-limited task queue.
+// Used to prevent firing an unbounded number of simultaneous network
+// requests (e.g. one Warnings fetch per team member row), which can
+// exceed the browser's connection limit and cause
+// net::ERR_INSUFFICIENT_RESOURCES failures on pages with many rows.
+
+const MAX_CONCURRENT = 10;
+
+let activeCount = 0;
+const queue = [];
+
+function runNext() {
+  if (activeCount >= MAX_CONCURRENT || queue.length === 0) {
+    return;
+  }
+  const { task, resolve, reject } = queue.shift();
+  activeCount += 1;
+  Promise.resolve()
+    .then(task)
+    .then(resolve, reject)
+    .finally(() => {
+      activeCount -= 1;
+      runNext();
+    });
+}
+
+/**
+ * Enqueue an async task to run once a concurrency slot is available.
+ * @param {() => Promise<any>} task - a function that returns a promise
+ * @returns {Promise<any>} resolves/rejects when the task itself resolves/rejects
+ */
+export function enqueueTask(task) {
+  return new Promise((resolve, reject) => {
+    queue.push({ task, resolve, reject });
+    runNext();
+  });
+}


### PR DESCRIPTION
## Problem
 
On the Team Member Tasks page, clicking **"Show Trackers"** is supposed to expand tracker/warning data for every visible team member. With a large org (~2,500 members), only a handful of rows would ever populate — most just stayed empty, even after waiting or refreshing.
 
## Root cause
 
Each team member row (`Warnings.jsx`) fired its own individual `GET /warnings/:userId` request when trackers were shown. The existing code staggered these using a per-user hash-based `setTimeout` (0–5000ms), but this still allowed an unbounded number of requests to fire close together.
 
With ~2,500 members, this produced thousands of near-simultaneous XHR requests, exceeding the browser's connection/resource limits. Confirmed via DevTools: the majority of requests failed with `net::ERR_INSUFFICIENT_RESOURCES`. Failed requests were silently caught and set `usersWarnings` to `[]` with no retry, so those rows never populated.
 
<img width="2880" height="1710" alt="Screenshot 2026-07-23 161834" src="https://github.com/user-attachments/assets/7dce4796-3168-49d4-ac7a-ee408425bec5" />

## Fix
 
- Added `src/utils/requestQueue.js`: a small shared concurrency-limited task queue (`enqueueTask`), capping true concurrent execution at 10 tasks at a time regardless of how many rows are on the page. Extra tasks wait in a FIFO queue until a slot frees up.
- Updated `src/components/Warnings/Warnings.jsx`:
  - Removed the old hash-based `setTimeout` stagger logic.
  - `fetchUsersWarningsById` now returns its promise so the queue can track completion.
  - The `useEffect` driven by `showTrackers` now enqueues each row's fetch via `enqueueTask` instead of scheduling an independent timer.
  
This fixes the root cause (too many concurrent connections) rather than just adjusting timing, and requires no backend changes.
 
## Testing done
 
- Reproduced the original issue on `dev.highestgood.com` with the full ~2,500-member dataset: confirmed via DevTools Network tab that the vast majority of `warnings` requests failed with `net::ERR_INSUFFICIENT_RESOURCES` before the fix.
- Applied the fix and re-tested: requests now complete successfully (`200`/`201`) in controlled batches, with the rest properly queued as `(pending)` rather than failing. (Run the backend on development branch)
- Let the full request queue drain and confirmed all tracker rows eventually populate with data.

<img width="2880" height="1716" alt="Screenshot 2026-07-23 181330" src="https://github.com/user-attachments/assets/8b31f0ee-6e38-426b-8078-829f38c8c14d" />

## Notes for reviewer
 
This was addressed as a frontend-only fix per priority/scope discussion — a backend batch endpoint (fetching warnings for multiple users in one call) would be more efficient long-term but is a larger change and likely warrants a separate PR if the team wants to pursue it.