### PR TITLE
Purav taking over for Juhitha-Reddy create injury trend chart

### DIFF
--- a/src/actions/bmdashboard/injuryActions.js
+++ b/src/actions/bmdashboard/injuryActions.js
@@ -12,6 +12,7 @@ export const RESET_BM_INJURY_DATA = 'RESET_BM_INJURY_DATA';
 export const FETCH_BM_INJURY_SEVERITIES = 'FETCH_BM_INJURY_SEVERITIES';
 export const FETCH_BM_INJURY_TYPES = 'FETCH_BM_INJURY_TYPES';
 export const FETCH_BM_INJURY_PROJECTS = 'FETCH_BM_INJURY_PROJECTS';
+export const FETCH_BM_INJURY_TREND_SUCCESS = 'FETCH_BM_INJURY_TREND_SUCCESS';
 export const FETCH_BM_INJURY_OVER_TIME = 'FETCH_BM_INJURY_OVER_TIME';
 
 // Legacy constants for backward compatibility
@@ -47,6 +48,7 @@ const setInjuryDataError = payload => ({ type: FETCH_BM_INJURY_DATA_FAILURE, pay
 const setInjurySeverities = payload => ({ type: FETCH_BM_INJURY_SEVERITIES, payload });
 const setInjuryTypes = payload => ({ type: FETCH_BM_INJURY_TYPES, payload });
 const setInjuryProjects = payload => ({ type: FETCH_BM_INJURY_PROJECTS, payload });
+const setInjuryTrendSuccess = payload => ({ type: FETCH_BM_INJURY_TREND_SUCCESS, payload });
 const setInjuryOverTime = payload => ({ type: FETCH_BM_INJURY_OVER_TIME, payload });
 
 // Legacy action creators for backward compatibility
@@ -98,6 +100,23 @@ export const fetchInjuryProjects = (filters) => async dispatch => {
     dispatch(setInjuryProjects(Array.isArray(res.data) ? res.data : []));
   } catch {
     dispatch(setInjuryProjects([]));
+  }
+};
+
+// Trend data: { months:[], serious:[], medium:[], low:[] }
+export const fetchInjuryTrend = filters => async dispatch => {
+  dispatch(setInjuryDataLoading());
+  try {
+    const params = cleanParams(filters);
+    const res = await axios.get(ENDPOINTS.BM_INJURY_TREND, { params, paramsSerializer });
+    const data =
+      res?.data && typeof res.data === 'object'
+        ? res.data
+        : { months: [], serious: [], medium: [], low: [] };
+    dispatch(setInjuryTrendSuccess(data));
+  } catch (error) {
+    const msg = error?.response?.data?.error || error?.message || 'Failed to fetch injury trend';
+    dispatch(setInjuryDataError(msg));
   }
 };
 
@@ -164,20 +183,24 @@ export const fetchInjuries = (projectId, startDate, endDate) => async dispatch =
   }
 };
 
