### PR TITLE
Abhishek 🔥: team member name/icons/buttons alignment to match production  

### DIFF
--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -412,7 +412,7 @@ const TeamMemberTask = React.memo(
                           <td
                             colSpan={2}
                             className={styles['team-member-tasks-user-name']}
-                            style={{ textAlign: 'left', alignItems: 'flex-start' }}
+                            style={{ textAlign: 'center', alignItems: 'center' }}
                           >
                             <Link
                               className={styles['team-member-tasks-user-name-link']}

--- a/src/components/TeamMemberTasks/style.module.css
+++ b/src/components/TeamMemberTasks/style.module.css
@@ -191,12 +191,12 @@
 
 .team-member-tasks-user-name {
   width: 50%;
-  text-align: left;
+  text-align: center;
   vertical-align: top !important;
   display: flex;
   flex-direction: column;
   justify-content: flex-start !important;
-  align-items: flex-start;
+  align-items: center;
 }
 
 .team-member-tasks td {

--- a/src/components/Teams/Teams.jsx
+++ b/src/components/Teams/Teams.jsx
@@ -31,7 +31,6 @@ import DeleteTeamPopup from './DeleteTeamPopup';
 import TeamStatusPopup from './TeamStatusPopup';
 import AddTeamPopup from '../UserProfile/TeamsAndProjects/AddTeamPopup';
 import CreateNewTeamPopup from './CreateNewTeamPopup';
-import styles from './Team.module.css';
 // constants
 const FILTER_ALL = 'all';
 const FILTER_ACTIVE = 'active';

--- a/src/components/Warnings/Warnings.module.css
+++ b/src/components/Warnings/Warnings.module.css
@@ -82,7 +82,7 @@
 
 .button__container {
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
   margin-bottom: 10px;
   gap: 0.5em; /* Adds spacing between the buttons */


### PR DESCRIPTION
## Problem
 
On the Team Member Tasks page, the name, icons (Google Doc, Report, People Report count), and Tracking/+/- buttons for each team member were left-aligned on dev, while production shows them centered under the member's name. This was flagged directly by Jae as a quick hotfix needed before the dev → main merge.
 
## Root cause
 
Two contributing factors:
 
1. `src/components/TeamMemberTasks/style.module.css` — `.team-member-tasks-user-name` used `text-align: left` / `align-items: flex-start` (changed from `center` in a previous PR based on a different, narrower concern).
2. `src/components/Warnings/Warnings.module.css` — `.button__container` used `justify-content: flex-start` (also changed from `center` previously).
3. The real blocker: `src/components/TeamMemberTasks/TeamMemberTask.jsx` hardcodes an **inline style** (`style={{ textAlign: 'left', alignItems: 'flex-start' }}`) directly on the relevant `<td>`, which overrides any CSS class regardless of specificity. This meant even reverting the CSS classes alone would not have fixed the visual issue.
## Fix
 
- Reverted `.team-member-tasks-user-name` back to `text-align: center` / `align-items: center`.
- Reverted `.button__container` back to `justify-content: center`.
- Updated the inline style in `TeamMemberTask.jsx` from `{ textAlign: 'left', alignItems: 'flex-start' }` to `{ textAlign: 'center', alignItems: 'center' }`, since this inline style was the actual cause overriding the CSS.
## Unrelated fix included
 
While testing locally, found `src/components/Teams/Teams.jsx` had the same CSS module (`Team.module.css`) imported twice under the same `styles` variable name, which threw a build error (`The symbol "styles" has already been declared`) and blocked the dev server from starting entirely for anyone on `development`. Removed the duplicate import so local development isn't blocked. This is unrelated to the alignment fix but was necessary to test locally.
 
## Testing done
 
- Run the frontend repo on `fix/team-member-tasks-center-alignment` branch and the backend on `development`
- Compared production vs. dev side-by-side at the same viewport width.
- Confirmed name, icons, and Tracking/+/- buttons are now centered under the member name on dev, matching production.
- Confirmed no regression to the Progress column, tablet-width layout, or button/row overlap fixes from the previous PR.
- Confirmed the dev server starts cleanly after removing the duplicate import in `Teams.jsx`.

<img width="2272" height="1498" alt="Screenshot 2026-07-26 112449" src="https://github.com/user-attachments/assets/08ca35b2-4c2c-4088-95f7-f0845a875871" />

