### PR TITLE
Purav Taking over unfinished PR #3861 - PR Review Team Analytics Dashboard

### DIFF
--- a/src/components/Analytics/AnalyticsDashboard.jsx
+++ b/src/components/Analytics/AnalyticsDashboard.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import ReviewersRequirementChart from './ReviewersRequirementChart';
+import styles from './AnalyticsDashboard.module.css';
+
+const durationOptions = [
+  { label: 'Last Week', value: 'lastWeek' },
+  { label: 'Last 2 weeks', value: 'last2weeks' },
+  { label: 'Last Month', value: 'lastMonth' },
+  { label: 'All Time', value: 'allTime' },
+];
+
+const AnalyticsDashboard = () => {
+  const darkMode = useSelector(state => state.theme.darkMode);
+  const [duration, setDuration] = useState('lastWeek');
+
+  return (
+    <div className={`${styles.page} ${darkMode ? styles.pageDark : ''}`}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>Reviewers Ranked by Requirement Satisfied</h2>
+
+        <div className={styles.filterGroup}>
+          <label className={styles.filterLabel} htmlFor="duration">
+            Duration:
+          </label>
+          <select
+            id="duration"
+            className={styles.filterSelect}
+            value={duration}
+            onChange={e => setDuration(e.target.value)}
+          >
+            {durationOptions.map(opt => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <p className={styles.helperText}>
+        Shows how many PR reviews each reviewer completed in the selected period, grouped by review
+        quality. The list length comes from the backend for that duration (not a fixed frontend
+        limit).
+      </p>
+
+      <div className={styles.chartCard}>
+        <ReviewersRequirementChart duration={duration} darkMode={darkMode} />
+      </div>
+    </div>
+  );
+};
+
+export default AnalyticsDashboard;

--- a/src/components/Analytics/AnalyticsDashboard.module.css
+++ b/src/components/Analytics/AnalyticsDashboard.module.css
@@ -1,0 +1,129 @@
+.page {
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem 2.5rem;
+  box-sizing: border-box;
+  min-height: calc(100vh - 120px);
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  font-weight: 600;
+  line-height: 1.3;
+  color: #052c65;
+  flex: 1 1 280px;
+}
+
+.filterGroup {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 0 0 auto;
+}
+
+.filterLabel {
+  margin: 0;
+  font-weight: 500;
+  color: #1f2937;
+  white-space: nowrap;
+}
+
+.filterSelect {
+  min-width: 160px;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  color: #111827;
+  font-size: 0.95rem;
+}
+
+.chartCard {
+  width: 100%;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+  padding: 1rem 0.75rem 1.25rem;
+  box-sizing: border-box;
+  overflow-x: auto;
+}
+
+.helperText {
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.statusMessage {
+  display: grid;
+  place-items: center;
+  min-height: 220px;
+  margin: 0;
+  text-align: center;
+  color: #374151;
+  font-size: 1rem;
+}
+
+/* Dark mode */
+.pageDark {
+  color: #f8fafc;
+}
+
+.pageDark .title {
+  color: #e2e8f0;
+}
+
+.pageDark .filterLabel {
+  color: #e2e8f0;
+}
+
+.pageDark .filterSelect {
+  background: #2d3748;
+  border-color: #4a5568;
+  color: #f8fafc;
+}
+
+.pageDark .chartCard {
+  background: #1a202c;
+  border-color: #4a5568;
+}
+
+.pageDark .helperText,
+.pageDark .statusMessage {
+  color: #cbd5e1;
+}
+
+@media (width <= 768px) {
+  .page {
+    padding: 1rem 0.75rem 2rem;
+  }
+
+  .header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filterGroup {
+    width: 100%;
+  }
+
+  .filterSelect {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .chartCard {
+    padding: 0.75rem 0.25rem 1rem;
+  }
+}

--- a/src/components/Analytics/PopularPRChart.jsx
+++ b/src/components/Analytics/PopularPRChart.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Bar, BarChart, LabelList, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+
+const data = [
+  { prNumber: 'PR1234', reviews: 10 },
+  { prNumber: 'PR1235', reviews: 8 },
+  { prNumber: 'PR1236', reviews: 15 },
+  { prNumber: 'PR1237', reviews: 5 },
+  { prNumber: 'PR1238', reviews: 12 },
+  { prNumber: 'PR1231', reviews: 12 },
+  { prNumber: 'PR1256', reviews: 17 },
+  { prNumber: 'PR1255', reviews: 19 },
+  { prNumber: 'PR1254', reviews: 1 },
+  { prNumber: 'PR1253', reviews: 2 },
+  { prNumber: 'PR1252', reviews: 7 },
+  { prNumber: 'PR1251', reviews: 9 },
+  { prNumber: 'PR1250', reviews: 11 },
+  { prNumber: 'PR1249', reviews: 19 },
+  { prNumber: 'PR1248', reviews: 0 },
+  { prNumber: 'PR1242', reviews: 2 },
+  { prNumber: 'PR1241', reviews: 50 },
+];
+
+const PopularPRChart = () => {
+  const filteredData = data;
+
+  return (
+    <div style={{ width: '100%', height: 500, overflowY: 'auto' }}>
+      <ResponsiveContainer width="100%" height={400}>
+        <BarChart
+          data={filteredData}
+          layout="vertical"
+          margin={{ top: 20, right: 30, left: 150, bottom: 40 }}
+        >
+          <XAxis
+            type="number"
+            label={{
+              value: 'Number of Reviews',
+              position: 'insideBottom',
+              offset: -5,
+            }}
+          />
+
+          <YAxis
+            dataKey="prNumber"
+            type="category"
+            label={{
+              value: 'PR Numbers',
+              angle: -90,
+              position: 'insideLeft',
+            }}
+            width={100}
+          />
+
+          <Tooltip />
+
+          <Bar dataKey="reviews" fill="#052C65">
+            <LabelList dataKey="reviews" position="right" />
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default PopularPRChart;

--- a/src/components/Analytics/ReviewersRequirementChart.jsx
+++ b/src/components/Analytics/ReviewersRequirementChart.jsx
@@ -1,0 +1,239 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  LabelList,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { ENDPOINTS } from '../../utils/URL';
+import styles from './AnalyticsDashboard.module.css';
+
+const useYAxisWidth = () => {
+  const [yAxisWidth, setYAxisWidth] = useState(180);
+
+  useEffect(() => {
+    const updateWidth = () => {
+      setYAxisWidth(window.innerWidth < 768 ? 110 : 180);
+    };
+
+    updateWidth();
+    window.addEventListener('resize', updateWidth);
+    return () => window.removeEventListener('resize', updateWidth);
+  }, []);
+
+  return yAxisWidth;
+};
+
+const COLORS = {
+  exceptional: '#052C65',
+  sufficient: '#4682B4',
+  needsChanges: '#FF8C00',
+  didNotReview: '#A9A9A9',
+};
+
+const getCount = (counts, key) => counts?.[key] || 0;
+
+const normalizeReviewCounts = item => {
+  const counts = item.counts || {};
+  const exceptional = getCount(counts, 'Exceptional');
+  const sufficient = getCount(counts, 'Sufficient');
+  const needsChanges = getCount(counts, 'Needs Changes');
+  const didNotReview = getCount(counts, 'Did Not Review');
+
+  return {
+    reviewer: item.reviewer,
+    exceptional,
+    sufficient,
+    needsChanges,
+    didNotReview,
+    total: exceptional + sufficient + needsChanges + didNotReview,
+  };
+};
+
+const CustomTooltip = ({ active, payload, label, darkMode }) => {
+  if (!active || !payload?.length) return null;
+
+  const textColor = darkMode ? '#f8fafc' : '#111827';
+
+  return (
+    <div
+      className={styles.customTooltip}
+      style={{
+        background: darkMode ? '#2d3748' : '#ffffff',
+        color: textColor,
+        border: `1px solid ${darkMode ? '#4a5568' : '#e5e7eb'}`,
+        borderRadius: 8,
+        padding: '10px 12px',
+        fontSize: 12,
+        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.25)',
+      }}
+    >
+      <strong style={{ display: 'block', marginBottom: 8, color: textColor }}>{label}</strong>
+      {payload.map(entry => (
+        <div
+          key={entry.dataKey}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 16,
+            marginTop: 4,
+          }}
+        >
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, color: textColor }}>
+            <span
+              aria-hidden="true"
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: 2,
+                background: entry.color,
+                flexShrink: 0,
+              }}
+            />
+            {entry.name}
+          </span>
+          <span style={{ color: textColor, fontWeight: 600 }}>{entry.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const ReviewersRequirementChart = ({ duration, darkMode = false }) => {
+  const [data, setData] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const yAxisWidth = useYAxisWidth();
+
+  useEffect(() => {
+    const fetchAPIData = async () => {
+      setIsLoading(true);
+      setErrorMessage('');
+
+      try {
+        const token = window.localStorage.getItem('token');
+        const response = await axios.get(ENDPOINTS.GITHUB_REVIEW_SUMMARY(duration), {
+          headers: {
+            Authorization: token,
+            'Content-Type': 'application/json',
+          },
+        });
+
+        setData(Array.isArray(response.data) ? response.data : []);
+      } catch (err) {
+        setData([]);
+        setErrorMessage('Unable to load GitHub review data for the selected duration.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchAPIData();
+  }, [duration]);
+
+  const sortedData = data
+    .map(normalizeReviewCounts)
+    .filter(item => item.reviewer)
+    .sort((a, b) => b.total - a.total);
+
+  if (isLoading) {
+    return <p className={styles.statusMessage}>Loading review data...</p>;
+  }
+
+  if (errorMessage) {
+    return <p className={styles.statusMessage}>{errorMessage}</p>;
+  }
+
+  if (!sortedData.length) {
+    return <p className={styles.statusMessage}>No review data found for this duration.</p>;
+  }
+
+  const axisColor = darkMode ? '#e2e8f0' : '#374151';
+  const gridColor = darkMode ? '#4a5568' : '#e5e7eb';
+  const labelColor = darkMode ? '#f8fafc' : '#111827';
+  const rowHeight = 34;
+  const chartHeight = Math.max(sortedData.length * rowHeight + 80, 360);
+
+  return (
+    <div style={{ width: '100%', minWidth: 520 }}>
+      <ResponsiveContainer width="100%" height={chartHeight}>
+        <BarChart
+          layout="vertical"
+          data={sortedData}
+          margin={{ top: 8, right: 48, left: 4, bottom: 8 }}
+          barCategoryGap={6}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke={gridColor} horizontal={false} />
+          <XAxis
+            type="number"
+            allowDecimals={false}
+            tick={{ fill: axisColor, fontSize: 12 }}
+            stroke={axisColor}
+          />
+          <YAxis
+            dataKey="reviewer"
+            type="category"
+            interval={0}
+            width={yAxisWidth}
+            tick={{ fill: axisColor, fontSize: 11 }}
+            stroke={axisColor}
+            tickFormatter={value => (value?.length > 22 ? `${value.slice(0, 20)}…` : value)}
+          />
+          <Tooltip
+            cursor={{ fill: darkMode ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)' }}
+            content={<CustomTooltip darkMode={darkMode} />}
+          />
+          <Legend wrapperStyle={{ color: axisColor, paddingTop: 8 }} />
+
+          <Bar
+            dataKey="exceptional"
+            name="Exceptional"
+            stackId="reviews"
+            fill={COLORS.exceptional}
+            maxBarSize={22}
+            isAnimationActive={false}
+          />
+          <Bar
+            dataKey="sufficient"
+            name="Sufficient"
+            stackId="reviews"
+            fill={COLORS.sufficient}
+            maxBarSize={22}
+            isAnimationActive={false}
+          />
+          <Bar
+            dataKey="needsChanges"
+            name="Needs Changes"
+            stackId="reviews"
+            fill={COLORS.needsChanges}
+            maxBarSize={22}
+            isAnimationActive={false}
+          />
+          <Bar
+            dataKey="didNotReview"
+            name="Did Not Review"
+            stackId="reviews"
+            fill={COLORS.didNotReview}
+            maxBarSize={22}
+            isAnimationActive={false}
+          >
+            <LabelList
+              dataKey="total"
+              position="right"
+              style={{ fill: labelColor, fontSize: 12, fontWeight: 600 }}
+            />
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default ReviewersRequirementChart;

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -516,7 +516,7 @@ export function Header(props) {
                   </NavLink>
                 </NavItem>
                 )}
-  
+
                 <NavItem>
                   <NavLink tag={Link} to="/timelog#currentWeek" disabled={headerDisabled}>
                     <span>{TIMELOG}</span>
@@ -838,6 +838,14 @@ export function Header(props) {
                         disabled={headerDisabled}
                       >
                         PR Analytics
+                      </DropdownItem>
+                      <DropdownItem
+                        tag={Link}
+                        to="/pr-dashboard/reviewers"
+                        className={fontColor}
+                        disabled={headerDisabled}
+                      >
+                        Reviewers by Requirement
                       </DropdownItem>
                       <DropdownItem
                         tag={Link}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -195,6 +195,9 @@ import BookingPage from './components/Booking/BookingPage';
 import BookingConfirmPage from './components/Booking/BookingConfirmPage';
 import PRPromotionsPage from './components/PRPromotions/PRPromotionsPage';
 import ReviewersStackedBarChart from './components/HGNPRDashboard/ReviewersStackedBarChart/ReviewersStackedBarChart';
+import PRReviewTeamAnalyticsDashboard from './components/Analytics/AnalyticsDashboard';
+import PopularPRChart from './components/Analytics/PopularPRChart';
+import ReviewersRequirementChart from './components/Analytics/ReviewersRequirementChart';
 import PRGradingDashboard from './components/PRGradingDashboard/PRGradingDashboard';
 import PRGradingScreen from './components/PRGradingScreen';
 import PRGradingTest from './components/PRGradingScreen/PRGradingTest'; //temporary route for testing - delete after testing
@@ -1067,6 +1070,25 @@ export default (
           path="/pr-team-analytics/reviewers-stacked-bar-chart"
           exact
           component={ReviewersStackedBarChart}
+        />
+        <ProtectedRoute
+          path="/analytics/dashboard"
+          exact
+          component={PRReviewTeamAnalyticsDashboard}
+          fallback
+        />
+        <ProtectedRoute
+          path="/pr-dashboard/reviewers"
+          exact
+          component={PRReviewTeamAnalyticsDashboard}
+          fallback
+        />
+        <ProtectedRoute path="/analytics/popular-prs" exact component={PopularPRChart} fallback />
+        <ProtectedRoute
+          path="/analytics/review-summary"
+          exact
+          component={ReviewersRequirementChart}
+          fallback
         />
         {/* /*  for support team*/}
         <Route path="/support/login" component={SupportLogin} />

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -688,6 +688,16 @@ export const ENDPOINTS = {
 
   //pull requests analysis
   PR_REVIEWS_INSIGHTS: `${APIEndpoint}/analytics/pr-review-insights`,
+  GITHUB_REVIEW_SUMMARY: (duration, sort = 'desc', team) => {
+    const params = new URLSearchParams({
+      duration,
+      sort,
+    });
+    if (team) {
+      params.set('team', team);
+    }
+    return `${APIEndpoint}/analytics/review-summary?${params.toString()}`;
+  },
   PR_GRADING_CONFIG: `${APIEndpoint}/pr-grading-config`,
   WEEKLY_GRADING: `${APIEndpoint}/weekly-grading`,
   WEEKLY_GRADING_SAVE: `${APIEndpoint}/weekly-grading/save`,


### PR DESCRIPTION
## Description

This PR is a **takeover** of the unfinished frontend work from [#3861](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3861) (`Manvitha-PR-Review-Team-Analytics-Dashboard`).

Manvitha's branch was outdated and conflicting with `development`, so this PR rebuilds the feature on **latest `development`** and only brings over the analytics feature work (not a full merge of the old branch).

### What this adds
- Horizontal stacked bar chart: **Reviewers Ranked by Requirement Satisfied**
- Duration filter: Last Week / Last 2 weeks / Last Month / All Time
- Calls backend `GET /api/analytics/review-summary`
- Responsive layout + dark mode support
- Header nav entry under **PR Dashboard → Reviewers by Requirement**

---

## Related PRs

| Type | PR |
|------|----|
| **Backend (required to test)** | [HGNRest #2285](https://github.com/OneCommunityGlobal/HGNRest/pull/2285) — Purav takeover of unfinished backend #1648 |
| Previous unfinished backend | [HGNRest #1648](https://github.com/OneCommunityGlobal/HGNRest/pull/1648) |
| Previous unfinished frontend (takeover source) | [#3861](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3861) |
| Closed older frontend version | [#3829](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3829) |

> **Important:** This frontend PR depends on backend PR **[#2285](https://github.com/OneCommunityGlobal/HGNRest/pull/2285)** (updated takeover of #1648). Please check out and run that backend branch while testing.

---

## Main changes explained

1. Added Analytics dashboard components that render reviewer review-quality counts (Exceptional / Sufficient / Needs Changes / Did Not Review).
2. Wired `GITHUB_REVIEW_SUMMARY` endpoint helper in `URL.js`.
3. Added routes:
   - `/pr-dashboard/reviewers` (preferred / linked from Header)
   - `/analytics/dashboard` (kept for original test path from #3861)
4. Improved UI vs old PR: layout alignment, responsive behavior, dark mode, readable tooltips.

---

## Backend + `.env` setup (required)

Reviewers **must** run the related backend PR and set a GitHub token, or the chart will stay empty / show an error.

### 1. Backend
1. Clone / open **HGNRest**
2. Check out the branch for **[#2285](https://github.com/OneCommunityGlobal/HGNRest/pull/2285)**  
   (`feature/Purav-PR-Review-Team-Analytics-Dashboard`)
3. Install deps and start the API as usual (backend typically on `http://localhost:4500`)

### 2. Environment variable
In the **backend** `.env`, add a valid GitHub token:

```bash
GITHUB_TOKEN=your_github_personal_access_token
```

How to create the token (same guidance as #2285 / #1648 / #3861):
- Follow: https://www.youtube.com/watch?v=3y5GrgzIVmI&t=15s
- Classic PAT with `public_repo`/`repo`, or fine-grained with **Pull requests: Read**
- Restart backend after adding the token

### 3. Frontend
1. Check out this branch: `feature/Purav-PR-Review-Team-Analytics-Dashboard`
2. `npm install` (or project equivalent)
3. Start frontend (Vite): usually `https://localhost:5173` or `http://localhost:5173`
4. Clear site data / cache if needed
5. Log in as any user that can access PR Dashboard

---

## How to test

### Primary path (recommended)
1. Open **PR Dashboard → Reviewers by Requirement**
2. Or go directly to: `http://localhost:5173/pr-dashboard/reviewers`
3. Confirm page title: **Reviewers Ranked by Requirement Satisfied**
4. Switch each duration and confirm chart updates:
   - Last Week
   - Last 2 weeks
   - Last Month
   - All Time
5. Confirm stacked bars + totals + tooltips look correct in **light mode** and **dark mode**
6. Confirm reviewer names are readable (not only on hover)
7. Confirm loading / empty / error states behave reasonably if API is slow or failing

### Alternate path (legacy from #3861)
- `http://localhost:5173/analytics/dashboard`
  (same component as `/pr-dashboard/reviewers`)

### Not this PR
These are different existing pages:
- `/pr-dashboard/analytics` → Top Popular PRs
- Do **not** expect this reviewers chart there

### Network check (optional)
In DevTools → Network, selecting a duration should call:

```text
GET /api/analytics/review-summary?duration=<lastWeek|last2weeks|lastMonth|allTime>&sort=desc
```

---

## Screenshots

> Reviewers: please attach your own verification screenshots too if possible.

### Light mode

<img width="1280" height="560" alt="image" src="https://github.com/user-attachments/assets/db09fcf5-3bba-4f2e-96ac-cc6e4abad139" />

### Dark mode

<img width="1271" height="598" alt="image" src="https://github.com/user-attachments/assets/f537c496-641a-4325-b756-5b32161db16b" />

### Navigation

<img width="270" height="179" alt="image" src="https://github.com/user-attachments/assets/c4fda3a7-0ae7-4c31-a571-b5d390e9e75f" />

---

## Video of changes

https://github.com/user-attachments/assets/bded8bf4-fcd7-4140-95d5-e20e4ece29ce

---

## Notes for reviewers

- This is a **takeover** of unfinished frontend work from **#3861**, rebuilt on latest `development`.
- Pair this with backend takeover **[#2285](https://github.com/OneCommunityGlobal/HGNRest/pull/2285)** (not the old unfinished #1648).
- Backend **#2285** + `GITHUB_TOKEN` are required for real data.
- Without the backend token/setup, the UI may show loading then empty/error — that does not mean the frontend route is broken.
- The frontend may take some time (**around 5–10 seconds**) when loading data for the first time.
- All Time can take longer because the backend aggregates more GitHub data.
- Chart row count is driven by backend results for the selected duration (not a hardcoded frontend limit).

---

## Test plan

- [ ] Backend [#2285](https://github.com/OneCommunityGlobal/HGNRest/pull/2285) is running with `GITHUB_TOKEN` set
- [ ] Can open `/pr-dashboard/reviewers` from Header → PR Dashboard
- [ ] `/analytics/dashboard` also loads the same dashboard
- [ ] All 4 duration options return/render data (or a clear empty/error state)
- [ ] Chart segments + tooltips readable in light mode
- [ ] Chart segments + tooltips readable in dark mode
- [ ] Layout looks aligned / usable on desktop and a narrower viewport
- [ ] Confirmed this is different from `/pr-dashboard/analytics` (Popular PRs)