### PR TITLE
Yuxuan - Enable editing and moving weekly summaries from the Timelog summaries tab

### DIFF
--- a/src/components/Timelog/Timelog.module.css
+++ b/src/components/Timelog/Timelog.module.css
@@ -244,28 +244,103 @@
   padding-right: 0 !important;
 }
 
-.button {
+.actionButton {
   margin-left: 10px;
   padding: 5px 10px;
-  border: 1px solid #ccc;
+  border: 1px solid transparent !important;
   border-radius: 5px;
   cursor: pointer;
   font-weight: bold;
+  line-height: 1.5;
+  text-decoration: none;
 }
 
 .editButton {
-  background-color: blue !important;
-  color: white;
+  background-color: #0069d9 !important;
+  border-color: #0062cc !important;
+  color: #fff !important;
+}
+
+.moveButton {
+  background-color: #5a6268 !important;
+  border-color: #545b62 !important;
+  color: #fff !important;
+}
+
+.moveControls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.moveControlsDark {
+  color: #f8f9fa;
+}
+
+.moveControls label {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 0;
+}
+
+.moveSelect {
+  min-height: 34px;
+  padding: 4px 28px 4px 8px;
+  border: 1px solid #6c757d;
+  border-radius: 4px;
+  background-color: #fff;
+  color: #212529;
+}
+
+.moveSelectDark {
+  border-color: #adb5bd;
+  background-color: #1c2541;
+  color: #f8f9fa;
+}
+
+.moveSelectDark option {
+  background-color: #1c2541;
+  color: #f8f9fa;
 }
 
 .saveButton {
-  background-color: green;
-  color: white;
+  background-color: #218838 !important;
+  border-color: #1e7e34 !important;
+  color: #fff !important;
 }
 
 .cancelButton {
-  background-color: red;
-  color: white;
+  background-color: #c82333 !important;
+  border-color: #bd2130 !important;
+  color: #fff !important;
+}
+
+.actionButton:hover:not(:disabled),
+.actionButton:focus-visible:not(:disabled) {
+  filter: brightness(1.12);
+  color: #fff !important;
+}
+
+.actionButton:focus-visible {
+  outline: 2px solid #212529;
+  outline-offset: 2px;
+}
+
+.actionButtonDark {
+  border-color: #dee2e6 !important;
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 18%);
+  color: #fff !important;
+}
+
+.actionButtonDark:focus-visible {
+  outline-color: #fff;
+}
+
+.actionButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .editTextarea {
@@ -390,18 +465,7 @@
   padding: 1px;
 }
 
