### PR TITLE
Abhishek 🔥: missing Progress column and layout issues at tablet widths on Team Member Tasks

### DIFF
--- a/src/components/CommunityPortal/Activities/LogAttendance.module.css
+++ b/src/components/CommunityPortal/Activities/LogAttendance.module.css
@@ -496,18 +496,18 @@
   overflow-x: auto;
 }
 
-table {
+.tableWrapper table {
   width: 100%;
   border-collapse: collapse;
   min-width: 700px;
 }
 
-thead {
+.tableWrapper thead {
   background: #f1f5f9;
 }
 
-th,
-td {
+.tableWrapper th,
+.tableWrapper td {
   padding: 14px 18px;
   border-bottom: 1px solid #e2e8f0;
   text-align: left;

--- a/src/components/TeamMemberTasks/style.module.css
+++ b/src/components/TeamMemberTasks/style.module.css
@@ -191,12 +191,12 @@
 
 .team-member-tasks-user-name {
   width: 50%;
-  text-align: center;
+  text-align: left;
   vertical-align: top !important;
   display: flex;
   flex-direction: column;
   justify-content: flex-start !important;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .team-member-tasks td {
@@ -669,32 +669,8 @@
   }
 
   .hours-btn-container {
-    margin-top: 10px;
     justify-content: flex-start;
     align-items: center;
-  }
-
-  .team-task-progress-container {
-    grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(3, auto);
-  }
-
-  .team-task-progress-time,
-  .team-task-progress-time-volunteers {
-    grid-column: 1 / span 2;
-    grid-row: 1 / span 1;
-  }
-
-  .followup-tooltip-container {
-    grid-column: 2 / span 1;
-    grid-row: 3 / span 1;
-    justify-self: start;
-  }
-
-  .team-task-progress-bar {
-    grid-column: 1 / span 3;
-    grid-row: 2 / span 1;
-    margin-bottom: 3px;
   }
 
   .team-member-tasks-bell {

--- a/src/components/Warnings/Warnings.module.css
+++ b/src/components/Warnings/Warnings.module.css
@@ -82,7 +82,7 @@
 
 .button__container {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   margin-bottom: 10px;
   gap: 0.5em; /* Adds spacing between the buttons */


### PR DESCRIPTION
## Problem
 
On the Team Member Tasks page, the Progress column (task completion count, progress bar, and "Days Old" badge) was missing entirely for every user at certain viewport widths, even though the same data displayed correctly at both narrow (≤768px) and very wide viewports. This was blocking the dev → main merge as a high-priority visual regression.
 
Two related smaller issues were also found and fixed along the way:
- The Tracking/+/- buttons for a team member could visually overlap the next task row's content at tablet widths.
- The icons row and Tracking/+/- buttons were offset from the member's name/role text instead of sharing the same left edge.
## Root cause
 
The actual root cause was **not** in `TeamMemberTasks` at all. `src/components/CommunityPortal/Activities/LogAttendance.module.css` (an unrelated component) contained bare, unscoped element selectors:
 
```css
table { width: 100%; border-collapse: collapse; min-width: 700px; }
thead { background: #f1f5f9; }
th, td { padding: 14px 18px; ... }
```
 
CSS Modules only scope class selectors (`.foo` → a hashed class name) — bare element selectors like `table`, `thead`, `th`, `td` are never scoped, so these rules leaked globally across the entire app once bundled. This forced **every** `<table>` on the site (including the unrelated Team Member Tasks subtable) to have `min-width: 700px`, `table-layout: fixed`, and unscoped cell padding — regardless of how much space was actually available in its container. At tablet widths, the subtable's cell had far less room than 700px, causing the Progress/Status content to overflow its cell in a way that made it effectively invisible without a visible scrollbar.
 
While tracking this down, we also found and cleaned up an unrelated, pre-existing dead/broken media query in `TeamMemberTasks/style.module.css` (`@media ((width <= 1240px) and (width >= 992px))`) that assigned CSS Grid properties (`grid-template-columns`, `grid-column`, `grid-row`) to elements that were never actual grid containers/items — this was inert in production but became actively harmful once we (mistakenly, mid-investigation) tried adding `display: grid` to make it "work." We reverted that entirely and removed the broken block, since the base flex/inline-grid layout already works correctly without it.
 
## Fix
 
- **`LogAttendance.module.css`**: scoped the previously-global `table`, `thead`, `th`, `td` selectors to `.tableWrapper table`, `.tableWrapper thead`, `.tableWrapper th`, `.tableWrapper td` so they only affect the Log Attendance table they were intended for.
- **`TeamMemberTasks/style.module.css`**:
  - Removed the broken/dead grid-positioning rules inside the `992px–1240px` media query (they were never valid — grid properties on non-grid containers/items).
  - Removed a `margin-top` on `.hours-btn-container` at that same breakpoint that was pushing the Tracking/+/- buttons down into the next row's content.
  - Changed `.team-member-tasks-user-name` from centered to left-aligned so the name/role column shares the same left edge as the icons/buttons row below it.
- **`Warnings.module.css`**: changed `.button__container` from `justify-content: center` to `flex-start` so the Tracking/+/- buttons are left-aligned by default (previously only left-aligned via a `≤767px` media query, leaving every width above that centered).
## Testing done
 
- Reproduced the original missing-Progress-column bug on dev at multiple widths (768px, 1024px, 2880px, and full-screen at various actual window widths) via DevTools Network/Elements/Computed inspection. (Run backend on `development`)
- Traced the issue through data (API response), Redux state, render logic, and finally CSS layout/computed styles before finding the actual global CSS leak.
- Verified the Progress column, progress bar, and "Days Old" badge now render correctly at 1024px (previously broken) after scoping the leaked selectors.
- Verified the Tracking/+/- button overlap with adjacent rows is resolved.
- Verified the icons/buttons row now aligns with the name/role text's left edge.
- Confirmed via full dev-server restart + Incognito window that results weren't affected by stale cache/HMR state.

<img width="1562" height="1198" alt="Screenshot 2026-07-24 150555" src="https://github.com/user-attachments/assets/60c123c3-4a5c-43c6-9e71-409fda07a9e6" />