### PR TITLE
Akshay fix Skills Overview data mismatch on HGN Questionnaire Dashboard

### DIFF
--- a/src/components/HGNHelpSkillsDashboard/SkillsOverviewPage.jsx
+++ b/src/components/HGNHelpSkillsDashboard/SkillsOverviewPage.jsx
@@ -1,5 +1,9 @@
-import { useState } from 'react';
+import jwtDecode from 'jwt-decode';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import config from '~/config.json';
+import httpService from '~/services/httpService';
+import { ENDPOINTS } from '~/utils/URL';
 import RadarChart from '../HGNSkillsDashboard/SkillsProfilePage/components/RadarChart';
 import Accordion from './Accordion';
 import { PreferenceFilterButtons, SkillFilterButtons } from './FilterButtons';
@@ -12,10 +16,47 @@ function SkillsOverviewPage() {
   const [selectedPreferences, setSelectedPreferences] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
   const darkMode = useSelector(state => state.theme.darkMode);
-  const userProfile = useSelector(state => state.userProfile);
+  const [profileData, setProfileData] = useState(null);
+  const [loadingProfile, setLoadingProfile] = useState(true);
+
+  // The skills survey lives behind its own endpoint and is not part of state.userProfile,
+  // so this page has to fetch it itself rather than read it from the store.
+  useEffect(() => {
+    const token = localStorage.getItem(config.tokenKey);
+    let userId;
+    try {
+      userId = token ? jwtDecode(token)?.userid : undefined;
+    } catch (_) {
+      userId = undefined;
+    }
+
+    if (!userId) {
+      setLoadingProfile(false);
+      return;
+    }
+
+    httpService.setjwt(token);
+    httpService
+      .get(ENDPOINTS.SKILLS_PROFILE(userId))
+      // isPlaceholder means the user has not filled in the survey yet
+      .then(({ data }) => setProfileData(data?.isPlaceholder ? null : data))
+      .catch(() => setProfileData(null))
+      .finally(() => setLoadingProfile(false));
+  }, []);
 
   const hasFilters =
     selectedSkills.length > 0 || selectedPreferences.length > 0 || searchQuery.trim().length > 0;
+
+  let radarContent;
+  if (loadingProfile) {
+    radarContent = <p className={styles.noDataMsg}>Loading your skills radar...</p>;
+  } else if (profileData?.skillInfo) {
+    radarContent = <RadarChart profileData={profileData} compact={false} />;
+  } else {
+    radarContent = (
+      <p className={styles.noDataMsg}>Complete the skills survey to view your radar chart.</p>
+    );
+  }
 
   return (
     <div className={`${styles.container} ${darkMode ? styles.darkMode : ''}`}>
@@ -24,13 +65,7 @@ function SkillsOverviewPage() {
       {/* Radar Chart for logged-in user */}
       <div className={`${styles.radarSection} ${darkMode ? styles.radarDark : ''}`}>
         <h2 className={styles.sectionTitle}>Your Skills Radar</h2>
-        <div className={styles.radarWrapper}>
-          {userProfile?.skillInfo ? (
-            <RadarChart profileData={userProfile} compact={false} />
-          ) : (
-            <p className={styles.noDataMsg}>Complete the skills survey to view your radar chart.</p>
-          )}
-        </div>
+        <div className={styles.radarWrapper}>{radarContent}</div>
       </div>
 
       {/* Search Bar */}


### PR DESCRIPTION
# Original Task

<img width="584" height="392" alt="image" src="https://github.com/user-attachments/assets/5be03511-4beb-4219-b3bf-e1a030500ae4" />
---

# Description
The Skills Overview page (`/hgnhelp/skills-overview`) never displays the logged-in user's HGN skills survey responses. The "Your Skills Radar" section always falls back to the empty-state message "Complete the skills survey to view your radar chart", even for users who have fully completed the survey. The same user's data renders correctly on `/hgn/profile/skills`, which makes the dashboard look inconsistent and untrustworthy.

Root cause is in `src/components/HGNHelpSkillsDashboard/SkillsOverviewPage.jsx`. The component reads the survey data from the wrong Redux slice, and nothing on this route ever requests it:

1. It selects `state.userProfile`, which is the HGN account profile slice (`userProfileByIdReducer`). Survey data lives in a different slice, `state.userSkills` (`userSkillsReducer`). The key `skillInfo` is never written to `userProfile` anywhere in the codebase, so the guard `userProfile?.skillInfo` is always falsy and the page always renders the empty state.
2. The endpoint that returns this data, `ENDPOINTS.SKILLS_PROFILE` (`/skills/profile/:userId`), is called from exactly one place in the app — `UserSkillsProfile.jsx`, which is the `/hgn/profile/skills` page. That is precisely why the data only ever appears there.

Because of point 2, simply pointing the selector at the correct slice is not a real fix: Redux state is in-memory, so it would only work if the user happened to visit `/hgn/profile/skills` first in the same session, and would break on refresh or direct navigation. This PR therefore has the Skills Overview page fetch its own data on mount, the same way the working page does.



## Related PRS (if any):
No backend PR is required for this fix. The backend is unaffected — `/skills/profile/:userId` already returns correct data and is consumed unchanged.

For context only, the Skills Overview route being fixed here was introduced by frontend PR #3360 in this repository.

## Main changes explained:
- Update `src/components/HGNHelpSkillsDashboard/SkillsOverviewPage.jsx` to fetch the logged-in user's skills profile on mount via `ENDPOINTS.SKILLS_PROFILE`, and render the radar chart from that response instead of from a Redux slice that never holds it.

## How to test:
1. Check into current branch `Akshay_fix_skills_overview_data_mismatch`
2. Run `npm install` to install dependencies, then run the app locally (`npm run start:local` for frontend, backend on port 4500)
3. Clear site data/cache
4. Log in as a user who **has completed** the HGN skills survey. (If not completed  Go To ' /hgnform ' and fill the form, make sure your name and slack are exactly same and then complete the form)
5. Go to `/hgn/profile/skills` and note the radar chart values
6. Go to `/hgnhelp/skills-overview` and verify the "Your Skills Radar" section now renders the radar chart, and that the values match what you saw in step 5
7. Refresh `/hgnhelp/skills-overview` directly (without visiting `/hgn/profile/skills` first) and verify the chart still renders — this is the case that was previously broken
8. Log in as a user who has **not** completed the survey, go to `/hgnhelp/skills-overview`, and verify the "Complete the skills survey to view your radar chart" message still shows, and that you are **not** redirected away from the page
9. Verify the "Find Community Members" search, skill filters and preference filters below the radar are unchanged and still return results
10. Verify all of the above in **dark mode**

## Screenshots or videos of changes:
<img width="1680" height="800" alt="image" src="https://github.com/user-attachments/assets/1d706851-ff34-4ca1-9f7e-60a1f212b1b4" />
<img width="1678" height="856" alt="image" src="https://github.com/user-attachments/assets/d6d493c2-c743-46d2-9ff9-d0884e631f9f" />


## Note:
Scope is deliberately limited to a single file. No shared reducer, action, route, endpoint or styling is touched, and `/hgn/profile/skills` is not modified, so no other page changes behaviour.

One intentional difference from `/hgn/profile/skills`: that page redirects the user to `/hgnform` with a toast when no survey data exists. This PR does **not** copy that redirect. On Skills Overview a user without survey data simply sees the existing inline empty-state message, since redirecting away from the overview page would be a behaviour change beyond the scope of this bug.
