### PR TITLE
Purav taking over for Vivek - Feature: Tracking Resolved Tasks

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -55,6 +55,7 @@ import {
   REPORTS,
   SEND_EMAILS,
   SCHEDULE_MEETINGS,
+  TASKS,
   TEAM_LOCATIONS,
   TEAMS,
   TIMELOG,
@@ -1128,6 +1129,7 @@ export function Header(props) {
                 {(canAccessUserManagement ||
                   canAccessBadgeManagement ||
                   canAccessProjects ||
+                  canUpdateTask ||
                   canAccessTeams ||
                   canAccessPopups ||
                   canAccessSendEmails ||
@@ -1171,6 +1173,16 @@ export function Header(props) {
                           disabled={headerDisabled}
                         >
                           {PROJECTS}
+                        </DropdownItem>
+                      )}
+                      {(canAccessProjects || canUpdateTask) && (
+                        <DropdownItem
+                          tag={Link}
+                          to="/resolvedtasks"
+                          className={fontColor}
+                          disabled={headerDisabled}
+                        >
+                          {TASKS}
                         </DropdownItem>
                       )}
                       {canAccessTeams && (

--- a/src/components/ResolvedTasks/ResolvedTasks.jsx
+++ b/src/components/ResolvedTasks/ResolvedTasks.jsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Container, Row, Col } from 'reactstrap';
+import { connect } from 'react-redux';
+import axios from 'axios';
+import moment from 'moment';
+import { Link } from 'react-router-dom';
+import { ENDPOINTS } from '~/utils/URL';
+import PropTypes from 'prop-types';
+import styles from './ResolvedTasks.module.css';
+
+const PAGE_SIZE = 20;
+
+const ResolvedTasks = props => {
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+  const darkMode = Boolean(props.theme?.darkMode);
+
+  const fetchResolvedTasks = useCallback(async currentPage => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await axios.get(ENDPOINTS.RESOLVED_TASKS(currentPage, PAGE_SIZE));
+      setTasks(response.data.tasks || []);
+      setTotalPages(response.data.pagination?.pages || 1);
+      setTotal(response.data.pagination?.total || 0);
+    } catch (err) {
+      setError(err.message);
+      setTasks([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchResolvedTasks(page);
+  }, [fetchResolvedTasks, page]);
+
+  const renderAssignedResources = resources => {
+    if (!resources || resources.length === 0) {
+      return (
+        <span className={darkMode ? styles.mutedTextDark : styles.mutedText}>
+          No resources assigned
+        </span>
+      );
+    }
+
+    return resources.map((res, index) => (
+      <div key={res.userID?._id || `${res.name}-${index}`} className={styles.resourceBlock}>
+        <div>{res.name}</div>
+        <div className={darkMode ? styles.mutedTextDark : styles.mutedText}>
+          {res.userID?.email || 'No email available'}
+        </div>
+      </div>
+    ));
+  };
+
+  const renderPagination = () => {
+    if (totalPages <= 1) return null;
+
+    const pageButtons = [];
+    const maxButtons = 5;
+    const half = Math.floor(maxButtons / 2);
+    let start = Math.max(page - half, 1);
+    let end = Math.min(start + maxButtons - 1, totalPages);
+
+    if (end - start < maxButtons - 1) {
+      start = Math.max(end - maxButtons + 1, 1);
+    }
+
+    for (let i = start; i <= end; i += 1) {
+      pageButtons.push(i);
+    }
+
+    const buttonClass = darkMode ? styles.pageButtonDark : styles.pageButton;
+    const activeClass = darkMode ? styles.pageButtonActiveDark : styles.pageButtonActive;
+
+    return (
+      <div className={styles.pagination}>
+        <button
+          type="button"
+          className={buttonClass}
+          onClick={() => setPage(prev => Math.max(prev - 1, 1))}
+          disabled={page === 1 || loading}
+        >
+          Previous
+        </button>
+        {pageButtons.map(pageNumber => (
+          <button
+            key={pageNumber}
+            type="button"
+            className={`${buttonClass} ${page === pageNumber ? activeClass : ''}`}
+            onClick={() => setPage(pageNumber)}
+            disabled={loading}
+          >
+            {pageNumber}
+          </button>
+        ))}
+        <button
+          type="button"
+          className={buttonClass}
+          onClick={() => setPage(prev => Math.min(prev + 1, totalPages))}
+          disabled={page === totalPages || loading}
+        >
+          Next
+        </button>
+        <span className={styles.pageInfo}>
+          Page {page} of {totalPages} ({total} total)
+        </span>
+      </div>
+    );
+  };
+
+  if (loading && tasks.length === 0) {
+    return (
+      <div className={`${styles.statusMessage} ${darkMode ? styles.pageDark : ''}`}>Loading...</div>
+    );
+  }
+
+  if (error && tasks.length === 0) {
+    return <div className={`${styles.statusMessage} ${styles.errorMessage}`}>Error: {error}</div>;
+  }
+
+  return (
+    <Container fluid className={`${styles.page} ${darkMode ? styles.pageDark : ''}`}>
+      <Row className="mb-4">
+        <Col>
+          <h2 className={styles.title}>Resolved and Closed Tasks</h2>
+          <div className={styles.tableWrapper}>
+            <table className={`${styles.table} ${darkMode ? styles.tableDark : ''}`}>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Task Name</th>
+                  <th>Assigned Resources</th>
+                  <th>Resolved/Closed By</th>
+                  <th>Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tasks.length === 0 ? (
+                  <tr>
+                    <td colSpan="5" className="text-center">
+                      No resolved tasks found.
+                    </td>
+                  </tr>
+                ) : (
+                  tasks.map(item => (
+                    <tr key={item._id}>
+                      <td>{item.taskId?.num || 'N/A'}</td>
+                      <td>
+                        {item.taskId ? (
+                          <Link
+                            to={`/wbs/tasks/${item.taskId._id}`}
+                            className={`${styles.taskLink} ${darkMode ? styles.taskLinkDark : ''}`}
+                          >
+                            {item.taskId.taskName}
+                          </Link>
+                        ) : (
+                          <span className={darkMode ? styles.mutedTextDark : styles.mutedText}>
+                            Task deleted/unavailable
+                          </span>
+                        )}
+                      </td>
+                      <td>{renderAssignedResources(item.taskId?.resources)}</td>
+                      <td>
+                        <div>
+                          {item.userId
+                            ? `${item.userId.firstName} ${item.userId.lastName}`
+                            : item.userName || 'Unknown'}
+                        </div>
+                        <div className={darkMode ? styles.mutedTextDark : styles.mutedText}>
+                          {item.userId?.email || item.userEmail || 'No email available'}
+                        </div>
+                      </td>
+                      <td>{moment(item.timestamp).format('LLL')}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          {renderPagination()}
+        </Col>
+      </Row>
+    </Container>
+  );
+};
+
+const mapStateToProps = state => ({
+  theme: state.theme,
+});
+
+ResolvedTasks.propTypes = {
+  theme: PropTypes.shape({
+    darkMode: PropTypes.bool,
+  }),
+};
+
+export default connect(mapStateToProps)(ResolvedTasks);

--- a/src/components/ResolvedTasks/ResolvedTasks.module.css
+++ b/src/components/ResolvedTasks/ResolvedTasks.module.css
@@ -1,0 +1,169 @@
+.page {
+  min-height: 100vh;
+  padding: 1.5rem;
+}
+
+.pageDark {
+  background-color: #1b2a41;
+  color: #f8f9fa;
+}
+
+.title {
+  margin-bottom: 1rem;
+}
+
+.statusMessage {
+  text-align: center;
+  margin-top: 3rem;
+}
+
+.errorMessage {
+  color: #dc3545;
+}
+
+.tableWrapper {
+  overflow-x: auto;
+  width: 100%;
+}
+
+.table {
+  width: 100%;
+  margin-bottom: 1rem;
+  border-collapse: collapse;
+  background-color: #fff;
+}
+
+.tableDark {
+  background-color: #3a506b;
+  color: #f8f9fa;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem;
+  border: 1px solid #dee2e6;
+  vertical-align: top;
+}
+
+.tableDark th,
+.tableDark td {
+  border-color: #1c2541;
+}
+
+.table thead th {
+  background-color: #e3f0fb;
+  font-weight: 600;
+  border-bottom: 2px solid #dee2e6;
+}
+
+.tableDark thead th {
+  background-color: #1c2541;
+  color: #f8f9fa;
+  border-bottom-color: #1b2a41;
+}
+
+.table tbody tr:nth-child(even) {
+  background-color: #f8f9fa;
+}
+
+.tableDark tbody tr:nth-child(even) {
+  background-color: #2f4157;
+}
+
+.table tbody tr:hover {
+  background-color: #eef5fb;
+}
+
+.tableDark tbody tr:hover {
+  background-color: #243447;
+}
+
+.taskLink {
+  color: #007bff;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.taskLink:hover {
+  text-decoration: underline;
+}
+
+.taskLinkDark {
+  color: #7ec8ff;
+}
+
+.taskLinkDark:hover {
+  color: #a8dbff;
+}
+
+.mutedText {
+  color: #6c757d;
+  font-size: 0.875rem;
+}
+
+.mutedTextDark {
+  color: #c5d0db;
+}
+
+.resourceBlock {
+  margin-bottom: 0.35rem;
+}
+
+.resourceBlock:last-child {
+  margin-bottom: 0;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.pageButton {
+  min-width: 2.25rem;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  background-color: #fff;
+  color: #212529;
+  cursor: pointer;
+}
+
+.pageButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.pageButton:hover:not(:disabled) {
+  background-color: #e9ecef;
+}
+
+.pageButtonActive {
+  background-color: #007bff;
+  border-color: #007bff;
+  color: #fff;
+}
+
+.pageButtonDark {
+  background-color: #1c2541;
+  border-color: #3a506b;
+  color: #f8f9fa;
+}
+
+.pageButtonDark:hover:not(:disabled) {
+  background-color: #2f4157;
+}
+
+.pageButtonActiveDark {
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+  color: #fff;
+}
+
+.pageInfo {
+  margin: 0 0.25rem;
+  font-size: 0.9rem;
+}

--- a/src/languages/en/ui.js
+++ b/src/languages/en/ui.js
@@ -48,6 +48,7 @@ export const BADGE_MANAGEMENT = 'Badge Management';
 export const VIEW_PROFILE = 'View Profile';
 export const WBS = 'WBS';
 export const WELCOME = 'Welcome';
+export const TASKS = 'Tasks';
 export const NOTICE = 'Notice';
 export const FIRST_NAME = 'First Name';
 export const LAST_NAME = 'Last Name';

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -85,6 +85,7 @@ import UserProfilePage from './components/HGNHelpSkillsDashboard/UserProfilePage
 import FeedbackModal from './components/HGNHelpSkillsDashboard/FeedbackModal';
 import ActivityAttendance from './components/CommunityPortal/Activities/ActivityAttendance';
 import ActivityAgenda from './components/CommunityPortal/Activities/ActivityAgenda';
+import ResolvedTasks from './components/ResolvedTasks/ResolvedTasks';
 import EventList from './components/CommunityPortal/Event/EventList/EventList';
 import ResourcesUsage from './components/CommunityPortal/Activities/activityId/ResourcesUsage';
 import EventParticipation from './components/CommunityPortal/Reports/Participation/EventParticipation';
@@ -377,6 +378,7 @@ export default (
       <ToastContainer />
       <Switch>
         <ProtectedRoute path="/weekly-summary" exact component={WeeklySummaryPage} />
+        <ProtectedRoute path="/resolvedtasks" exact component={ResolvedTasks} />
         <ProtectedRoute path="/hgnhelp" exact component={HelpPage} />
         <ProtectedRoute path="/dashboard" exact component={Dashboard} />
         <ProtectedRoute path="/dashboard/:userId" exact component={Dashboard} />

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -113,6 +113,7 @@ export const ENDPOINTS = {
   TASK_WBS: wbsId => `${APIEndpoint}/task/wbs/${wbsId}`,
   TASKS_UPDATE: `${APIEndpoint}/tasks/update`,
   TASKS_BY_USERID: userId => `${APIEndpoint}/tasks/user/${userId}`,
+  RESOLVED_TASKS: (page, limit) => `${APIEndpoint}/tasks/resolved?page=${page}&limit=${limit}`,
   // TASKS_BY_userID: userId => `${APIEndpoint}/tasks/userProfile/${userId}`,
   TASK_DEL: (taskId, motherId) => `${APIEndpoint}/task/del/${taskId}/${motherId}`,
   GET_TASK: taskId => `${APIEndpoint}/task/${taskId}`,


### PR DESCRIPTION
## Summary
- Takes over frontend work from PR #4797 with a clean branch based on latest `development` (feature-only changes; no unrelated Header/yarn.lock noise).
- Adds **Resolved and Closed Tasks** page under Other Links → Tasks, with clickable task names, assigned resources (name + email), resolver info, and date.
- Fixes reviewer feedback: proper light/dark mode via CSS modules, server-side pagination, and a `No resources assigned` fallback.

**Related PRs**
- Backend: https://github.com/OneCommunityGlobal/HGNRest/pull/2031
- Supersedes frontend: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4797

## Main Changes
- `ResolvedTasks.jsx` + `ResolvedTasks.module.css` – new page with table, pagination, and dark mode
- `Header.jsx` – Tasks link in Other Links
- `ui.js` – `TASKS` translation key
- `URL.js` – `RESOLVED_TASKS` endpoint
- `routes.jsx` – `/resolvedtasks` ProtectedRoute

## How to Test
1. Check out `Purav-takeover-ResolvedTask-Tracking` (and backend branch for #2031).
2. Run `npm install` / start frontend + backend.
3. Log in as an admin user.
4. Complete/resolve/close an assigned task.
5. Hover **Other Links** → click **Tasks**.
6. Verify table columns, task name navigation to WBS, pagination, and light/dark themes.

## Verification Checklist
### Functionality
- [ ] Resolved and Closed Tasks page loads
- [ ] Columns: Task Number, Task Name (clickable), Assigned Resources, Resolved/Closed By, Date
- [ ] Empty resources show `No resources assigned`
- [ ] Pagination works when more than 20 items exist
- [ ] Task Name navigates to WBS task details

### Styling
- [ ] Light mode renders correctly
- [ ] Dark mode renders correctly (table, links, muted text, pagination)

Made with [Cursor](https://cursor.com)