### PR TITLE
Yuxuan - Fix Total Org Summary weekly date presets

### DIFF
--- a/src/components/TotalOrgSummary/HoursWorkedPieChart/HoursWorkedPieChart.jsx
+++ b/src/components/TotalOrgSummary/HoursWorkedPieChart/HoursWorkedPieChart.jsx
@@ -66,7 +66,12 @@ export const getReadableTextColor = (bgColor, fallbackDarkMode) => {
 const getLabelToneClass = color =>
   color === '#FFFFFF' ? 'hours-distribution-label-light' : 'hours-distribution-label-dark';
 
-export const renderCenterLabel = ({ darkMode, isMobile, totalHours }) => {
+export const renderCenterLabel = ({
+  darkMode,
+  isMobile,
+  totalHours,
+  centerLabelLines = ['TOTAL HOURS', 'WORKED'],
+}) => {
   const centerFill = darkMode ? '#D1D5DB' : '#696969';
   const totalText = formatNumber(totalHours || 0);
   const centerValueFontSize = totalText.length > 6 ? (isMobile ? 24 : 30) : isMobile ? 30 : 36;
@@ -81,7 +86,7 @@ export const renderCenterLabel = ({ darkMode, isMobile, totalHours }) => {
         fill={centerFill}
         fontSize={isMobile ? 16 : 20}
       >
-        TOTAL HOURS
+        {centerLabelLines[0]}
       </text>
       <text
         x="50%"
@@ -91,7 +96,7 @@ export const renderCenterLabel = ({ darkMode, isMobile, totalHours }) => {
         fill={centerFill}
         fontSize={isMobile ? 16 : 20}
       >
-        WORKED
+        {centerLabelLines[1]}
       </text>
       <text
         x="50%"
@@ -209,6 +214,7 @@ export default function HoursWorkedPieChart({
   colors,
   totalHours = 0,
   darkMode = false,
+  centerLabelLines = ['TOTAL HOURS', 'WORKED'],
 }) {
   let innerRadius = 80;
   let outerRadius = 160;
@@ -257,7 +263,12 @@ export default function HoursWorkedPieChart({
                 <Cell key={`cell-${index}`} fill={colors[index % colors.length]} />
               ))}
           </Pie>
-          {renderCenterLabel({ darkMode, isMobile, totalHours: displayTotalHours })}
+          {renderCenterLabel({
+            darkMode,
+            isMobile,
+            totalHours: displayTotalHours,
+            centerLabelLines,
+          })}
           {/* <Tooltip content={<CustomTooltip tooltipType="hoursDistribution" />} /> */}
           <Tooltip
             content={<CustomTooltip tooltipType="hoursDistribution" darkMode={darkMode} />}
@@ -274,4 +285,5 @@ HoursWorkedPieChart.propTypes = {
   colors: PropTypes.array,
   totalHours: PropTypes.number,
   darkMode: PropTypes.bool,
+  centerLabelLines: PropTypes.arrayOf(PropTypes.string),
 };

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -237,7 +237,14 @@ function buildPDFStyles(darkMode) {
     }
     [data-pdf-title] p {
       font-size: 1.5em !important; font-weight: bold !important; text-align: center !important;
-      margin: 10px !important; color: #333 !important;
+      margin: 10px !important; color: ${darkMode ? '#fff' : '#333'} !important;
+      text-shadow: ${darkMode ? '0 1px 4px #000, 0 0 2px #000' : 'none'} !important;
+    }
+    [data-pdf-label] {
+      color: ${darkMode ? '#fff' : '#000'} !important;
+      background-color: transparent !important;
+      border-color: ${darkMode ? '#64748b' : '#e0e0e0'} !important;
+      opacity: 1 !important;
     }
     ${
       darkMode
@@ -369,6 +376,7 @@ function ReportHeader({
 
 function DateRangeModal({
   showDatePicker,
+  darkMode,
   startDate,
   endDate,
   onToggle,
@@ -378,7 +386,11 @@ function DateRangeModal({
   onApply,
 }) {
   return (
-    <Modal isOpen={showDatePicker} toggle={onToggle}>
+    <Modal
+      isOpen={showDatePicker}
+      toggle={onToggle}
+      className={darkMode ? styles.dateRangeModalDark : undefined}
+    >
       <ModalHeader toggle={onToggle}>Select Date Range</ModalHeader>
       <ModalBody>
         <div className="d-flex flex-column gap-4">
@@ -391,7 +403,8 @@ function DateRangeModal({
                 id="start-date"
                 selected={startDate}
                 onChange={onStartChange}
-                className="form-control"
+                className={clsx('form-control', darkMode && styles.datePickerInputDark)}
+                calendarClassName={darkMode ? 'total-org-datepicker-dark' : undefined}
                 dateFormat="MM/dd/yyyy"
                 placeholderText="Select start date"
               />
@@ -406,7 +419,8 @@ function DateRangeModal({
                 id="end-date"
                 selected={endDate}
                 onChange={onEndChange}
-                className="form-control"
+                className={clsx('form-control', darkMode && styles.datePickerInputDark)}
+                calendarClassName={darkMode ? 'total-org-datepicker-dark' : undefined}
                 dateFormat="MM/dd/yyyy"
                 placeholderText="Select end date"
                 minDate={startDate}
@@ -609,6 +623,7 @@ function TotalOrgSummary(props) {
         />
         <DateRangeModal
           showDatePicker={showDatePicker}
+          darkMode={darkMode}
           startDate={startDate}
           endDate={endDate}
           onToggle={() => setShowDatePicker(!showDatePicker)}
@@ -698,7 +713,7 @@ function TotalOrgSummary(props) {
         </AccordianWrapper>
         <AccordianWrapper title="Volunteer Workload and Task Completion Analysis">
           <Row>
-            <Col lg={{ size: 6 }}>
+            <Col lg={{ size: 12 }}>
               <div
                 className={clsx(styles.componentContainer, styles.componentBorder)}
                 data-pdf-block
@@ -716,12 +731,28 @@ function TotalOrgSummary(props) {
                   className="d-flex flex-column justify-content-center mt-4 gap-3"
                   style={{ gap: '20px' }}
                 >
-                  <VolunteerHoursDistribution
-                    isLoading={isLoading}
-                    darkMode={darkMode}
-                    hoursData={volunteerStats?.volunteerHoursStats}
-                    totalHoursData={volunteerStats?.totalHoursWorked}
-                  />
+                  <div className="d-flex flex-row flex-wrap justify-content-center gap-4">
+                    <VolunteerHoursDistribution
+                      isLoading={isLoading}
+                      darkMode={darkMode}
+                      hoursData={
+                        volunteerStats?.volunteerWorkedHoursStats ??
+                        volunteerStats?.volunteerHoursStats
+                      }
+                      totalHoursData={volunteerStats?.totalHoursWorked}
+                      title="Actual Hours Worked"
+                      legendTitle="Actual Hours Worked"
+                    />
+                    <VolunteerHoursDistribution
+                      isLoading={isLoading}
+                      darkMode={darkMode}
+                      hoursData={volunteerStats?.volunteerCommittedHoursStats}
+                      title="Weekly Committed Hours"
+                      legendTitle="Weekly Committed Hours"
+                      centerLabelLines={['TOTAL', 'VOLUNTEERS']}
+                      useBucketCounts
+                    />
+                  </div>
                   <div className="d-flex flex-column align-items-center justify-content-center">
                     <NumbersVolunteerWorked
                       isLoading={isLoading}
@@ -739,7 +770,7 @@ function TotalOrgSummary(props) {
                 </div>
               </div>
             </Col>
-            <Col lg={{ size: 3 }}>
+            <Col lg={{ size: 6 }}>
               <div
                 className={clsx(styles.componentContainer, styles.componentBorder)}
                 data-pdf-block
@@ -762,7 +793,7 @@ function TotalOrgSummary(props) {
                 </div>
               </div>
             </Col>
-            <Col lg={{ size: 3 }}>
+            <Col lg={{ size: 6 }}>
               <div
                 className={clsx(styles.componentContainer, styles.componentBorder)}
                 data-pdf-block

--- a/src/components/TotalOrgSummary/TotalOrgSummary.jsx
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.jsx
@@ -47,34 +47,7 @@ import WorkDistributionBarChart from './VolunteerRolesTeamDynamics/WorkDistribut
 import VolunteerStatus from './VolunteerStatus/VolunteerStatus';
 import VolunteerStatusChart from './VolunteerStatus/VolunteerStatusChart';
 import VolunteerTrendsLineChart from './VolunteerTrendsLineChart/VolunteerTrendsLineChart';
-
-/*
-  BUG FIX: these two functions previously subtracted an EXTRA 7 days
-  (`daysToSubtract - 7` / `daysToAdd` computed the same way), which meant the
-  module-level `fromDate`/`toDate` constants actually described LAST week's
-  Sunday-Saturday range, not the current week. Since those same constants
-  were wired up to the "Current Week" dropdown option, clicking "Current
-  Week" never actually fetched the current week - it fetched last week. And
-  "Previous Week" (which shifts fromDate/toDate back another 7 days via
-  getPreviousWeekDates) was actually fetching the week before last.
-
-  These now correctly compute the CURRENT week's Sunday-Saturday range.
-*/
-function calculateStartDate() {
-  const currentDate = new Date();
-  currentDate.setHours(0, 0, 0, 0);
-  const dayOfWeek = currentDate.getDay();
-  currentDate.setDate(currentDate.getDate() - dayOfWeek);
-  return currentDate.toISOString().split('T')[0];
-}
-
-function calculateEndDate() {
-  const currentDate = new Date();
-  currentDate.setHours(0, 0, 0, 0);
-  const dayOfWeek = currentDate.getDay();
-  currentDate.setDate(currentDate.getDate() + (6 - dayOfWeek));
-  return currentDate.toISOString().split('T')[0];
-}
+import { formatLocalDateForApi, getCurrentWeekDates, getPreviousWeekDates } from './dateRangeUtils';
 
 function shiftDate(date, diffDays, type) {
   if (type === 'Week Over Week') return new Date(date.setDate(date.getDate() - diffDays));
@@ -305,17 +278,6 @@ async function fetchOrgStats(props, selectedComparison, currentFromDate, current
   return { ...volunteerStatsResponse.data, taskAndProjectStats: taskAndProjectStatsResponse };
 }
 
-function getPreviousWeekDates(fromDate, toDate) {
-  const prevWeekStart = new Date(fromDate);
-  const prevWeekEnd = new Date(toDate);
-  prevWeekStart.setDate(prevWeekStart.getDate() - 7);
-  prevWeekEnd.setDate(prevWeekEnd.getDate() - 7);
-  return {
-    start: prevWeekStart.toISOString().split('T')[0],
-    end: prevWeekEnd.toISOString().split('T')[0],
-  };
-}
-
 async function generateTotalOrgPdf({ rootRef, darkMode, volunteerStats, isLoading }) {
   if (!validatePDFPrerequisites(volunteerStats, isLoading)) return;
   await new Promise(resolve => setTimeout(resolve, 5000));
@@ -465,8 +427,7 @@ function DateRangeModal({
   );
 }
 
-const fromDate = calculateStartDate();
-const toDate = calculateEndDate();
+const { start: fromDate, end: toDate } = getPreviousWeekDates();
 
 function TotalOrgSummary(props) {
   const { darkMode, error } = props;
@@ -580,10 +541,11 @@ function TotalOrgSummary(props) {
     setShowDatePicker(false);
     setSelectedComparison('No Comparison');
     if (option === 'Current Week') {
-      setCurrentFromDate(fromDate);
-      setCurrentToDate(toDate);
+      const { start, end } = getCurrentWeekDates();
+      setCurrentFromDate(start);
+      setCurrentToDate(end);
     } else if (option === 'Previous Week') {
-      const { start, end } = getPreviousWeekDates(fromDate, toDate);
+      const { start, end } = getPreviousWeekDates();
       setCurrentFromDate(start);
       setCurrentToDate(end);
     }
@@ -594,8 +556,8 @@ function TotalOrgSummary(props) {
       setSelectedDateRange(`${startDate.toLocaleDateString()} - ${endDate.toLocaleDateString()}`);
       setShowDatePicker(false);
       setSelectedComparison('No Comparison');
-      setCurrentFromDate(startDate.toISOString().split('T')[0]);
-      setCurrentToDate(endDate.toISOString().split('T')[0]);
+      setCurrentFromDate(formatLocalDateForApi(startDate));
+      setCurrentToDate(formatLocalDateForApi(endDate));
     }
   };
 

--- a/src/components/TotalOrgSummary/TotalOrgSummary.module.css
+++ b/src/components/TotalOrgSummary/TotalOrgSummary.module.css
@@ -509,6 +509,70 @@
   color: white;
 }
 
+.dateRangeModalDark :global(.modal-content) {
+  color: #f8fafc;
+  background-color: #1c2541;
+  border-color: #475569;
+}
+
+.dateRangeModalDark :global(.close) {
+  color: #fff;
+  opacity: 1;
+}
+
+.dateRangeModalDark :global(.btn-close) {
+  filter: invert(1) grayscale(100%) brightness(200%);
+}
+
+.datePickerInputDark {
+  color: #f8fafc !important;
+  background-color: #111827 !important;
+  border-color: #64748b !important;
+}
+
+.datePickerInputDark::placeholder {
+  color: #cbd5e1 !important;
+  opacity: 1;
+}
+
+:global(.total-org-datepicker-dark.react-datepicker),
+:global(.total-org-datepicker-dark .react-datepicker__month-container) {
+  color: #f8fafc;
+  background-color: #111827;
+  border-color: #64748b;
+}
+
+:global(.total-org-datepicker-dark .react-datepicker__header) {
+  background-color: #1e293b;
+  border-bottom-color: #64748b;
+}
+
+:global(.total-org-datepicker-dark .react-datepicker__current-month),
+:global(.total-org-datepicker-dark .react-datepicker__day-name),
+:global(.total-org-datepicker-dark .react-datepicker__day) {
+  color: #f8fafc;
+}
+
+:global(.total-org-datepicker-dark .react-datepicker__day:hover),
+:global(.total-org-datepicker-dark .react-datepicker__day--keyboard-selected) {
+  color: #fff;
+  background-color: #475569;
+}
+
+:global(.total-org-datepicker-dark .react-datepicker__day--selected) {
+  color: #fff;
+  background-color: #2563eb;
+}
+
+:global(.total-org-datepicker-dark .react-datepicker__day--outside-month),
+:global(.total-org-datepicker-dark .react-datepicker__day--disabled) {
+  color: #94a3b8;
+}
+
+:global(.total-org-datepicker-dark .react-datepicker__navigation-icon::before) {
+  border-color: #f8fafc;
+}
+
 .whiteSmoke {
   background-color: #f5f5f5;
 }

--- a/src/components/TotalOrgSummary/VolunteerHoursDistribution/VolunteerHoursDistribution.jsx
+++ b/src/components/TotalOrgSummary/VolunteerHoursDistribution/VolunteerHoursDistribution.jsx
@@ -4,7 +4,7 @@ import HoursWorkedPieChart from '../HoursWorkedPieChart/HoursWorkedPieChart';
 // Components
 import Loading from '../../common/Loading';
 
-const COLORS = ['#00AFF4', '#FFA500', '#00B030', '#EC52CB', '#F8FF00'];
+const COLORS = ['#00AFF4', '#FFA500', '#00B030', '#EC52CB', '#F8FF00', '#7C4DFF'];
 
 // --- Helper Functions ---
 
@@ -92,10 +92,19 @@ export function formatRangeLabel(rangeStr) {
   }
 }
 
-function buildChartData(hoursData, totalHoursData) {
+export function formatCommittedRangeLabel(rangeStr) {
+  const normalizedRange = normalizeBucketId(rangeStr);
+  if (normalizedRange === '40') return '40 hrs';
+  if (normalizedRange === '40+') return 'Over 40 hrs';
+  return formatRangeLabel(normalizedRange);
+}
+
+function buildChartData(hoursData, totalHoursData, useBucketCounts = false) {
   const normalizedHoursData = mergeHoursBuckets(hoursData);
   const totalVolunteers = normalizedHoursData.reduce((total, cur) => total + (cur.count || 0), 0);
-  const totalHoursWorked = Number(totalHoursData?.current ?? totalHoursData?.count ?? 0);
+  const totalHoursWorked = useBucketCounts
+    ? totalVolunteers
+    : Number(totalHoursData?.current ?? totalHoursData?.count ?? 0);
 
   const hoursByBucket = allocateRoundedHoursByCount(normalizedHoursData, totalHoursWorked);
   const totalAllocatedHours = hoursByBucket.reduce(
@@ -104,13 +113,18 @@ function buildChartData(hoursData, totalHoursData) {
   );
 
   const userData = hoursByBucket.map(range => {
-    const value = totalHoursWorked > 0 ? range.allocatedHours || 0 : range.count || 0;
-    const denominator = totalHoursWorked > 0 ? totalAllocatedHours : totalVolunteers;
+    let value = range.count || 0;
+    let denominator = totalVolunteers;
+    if (!useBucketCounts && totalHoursWorked > 0) {
+      value = range.allocatedHours || 0;
+      denominator = totalAllocatedHours;
+    }
 
     return {
-      name: formatRangeLabel(range._id),
+      name: useBucketCounts ? formatCommittedRangeLabel(range._id) : formatRangeLabel(range._id),
       value,
       percentage: denominator ? Math.round((value / denominator) * 100) : 0,
+      ...(useBucketCounts && { valueType: 'volunteers' }),
     };
   });
 
@@ -119,21 +133,23 @@ function buildChartData(hoursData, totalHoursData) {
 
 // --- Sub-Components ---
 
-function HoursWorkList({ data, darkMode }) {
+function HoursWorkList({ data, darkMode, title = 'Hours Worked', useCommittedLabels = false }) {
   if (!data) return <div />;
 
   const ranges = data.map((elem, index) => {
     return {
       name: elem._id,
       count: elem.count,
-      displayName: formatRangeLabel(elem._id),
+      displayName: useCommittedLabels
+        ? formatCommittedRangeLabel(elem._id)
+        : formatRangeLabel(elem._id),
       color: COLORS[index % COLORS.length],
     };
   });
 
   return (
     <div>
-      <h6 style={{ color: darkMode ? 'white' : 'grey' }}>Hours Worked</h6>
+      <h6 style={{ color: darkMode ? 'white' : 'grey' }}>{title}</h6>
       <div>
         <ul className="list-unstyled">
           {ranges.map(item => (
@@ -162,6 +178,10 @@ export default function VolunteerHoursDistribution({
   darkMode,
   hoursData,
   totalHoursData,
+  title = 'Actual Hours Worked',
+  legendTitle = 'Hours Worked',
+  centerLabelLines = ['TOTAL HOURS', 'WORKED'],
+  useBucketCounts = false,
 }) {
   // FIXED: Comparing with 'undefined' directly instead of using 'typeof' on an object property
   const [windowSize, setWindowSize] = useState({
@@ -198,21 +218,31 @@ export default function VolunteerHoursDistribution({
   const { normalizedHoursData, userData, totalHoursWorked } = buildChartData(
     hoursData,
     totalHoursData,
+    useBucketCounts,
   );
 
   return (
-    <div
-      className="d-flex flex-row flex-wrap align-items-center justify-content-center"
-      style={{ gap: '20px' }}
-    >
-      <HoursWorkedPieChart
-        darkMode={darkMode}
-        windowSize={windowSize}
-        userData={userData}
-        totalHours={totalHoursWorked}
-        colors={COLORS}
-      />
-      <HoursWorkList data={normalizedHoursData} darkMode={darkMode} />
+    <div className="d-flex flex-column align-items-center">
+      <h5 style={{ color: darkMode ? 'white' : 'inherit' }}>{title}</h5>
+      <div
+        className="d-flex flex-row flex-wrap align-items-center justify-content-center"
+        style={{ gap: '20px' }}
+      >
+        <HoursWorkedPieChart
+          darkMode={darkMode}
+          windowSize={windowSize}
+          userData={userData}
+          totalHours={totalHoursWorked}
+          colors={COLORS}
+          centerLabelLines={centerLabelLines}
+        />
+        <HoursWorkList
+          data={normalizedHoursData}
+          darkMode={darkMode}
+          title={legendTitle}
+          useCommittedLabels={useBucketCounts}
+        />
+      </div>
     </div>
   );
 }
@@ -220,7 +250,11 @@ export default function VolunteerHoursDistribution({
 // Extra named exports for automated testing
 export { HoursWorkList, mergeHoursBuckets };
 
-export function computeDistribution(hoursData, totalHoursData) {
-  const { userData, totalVolunteers, totalHoursWorked } = buildChartData(hoursData, totalHoursData);
+export function computeDistribution(hoursData, totalHoursData, useBucketCounts = false) {
+  const { userData, totalVolunteers, totalHoursWorked } = buildChartData(
+    hoursData,
+    totalHoursData,
+    useBucketCounts,
+  );
   return { userData, totalVolunteers, totalHoursWorked };
 }

--- a/src/components/TotalOrgSummary/VolunteerHoursDistribution/__tests__/VolunteerHoursDistribution.test.jsx
+++ b/src/components/TotalOrgSummary/VolunteerHoursDistribution/__tests__/VolunteerHoursDistribution.test.jsx
@@ -54,4 +54,46 @@ describe('VolunteerHoursDistribution wrapper', () => {
       totalHoursWorked: 1234,
     });
   });
+
+  it('renders committed-hours buckets as volunteer counts with a volunteer center total', () => {
+    const committedHoursData = [
+      { _id: 10, count: 2 },
+      { _id: 20, count: 3 },
+      { _id: 30, count: 1 },
+      { _id: 40, count: 1 },
+      { _id: '40+', count: 1 },
+    ];
+
+    render(
+      <VolunteerHoursDistribution
+        isLoading={false}
+        darkMode={false}
+        hoursData={committedHoursData}
+        title="Weekly Committed Hours"
+        legendTitle="Weekly Committed Hours"
+        centerLabelLines={['TOTAL', 'VOLUNTEERS']}
+        useBucketCounts
+      />,
+      { container },
+    );
+
+    expect(screen.getAllByText('Weekly Committed Hours')).toHaveLength(2);
+    expect(screen.getByText('TOTAL')).toBeInTheDocument();
+    expect(screen.getByText('VOLUNTEERS')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByText('40 hrs')).toBeInTheDocument();
+    expect(screen.getByText('Over 40 hrs')).toBeInTheDocument();
+
+    expect(computeDistribution(committedHoursData, undefined, true)).toEqual({
+      userData: [
+        { name: '10-19 hrs', value: 2, percentage: 25, valueType: 'volunteers' },
+        { name: '20-29 hrs', value: 3, percentage: 38, valueType: 'volunteers' },
+        { name: '30-39 hrs', value: 1, percentage: 13, valueType: 'volunteers' },
+        { name: '40 hrs', value: 1, percentage: 13, valueType: 'volunteers' },
+        { name: 'Over 40 hrs', value: 1, percentage: 13, valueType: 'volunteers' },
+      ],
+      totalVolunteers: 8,
+      totalHoursWorked: 8,
+    });
+  });
 });

--- a/src/components/TotalOrgSummary/VolunteerHoursDistribution/__tests__/VolunteerHoursDistribution.test.jsx
+++ b/src/components/TotalOrgSummary/VolunteerHoursDistribution/__tests__/VolunteerHoursDistribution.test.jsx
@@ -3,6 +3,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { renderCenterLabel } from '../../HoursWorkedPieChart/HoursWorkedPieChart';
 import VolunteerHoursDistribution, { computeDistribution } from '../VolunteerHoursDistribution';
 
 let container = null;
@@ -78,9 +79,6 @@ describe('VolunteerHoursDistribution wrapper', () => {
     );
 
     expect(screen.getAllByText('Weekly Committed Hours')).toHaveLength(2);
-    expect(screen.getByText('TOTAL')).toBeInTheDocument();
-    expect(screen.getByText('VOLUNTEERS')).toBeInTheDocument();
-    expect(screen.getByText('8')).toBeInTheDocument();
     expect(screen.getByText('40 hrs')).toBeInTheDocument();
     expect(screen.getByText('Over 40 hrs')).toBeInTheDocument();
 
@@ -95,5 +93,23 @@ describe('VolunteerHoursDistribution wrapper', () => {
       totalVolunteers: 8,
       totalHoursWorked: 8,
     });
+  });
+
+  it('renders the committed distribution center label', () => {
+    render(
+      <svg>
+        {renderCenterLabel({
+          darkMode: false,
+          isMobile: false,
+          totalHours: 8,
+          centerLabelLines: ['TOTAL', 'VOLUNTEERS'],
+        })}
+      </svg>,
+      { container },
+    );
+
+    expect(screen.getByText('TOTAL')).toBeInTheDocument();
+    expect(screen.getByText('VOLUNTEERS')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
   });
 });

--- a/src/components/TotalOrgSummary/__tests__/dateRangeUtils.test.jsx
+++ b/src/components/TotalOrgSummary/__tests__/dateRangeUtils.test.jsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatLocalDateForApi,
+  getCurrentWeekDates,
+  getPreviousWeekDates,
+} from '../dateRangeUtils';
+
+describe('TotalOrgSummary date range utilities', () => {
+  it('returns the current Sunday through Saturday range for current week', () => {
+    const result = getCurrentWeekDates(new Date('2026-06-25T12:00:00'));
+
+    expect(result).toEqual({
+      start: '2026-06-21',
+      end: '2026-06-27',
+    });
+  });
+
+  it('returns the previous Sunday through Saturday range for previous week', () => {
+    const result = getPreviousWeekDates(new Date('2026-06-25T12:00:00'));
+
+    expect(result).toEqual({
+      start: '2026-06-14',
+      end: '2026-06-20',
+    });
+  });
+
+  it('formats custom date picker values without UTC shifting', () => {
+    const result = formatLocalDateForApi(new Date(2026, 5, 21, 0, 0, 0));
+
+    expect(result).toBe('2026-06-21');
+  });
+});

--- a/src/components/TotalOrgSummary/dateRangeUtils.js
+++ b/src/components/TotalOrgSummary/dateRangeUtils.js
@@ -1,0 +1,46 @@
+function formatDateForApi(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function getWeekBounds(baseDate = new Date()) {
+  const normalizedDate = new Date(baseDate);
+  normalizedDate.setHours(0, 0, 0, 0);
+
+  const weekStart = new Date(normalizedDate);
+  weekStart.setDate(normalizedDate.getDate() - normalizedDate.getDay());
+
+  const weekEnd = new Date(weekStart);
+  weekEnd.setDate(weekStart.getDate() + 6);
+
+  return { start: weekStart, end: weekEnd };
+}
+
+export function getCurrentWeekDates(baseDate = new Date()) {
+  const { start, end } = getWeekBounds(baseDate);
+  return {
+    start: formatDateForApi(start),
+    end: formatDateForApi(end),
+  };
+}
+
+export function getPreviousWeekDates(baseDate = new Date()) {
+  const { start, end } = getWeekBounds(baseDate);
+
+  const previousWeekStart = new Date(start);
+  previousWeekStart.setDate(previousWeekStart.getDate() - 7);
+
+  const previousWeekEnd = new Date(end);
+  previousWeekEnd.setDate(previousWeekEnd.getDate() - 7);
+
+  return {
+    start: formatDateForApi(previousWeekStart),
+    end: formatDateForApi(previousWeekEnd),
+  };
+}
+
+export function formatLocalDateForApi(date) {
+  return formatDateForApi(date);
+}


### PR DESCRIPTION
# Description

This PR fixes the weekly date preset behavior in the Total Org Summary report.

Previously, **Current Week** requested the previous completed week instead of the actual current Sunday–Saturday week, while **Previous Week** requested two weeks ago. The initial **Previous Week** label also did not match the initial requested date range. In addition, custom date selection formatted dates through UTC conversion, which could shift calendar dates in some environments.

This PR restores the shared week date utilities so the frontend requests the correct date ranges and preserves local calendar dates for custom selections.

## Related PRS (if any):

This frontend PR is related to the backend PR [#2295](https://github.com/OneCommunityGlobal/HGNRest/pull/2295).

To test this frontend PR, please also check out backend PR [#2295](https://github.com/OneCommunityGlobal/HGNRest/pull/2295).

## Main changes explained:

- Restored `dateRangeUtils.js` for shared week date calculations.
- Updated **Current Week** to request the actual current Sunday–Saturday week.
- Updated **Previous Week** to request the immediately preceding Sunday–Saturday week.
- Fixed the initial **Previous Week** label so it matches the initial requested date range.
- Updated custom date formatting to preserve local calendar dates instead of relying on UTC conversion.
- Added regression tests covering Current Week, Previous Week, and custom date formatting.

## How to test:

1. Check out this frontend branch together with backend PR #2295.
2. Run `npm install`, then start the frontend using `npm run start:local`.
3. Start the backend with `npm start`.
4. Clear browser cache/site data.
5. Log in as an Admin user.
6. Go to **Dashboard → Total Org Summary**.
7. Select **Current Week** and verify that the request covers the current Sunday–Saturday week.
8. Select **Previous Week** and verify that the request covers the immediately preceding Sunday–Saturday week.
9. Select a custom date range and verify that the `/reports/volunteerstats` request uses the exact selected dates.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/a7892acc-0d61-4bb5-b8cb-fae6916b1d41


- Updated Current Week request dates.
- Updated Previous Week request dates.
- Verified custom date range requests in the browser Network tab.

## Note:

- This PR only updates frontend date-range calculations.
- Chart rendering, visualization logic, bucket definitions, and API response handling were not changed.
- The related backend PR (#2295) ensures both backend calculations use identical date boundaries.