-span.activeUser i.fa-circle {
-  color: lawngreen !important;
-}
-
-span.notActiveUser i.fa-circle {
-  color: #dee2e6 !important;
-}
-
-span.scheduledUser i.fa-circle {
-  color: orange !important;
-}
-
-span.pausedUser i.fa-circle {
-  color: red !important;
-}
+span.activeUser i.fa-circle { color: lawngreen !important; }
+span.notActiveUser i.fa-circle { color: #dee2e6 !important; }
+span.scheduledUser i.fa-circle { color: orange !important; }
+span.pausedUser i.fa-circle { color: red !important; }

--- a/src/components/Timelog/WeeklySummaries.jsx
+++ b/src/components/Timelog/WeeklySummaries.jsx
@@ -1,15 +1,45 @@
 import { useState, useEffect } from 'react';
 import parse from 'html-react-parser';
-import { getUserProfile, updateUserProfile } from '../../actions/userProfile';
 import hasPermission from '../../utils/permissions';
 import { useDispatch, useSelector } from 'react-redux';
 import { Editor } from '@tinymce/tinymce-react';
 import Spinner from 'react-bootstrap/Spinner';
+import { Button } from 'reactstrap';
 import { updateWeeklySummaries } from '../../actions/weeklySummaries';
-import WeeklySummary from '../WeeklySummary/WeeklySummary';
 import styles from './Timelog.module.css';
 
-function WeeklySummaries({ userProfile, onEditSummary }) {
+export const moveWeeklySummary = (
+  weeklySummaries,
+  sourceIndex,
+  destinationIndex,
+  uploadDate = new Date().toISOString(),
+) => {
+  if (
+    !Array.isArray(weeklySummaries) ||
+    sourceIndex === destinationIndex ||
+    !weeklySummaries[sourceIndex]?.summary ||
+    weeklySummaries[destinationIndex]?.summary
+  ) {
+    return null;
+  }
+
+  return weeklySummaries.map((item, index) => {
+    if (index === sourceIndex) {
+      const { uploadDate: _uploadDate, ...sourceWithoutUploadDate } = item;
+      return { ...sourceWithoutUploadDate, summary: '' };
+    }
+    if (index === destinationIndex) {
+      return {
+        ...item,
+        summary: weeklySummaries[sourceIndex].summary,
+        uploadDate,
+      };
+    }
+    return item;
+  });
+};
+
+function WeeklySummaries({ userProfile }) {
   const darkMode = useSelector(state => state.theme.darkMode);
 
   // Initialize state variables for editing and original summaries
@@ -23,11 +53,11 @@ function WeeklySummaries({ userProfile, onEditSummary }) {
   ]);
 
   const [LoadingHandleSave, setLoadingHandleSave] = useState(null);
+  const [moveSourceIndex, setMoveSourceIndex] = useState(null);
+  const [moveDestinationIndex, setMoveDestinationIndex] = useState('');
+  const [isMoving, setIsMoving] = useState(false);
 
   const [wordCount, setWordCount] = useState(0);
-
-  const [showModal, setShowModal] = useState(false);
-  const [modalTab, setModalTab] = useState('1');
 
   const dispatch = useDispatch();
   const canEdit = dispatch(hasPermission('putUserProfile'));
@@ -84,16 +114,12 @@ function WeeklySummaries({ userProfile, onEditSummary }) {
         ),
       };
 
-      // This code updates the summary.
-      await dispatch(updateUserProfile(userProfile));
-
-      // This code saves edited weekly summaries in MongoDB.
-      await dispatch(updateWeeklySummaries(userProfile._id, updatedUserProfile));
-      await dispatch(getUserProfile(userProfile._id));
-      await setLoadingHandleSave(null);
+      const status = await dispatch(updateWeeklySummaries(userProfile._id, updatedUserProfile));
+      if (status === 200) {
+        // Toggle off editing mode only after the update succeeds.
+        toggleEdit(index);
+      }
       setLoadingHandleSave(null);
-      // Toggle off editing mode
-      toggleEdit(index);
     } else {
       // Invalid summary, show an error message or handle it as needed
       // eslint-disable-next-line no-alert
@@ -101,17 +127,38 @@ function WeeklySummaries({ userProfile, onEditSummary }) {
     }
   };
 
