### PR TITLE
Roshini Seelamsetty: Team Stats chart is mixing up hours and volunteer counts - Teams and Blue Squares Dashboard

### DIFF
--- a/src/components/TotalOrgSummary/TeamStats/TeamStatsBarChart.jsx
+++ b/src/components/TotalOrgSummary/TeamStats/TeamStatsBarChart.jsx
@@ -61,7 +61,7 @@ function TeamStatsBarChart({ data, yAxisLabel }) {
         >
           <XAxis type="number" tick={{ fill: darkMode ? 'white' : '#666' }}>
             <Label
-              value="Total Volunteers"
+              value="Total Hours Contributed"
               position="insideBottom"
               offset={-10}
               style={{


### PR DESCRIPTION
# Description

<img width="805" height="682" alt="Screenshot 2026-08-13 at 14 46 03" src="https://github.com/user-attachments/assets/837dbb8a-471a-4031-a977-de82ed32b127" />


## Related PRS (if any):
None

## Main changes explained:
- Update [TeamStatsChart component file] — changed x-axis label string from "Total Volunteers" to "Total Hours Contributed"

## How to test:
1. Check into current branch
2. Run npm install and start the app locally
3. Clear site data/cache
4. Log in as Manager / Admin / Tester
5. Go to Dashboard → Total Org Summary → Teams and Blue Squares Dashboard → Team Stats chart
6. Verify the x-axis label now reads "Total Hours Contributed" (not "Total Volunteers")
7. Verify the bar values (e.g., "Not In Team" ≈ 1555, "In Team" ≈ 948) still align correctly with the corrected axis and tooltip hours values

## Screenshots or videos of changes:

<img width="1503" height="857" alt="After" src="https://github.com/user-attachments/assets/412f706a-f86c-44fd-ae15-febe0d2b8be4" />