-// Function to get injury data (non-Redux version for direct component use)
-export const getInjuryData = async (projectId, startDate, endDate) => {
-  // Build query parameters
+// Function to get injury trend data (non-Redux version for direct component use)
+export const getInjuryData = async (projectId, startDate, endDate, projectIds = []) => {
   const params = {};
-  if (projectId && projectId !== 'all') {
-    params.projectId = projectId;
+  let ids = [];
+  if (Array.isArray(projectIds) && projectIds.length) {
+    ids = projectIds;
+  } else if (projectId && projectId !== 'all') {
+    ids = [projectId];
+  }
+
+  // Backend trend-data filters by ObjectId projectId values.
+  if (ids.length) {
+    params.projectId = ids.join(',');
   }
   if (startDate) params.startDate = startDate;
   if (endDate) params.endDate = endDate;
 
-  // API call
-  const response = await axios.get(ENDPOINTS.INJURIES, { params });
-
-  // Return the data directly
+  const response = await axios.get(ENDPOINTS.BM_INJURY_TREND, { params });
   return response.data;
 };
 

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
@@ -7,7 +7,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
   LabelList,
 } from 'recharts';
@@ -16,11 +15,45 @@ import 'react-datepicker/dist/react-datepicker.css';
 import { fetchInjuryProjects, fetchInjuryTrend } from '../../../actions/bmdashboard/injuryActions';
 import styles from './InjuryTrendChart.module.css';
 
+// Keep severity colors aligned with Phase 2 requirements.
 const SEVERITY_COLORS = {
   serious: '#dc3545',
   medium: '#fd7e14',
   low: '#28a745',
 };
+
+const LEGEND_ITEMS = [
+  { key: 'serious', label: 'Serious', color: SEVERITY_COLORS.serious },
+  { key: 'medium', label: 'Medium', color: SEVERITY_COLORS.medium },
+  { key: 'low', label: 'Low Level', color: SEVERITY_COLORS.low },
+];
+
+// Demo series used for All Projects when API has no data yet.
+const DUMMY_ALL_PROJECTS_TREND = {
+  months: [
+    'Jan 2024',
+    'Feb 2024',
+    'Mar 2024',
+    'Apr 2024',
+    'May 2024',
+    'Jun 2024',
+    'Jul 2024',
+    'Aug 2024',
+    'Sep 2024',
+    'Oct 2024',
+    'Nov 2024',
+    'Dec 2024',
+  ],
+  serious: [0, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1],
+  medium: [0, 0, 0, 1, 1, 2, 1, 0, 0, 0, 2, 5],
+  low: [1, 2, 2, 3, 4, 5, 6, 7, 3, 2, 1, 2],
+};
+
+const DUMMY_PROJECTS = [
+  { _id: 'dummy-building-1', name: 'Building 1', projectIds: ['dummy-building-1'] },
+  { _id: 'dummy-building-2', name: 'Building 2', projectIds: ['dummy-building-2'] },
+  { _id: 'dummy-site-a', name: 'Site A', projectIds: ['dummy-site-a'] },
+];
 
 const toYMD = date => {
   if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
@@ -28,6 +61,18 @@ const toYMD = date => {
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
+};
+
+const formatDateLabel = date => {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return 'ALL';
+  return toYMD(date);
+};
+
+const hasTrendValues = trend => {
+  const serious = Array.isArray(trend?.serious) ? trend.serious : [];
+  const medium = Array.isArray(trend?.medium) ? trend.medium : [];
+  const low = Array.isArray(trend?.low) ? trend.low : [];
+  return [...serious, ...medium, ...low].some(value => Number(value) > 0);
 };
 
 function InjuryTrendTooltip({ active, payload, label, projectLabel, darkMode }) {
@@ -59,8 +104,8 @@ function InjuryTrendChart() {
   } = useSelector(state => state.bmInjury || {});
 
   const [selectedProjectId, setSelectedProjectId] = useState('all');
-  const [dateRange, setDateRange] = useState([null, null]);
-  const [startDate, endDate] = dateRange;
+  const [startDate, setStartDate] = useState(null);
+  const [endDate, setEndDate] = useState(null);
 
   useEffect(() => {
     dispatch(fetchInjuryProjects({}));
@@ -71,11 +116,15 @@ function InjuryTrendChart() {
     let projectIds = [];
     if (selectedProject?.projectIds?.length) {
       projectIds = selectedProject.projectIds;
-    } else if (selectedProjectId !== 'all') {
+    } else if (selectedProjectId !== 'all' && !String(selectedProjectId).startsWith('dummy-')) {
       projectIds = [selectedProjectId];
     }
 
-    // Backend trend-data accepts ObjectId(s) in projectId; omit for All Projects.
+    // Skip API calls for local dummy project selections.
+    if (String(selectedProjectId).startsWith('dummy-')) {
+      return undefined;
+    }
+
     const params = {
       startDate: toYMD(startDate),
       endDate: toYMD(endDate),
@@ -85,6 +134,7 @@ function InjuryTrendChart() {
     }
 
     dispatch(fetchInjuryTrend(params));
+    return undefined;
   }, [dispatch, projects, selectedProjectId, startDate, endDate]);
 
   useEffect(() => {
@@ -98,17 +148,40 @@ function InjuryTrendChart() {
     };
   }, [darkMode]);
 
+  const projectOptions = useMemo(() => {
+    if (projects.length) return projects;
+    return DUMMY_PROJECTS;
+  }, [projects]);
+
   const selectedProjectLabel = useMemo(() => {
-    if (selectedProjectId === 'all') return 'All Projects';
-    const match = projects.find(project => String(project._id) === selectedProjectId);
+    if (selectedProjectId === 'all') return 'ALL';
+    const match = projectOptions.find(project => String(project._id) === selectedProjectId);
     return match?.name || 'Selected Project';
-  }, [projects, selectedProjectId]);
+  }, [projectOptions, selectedProjectId]);
+
+  const dateFilterLabel = useMemo(() => {
+    if (!startDate && !endDate) return 'ALL';
+    if (startDate && endDate) return `${formatDateLabel(startDate)} – ${formatDateLabel(endDate)}`;
+    if (startDate) return `From ${formatDateLabel(startDate)}`;
+    return `Until ${formatDateLabel(endDate)}`;
+  }, [startDate, endDate]);
+
+  const usingDummyData = useMemo(() => {
+    if (String(selectedProjectId).startsWith('dummy-')) return true;
+    if (selectedProjectId === 'all' && !loading && !hasTrendValues(trend)) return true;
+    return false;
+  }, [selectedProjectId, loading, trend]);
+
+  const activeTrend = useMemo(() => {
+    if (usingDummyData) return DUMMY_ALL_PROJECTS_TREND;
+    return trend;
+  }, [usingDummyData, trend]);
 
   const chartData = useMemo(() => {
-    const months = Array.isArray(trend.months) ? trend.months : [];
-    const serious = Array.isArray(trend.serious) ? trend.serious : [];
-    const medium = Array.isArray(trend.medium) ? trend.medium : [];
-    const low = Array.isArray(trend.low) ? trend.low : [];
+    const months = Array.isArray(activeTrend.months) ? activeTrend.months : [];
+    const serious = Array.isArray(activeTrend.serious) ? activeTrend.serious : [];
+    const medium = Array.isArray(activeTrend.medium) ? activeTrend.medium : [];
+    const low = Array.isArray(activeTrend.low) ? activeTrend.low : [];
 
     return months.map((month, index) => ({
       month,
@@ -116,63 +189,101 @@ function InjuryTrendChart() {
       medium: Number(medium[index]) || 0,
       low: Number(low[index]) || 0,
     }));
-  }, [trend]);
+  }, [activeTrend]);
 
-  const hasAnyData = useMemo(() => {
-    return chartData.some(row => row.serious > 0 || row.medium > 0 || row.low > 0);
-  }, [chartData]);
+  const hasAnyData = chartData.some(row => row.serious > 0 || row.medium > 0 || row.low > 0);
+  const tickColor = darkMode ? '#cfd7e3' : '#555';
+  const gridStroke = darkMode ? 'rgba(255,255,255,0.12)' : '#d9d9d9';
 
-  const tickColor = darkMode ? '#cfd7e3' : '#666';
-  const gridStroke = darkMode ? 'rgba(255,255,255,0.12)' : '#e0e0e0';
+  const datePickerProps = {
+    showMonthDropdown: true,
+    showYearDropdown: true,
+    dropdownMode: 'select',
+    yearDropdownItemNumber: 15,
+    scrollableYearDropdown: true,
+    dateFormat: 'yyyy-MM-dd',
+    className: styles.datepicker,
+    isClearable: true,
+  };
 
   return (
-    <div className={`${styles.container} ${darkMode ? styles.darkMode : ''}`}>
-      <header className={styles.header}>
-        <div>
-          <h2 className={styles.title}>Injury Trend Over Time</h2>
-          <p className={styles.subtitle}>
-            Track monthly injury counts by severity across projects.
-          </p>
-        </div>
-      </header>
+    <div className={`${styles.page} ${darkMode ? styles.darkMode : ''}`}>
+      <div className={styles.panel}>
+        <div className={styles.topBar}>
+          <h2 className={styles.title}>Injuries Tracking</h2>
 
-      <div className={styles.filters}>
-        <div className={styles.filterItem}>
-          <label htmlFor="injury-project-select">Project</label>
-          <select
-            id="injury-project-select"
-            className={styles.select}
-            value={selectedProjectId}
-            onChange={event => setSelectedProjectId(event.target.value)}
-          >
-            <option value="all">All Projects</option>
-            {projects.map(project => (
-              <option key={String(project._id)} value={String(project._id)}>
-                {project.name}
-              </option>
-            ))}
-          </select>
+          <div className={styles.headerFilters}>
+            <div className={styles.filterGroup}>
+              <label htmlFor="injury-project-select" className={styles.filterLabel}>
+                Project
+              </label>
+              <select
+                id="injury-project-select"
+                className={styles.select}
+                value={selectedProjectId}
+                onChange={event => setSelectedProjectId(event.target.value)}
+              >
+                <option value="all">ALL</option>
+                {projectOptions.map(project => (
+                  <option key={String(project._id)} value={String(project._id)}>
+                    {project.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className={styles.filterGroup}>
+              <span className={styles.filterLabel}>Dates</span>
+              <div className={styles.dateInputs}>
+                <DatePicker
+                  id="injury-start-date"
+                  selected={startDate}
+                  onChange={setStartDate}
+                  selectsStart
+                  startDate={startDate}
+                  endDate={endDate}
+                  placeholderText="Start date"
+                  {...datePickerProps}
+                />
+                <DatePicker
+                  id="injury-end-date"
+                  selected={endDate}
+                  onChange={setEndDate}
+                  selectsEnd
+                  startDate={startDate}
+                  endDate={endDate}
+                  minDate={startDate}
+                  placeholderText="End date"
+                  {...datePickerProps}
+                />
+              </div>
+            </div>
+          </div>
         </div>
 
-        <div className={styles.filterItem}>
-          <label htmlFor="injury-date-range">Date range</label>
-          <DatePicker
-            id="injury-date-range"
-            selectsRange
-            startDate={startDate}
-            endDate={endDate}
-            onChange={setDateRange}
-            placeholderText="Select start and end date"
-            isClearable
-            dateFormat="yyyy-MM-dd"
-            className={styles.datepicker}
-          />
+        <div className={styles.legendRow} aria-label="Injury severity legend">
+          {LEGEND_ITEMS.map(item => (
+            <div key={item.key} className={styles.legendItem}>
+              <span className={styles.legendLine} style={{ backgroundColor: item.color }} />
+              <span>{item.label}</span>
+            </div>
+          ))}
         </div>
-      </div>
 
-      <div className={styles.chartCard}>
-        {loading && <div className={styles.statusMessage}>Loading injury trend…</div>}
-        {error && (
+        <div className={styles.metaRow}>
+          <span>
+            <strong>Project:</strong> {selectedProjectLabel}
+          </span>
+          <span>
+            <strong>Dates:</strong> {dateFilterLabel}
+          </span>
+          {usingDummyData && <span className={styles.demoBadge}>Demo data</span>}
+        </div>
+
+        {loading && !usingDummyData && (
+          <div className={styles.statusMessage}>Loading injury trend…</div>
+        )}
+        {error && !usingDummyData && (
           <div className={`${styles.statusMessage} ${styles.statusError}`}>
             Failed to load injury trend: {String(error)}
           </div>
@@ -181,83 +292,77 @@ function InjuryTrendChart() {
           <div className={styles.statusMessage}>No injuries recorded for the selected filters.</div>
         )}
 
-        {!loading && !error && hasAnyData && (
-          <ResponsiveContainer width="100%" height={420}>
-            <LineChart data={chartData} margin={{ top: 24, right: 28, left: 8, bottom: 48 }}>
-              <CartesianGrid stroke={gridStroke} strokeDasharray="3 3" />
-              <XAxis
-                dataKey="month"
-                tick={{ fill: tickColor }}
-                label={{
-                  value: 'Month',
-                  position: 'insideBottom',
-                  offset: -24,
-                  style: { fill: tickColor },
-                }}
-              />
-              <YAxis
-                allowDecimals={false}
-                tick={{ fill: tickColor }}
-                label={{
-                  value: 'Number of Injuries',
-                  angle: -90,
-                  position: 'insideLeft',
-                  style: { fill: tickColor },
-                }}
-              />
-              <Tooltip
-                content={
-                  <InjuryTrendTooltip projectLabel={selectedProjectLabel} darkMode={darkMode} />
-                }
-              />
-              <Legend verticalAlign="bottom" height={36} wrapperStyle={{ color: tickColor }} />
-              <Line
-                type="monotone"
-                dataKey="serious"
-                name="Serious"
-                stroke={SEVERITY_COLORS.serious}
-                strokeWidth={2}
-                dot={{ r: 3 }}
-                activeDot={{ r: 5 }}
-              >
-                <LabelList
+        {hasAnyData && (
+          <div className={styles.chartArea}>
+            <ResponsiveContainer width="100%" height={400}>
+              <LineChart data={chartData} margin={{ top: 16, right: 20, left: 8, bottom: 28 }}>
+                <CartesianGrid stroke={gridStroke} strokeDasharray="0" />
+                <XAxis
+                  dataKey="month"
+                  tick={{ fill: tickColor, fontSize: 12 }}
+                  interval="preserveStartEnd"
+                  minTickGap={28}
+                  label={{
+                    value: 'Month',
+                    position: 'insideBottom',
+                    offset: -12,
+                    style: { fill: tickColor, fontSize: 13 },
+                  }}
+                />
+                <YAxis allowDecimals={false} tick={{ fill: tickColor, fontSize: 12 }} width={40} />
+                <Tooltip
+                  content={
+                    <InjuryTrendTooltip projectLabel={selectedProjectLabel} darkMode={darkMode} />
+                  }
+                />
+                <Line
+                  type="monotone"
                   dataKey="serious"
-                  position="top"
-                  style={{ fill: SEVERITY_COLORS.serious, fontSize: 10 }}
-                />
-              </Line>
-              <Line
-                type="monotone"
-                dataKey="medium"
-                name="Medium"
-                stroke={SEVERITY_COLORS.medium}
-                strokeWidth={2}
-                dot={{ r: 3 }}
-                activeDot={{ r: 5 }}
-              >
-                <LabelList
+                  name="Serious"
+                  stroke={SEVERITY_COLORS.serious}
+                  strokeWidth={2.5}
+                  dot={{ r: 3 }}
+                  activeDot={{ r: 5 }}
+                >
+                  <LabelList
+                    dataKey="serious"
+                    position="top"
+                    style={{ fill: SEVERITY_COLORS.serious, fontSize: 10 }}
+                  />
+                </Line>
+                <Line
+                  type="monotone"
                   dataKey="medium"
-                  position="top"
-                  style={{ fill: SEVERITY_COLORS.medium, fontSize: 10 }}
-                />
-              </Line>
-              <Line
-                type="monotone"
-                dataKey="low"
-                name="Low"
-                stroke={SEVERITY_COLORS.low}
-                strokeWidth={2}
-                dot={{ r: 3 }}
-                activeDot={{ r: 5 }}
-              >
-                <LabelList
+                  name="Medium"
+                  stroke={SEVERITY_COLORS.medium}
+                  strokeWidth={2.5}
+                  dot={{ r: 3 }}
+                  activeDot={{ r: 5 }}
+                >
+                  <LabelList
+                    dataKey="medium"
+                    position="top"
+                    style={{ fill: SEVERITY_COLORS.medium, fontSize: 10 }}
+                  />
+                </Line>
+                <Line
+                  type="monotone"
                   dataKey="low"
-                  position="top"
-                  style={{ fill: SEVERITY_COLORS.low, fontSize: 10 }}
-                />
-              </Line>
-            </LineChart>
-          </ResponsiveContainer>
+                  name="Low Level"
+                  stroke={SEVERITY_COLORS.low}
+                  strokeWidth={2.5}
+                  dot={{ r: 3 }}
+                  activeDot={{ r: 5 }}
+                >
+                  <LabelList
+                    dataKey="low"
+                    position="top"
+                    style={{ fill: SEVERITY_COLORS.low, fontSize: 10 }}
+                  />
+                </Line>
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
         )}
       </div>
     </div>

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
@@ -1,0 +1,267 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  LabelList,
+} from 'recharts';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import { fetchInjuryProjects, fetchInjuryTrend } from '../../../actions/bmdashboard/injuryActions';
+import styles from './InjuryTrendChart.module.css';
+
+const SEVERITY_COLORS = {
+  serious: '#dc3545',
+  medium: '#fd7e14',
+  low: '#28a745',
+};
+
+const toYMD = date => {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+function InjuryTrendTooltip({ active, payload, label, projectLabel, darkMode }) {
+  if (!active || !payload?.length) return null;
+
+  return (
+    <div className={`${styles.tooltip} ${darkMode ? styles.tooltipDark : ''}`}>
+      <div className={styles.tooltipTitle}>{label}</div>
+      {projectLabel && <div className={styles.tooltipProject}>{projectLabel}</div>}
+      {payload.map(item => (
+        <div key={item.dataKey} className={styles.tooltipRow}>
+          <span className={styles.tooltipMarker} style={{ backgroundColor: item.color }} />
+          <span>{item.name}</span>
+          <span>{Number(item.value) || 0}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function InjuryTrendChart() {
+  const dispatch = useDispatch();
+  const darkMode = useSelector(state => state.theme?.darkMode);
+  const {
+    projects = [],
+    trend = { months: [], serious: [], medium: [], low: [] },
+    loading,
+    error,
+  } = useSelector(state => state.bmInjury || {});
+
+  const [selectedProjectId, setSelectedProjectId] = useState('all');
+  const [dateRange, setDateRange] = useState([null, null]);
+  const [startDate, endDate] = dateRange;
+
+  useEffect(() => {
+    dispatch(fetchInjuryProjects({}));
+  }, [dispatch]);
+
+  useEffect(() => {
+    const selectedProject = projects.find(project => String(project._id) === selectedProjectId);
+    let projectIds = [];
+    if (selectedProject?.projectIds?.length) {
+      projectIds = selectedProject.projectIds;
+    } else if (selectedProjectId !== 'all') {
+      projectIds = [selectedProjectId];
+    }
+
+    // Backend trend-data accepts ObjectId(s) in projectId; omit for All Projects.
+    const params = {
+      startDate: toYMD(startDate),
+      endDate: toYMD(endDate),
+    };
+    if (projectIds.length) {
+      params.projectId = projectIds.join(',');
+    }
+
+    dispatch(fetchInjuryTrend(params));
+  }, [dispatch, projects, selectedProjectId, startDate, endDate]);
+
+  useEffect(() => {
+    if (darkMode) {
+      document.body.classList.add('injury-dark-body');
+    } else {
+      document.body.classList.remove('injury-dark-body');
+    }
+    return () => {
+      document.body.classList.remove('injury-dark-body');
+    };
+  }, [darkMode]);
+
+  const selectedProjectLabel = useMemo(() => {
+    if (selectedProjectId === 'all') return 'All Projects';
+    const match = projects.find(project => String(project._id) === selectedProjectId);
+    return match?.name || 'Selected Project';
+  }, [projects, selectedProjectId]);
+
+  const chartData = useMemo(() => {
+    const months = Array.isArray(trend.months) ? trend.months : [];
+    const serious = Array.isArray(trend.serious) ? trend.serious : [];
+    const medium = Array.isArray(trend.medium) ? trend.medium : [];
+    const low = Array.isArray(trend.low) ? trend.low : [];
+
+    return months.map((month, index) => ({
+      month,
+      serious: Number(serious[index]) || 0,
+      medium: Number(medium[index]) || 0,
+      low: Number(low[index]) || 0,
+    }));
+  }, [trend]);
+
+  const hasAnyData = useMemo(() => {
+    return chartData.some(row => row.serious > 0 || row.medium > 0 || row.low > 0);
+  }, [chartData]);
+
+  const tickColor = darkMode ? '#cfd7e3' : '#666';
+  const gridStroke = darkMode ? 'rgba(255,255,255,0.12)' : '#e0e0e0';
+
+  return (
+    <div className={`${styles.container} ${darkMode ? styles.darkMode : ''}`}>
+      <header className={styles.header}>
+        <div>
+          <h2 className={styles.title}>Injury Trend Over Time</h2>
+          <p className={styles.subtitle}>
+            Track monthly injury counts by severity across projects.
+          </p>
+        </div>
+      </header>
+
+      <div className={styles.filters}>
+        <div className={styles.filterItem}>
+          <label htmlFor="injury-project-select">Project</label>
+          <select
+            id="injury-project-select"
+            className={styles.select}
+            value={selectedProjectId}
+            onChange={event => setSelectedProjectId(event.target.value)}
+          >
+            <option value="all">All Projects</option>
+            {projects.map(project => (
+              <option key={String(project._id)} value={String(project._id)}>
+                {project.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.filterItem}>
+          <label htmlFor="injury-date-range">Date range</label>
+          <DatePicker
+            id="injury-date-range"
+            selectsRange
+            startDate={startDate}
+            endDate={endDate}
+            onChange={setDateRange}
+            placeholderText="Select start and end date"
+            isClearable
+            dateFormat="yyyy-MM-dd"
+            className={styles.datepicker}
+          />
+        </div>
+      </div>
+
+      <div className={styles.chartCard}>
+        {loading && <div className={styles.statusMessage}>Loading injury trend…</div>}
+        {error && (
+          <div className={`${styles.statusMessage} ${styles.statusError}`}>
+            Failed to load injury trend: {String(error)}
+          </div>
+        )}
+        {!loading && !error && !hasAnyData && (
+          <div className={styles.statusMessage}>No injuries recorded for the selected filters.</div>
+        )}
+
+        {!loading && !error && hasAnyData && (
+          <ResponsiveContainer width="100%" height={420}>
+            <LineChart data={chartData} margin={{ top: 24, right: 28, left: 8, bottom: 48 }}>
+              <CartesianGrid stroke={gridStroke} strokeDasharray="3 3" />
+              <XAxis
+                dataKey="month"
+                tick={{ fill: tickColor }}
+                label={{
+                  value: 'Month',
+                  position: 'insideBottom',
+                  offset: -24,
+                  style: { fill: tickColor },
+                }}
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fill: tickColor }}
+                label={{
+                  value: 'Number of Injuries',
+                  angle: -90,
+                  position: 'insideLeft',
+                  style: { fill: tickColor },
+                }}
+              />
+              <Tooltip
+                content={
+                  <InjuryTrendTooltip projectLabel={selectedProjectLabel} darkMode={darkMode} />
+                }
+              />
+              <Legend verticalAlign="bottom" height={36} wrapperStyle={{ color: tickColor }} />
+              <Line
+                type="monotone"
+                dataKey="serious"
+                name="Serious"
+                stroke={SEVERITY_COLORS.serious}
+                strokeWidth={2}
+                dot={{ r: 3 }}
+                activeDot={{ r: 5 }}
+              >
+                <LabelList
+                  dataKey="serious"
+                  position="top"
+                  style={{ fill: SEVERITY_COLORS.serious, fontSize: 10 }}
+                />
+              </Line>
+              <Line
+                type="monotone"
+                dataKey="medium"
+                name="Medium"
+                stroke={SEVERITY_COLORS.medium}
+                strokeWidth={2}
+                dot={{ r: 3 }}
+                activeDot={{ r: 5 }}
+              >
+                <LabelList
+                  dataKey="medium"
+                  position="top"
+                  style={{ fill: SEVERITY_COLORS.medium, fontSize: 10 }}
+                />
+              </Line>
+              <Line
+                type="monotone"
+                dataKey="low"
+                name="Low"
+                stroke={SEVERITY_COLORS.low}
+                strokeWidth={2}
+                dot={{ r: 3 }}
+                activeDot={{ r: 5 }}
+              >
+                <LabelList
+                  dataKey="low"
+                  position="top"
+                  style={{ fill: SEVERITY_COLORS.low, fontSize: 10 }}
+                />
+              </Line>
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default InjuryTrendChart;

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
@@ -74,33 +74,74 @@ const formatDateLabel = date => {
   return toYMD(date);
 };
 
-const hasTrendValues = trend => {
-  const serious = Array.isArray(trend?.serious) ? trend.serious : [];
-  const medium = Array.isArray(trend?.medium) ? trend.medium : [];
-  const low = Array.isArray(trend?.low) ? trend.low : [];
-  return [...serious, ...medium, ...low].some(value => Number(value) > 0);
+const normalizeProjectName = name =>
+  String(name || '')
+    .trim()
+    .toLowerCase();
+
+// Distinct 12-month profiles. Every injury count is owned by a named project.
+const PROJECT_PROFILES = {
+  akv_test: {
+    serious: [3, 1, 0, 0, 2, 0, 0, 1, 0, 0, 2, 0],
+    medium: [0, 0, 2, 1, 0, 0, 3, 0, 1, 0, 0, 1],
+    low: [1, 0, 1, 0, 2, 1, 0, 0, 3, 1, 0, 2],
+  },
+  'building 1': {
+    serious: [0, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1],
+    medium: [0, 0, 0, 1, 1, 2, 1, 0, 0, 0, 2, 5],
+    low: [1, 2, 2, 3, 4, 5, 6, 7, 3, 2, 1, 2],
+  },
+  'building 2': {
+    serious: [1, 0, 0, 2, 0, 1, 0, 0, 3, 0, 1, 0],
+    medium: [2, 1, 0, 0, 0, 1, 0, 2, 0, 1, 0, 0],
+    low: [0, 1, 3, 1, 0, 2, 1, 0, 0, 4, 2, 1],
+  },
+  'commercial test - project': {
+    serious: [0, 0, 2, 0, 1, 0, 2, 0, 0, 1, 0, 2],
+    medium: [1, 0, 1, 2, 0, 0, 0, 3, 1, 0, 2, 0],
+    low: [2, 3, 0, 0, 1, 2, 0, 1, 0, 0, 1, 3],
+  },
+  'housing project': {
+    serious: [0, 1, 0, 0, 0, 2, 0, 1, 0, 0, 0, 3],
+    medium: [0, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0],
+    low: [3, 0, 2, 1, 0, 0, 2, 0, 1, 2, 0, 0],
+  },
+  'residential test - project': {
+    serious: [2, 0, 1, 0, 0, 0, 1, 0, 2, 0, 0, 0],
+    medium: [0, 2, 0, 3, 0, 1, 0, 0, 0, 2, 0, 1],
+    low: [1, 1, 0, 2, 3, 0, 0, 2, 1, 0, 3, 0],
+  },
+  'solar panel project': {
+    serious: [0, 0, 0, 1, 0, 0, 0, 2, 0, 3, 0, 0],
+    medium: [1, 0, 2, 0, 1, 0, 2, 0, 0, 0, 3, 1],
+    low: [0, 2, 1, 0, 0, 3, 1, 1, 0, 1, 0, 2],
+  },
 };
 
-const hashString = value => {
-  let hash = 0;
-  const text = String(value || '');
-  for (let i = 0; i < text.length; i += 1) {
-    hash = (hash * 31 + text.charCodeAt(i)) >>> 0;
-  }
-  return hash;
-};
+const FALLBACK_PROFILE_BANK = [
+  {
+    serious: [1, 0, 2, 0, 0, 1, 0, 0, 2, 0, 1, 0],
+    medium: [0, 2, 0, 1, 0, 0, 2, 1, 0, 0, 0, 3],
+    low: [2, 0, 1, 0, 3, 0, 1, 0, 0, 2, 0, 1],
+  },
+  {
+    serious: [0, 3, 0, 0, 1, 0, 2, 0, 0, 0, 1, 0],
+    medium: [2, 0, 0, 2, 0, 1, 0, 0, 1, 0, 2, 0],
+    low: [0, 1, 2, 0, 0, 2, 0, 3, 0, 1, 0, 2],
+  },
+  {
+    serious: [2, 0, 0, 1, 0, 0, 0, 2, 0, 1, 0, 0],
+    medium: [0, 1, 0, 0, 2, 0, 1, 0, 0, 3, 0, 1],
+    low: [1, 0, 3, 1, 0, 1, 0, 0, 2, 0, 1, 0],
+  },
+];
 
 const buildMonthWindow = (startDate, endDate) => {
   const end = endDate instanceof Date && !Number.isNaN(endDate.getTime()) ? endDate : new Date();
-  let start =
+  const start =
     startDate instanceof Date && !Number.isNaN(startDate.getTime())
-      ? startDate
+      ? new Date(startDate.getFullYear(), startDate.getMonth(), 1)
       : new Date(end.getFullYear(), end.getMonth() - 11, 1);
-
-  // Keep a readable chart window when only one bound is set.
-  if (!(startDate instanceof Date) || Number.isNaN(startDate?.getTime())) {
-    start = new Date(end.getFullYear(), end.getMonth() - 11, 1);
-  }
 
   const months = [];
   const cursor = new Date(start.getFullYear(), start.getMonth(), 1);
@@ -111,7 +152,6 @@ const buildMonthWindow = (startDate, endDate) => {
     months.push({
       key: `${cursor.getFullYear()}-${cursor.getMonth()}`,
       label: `${MONTH_LABELS[cursor.getMonth()]} ${cursor.getFullYear()}`,
-      year: cursor.getFullYear(),
       monthIndex: cursor.getMonth(),
     });
     cursor.setMonth(cursor.getMonth() + 1);
@@ -124,27 +164,23 @@ const buildMonthWindow = (startDate, endDate) => {
         {
           key: `${end.getFullYear()}-${end.getMonth()}`,
           label: `${MONTH_LABELS[end.getMonth()]} ${end.getFullYear()}`,
-          year: end.getFullYear(),
           monthIndex: end.getMonth(),
         },
       ];
 };
 
+const fitProfileToMonths = (profile, months) => ({
+  serious: months.map((_, index) => Number(profile.serious[index % profile.serious.length]) || 0),
+  medium: months.map((_, index) => Number(profile.medium[index % profile.medium.length]) || 0),
+  low: months.map((_, index) => Number(profile.low[index % profile.low.length]) || 0),
+});
+
 // Every demo injury is tied to a project — there are no orphan/unlinked injuries.
-const buildProjectSeries = (project, months) => {
-  const seed = hashString(project.name || project._id);
-  const serious = [];
-  const medium = [];
-  const low = [];
-
-  months.forEach((month, index) => {
-    const mix = (seed + month.monthIndex * 17 + index * 13) % 10;
-    serious.push(mix === 1 || mix === 7 ? ((seed + index) % 3) + 1 : 0);
-    medium.push(mix === 2 || mix === 5 || mix === 8 ? ((seed + index * 2) % 3) + 1 : 0);
-    low.push(mix === 0 || mix === 3 || mix === 6 || mix === 9 ? ((seed + index) % 4) + 1 : 0);
-  });
-
-  return { serious, medium, low };
+const buildProjectSeries = (project, months, projectIndex = 0) => {
+  const profile =
+    PROJECT_PROFILES[normalizeProjectName(project.name)] ||
+    FALLBACK_PROFILE_BANK[projectIndex % FALLBACK_PROFILE_BANK.length];
+  return fitProfileToMonths(profile, months);
 };
 
 const sumSeries = (left = [], right = []) => {
@@ -174,7 +210,11 @@ const buildLinkedDummyTrend = (projectList, selectedProjectId, startDate, endDat
 
   const totals = selectedProjects.reduce(
     (acc, project) => {
-      const series = buildProjectSeries(project, months);
+      const projectIndex = Math.max(
+        0,
+        projectList.findIndex(item => String(item._id) === String(project._id)),
+      );
+      const series = buildProjectSeries(project, months, projectIndex);
       return {
         serious: sumSeries(acc.serious, series.serious),
         medium: sumSeries(acc.medium, series.medium),
@@ -217,12 +257,7 @@ function InjuryTrendTooltip({ active, payload, label, projectLabel, darkMode }) 
 function InjuryTrendChart() {
   const dispatch = useDispatch();
   const darkMode = useSelector(state => state.theme?.darkMode);
-  const {
-    projects = [],
-    trend = { months: [], serious: [], medium: [], low: [] },
-    loading,
-    error,
-  } = useSelector(state => state.bmInjury || {});
+  const { projects = [], loading, error } = useSelector(state => state.bmInjury || {});
 
   const [selectedProjectId, setSelectedProjectId] = useState('all');
   const [startDate, setStartDate] = useState(null);
@@ -294,16 +329,19 @@ function InjuryTrendChart() {
     [projectOptions, selectedProjectId, startDate, endDate],
   );
 
-  const usingDummyData = useMemo(() => {
-    if (String(selectedProjectId).startsWith('dummy-')) return true;
-    if (!loading && !hasTrendValues(trend)) return true;
-    return false;
-  }, [selectedProjectId, loading, trend]);
+  const allProjectsDummyTrend = useMemo(
+    () => buildLinkedDummyTrend(projectOptions, 'all', startDate, endDate),
+    [projectOptions, startDate, endDate],
+  );
+
+  // Always render project-linked demo series so each project is distinct and
+  // ALL is the true sum of every project's injuries (API may not filter yet).
+  const usingDummyData = true;
 
   const activeTrend = useMemo(() => {
-    if (usingDummyData) return linkedDummyTrend;
-    return trend;
-  }, [usingDummyData, linkedDummyTrend, trend]);
+    if (selectedProjectId === 'all') return allProjectsDummyTrend;
+    return linkedDummyTrend;
+  }, [selectedProjectId, allProjectsDummyTrend, linkedDummyTrend]);
 
   const chartData = useMemo(() => {
     const months = Array.isArray(activeTrend.months) ? activeTrend.months : [];

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
@@ -28,31 +28,37 @@ const LEGEND_ITEMS = [
   { key: 'low', label: 'Low Level', color: SEVERITY_COLORS.low },
 ];
 
-// Demo series used for All Projects when API has no data yet.
-const DUMMY_ALL_PROJECTS_TREND = {
-  months: [
-    'Jan 2024',
-    'Feb 2024',
-    'Mar 2024',
-    'Apr 2024',
-    'May 2024',
-    'Jun 2024',
-    'Jul 2024',
-    'Aug 2024',
-    'Sep 2024',
-    'Oct 2024',
-    'Nov 2024',
-    'Dec 2024',
-  ],
-  serious: [0, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1],
-  medium: [0, 0, 0, 1, 1, 2, 1, 0, 0, 0, 2, 5],
-  low: [1, 2, 2, 3, 4, 5, 6, 7, 3, 2, 1, 2],
-};
+const MONTH_LABELS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
 
-const DUMMY_PROJECTS = [
+const FALLBACK_PROJECTS = [
+  { _id: 'dummy-akv-test', name: 'akv_test', projectIds: ['dummy-akv-test'] },
   { _id: 'dummy-building-1', name: 'Building 1', projectIds: ['dummy-building-1'] },
   { _id: 'dummy-building-2', name: 'Building 2', projectIds: ['dummy-building-2'] },
-  { _id: 'dummy-site-a', name: 'Site A', projectIds: ['dummy-site-a'] },
+  {
+    _id: 'dummy-commercial',
+    name: 'Commercial Test - Project',
+    projectIds: ['dummy-commercial'],
+  },
+  { _id: 'dummy-housing', name: 'Housing Project', projectIds: ['dummy-housing'] },
+  {
+    _id: 'dummy-residential',
+    name: 'Residential Test - Project',
+    projectIds: ['dummy-residential'],
+  },
+  { _id: 'dummy-solar', name: 'Solar Panel Project', projectIds: ['dummy-solar'] },
 ];
 
 const toYMD = date => {
@@ -73,6 +79,121 @@ const hasTrendValues = trend => {
   const medium = Array.isArray(trend?.medium) ? trend.medium : [];
   const low = Array.isArray(trend?.low) ? trend.low : [];
   return [...serious, ...medium, ...low].some(value => Number(value) > 0);
+};
+
+const hashString = value => {
+  let hash = 0;
+  const text = String(value || '');
+  for (let i = 0; i < text.length; i += 1) {
+    hash = (hash * 31 + text.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+};
+
+const buildMonthWindow = (startDate, endDate) => {
+  const end = endDate instanceof Date && !Number.isNaN(endDate.getTime()) ? endDate : new Date();
+  let start =
+    startDate instanceof Date && !Number.isNaN(startDate.getTime())
+      ? startDate
+      : new Date(end.getFullYear(), end.getMonth() - 11, 1);
+
+  // Keep a readable chart window when only one bound is set.
+  if (!(startDate instanceof Date) || Number.isNaN(startDate?.getTime())) {
+    start = new Date(end.getFullYear(), end.getMonth() - 11, 1);
+  }
+
+  const months = [];
+  const cursor = new Date(start.getFullYear(), start.getMonth(), 1);
+  const last = new Date(end.getFullYear(), end.getMonth(), 1);
+  let guard = 0;
+
+  while (cursor <= last && guard < 36) {
+    months.push({
+      key: `${cursor.getFullYear()}-${cursor.getMonth()}`,
+      label: `${MONTH_LABELS[cursor.getMonth()]} ${cursor.getFullYear()}`,
+      year: cursor.getFullYear(),
+      monthIndex: cursor.getMonth(),
+    });
+    cursor.setMonth(cursor.getMonth() + 1);
+    guard += 1;
+  }
+
+  return months.length
+    ? months
+    : [
+        {
+          key: `${end.getFullYear()}-${end.getMonth()}`,
+          label: `${MONTH_LABELS[end.getMonth()]} ${end.getFullYear()}`,
+          year: end.getFullYear(),
+          monthIndex: end.getMonth(),
+        },
+      ];
+};
+
+// Every demo injury is tied to a project — there are no orphan/unlinked injuries.
+const buildProjectSeries = (project, months) => {
+  const seed = hashString(project.name || project._id);
+  const serious = [];
+  const medium = [];
+  const low = [];
+
+  months.forEach((month, index) => {
+    const mix = (seed + month.monthIndex * 17 + index * 13) % 10;
+    serious.push(mix === 1 || mix === 7 ? ((seed + index) % 3) + 1 : 0);
+    medium.push(mix === 2 || mix === 5 || mix === 8 ? ((seed + index * 2) % 3) + 1 : 0);
+    low.push(mix === 0 || mix === 3 || mix === 6 || mix === 9 ? ((seed + index) % 4) + 1 : 0);
+  });
+
+  return { serious, medium, low };
+};
+
+const sumSeries = (left = [], right = []) => {
+  const length = Math.max(left.length, right.length);
+  return Array.from(
+    { length },
+    (_, index) => (Number(left[index]) || 0) + (Number(right[index]) || 0),
+  );
+};
+
+const buildLinkedDummyTrend = (projectList, selectedProjectId, startDate, endDate) => {
+  const months = buildMonthWindow(startDate, endDate);
+  const selectedProjects =
+    selectedProjectId === 'all'
+      ? projectList
+      : projectList.filter(project => String(project._id) === String(selectedProjectId));
+
+  // Refuse to invent injuries that are not linked to a project.
+  if (!selectedProjects.length) {
+    return {
+      months: months.map(month => month.label),
+      serious: months.map(() => 0),
+      medium: months.map(() => 0),
+      low: months.map(() => 0),
+    };
+  }
+
+  const totals = selectedProjects.reduce(
+    (acc, project) => {
+      const series = buildProjectSeries(project, months);
+      return {
+        serious: sumSeries(acc.serious, series.serious),
+        medium: sumSeries(acc.medium, series.medium),
+        low: sumSeries(acc.low, series.low),
+      };
+    },
+    {
+      serious: months.map(() => 0),
+      medium: months.map(() => 0),
+      low: months.map(() => 0),
+    },
+  );
+
+  return {
+    months: months.map(month => month.label),
+    serious: totals.serious,
+    medium: totals.medium,
+    low: totals.low,
+  };
 };
 
 function InjuryTrendTooltip({ active, payload, label, projectLabel, darkMode }) {
@@ -107,20 +228,27 @@ function InjuryTrendChart() {
   const [startDate, setStartDate] = useState(null);
   const [endDate, setEndDate] = useState(null);
 
+  const projectOptions = useMemo(() => {
+    if (projects.length) return projects;
+    return FALLBACK_PROJECTS;
+  }, [projects]);
+
   useEffect(() => {
     dispatch(fetchInjuryProjects({}));
   }, [dispatch]);
 
   useEffect(() => {
-    const selectedProject = projects.find(project => String(project._id) === selectedProjectId);
+    const selectedProject = projectOptions.find(
+      project => String(project._id) === selectedProjectId,
+    );
     let projectIds = [];
     if (selectedProject?.projectIds?.length) {
-      projectIds = selectedProject.projectIds;
+      projectIds = selectedProject.projectIds.filter(id => !String(id).startsWith('dummy-'));
     } else if (selectedProjectId !== 'all' && !String(selectedProjectId).startsWith('dummy-')) {
       projectIds = [selectedProjectId];
     }
 
-    // Skip API calls for local dummy project selections.
+    // Local fallback projects are demo-only and are not queried from the API.
     if (String(selectedProjectId).startsWith('dummy-')) {
       return undefined;
     }
@@ -135,7 +263,7 @@ function InjuryTrendChart() {
 
     dispatch(fetchInjuryTrend(params));
     return undefined;
-  }, [dispatch, projects, selectedProjectId, startDate, endDate]);
+  }, [dispatch, projectOptions, selectedProjectId, startDate, endDate]);
 
   useEffect(() => {
     if (darkMode) {
@@ -147,11 +275,6 @@ function InjuryTrendChart() {
       document.body.classList.remove('injury-dark-body');
     };
   }, [darkMode]);
-
-  const projectOptions = useMemo(() => {
-    if (projects.length) return projects;
-    return DUMMY_PROJECTS;
-  }, [projects]);
 
   const selectedProjectLabel = useMemo(() => {
     if (selectedProjectId === 'all') return 'ALL';
@@ -166,16 +289,21 @@ function InjuryTrendChart() {
     return `Until ${formatDateLabel(endDate)}`;
   }, [startDate, endDate]);
 
+  const linkedDummyTrend = useMemo(
+    () => buildLinkedDummyTrend(projectOptions, selectedProjectId, startDate, endDate),
+    [projectOptions, selectedProjectId, startDate, endDate],
+  );
+
   const usingDummyData = useMemo(() => {
     if (String(selectedProjectId).startsWith('dummy-')) return true;
-    if (selectedProjectId === 'all' && !loading && !hasTrendValues(trend)) return true;
+    if (!loading && !hasTrendValues(trend)) return true;
     return false;
   }, [selectedProjectId, loading, trend]);
 
   const activeTrend = useMemo(() => {
-    if (usingDummyData) return DUMMY_ALL_PROJECTS_TREND;
+    if (usingDummyData) return linkedDummyTrend;
     return trend;
-  }, [usingDummyData, trend]);
+  }, [usingDummyData, linkedDummyTrend, trend]);
 
   const chartData = useMemo(() => {
     const months = Array.isArray(activeTrend.months) ? activeTrend.months : [];

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
@@ -143,30 +143,20 @@ const buildMonthWindow = (startDate, endDate) => {
       ? new Date(startDate.getFullYear(), startDate.getMonth(), 1)
       : new Date(end.getFullYear(), end.getMonth() - 11, 1);
 
-  const months = [];
-  const cursor = new Date(start.getFullYear(), start.getMonth(), 1);
-  const last = new Date(end.getFullYear(), end.getMonth(), 1);
-  let guard = 0;
+  const startMonthIndex = start.getFullYear() * 12 + start.getMonth();
+  const endMonthIndex = end.getFullYear() * 12 + end.getMonth();
+  const monthCount = Math.min(Math.max(endMonthIndex - startMonthIndex + 1, 1), 36);
 
-  while (cursor <= last && guard < 36) {
-    months.push({
-      key: `${cursor.getFullYear()}-${cursor.getMonth()}`,
-      label: `${MONTH_LABELS[cursor.getMonth()]} ${cursor.getFullYear()}`,
-      monthIndex: cursor.getMonth(),
-    });
-    cursor.setMonth(cursor.getMonth() + 1);
-    guard += 1;
-  }
-
-  return months.length
-    ? months
-    : [
-        {
-          key: `${end.getFullYear()}-${end.getMonth()}`,
-          label: `${MONTH_LABELS[end.getMonth()]} ${end.getFullYear()}`,
-          monthIndex: end.getMonth(),
-        },
-      ];
+  return Array.from({ length: monthCount }, (_, offset) => {
+    const absoluteMonth = startMonthIndex + offset;
+    const year = Math.floor(absoluteMonth / 12);
+    const monthIndex = absoluteMonth % 12;
+    return {
+      key: `${year}-${monthIndex}`,
+      label: `${MONTH_LABELS[monthIndex]} ${year}`,
+      monthIndex,
+    };
+  });
 };
 
 const fitProfileToMonths = (profile, months) => ({
@@ -257,7 +247,7 @@ function InjuryTrendTooltip({ active, payload, label, projectLabel, darkMode }) 
 function InjuryTrendChart() {
   const dispatch = useDispatch();
   const darkMode = useSelector(state => state.theme?.darkMode);
-  const { projects = [], loading, error } = useSelector(state => state.bmInjury || {});
+  const { projects = [] } = useSelector(state => state.bmInjury || {});
 
   const [selectedProjectId, setSelectedProjectId] = useState('all');
   const [startDate, setStartDate] = useState(null);
@@ -296,6 +286,7 @@ function InjuryTrendChart() {
       params.projectId = projectIds.join(',');
     }
 
+    // Keep API warm for backend pairing; chart still renders project-linked demo series.
     dispatch(fetchInjuryTrend(params));
     return undefined;
   }, [dispatch, projectOptions, selectedProjectId, startDate, endDate]);
@@ -336,8 +327,6 @@ function InjuryTrendChart() {
 
   // Always render project-linked demo series so each project is distinct and
   // ALL is the true sum of every project's injuries (API may not filter yet).
-  const usingDummyData = true;
-
   const activeTrend = useMemo(() => {
     if (selectedProjectId === 'all') return allProjectsDummyTrend;
     return linkedDummyTrend;
@@ -443,18 +432,10 @@ function InjuryTrendChart() {
           <span>
             <strong>Dates:</strong> {dateFilterLabel}
           </span>
-          {usingDummyData && <span className={styles.demoBadge}>Demo data</span>}
+          <span className={styles.demoBadge}>Demo data</span>
         </div>
 
-        {loading && !usingDummyData && (
-          <div className={styles.statusMessage}>Loading injury trend…</div>
-        )}
-        {error && !usingDummyData && (
-          <div className={`${styles.statusMessage} ${styles.statusError}`}>
-            Failed to load injury trend: {String(error)}
-          </div>
-        )}
-        {!loading && !error && !hasAnyData && (
+        {!hasAnyData && (
           <div className={styles.statusMessage}>No injuries recorded for the selected filters.</div>
         )}
 

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
@@ -359,6 +359,9 @@ function InjuryTrendChart() {
     dateFormat: 'yyyy-MM-dd',
     className: styles.datepicker,
     isClearable: true,
+    // Portal keeps the calendar from covering/collapsing the sibling date input.
+    withPortal: true,
+    portalId: 'injury-datepicker-portal',
   };
 
   return (
@@ -390,27 +393,33 @@ function InjuryTrendChart() {
             <div className={styles.filterGroup}>
               <span className={styles.filterLabel}>Dates</span>
               <div className={styles.dateInputs}>
-                <DatePicker
-                  id="injury-start-date"
-                  selected={startDate}
-                  onChange={setStartDate}
-                  selectsStart
-                  startDate={startDate}
-                  endDate={endDate}
-                  placeholderText="Start date"
-                  {...datePickerProps}
-                />
-                <DatePicker
-                  id="injury-end-date"
-                  selected={endDate}
-                  onChange={setEndDate}
-                  selectsEnd
-                  startDate={startDate}
-                  endDate={endDate}
-                  minDate={startDate}
-                  placeholderText="End date"
-                  {...datePickerProps}
-                />
+                <div className={styles.dateField}>
+                  <DatePicker
+                    id="injury-start-date"
+                    selected={startDate}
+                    onChange={setStartDate}
+                    selectsStart
+                    startDate={startDate}
+                    endDate={endDate}
+                    placeholderText="Start date"
+                    popperPlacement="bottom-start"
+                    {...datePickerProps}
+                  />
+                </div>
+                <div className={styles.dateField}>
+                  <DatePicker
+                    id="injury-end-date"
+                    selected={endDate}
+                    onChange={setEndDate}
+                    selectsEnd
+                    startDate={startDate}
+                    endDate={endDate}
+                    minDate={startDate}
+                    placeholderText="End date"
+                    popperPlacement="bottom-end"
+                    {...datePickerProps}
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
@@ -358,10 +358,9 @@ function InjuryTrendChart() {
     scrollableYearDropdown: true,
     dateFormat: 'yyyy-MM-dd',
     className: styles.datepicker,
+    calendarClassName: darkMode ? styles.datepickerCalendarDark : undefined,
+    popperClassName: styles.datepickerPopper,
     isClearable: true,
-    // Portal keeps the calendar from covering/collapsing the sibling date input.
-    withPortal: true,
-    portalId: 'injury-datepicker-portal',
   };
 
   return (
@@ -393,33 +392,29 @@ function InjuryTrendChart() {
             <div className={styles.filterGroup}>
               <span className={styles.filterLabel}>Dates</span>
               <div className={styles.dateInputs}>
-                <div className={styles.dateField}>
-                  <DatePicker
-                    id="injury-start-date"
-                    selected={startDate}
-                    onChange={setStartDate}
-                    selectsStart
-                    startDate={startDate}
-                    endDate={endDate}
-                    placeholderText="Start date"
-                    popperPlacement="bottom-start"
-                    {...datePickerProps}
-                  />
-                </div>
-                <div className={styles.dateField}>
-                  <DatePicker
-                    id="injury-end-date"
-                    selected={endDate}
-                    onChange={setEndDate}
-                    selectsEnd
-                    startDate={startDate}
-                    endDate={endDate}
-                    minDate={startDate}
-                    placeholderText="End date"
-                    popperPlacement="bottom-end"
-                    {...datePickerProps}
-                  />
-                </div>
+                <DatePicker
+                  id="injury-start-date"
+                  selected={startDate}
+                  onChange={setStartDate}
+                  selectsStart
+                  startDate={startDate}
+                  endDate={endDate}
+                  placeholderText="Start date"
+                  popperPlacement="bottom-start"
+                  {...datePickerProps}
+                />
+                <DatePicker
+                  id="injury-end-date"
+                  selected={endDate}
+                  onChange={setEndDate}
+                  selectsEnd
+                  startDate={startDate}
+                  endDate={endDate}
+                  minDate={startDate}
+                  placeholderText="End date"
+                  popperPlacement="bottom-end"
+                  {...datePickerProps}
+                />
               </div>
             </div>
           </div>

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.jsx
@@ -359,7 +359,6 @@ function InjuryTrendChart() {
     dateFormat: 'yyyy-MM-dd',
     className: styles.datepicker,
     calendarClassName: darkMode ? styles.datepickerCalendarDark : undefined,
-    popperClassName: styles.datepickerPopper,
     isClearable: true,
   };
 
@@ -392,29 +391,35 @@ function InjuryTrendChart() {
             <div className={styles.filterGroup}>
               <span className={styles.filterLabel}>Dates</span>
               <div className={styles.dateInputs}>
-                <DatePicker
-                  id="injury-start-date"
-                  selected={startDate}
-                  onChange={setStartDate}
-                  selectsStart
-                  startDate={startDate}
-                  endDate={endDate}
-                  placeholderText="Start date"
-                  popperPlacement="bottom-start"
-                  {...datePickerProps}
-                />
-                <DatePicker
-                  id="injury-end-date"
-                  selected={endDate}
-                  onChange={setEndDate}
-                  selectsEnd
-                  startDate={startDate}
-                  endDate={endDate}
-                  minDate={startDate}
-                  placeholderText="End date"
-                  popperPlacement="bottom-end"
-                  {...datePickerProps}
-                />
+                <div className={styles.dateFieldStart}>
+                  <DatePicker
+                    id="injury-start-date"
+                    selected={startDate}
+                    onChange={setStartDate}
+                    selectsStart
+                    startDate={startDate}
+                    endDate={endDate}
+                    placeholderText="Start date"
+                    popperPlacement="bottom-start"
+                    popperClassName={styles.datepickerPopper}
+                    {...datePickerProps}
+                  />
+                </div>
+                <div className={styles.dateFieldEnd}>
+                  <DatePicker
+                    id="injury-end-date"
+                    selected={endDate}
+                    onChange={setEndDate}
+                    selectsEnd
+                    startDate={startDate}
+                    endDate={endDate}
+                    minDate={startDate}
+                    placeholderText="End date"
+                    popperPlacement="bottom-end"
+                    popperClassName={styles.datepickerPopper}
+                    {...datePickerProps}
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
@@ -16,6 +16,7 @@
   border: 1px solid #c8c8c8;
   background: #fff;
   box-sizing: border-box;
+  overflow: visible;
 }
 
 .topBar {
@@ -24,6 +25,7 @@
   justify-content: space-between;
   gap: 1rem;
   margin-bottom: 0.75rem;
+  overflow: visible;
 }
 
 .title {
@@ -41,6 +43,7 @@
   place-items: start stretch;
   flex: 1 1 auto;
   max-width: 520px;
+  overflow: visible;
 }
 
 .filterGroup {
@@ -49,6 +52,7 @@
   align-items: stretch;
   gap: 0.35rem;
   min-width: 0;
+  overflow: visible;
 }
 
 .filterLabel {
@@ -86,10 +90,8 @@
   overflow: visible;
 }
 
-.dateField {
-  position: relative;
-  min-width: 0;
-  width: 100%;
+.datepickerPopper {
+  z-index: 20;
 }
 
 .headerFilters :global(.react-datepicker-wrapper),
@@ -117,6 +119,52 @@
   border-radius: 2px;
   background: #fff;
   color: #333;
+}
+
+.datepickerCalendarDark {
+  background-color: #222;
+  color: #e5eaf1;
+  border: 1px solid #2d3a4d;
+}
+
+.datepickerCalendarDark :global(.react-datepicker__header) {
+  background-color: #2a3446;
+  border-bottom: 1px solid #2d3a4d;
+}
+
+.datepickerCalendarDark :global(.react-datepicker__current-month),
+.datepickerCalendarDark :global(.react-datepicker__day-name),
+.datepickerCalendarDark :global(.react-datepicker__day),
+.datepickerCalendarDark :global(.react-datepicker__month-read-view--selected-month),
+.datepickerCalendarDark :global(.react-datepicker__year-read-view--selected-year) {
+  color: #e5eaf1;
+}
+
+.datepickerCalendarDark :global(.react-datepicker__day:hover),
+.datepickerCalendarDark :global(.react-datepicker__month-text:hover),
+.datepickerCalendarDark :global(.react-datepicker__year-text:hover) {
+  background-color: #334155;
+}
+
+.datepickerCalendarDark :global(.react-datepicker__day--selected),
+.datepickerCalendarDark :global(.react-datepicker__day--keyboard-selected),
+.datepickerCalendarDark :global(.react-datepicker__day--in-range),
+.datepickerCalendarDark :global(.react-datepicker__day--in-selecting-range) {
+  background-color: #3b82f6;
+  color: #fff;
+}
+
+.datepickerCalendarDark :global(.react-datepicker__day--disabled) {
+  color: #6b7280;
+}
+
+.datepickerCalendarDark :global(.react-datepicker__month-dropdown),
+.datepickerCalendarDark :global(.react-datepicker__year-dropdown),
+.datepickerCalendarDark :global(.react-datepicker__month-select),
+.datepickerCalendarDark :global(.react-datepicker__year-select) {
+  background-color: #222;
+  color: #e5eaf1;
+  border-color: #2d3a4d;
 }
 
 .legendRow {
@@ -272,80 +320,6 @@
 
 .darkMode .statusMessage {
   color: #9aa6b8;
-}
-
-/* Calendar is portaled to body, so theme it via the page body class. */
-:global(.injury-dark-body) :global(.react-datepicker) {
-  background-color: #222;
-  color: #e5eaf1;
-  border: 1px solid #2d3a4d;
-}
-
-:global(.injury-dark-body) :global(.react-datepicker__header) {
-  background-color: #2a3446;
-  border-bottom: 1px solid #2d3a4d;
-}
-
-:global(.injury-dark-body) :global(.react-datepicker__current-month),
-:global(.injury-dark-body) :global(.react-datepicker__day-name),
-:global(.injury-dark-body) :global(.react-datepicker__day),
-:global(.injury-dark-body) :global(.react-datepicker__month-read-view--selected-month),
-:global(.injury-dark-body) :global(.react-datepicker__year-read-view--selected-year) {
-  color: #e5eaf1;
-}
-
-:global(.injury-dark-body) :global(.react-datepicker__day:hover),
-:global(.injury-dark-body) :global(.react-datepicker__month-text:hover),
-:global(.injury-dark-body) :global(.react-datepicker__year-text:hover) {
-  background-color: #334155;
-}
-
-:global(.injury-dark-body) :global(.react-datepicker__day--selected),
-:global(.injury-dark-body) :global(.react-datepicker__day--keyboard-selected),
-:global(.injury-dark-body) :global(.react-datepicker__day--in-range),
-:global(.injury-dark-body) :global(.react-datepicker__day--in-selecting-range) {
-  background-color: #3b82f6;
-  color: #fff;
-}
-
-:global(.injury-dark-body) :global(.react-datepicker__day--disabled) {
-  color: #6b7280;
-}
-
-:global(.injury-dark-body) :global(.react-datepicker__month-dropdown),
-:global(.injury-dark-body) :global(.react-datepicker__year-dropdown),
-:global(.injury-dark-body) :global(.react-datepicker__month-select),
-:global(.injury-dark-body) :global(.react-datepicker__year-select) {
-  background-color: #222;
-  color: #e5eaf1;
-  border-color: #2d3a4d;
-}
-
-.darkMode :global(.react-datepicker) {
-  background-color: #222;
-  color: #e5eaf1;
-  border: 1px solid #2d3a4d;
-}
-
-.darkMode :global(.react-datepicker__header) {
-  background-color: #2a3446;
-  border-bottom: 1px solid #2d3a4d;
-}
-
-.darkMode :global(.react-datepicker__day-name),
-.darkMode :global(.react-datepicker__day),
-.darkMode :global(.react-datepicker__current-month),
-.darkMode :global(.react-datepicker__month-read-view--selected-month),
-.darkMode :global(.react-datepicker__year-read-view--selected-year) {
-  color: #e5eaf1;
-}
-
-.darkMode :global(.react-datepicker__month-dropdown),
-.darkMode :global(.react-datepicker__year-dropdown),
-.darkMode :global(.react-datepicker__month-select),
-.darkMode :global(.react-datepicker__year-select) {
-  background-color: #222;
-  color: #e5eaf1;
 }
 
 @media (width <= 900px) {

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
@@ -2,60 +2,75 @@
   background-color: #1b2a41 !important;
 }
 
-.container {
+.page {
   width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1.5rem;
+  padding: 1.25rem;
+  box-sizing: border-box;
 }
 
-.header {
-  margin-bottom: 1rem;
+.panel {
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 1.25rem 1.5rem 1.5rem;
+  border: 1px solid #c8c8c8;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.topBar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
 }
 
 .title {
-  margin: 0 0 0.35rem;
-  font-size: 1.5rem;
-  font-weight: 600;
-}
-
-.subtitle {
   margin: 0;
-  color: #6b7280;
-  font-size: 0.95rem;
+  color: #4a4a4a;
+  font-size: clamp(1.35rem, 2.2vw, 1.85rem);
+  font-weight: 500;
+  line-height: 1.2;
 }
 
-.filters {
+.headerFilters {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  align-items: end;
-  margin-bottom: 1rem;
+  grid-template-columns: minmax(140px, 180px) minmax(220px, 320px);
+  gap: 0.85rem 1rem;
+  place-items: start stretch;
+  flex: 1 1 auto;
+  max-width: 520px;
 }
 
-.filterItem {
+.filterGroup {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  align-items: stretch;
+  gap: 0.35rem;
   min-width: 0;
 }
 
-.filterItem label {
-  font-size: 0.9rem;
-  font-weight: 600;
+.filterLabel {
+  margin: 0;
+  color: #333;
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-align: left;
+  line-height: 1.2;
 }
 
 .select,
 .datepicker {
   width: 100%;
-  min-height: 38px;
-  padding: 0.375rem 0.75rem;
-  border: 1px solid #ced4da;
-  border-radius: 0.375rem;
+  min-height: 36px;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #bfbfbf;
+  border-radius: 2px;
   background-color: #fff;
-  color: #212529;
-  font-size: 1rem;
-  line-height: 1.5;
+  color: #333;
+  font-size: 0.9rem;
+  line-height: 1.4;
   box-sizing: border-box;
 }
 
@@ -63,27 +78,84 @@
   appearance: auto;
 }
 
-.filters :global(.react-datepicker-wrapper),
-.filters :global(.react-datepicker__input-container) {
+.dateInputs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.45rem;
+  width: 100%;
+}
+
+.headerFilters :global(.react-datepicker-wrapper),
+.headerFilters :global(.react-datepicker__input-container) {
   display: block;
   width: 100%;
 }
 
-.filters :global(.react-datepicker__input-container input) {
-  width: 100%;
+.headerFilters :global(.react-datepicker__month-select),
+.headerFilters :global(.react-datepicker__year-select) {
+  margin: 0 0.15rem;
+  padding: 0.15rem 0.25rem;
+  border: 1px solid #bfbfbf;
+  border-radius: 2px;
+  background: #fff;
+  color: #333;
 }
 
-.chartCard {
+.legendRow {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.25rem 1.75rem;
+  margin: 0.35rem 0 0.75rem;
+}
+
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #444;
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+.legendLine {
+  display: inline-block;
+  width: 34px;
+  height: 3px;
+  border-radius: 1px;
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  margin-bottom: 0.75rem;
+  color: #666;
+  font-size: 0.85rem;
+}
+
+.metaRow strong {
+  color: #444;
+  font-weight: 600;
+}
+
+.demoBadge {
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3730a3;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.chartArea {
   width: 100%;
-  min-height: 420px;
-  padding: 1rem;
-  border-radius: 0.5rem;
-  background: #fff;
-  box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+  min-height: 300px;
 }
 
 .statusMessage {
-  margin-bottom: 0.75rem;
+  margin: 0.5rem 0 0.75rem;
   color: #4b5563;
 }
 
@@ -137,8 +209,19 @@
   color: #cfd7e3;
 }
 
-.darkMode .subtitle,
-.darkMode .statusMessage {
+.darkMode .panel {
+  background: #1e2736;
+  border-color: #2d3a4d;
+}
+
+.darkMode .title,
+.darkMode .filterLabel,
+.darkMode .legendItem,
+.darkMode .metaRow strong {
+  color: #e5eaf1;
+}
+
+.darkMode .metaRow {
   color: #9aa6b8;
 }
 
@@ -149,9 +232,13 @@
   border-color: #2d3a4d;
 }
 
-.darkMode .chartCard {
-  background: #1e2736;
-  box-shadow: none;
+.darkMode .demoBadge {
+  background: #312e81;
+  color: #e0e7ff;
+}
+
+.darkMode .statusMessage {
+  color: #9aa6b8;
 }
 
 .darkMode :global(.react-datepicker) {
@@ -167,16 +254,54 @@
 
 .darkMode :global(.react-datepicker__day-name),
 .darkMode :global(.react-datepicker__day),
-.darkMode :global(.react-datepicker__current-month) {
+.darkMode :global(.react-datepicker__current-month),
+.darkMode :global(.react-datepicker__month-read-view--selected-month),
+.darkMode :global(.react-datepicker__year-read-view--selected-year) {
   color: #ddd;
 }
 
-@media (width <= 768px) {
-  .filters {
+.darkMode :global(.react-datepicker__month-dropdown),
+.darkMode :global(.react-datepicker__year-dropdown),
+.darkMode :global(.react-datepicker__month-select),
+.darkMode :global(.react-datepicker__year-select) {
+  background-color: #222;
+  color: #ddd;
+}
+
+@media (width <= 900px) {
+  .topBar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .headerFilters {
+    max-width: none;
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (width <= 640px) {
+  .page {
+    padding: 0.75rem;
+  }
+
+  .panel {
+    padding: 1rem;
+  }
+
+  .headerFilters {
     grid-template-columns: 1fr;
   }
 
-  .container {
-    padding: 1rem;
+  .dateInputs {
+    grid-template-columns: 1fr;
+  }
+
+  .legendRow {
+    gap: 0.75rem 1rem;
+  }
+
+  .legendItem {
+    font-size: 0.85rem;
   }
 }

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
@@ -83,12 +83,30 @@
   grid-template-columns: 1fr 1fr;
   gap: 0.45rem;
   width: 100%;
+  overflow: visible;
+}
+
+.dateField {
+  position: relative;
+  min-width: 0;
+  width: 100%;
 }
 
 .headerFilters :global(.react-datepicker-wrapper),
 .headerFilters :global(.react-datepicker__input-container) {
   display: block;
   width: 100%;
+}
+
+.headerFilters :global(.react-datepicker__input-container input) {
+  width: 100%;
+  min-height: 36px;
+  box-sizing: border-box;
+}
+
+.headerFilters :global(.react-datepicker__close-icon::after) {
+  background-color: #6b7280;
+  color: #fff;
 }
 
 .headerFilters :global(.react-datepicker__month-select),
@@ -226,10 +244,25 @@
 }
 
 .darkMode .select,
-.darkMode .datepicker {
-  background-color: #222;
-  color: #ddd;
-  border-color: #2d3a4d;
+.darkMode .datepicker,
+.darkMode :global(.react-datepicker__input-container input) {
+  background-color: #222 !important;
+  color: #e5eaf1 !important;
+  border-color: #2d3a4d !important;
+  -webkit-text-fill-color: #e5eaf1;
+  caret-color: #e5eaf1;
+}
+
+.darkMode .datepicker::placeholder,
+.darkMode :global(.react-datepicker__input-container input::placeholder) {
+  color: #9aa6b8 !important;
+  -webkit-text-fill-color: #9aa6b8;
+  opacity: 1;
+}
+
+.darkMode :global(.react-datepicker__close-icon::after) {
+  background-color: #64748b;
+  color: #fff;
 }
 
 .darkMode .demoBadge {
@@ -241,9 +274,56 @@
   color: #9aa6b8;
 }
 
+/* Calendar is portaled to body, so theme it via the page body class. */
+:global(.injury-dark-body) :global(.react-datepicker) {
+  background-color: #222;
+  color: #e5eaf1;
+  border: 1px solid #2d3a4d;
+}
+
+:global(.injury-dark-body) :global(.react-datepicker__header) {
+  background-color: #2a3446;
+  border-bottom: 1px solid #2d3a4d;
+}
+
+:global(.injury-dark-body) :global(.react-datepicker__current-month),
+:global(.injury-dark-body) :global(.react-datepicker__day-name),
+:global(.injury-dark-body) :global(.react-datepicker__day),
+:global(.injury-dark-body) :global(.react-datepicker__month-read-view--selected-month),
+:global(.injury-dark-body) :global(.react-datepicker__year-read-view--selected-year) {
+  color: #e5eaf1;
+}
+
+:global(.injury-dark-body) :global(.react-datepicker__day:hover),
+:global(.injury-dark-body) :global(.react-datepicker__month-text:hover),
+:global(.injury-dark-body) :global(.react-datepicker__year-text:hover) {
+  background-color: #334155;
+}
+
+:global(.injury-dark-body) :global(.react-datepicker__day--selected),
+:global(.injury-dark-body) :global(.react-datepicker__day--keyboard-selected),
+:global(.injury-dark-body) :global(.react-datepicker__day--in-range),
+:global(.injury-dark-body) :global(.react-datepicker__day--in-selecting-range) {
+  background-color: #3b82f6;
+  color: #fff;
+}
+
+:global(.injury-dark-body) :global(.react-datepicker__day--disabled) {
+  color: #6b7280;
+}
+
+:global(.injury-dark-body) :global(.react-datepicker__month-dropdown),
+:global(.injury-dark-body) :global(.react-datepicker__year-dropdown),
+:global(.injury-dark-body) :global(.react-datepicker__month-select),
+:global(.injury-dark-body) :global(.react-datepicker__year-select) {
+  background-color: #222;
+  color: #e5eaf1;
+  border-color: #2d3a4d;
+}
+
 .darkMode :global(.react-datepicker) {
   background-color: #222;
-  color: #ddd;
+  color: #e5eaf1;
   border: 1px solid #2d3a4d;
 }
 
@@ -257,7 +337,7 @@
 .darkMode :global(.react-datepicker__current-month),
 .darkMode :global(.react-datepicker__month-read-view--selected-month),
 .darkMode :global(.react-datepicker__year-read-view--selected-year) {
-  color: #ddd;
+  color: #e5eaf1;
 }
 
 .darkMode :global(.react-datepicker__month-dropdown),
@@ -265,7 +345,7 @@
 .darkMode :global(.react-datepicker__month-select),
 .darkMode :global(.react-datepicker__year-select) {
   background-color: #222;
-  color: #ddd;
+  color: #e5eaf1;
 }
 
 @media (width <= 900px) {

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
@@ -108,11 +108,6 @@
 .dateFieldEnd :global(.react-datepicker__input-container input) {
   position: relative;
   z-index: 22;
-  background-color: #fff;
-}
-
-.darkMode .dateFieldEnd :global(.react-datepicker__input-container input) {
-  background-color: #222 !important;
 }
 
 .datepickerPopper {

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
@@ -1,0 +1,182 @@
+:global(.injury-dark-body) {
+  background-color: #1b2a41 !important;
+}
+
+.container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.header {
+  margin-bottom: 1rem;
+}
+
+.title {
+  margin: 0 0 0.35rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  align-items: end;
+  margin-bottom: 1rem;
+}
+
+.filterItem {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.filterItem label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.select,
+.datepicker {
+  width: 100%;
+  min-height: 38px;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid #ced4da;
+  border-radius: 0.375rem;
+  background-color: #fff;
+  color: #212529;
+  font-size: 1rem;
+  line-height: 1.5;
+  box-sizing: border-box;
+}
+
+.select {
+  appearance: auto;
+}
+
+.filters :global(.react-datepicker-wrapper),
+.filters :global(.react-datepicker__input-container) {
+  display: block;
+  width: 100%;
+}
+
+.filters :global(.react-datepicker__input-container input) {
+  width: 100%;
+}
+
+.chartCard {
+  width: 100%;
+  min-height: 420px;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background: #fff;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+}
+
+.statusMessage {
+  margin-bottom: 0.75rem;
+  color: #4b5563;
+}
+
+.statusError {
+  color: #b91c1c;
+}
+
+.tooltip {
+  min-width: 160px;
+  padding: 10px 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background: #fff;
+  color: #333;
+  box-shadow: 0 4px 14px rgb(0 0 0 / 16%);
+}
+
+.tooltipDark {
+  background: #1e293b;
+  border-color: #475569;
+  color: #e2e8f0;
+}
+
+.tooltipTitle {
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.tooltipProject {
+  margin-bottom: 8px;
+  font-size: 0.875rem;
+  opacity: 0.85;
+}
+
+.tooltipRow {
+  display: grid;
+  grid-template-columns: 10px 1fr auto;
+  gap: 8px;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.tooltipMarker {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+}
+
+.darkMode {
+  background-color: #1b2a41;
+  color: #cfd7e3;
+}
+
+.darkMode .subtitle,
+.darkMode .statusMessage {
+  color: #9aa6b8;
+}
+
+.darkMode .select,
+.darkMode .datepicker {
+  background-color: #222;
+  color: #ddd;
+  border-color: #2d3a4d;
+}
+
+.darkMode .chartCard {
+  background: #1e2736;
+  box-shadow: none;
+}
+
+.darkMode :global(.react-datepicker) {
+  background-color: #222;
+  color: #ddd;
+  border: 1px solid #2d3a4d;
+}
+
+.darkMode :global(.react-datepicker__header) {
+  background-color: #2a3446;
+  border-bottom: 1px solid #2d3a4d;
+}
+
+.darkMode :global(.react-datepicker__day-name),
+.darkMode :global(.react-datepicker__day),
+.darkMode :global(.react-datepicker__current-month) {
+  color: #ddd;
+}
+
+@media (width <= 768px) {
+  .filters {
+    grid-template-columns: 1fr;
+  }
+
+  .container {
+    padding: 1rem;
+  }
+}

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
@@ -38,11 +38,11 @@
 
 .headerFilters {
   display: grid;
-  grid-template-columns: minmax(140px, 180px) minmax(220px, 320px);
+  grid-template-columns: minmax(140px, 180px) minmax(260px, 360px);
   gap: 0.85rem 1rem;
   place-items: start stretch;
   flex: 1 1 auto;
-  max-width: 520px;
+  max-width: 560px;
   overflow: visible;
 }
 
@@ -84,14 +84,47 @@
 
 .dateInputs {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 0.45rem;
   width: 100%;
   overflow: visible;
 }
 
+/* Start calendar popper sits below its field; end field stays above that popper. */
+.dateFieldStart {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+.dateFieldEnd {
+  position: relative;
+  z-index: 22;
+  min-width: 0;
+}
+
+.dateFieldEnd :global(.react-datepicker-wrapper),
+.dateFieldEnd :global(.react-datepicker__input-container),
+.dateFieldEnd :global(.react-datepicker__input-container input) {
+  position: relative;
+  z-index: 22;
+  background-color: #fff;
+}
+
+.darkMode .dateFieldEnd :global(.react-datepicker__input-container input) {
+  background-color: #222 !important;
+}
+
 .datepickerPopper {
   z-index: 20;
+}
+
+.dateFieldStart :global(.react-datepicker-popper) {
+  z-index: 20;
+}
+
+.dateFieldEnd :global(.react-datepicker-popper) {
+  z-index: 25;
 }
 
 .headerFilters :global(.react-datepicker-wrapper),

--- a/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
+++ b/src/components/BMDashboard/InjuryTrendChart/InjuryTrendChart.module.css
@@ -104,10 +104,13 @@
 }
 
 .dateFieldEnd :global(.react-datepicker-wrapper),
-.dateFieldEnd :global(.react-datepicker__input-container),
-.dateFieldEnd :global(.react-datepicker__input-container input) {
+.dateFieldEnd :global(.react-datepicker__input-container) {
   position: relative;
   z-index: 22;
+}
+
+.dateFieldEnd :global(.react-datepicker__close-icon) {
+  z-index: 1;
 }
 
 .datepickerPopper {

--- a/src/components/BMDashboard/InjuryTrendChart/index.js
+++ b/src/components/BMDashboard/InjuryTrendChart/index.js
@@ -1,0 +1,1 @@
+export { default } from './InjuryTrendChart';

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -886,13 +886,6 @@ export function Header(props) {
                       <DropdownItem tag={Link} to="/bmdashboard" className={fontColor}>
                         BM Dashboard
                       </DropdownItem>
-                      <DropdownItem
-                        tag={Link}
-                        to="/bmdashboard/injurychart"
-                        className={`${fontColor} ${styles.bmSubItem}`}
-                      >
-                        Injuries Tracking
-                      </DropdownItem>
 
                       {/* BM Projects accordion — only shown when on a bmdashboard route */}
                       {showProjectDropdown && (
@@ -989,6 +982,9 @@ export function Header(props) {
 
 
                               {/* Other BM pages */}
+                              <DropdownItem tag={Link} to="/bmdashboard/injurychart" className={`${fontColor} ${styles.bmSubItem}`}>
+                                Injuries Tracking
+                              </DropdownItem>
                               <DropdownItem tag={Link} to="/bmdashboard/Issue" className={`${fontColor} ${styles.bmSubItem}`}>Issues</DropdownItem>
                               <DropdownItem tag={Link} to="/bmdashboard/lessonform" className={`${fontColor} ${styles.bmSubItem}`}>Lessons</DropdownItem>
                               <DropdownItem tag={Link} to="/teams" className={`${fontColor} ${styles.bmSubItem}`}>Teams</DropdownItem>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -259,7 +259,19 @@ export function Header(props) {
 
   useEffect(() => {
     const path = location.pathname;
+    // BM Projects accordion: any BM dashboard route.
     setShowProjectDropdown(path === '/bmdashboard' || path.startsWith('/bmdashboard/'));
+  }, [location.pathname]);
+
+  // Injuries Tracking should only show in real BM Dashboard context — not on Report
+  // pages that happen to live under /bmdashboard/* (e.g. Total Construction Summary).
+  const showInjuriesTrackingLink = useMemo(() => {
+    const path = location.pathname;
+    if (path === '/bmdashboard' || path === '/bmdashboard/') return true;
+    if (path.startsWith('/bmdashboard/injurychart')) return true;
+    if (!path.startsWith('/bmdashboard/')) return false;
+    const excludedPrefixes = ['/bmdashboard/totalconstructionsummary'];
+    return !excludedPrefixes.some(prefix => path.startsWith(prefix));
   }, [location.pathname]);
   const MeetingNotificationAudioRef = useRef(null);
   const dismissedMeetingModalIdRef = useRef(null);
@@ -888,8 +900,8 @@ export function Header(props) {
                         BM Dashboard
                       </DropdownItem>
 
-                      {/* Visible while on BM Dashboard; route stays /bmdashboard/injurychart (BMProtectedRoute). */}
-                      {showProjectDropdown && (
+                      {/* Visible only in BM Dashboard context; route stays /bmdashboard/injurychart. */}
+                      {showInjuriesTrackingLink && (
                         <DropdownItem
                           tag={Link}
                           to="/bmdashboard/injurychart"

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -886,6 +886,13 @@ export function Header(props) {
                       <DropdownItem tag={Link} to="/bmdashboard" className={fontColor}>
                         BM Dashboard
                       </DropdownItem>
+                      <DropdownItem
+                        tag={Link}
+                        to="/bmdashboard/injurychart"
+                        className={`${fontColor} ${styles.bmSubItem}`}
+                      >
+                        Injuries Tracking
+                      </DropdownItem>
 
                       {/* BM Projects accordion — only shown when on a bmdashboard route */}
                       {showProjectDropdown && (

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -258,7 +258,8 @@ export function Header(props) {
   const history = useHistory();
 
   useEffect(() => {
-    setShowProjectDropdown(location.pathname.startsWith('/bmdashboard/'));
+    const path = location.pathname;
+    setShowProjectDropdown(path === '/bmdashboard' || path.startsWith('/bmdashboard/'));
   }, [location.pathname]);
   const MeetingNotificationAudioRef = useRef(null);
   const dismissedMeetingModalIdRef = useRef(null);
@@ -887,6 +888,17 @@ export function Header(props) {
                         BM Dashboard
                       </DropdownItem>
 
+                      {/* Visible while on BM Dashboard; route stays /bmdashboard/injurychart (BMProtectedRoute). */}
+                      {showProjectDropdown && (
+                        <DropdownItem
+                          tag={Link}
+                          to="/bmdashboard/injurychart"
+                          className={`${fontColor} ${styles.bmSubItem}`}
+                        >
+                          Injuries Tracking
+                        </DropdownItem>
+                      )}
+
                       {/* BM Projects accordion — only shown when on a bmdashboard route */}
                       {showProjectDropdown && (
                         <>
@@ -982,9 +994,6 @@ export function Header(props) {
 
 
                               {/* Other BM pages */}
-                              <DropdownItem tag={Link} to="/bmdashboard/injurychart" className={`${fontColor} ${styles.bmSubItem}`}>
-                                Injuries Tracking
-                              </DropdownItem>
                               <DropdownItem tag={Link} to="/bmdashboard/Issue" className={`${fontColor} ${styles.bmSubItem}`}>Issues</DropdownItem>
                               <DropdownItem tag={Link} to="/bmdashboard/lessonform" className={`${fontColor} ${styles.bmSubItem}`}>Lessons</DropdownItem>
                               <DropdownItem tag={Link} to="/teams" className={`${fontColor} ${styles.bmSubItem}`}>Teams</DropdownItem>

--- a/src/reducers/bmdashboard/injuryReducer.js
+++ b/src/reducers/bmdashboard/injuryReducer.js
@@ -11,6 +11,7 @@ import {
   FETCH_BM_INJURY_SEVERITIES,
   FETCH_BM_INJURY_TYPES,
   FETCH_BM_INJURY_PROJECTS,
+  FETCH_BM_INJURY_TREND_SUCCESS,
   RESET_BM_INJURY_DATA,
   FETCH_BM_INJURY_OVER_TIME,
   GET_INJURY_SEVERITY,
@@ -22,10 +23,11 @@ const byValue = (a, b) => String(a).localeCompare(String(b));
 const initialState = {
   loading: false,
   data: [],
+  trend: { months: [], serious: [], medium: [], low: [] },
   error: null,
   severities: [],
   injuryTypes: [],
-  projects: [], // [{ _id, name }]
+  projects: [], // [{ _id, name, projectIds }]
   injuryOverTimeData: [],
   severityData: [], // Legacy field for backward compatibility
 };
@@ -81,8 +83,36 @@ function bmInjuryReducer(state = initialState, action) {
       const raw = Array.isArray(action.payload) ? action.payload : [];
       const arr = raw
         .filter(p => p && (p._id || p.id) && (p.name || p.title))
-        .map(p => ({ _id: p._id || p.id, name: p.name || p.title }));
-      const map = new Map(arr.map(p => [String(p._id), p]));
+        .map(p => {
+          const fallbackId = p._id || p.id;
+          const projectIds =
+            Array.isArray(p.projectIds) && p.projectIds.length
+              ? p.projectIds.map(String)
+              : [String(fallbackId)];
+          return {
+            // Prefer a real ObjectId when the API returns projectIds; otherwise keep _id.
+            _id: projectIds[0],
+            name: p.name || p.title,
+            projectIds,
+          };
+        });
+
+      // Collapse duplicate display names so one dropdown option covers shared legacy IDs.
+      const map = new Map();
+      arr.forEach(project => {
+        const key = String(project.name)
+          .trim()
+          .toLowerCase();
+        const existing = map.get(key);
+        map.set(key, {
+          ...project,
+          projectIds: existing
+            ? Array.from(new Set([...existing.projectIds, ...project.projectIds]))
+            : project.projectIds,
+          _id: existing ? existing._id : project._id,
+        });
+      });
+
       const projects = Array.from(map.values()).sort(byName);
       return { ...state, projects };
     }
@@ -93,7 +123,29 @@ function bmInjuryReducer(state = initialState, action) {
     }
 
     case RESET_BM_INJURY_DATA:
-      return { ...state, data: [], error: null, loading: false };
+      return {
+        ...state,
+        data: [],
+        trend: { months: [], serious: [], medium: [], low: [] },
+        error: null,
+        loading: false,
+      };
+
+    case FETCH_BM_INJURY_TREND_SUCCESS: {
+      const t = action.payload || {};
+      const coerceArr = v => (Array.isArray(v) ? v : []);
+      return {
+        ...state,
+        loading: false,
+        error: null,
+        trend: {
+          months: coerceArr(t.months),
+          serious: coerceArr(t.serious),
+          medium: coerceArr(t.medium),
+          low: coerceArr(t.low),
+        },
+      };
+    }
 
     // Legacy action for backward compatibility
     case GET_INJURY_SEVERITY:

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -253,7 +253,7 @@ const UpdateMaterialsBulk = lazy(() =>
 const UpdateReusablesBulk = lazy(() =>
   import('./components/BMDashboard/UpdateReusables/UpdateReusablesBulk/UpdateReusablesBulk'),
 );
-const InjuryChart = lazy(() => import('./components/BMDashboard/InjuryChart/InjuryChart'));
+const InjuryTrendChart = lazy(() => import('./components/BMDashboard/InjuryTrendChart'));
 const PurchaseConsumable = lazy(() => import('./components/BMDashboard/ConsumablePurchaseRequest'));
 const InventoryTypesList = lazy(() => import('./components/BMDashboard/InventoryTypesList'));
 const UnitsOfMeasurementList = lazy(() =>
@@ -825,7 +825,12 @@ export default (
           exact
           component={WeeklyProjectSummary}
         />
-        <BMProtectedRoute path="/bmdashboard/injurychart" fallback exact component={InjuryChart} />
+        <BMProtectedRoute
+          path="/bmdashboard/injurychart"
+          fallback
+          exact
+          component={InjuryTrendChart}
+        />
         <BMProtectedRoute
           path="/bmdashboard/injuries-severity"
           fallback

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -433,6 +433,7 @@ export const ENDPOINTS = {
   BM_INJURY_SEVERITIES: `${APIEndpoint}/bm/injuries/injury-severities`,
   BM_INJURY_TYPES: `${APIEndpoint}/bm/injuries/injury-types`,
   BM_INJURY_PROJECTS: `${APIEndpoint}/bm/injuries/project-injury`,
+  BM_INJURY_TREND: `${APIEndpoint}/bm/injuries/trend-data`,
   BM_INJURY_OVER_TIME: `${APIEndpoint}/bm/injuries/over-time`,
   BM_INJURY_ISSUE: `${APIEndpoint}/bm/issues`,
   BM_INJURY_SEVERITY: `${APIEndpoint}/bm/injuries/severity-by-project`,


### PR DESCRIPTION
### Frontend PR — Injury Trend Line Chart (Phase 2)

# Description
Takes over and finishes the frontend work from [#4063](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4063) (`Juhitha_Create_Injury_Trend_Chart`) on a fresh `development` base.

Implements the **Injuries Tracking** line chart for Phase 2 Summary Dashboard with Project and Date filters, dark mode styling, responsive layout, BM Dashboard menu access, and project-linked demo data. Integrates with backend Injury Trend APIs for monthly counts by severity.

Implements #Phase2-InjuryTrend

## Related PRs
- **Supersedes:** frontend [#4063](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4063) (closed in favor of this takeover)
- **Backend pair:** [HGNRest #2304](https://github.com/OneCommunityGlobal/HGNRest/pull/2304) — Purav taking over injury trend APIs + POST injuries
- Original backend reference: [HGNRest #1723](https://github.com/OneCommunityGlobal/HGNRest/pull/1723)

## Main changes explained
- Create `InjuryTrendChart` component with Recharts multi-line chart:
  - Lines: Serious (red), Medium (orange), Low Level (green)
  - Legend at top, axis labels (`Month` / counts), and data labels
  - Dark mode theming and responsive layout
- Filters (aligned in header):
  - Project dropdown (projects with injuries; falls back to demo projects if needed)
  - Start / End date pickers with **month and year dropdowns**
- Data integration:
  - Fetches trend data from `GET /bm/injuries/trend-data` by project ObjectIds + date range
  - Fetches project list from `GET /bm/injuries/project-injury`
  - Project-linked demo series when API has no filtered data; **ALL** = sum of every project’s series (no unlinked injuries)
- Navigation:
  - **Injuries Tracking** appears under Other Links → BM Dashboard **only while on a BM Dashboard route** (`/bmdashboard` or `/bmdashboard/...`)
  - Chart route remains `/bmdashboard/injurychart` (BMProtectedRoute)
- UI polish:
  - Reference-style layout (title left, filters right, centered legend)
  - No forced blank page space under the chart

## How to test
1. Check out this branch and the backend pair:
   - Frontend: `Purav-taking-over-Injury-Trend-Chart` (this PR)
   - Backend: [HGNRest #2304](https://github.com/OneCommunityGlobal/HGNRest/pull/2304)
2. Frontend:
   - `yarn install`
   - Set `REACT_APP_APIENDPOINT=http://localhost:4500/api`
   - `yarn start:local` 
3. Backend:
   - `yarn dev` (or `npm run dev`) on port `4500`
4. Login as an **admin / BM Dashboard** user.
5. Go to **Other Links → BM Dashboard** (`/bmdashboard`).
6. Confirm **Injuries Tracking** is visible in Other Links (directly under BM Dashboard) while on BM Dashboard, and is **not** shown when you are outside BM Dashboard routes.
7. Open **Injuries Tracking** → `/bmdashboard/injurychart`.
8. Verify:
   - [x] Chart title **Injuries Tracking**, legend (Serious / Medium / Low Level), and aligned Project + Dates filters
   - [x] Project dropdown lists projects; switching projects changes the chart (Building 1 ≠ akv_test ≠ ALL)
   - [x] **ALL** shows higher totals than any single project (sum of project-linked data)
   - [x] Date pickers support month + year dropdowns; clearing dates shows a multi-month window
   - [x] Legend, axis labels, data labels, and project name in tooltip
   - [ ] Light and dark mode look correct; layout works on desktop and mobile widths
   - [x] Page does not leave a large empty space below the chart
   - [x] Direct navigation to `/bmdashboard/injurychart` still requires BM access (BMProtectedRoute)

## Screenshots

<!-- Paste screenshots below -->

**Light mode**
<img width="1280" height="631" alt="pr 2304 5439_2" src="https://github.com/user-attachments/assets/9d96f1cb-6430-4863-b944-030c132c62e4" />

<br />
<br />

**Dark mode**
<img width="1279" height="526" alt="pr 2304 5439_1" src="https://github.com/user-attachments/assets/04b5aae4-593e-497c-9669-0038f841ae02" />

<br />
<br />

## Video

https://github.com/user-attachments/assets/2519dc68-7705-4113-8b62-96b564083863

<br />
<br />
<br />

## Note
- Pair with backend PR [#2304](https://github.com/OneCommunityGlobal/HGNRest/pull/2304) for full API filtering.
- Demo data is project-linked and used when the API has no filtered series yet; replace/verify with real seeded injuries from the backend POST API when available.