-  const handleEditSummary = (tabIndex) => {
-    // Map the tab index to the correct tab number
-    const tabNumber = String(tabIndex + 1);
-    setModalTab(tabNumber);
-    setShowModal(true);
+  const handleMove = async () => {
+    const destinationIndex = Number(moveDestinationIndex);
+    const weeklySummaries = moveWeeklySummary(
+      userProfile.weeklySummaries,
+      moveSourceIndex,
+      destinationIndex,
+    );
+
+    if (!weeklySummaries) return;
+
+    const mediaFolderUrl = userProfile.adminLinks?.find(
+      link => link.Name === 'Media Folder',
+    )?.Link;
+
+    setIsMoving(true);
+    const status = await dispatch(
+      updateWeeklySummaries(userProfile._id, {
+        mediaUrl: mediaFolderUrl || userProfile.mediaUrl || '',
+        weeklySummaries,
+        weeklySummariesCount: userProfile.weeklySummariesCount || 0,
+      }),
+    );
+    if (status === 200) {
+      setMoveSourceIndex(null);
+      setMoveDestinationIndex('');
+    }
+    setIsMoving(false);
   };
 
-  const handleCloseModal = () => {
-    setShowModal(false);
-    // Refresh the user profile to get updated summaries
-    dispatch(getUserProfile(userProfile._id));
+  const cancelMove = () => {
+    setMoveSourceIndex(null);
+    setMoveDestinationIndex('');
   };
 
   // Images are not allowed while editing weekly summaries
@@ -152,22 +199,28 @@ function WeeklySummaries({ userProfile, onEditSummary }) {
           />
 
           <div style={{ marginTop: '10px' }}>
-            <button
-              type="button"
-              className={`${styles.button} ${styles.saveButton}`}
+            <Button
+              color="success"
+              size="sm"
+              className={`${styles.actionButton} ${styles.saveButton} ${
+                darkMode ? styles.actionButtonDark : ''
+              }`}
               onClick={() => handleSave(index)}
               disabled={LoadingHandleSave === index}
             >
               {LoadingHandleSave === index ? <Spinner animation="border" size="sm" /> : 'Save'}
-            </button>
+            </Button>
 
-            <button
-              type="button"
-              className={`${styles.button} ${styles.cancelButton}`}
+            <Button
+              color="danger"
+              size="sm"
+              className={`${styles.actionButton} ${styles.cancelButton} ${
+                darkMode ? styles.actionButtonDark : ''
+              }`}
               onClick={() => handleCancel(index)}
             >
               Cancel
-            </button>
+            </Button>
           </div>
         </div>
       );
@@ -178,9 +231,89 @@ function WeeklySummaries({ userProfile, onEditSummary }) {
         <div className={darkMode ? 'bg-yinmn-blue summary-text-light' : ''}>
           <h3>{title}</h3>
           {parse(editedSummaries[index])}
-          <button type="button" className={`${styles.button} ${styles.editButton}`} onClick={() => toggleEdit(index)}>
+          <Button
+            color="primary"
+            size="sm"
+            className={`${styles.actionButton} ${styles.editButton} ${
+              darkMode ? styles.actionButtonDark : ''
+            }`}
+            onClick={() => toggleEdit(index)}
+          >
             Edit
-          </button>
+          </Button>
+          <Button
+            color="secondary"
+            size="sm"
+            className={`${styles.actionButton} ${styles.moveButton} ${
+              darkMode ? styles.actionButtonDark : ''
+            }`}
+            onClick={() => {
+              setMoveSourceIndex(index);
+              setMoveDestinationIndex('');
+            }}
+          >
+            Move
+          </Button>
+          {moveSourceIndex === index && (
+            <div
+              className={`${styles.moveControls} ${
+                darkMode ? styles.moveControlsDark : ''
+              }`}
+            >
+              <label htmlFor={`move-summary-${index}`}>
+                Move to
+                <select
+                  id={`move-summary-${index}`}
+                  className={`${styles.moveSelect} ${
+                    darkMode ? styles.moveSelectDark : ''
+                  }`}
+                  value={moveDestinationIndex}
+                  onChange={event => setMoveDestinationIndex(event.target.value)}
+                  disabled={isMoving}
+                >
+                  <option value="">Select a week</option>
+                  {[
+                    "This week's summary",
+                    "Last week's summary",
+                    "The week before last's summary",
+                  ].map((weekTitle, destinationIndex) => (
+                    <option
+                      key={weekTitle}
+                      value={destinationIndex}
+                      disabled={
+                        destinationIndex === index ||
+                        Boolean(userProfile.weeklySummaries[destinationIndex]?.summary)
+                      }
+                    >
+                      {weekTitle}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <Button
+                color="success"
+                size="sm"
+                className={`${styles.actionButton} ${styles.saveButton} ${
+                  darkMode ? styles.actionButtonDark : ''
+                }`}
+                onClick={handleMove}
+                disabled={moveDestinationIndex === '' || isMoving}
+              >
+                {isMoving ? <Spinner animation="border" size="sm" /> : 'Confirm Move'}
+              </Button>
+              <Button
+                color="danger"
+                size="sm"
+                className={`${styles.actionButton} ${styles.cancelButton} ${
+                  darkMode ? styles.actionButtonDark : ''
+                }`}
+                onClick={cancelMove}
+                disabled={isMoving}
+              >
+                Cancel
+              </Button>
+            </div>
+          )}
         </div>
       );
     }
@@ -193,30 +326,25 @@ function WeeklySummaries({ userProfile, onEditSummary }) {
         </div>
       );
     }
-    // Display a message when there's no summary with an edit button (always show edit button for missing summaries)
+    // Display a message and allow authorized users to add a missing summary.
     return (
       <div>
         <h3>{title}</h3>
         <p className={darkMode ? 'bg-yinmn-blue text-light' : ''}>
           {userProfile.firstName} {userProfile.lastName} did not submit a summary.
         </p>
-        <button 
-          type="button" 
-          className={`${styles.button} ${styles.editButton}`}
-          style={{
-                  marginLeft: '10px',
-                  padding: '5px 10px',
-                  border: 'none',
-                  borderRadius: '5px',
-                  cursor: 'pointer',
-                  fontWeight: 'bold',
-                  backgroundColor: 'blue',
-                  color: 'white',
-                }}
-          onClick={() => handleEditSummary(index)}
-        >
-          Edit
-        </button>
+        {(canEdit || currentUserID === loggedInUserId) && (
+          <Button
+            color="primary"
+            size="sm"
+            className={`${styles.actionButton} ${styles.editButton} ${
+              darkMode ? styles.actionButtonDark : ''
+            }`}
+            onClick={() => toggleEdit(index)}
+          >
+            Edit
+          </Button>
+        )}
       </div>
     );
   };
@@ -226,18 +354,6 @@ function WeeklySummaries({ userProfile, onEditSummary }) {
       {renderSummary("This week's summary", userProfile.weeklySummaries[0]?.summary, 0)}
       {renderSummary("Last week's summary", userProfile.weeklySummaries[1]?.summary, 1)}
       {renderSummary("The week before last's summary", userProfile.weeklySummaries[2]?.summary, 2)}
-      
-      {showModal && (
-        <WeeklySummary
-          isModal={true}
-          displayUserId={userProfile._id}
-          setPopup={handleCloseModal}
-          userRole={userProfile.role}
-          isNotAllowedToEdit={false}
-          darkMode={darkMode}
-          initialActiveTab={modalTab}
-        />
-      )}
     </div>
   );
 }

--- a/src/components/Timelog/__tests__/WeeklySummaries.test.jsx
+++ b/src/components/Timelog/__tests__/WeeklySummaries.test.jsx
@@ -1,11 +1,19 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { BrowserRouter } from 'react-router-dom';
-import WeeklySummaries from '../WeeklySummaries';
+import WeeklySummaries, { moveWeeklySummary } from '../WeeklySummaries';
+
+const actionMocks = vi.hoisted(() => ({
+  updateWeeklySummaries: vi.fn(() => async () => 200),
+}));
+
+vi.mock('../../../actions/weeklySummaries', () => ({
+  updateWeeklySummaries: actionMocks.updateWeeklySummaries,
+}));
 
 // Mock dependencies
 vi.mock('html-react-parser', () => ({
@@ -59,6 +67,57 @@ const renderWeeklySummaries = props => {
 };
 
 describe('WeeklySummaries Component', () => {
+  beforeEach(() => {
+    actionMocks.updateWeeklySummaries.mockClear();
+  });
+
+  it('moves summary content to an empty week while preserving week dates', () => {
+    const uploadDate = '2026-07-30T12:00:00.000Z';
+    const weeklySummaries = [
+      {
+        summary: 'Summary of this week',
+        dueDate: '2026-08-01T23:59:59.999Z',
+        uploadDate: '2026-07-29T12:00:00.000Z',
+      },
+      {
+        summary: '',
+        dueDate: '2026-07-25T23:59:59.999Z',
+      },
+      {
+        summary: 'Summary of the week before last',
+        dueDate: '2026-07-18T23:59:59.999Z',
+      },
+      {
+        summary: 'Hidden fourth summary',
+        dueDate: '2026-07-11T23:59:59.999Z',
+      },
+    ];
+
+    const result = moveWeeklySummary(weeklySummaries, 0, 1, uploadDate);
+
+    expect(result[0]).toEqual({
+      summary: '',
+      dueDate: weeklySummaries[0].dueDate,
+    });
+    expect(result[1]).toEqual({
+      summary: weeklySummaries[0].summary,
+      dueDate: weeklySummaries[1].dueDate,
+      uploadDate,
+    });
+    expect(result[2]).toEqual(weeklySummaries[2]);
+    expect(result[3]).toEqual(weeklySummaries[3]);
+  });
+
+  it('does not move a summary onto an occupied week', () => {
+    const weeklySummaries = [
+      { summary: 'Current week' },
+      { summary: 'Last week' },
+      { summary: '' },
+    ];
+
+    expect(moveWeeklySummary(weeklySummaries, 0, 1)).toBeNull();
+  });
+
   it('renders no summaries message when there are no summaries', () => {
     const userProfile = {
       _id: 'user123',
@@ -104,5 +163,84 @@ describe('WeeklySummaries Component', () => {
 
     const noSubmissionMessages = screen.getAllByText('John Doe did not submit a summary.');
     expect(noSubmissionMessages.length).toBe(3);
+  });
+
+  it("opens the inline editor for an empty last week's summary", () => {
+    const userProfile = {
+      _id: 'user123',
+      weeklySummaries: [
+        { summary: '<p>Summary of this week</p>' },
+        { summary: '' },
+        { summary: '<p>Summary of the week before last</p>' },
+      ],
+      firstName: 'John',
+      lastName: 'Doe',
+    };
+
+    renderWeeklySummaries({ userProfile });
+
+    const editButtons = screen.getAllByRole('button', { name: 'Edit' });
+    fireEvent.click(editButtons[1]);
+
+    expect(screen.getByTestId('mock-editor')).toBeInTheDocument();
+    expect(screen.getByText("Last week's summary")).toBeInTheDocument();
+  });
+
+  it('moves a summary to an empty destination in one update', async () => {
+    const userProfile = {
+      _id: 'user123',
+      weeklySummaries: [
+        {
+          summary: '<p>Summary of this week</p>',
+          dueDate: '2026-08-01T23:59:59.999Z',
+          uploadDate: '2026-07-29T12:00:00.000Z',
+        },
+        { summary: '', dueDate: '2026-07-25T23:59:59.999Z' },
+        {
+          summary: '<p>Summary of the week before last</p>',
+          dueDate: '2026-07-18T23:59:59.999Z',
+        },
+        {
+          summary: '<p>Hidden fourth summary</p>',
+          dueDate: '2026-07-11T23:59:59.999Z',
+        },
+      ],
+      weeklySummariesCount: 3,
+      mediaUrl: '',
+      adminLinks: [
+        {
+          Name: 'Media Folder',
+          Link: 'https://example.com/media',
+        },
+      ],
+      firstName: 'John',
+      lastName: 'Doe',
+    };
+
+    renderWeeklySummaries({ userProfile });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Move' })[0]);
+
+    const destinationSelect = screen.getByLabelText('Move to');
+    expect(destinationSelect.options[1]).toBeDisabled();
+    expect(destinationSelect.options[2]).not.toBeDisabled();
+    expect(destinationSelect.options[3]).toBeDisabled();
+
+    fireEvent.change(destinationSelect, { target: { value: '1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Move' }));
+
+    await waitFor(() => expect(actionMocks.updateWeeklySummaries).toHaveBeenCalledTimes(1));
+
+    const [userId, update] = actionMocks.updateWeeklySummaries.mock.calls[0];
+    expect(userId).toBe(userProfile._id);
+    expect(update.weeklySummaries[0]).toEqual({
+      summary: '',
+      dueDate: userProfile.weeklySummaries[0].dueDate,
+    });
+    expect(update.weeklySummaries[1].summary).toBe(userProfile.weeklySummaries[0].summary);
+    expect(update.weeklySummaries[1].dueDate).toBe(userProfile.weeklySummaries[1].dueDate);
+    expect(update.weeklySummaries[1].uploadDate).toBeTruthy();
+    expect(update.weeklySummaries[3]).toEqual(userProfile.weeklySummaries[3]);
+    expect(update.mediaUrl).toBe(userProfile.adminLinks[0].Link);
   });
 });


### PR DESCRIPTION
# Description

This PR fixes the weekly summary editing and moving workflow in the Timelog Summaries tab.

Previously, empty summaries used a separate pseudo-modal workflow, causing the Edit action to appear unresponsive. Users were also unable to move weekly summaries directly from the Timelog Summaries tab.

This PR unifies the editing experience by using the inline editor for both empty and populated summaries. It also enables moving summaries into empty weeks while preserving weekly dates and media links, refreshing upload timestamps, and issuing a single profile update for each move operation.

In addition, the summary action controls are restored for both light mode and dark mode, and regression tests have been added to prevent future regressions.

## Related PRS (if any):

No related backend PR.

## Main changes explained:

- Updated `WeeklySummaries.jsx` so both empty and populated summaries use the same inline editing experience.
- Added support for moving summaries into empty weeks while preserving weekly dates and media links.
- Refreshed upload timestamps after moving summaries and ensured only one profile update is triggered for each move operation.
- Updated `Timelog.module.css` to restore visible summary action controls in both light mode and dark mode.
- Added regression tests covering weekly summary editing and moving behavior.

## How to test:

1. Check out this branch.
2. Run:
   ```bash
   npm install
   npm run start:local
   ```
3. Clear browser cache/site data.
4. Log in as an Admin user.
5. Navigate to **Dashboard → Timelog → Summaries**.
6. Verify that:
   - Empty weekly summaries can be edited directly using the inline editor.
   - Existing weekly summaries continue to use the same inline editor.
   - Weekly summaries can only be moved into empty weeks.
   - Moving a summary preserves the weekly dates and attached media.
   - Upload timestamps are refreshed after moving.
   - Only one profile update is triggered for each move operation.
7. Verify the feature works correctly in both Light Mode and Dark Mode.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/155042d2-1acb-4b6e-bc29-b518c2335e6f


## Note:

- This PR only changes frontend behavior.
- No backend API changes are required.
- Regression tests were added for the updated editing and moving workflow.