### PR TITLE
Mahitha - Add suppliers and orders page

### DIFF
--- a/src/components/KitchenInventory/Orders/OrdersPage.jsx
+++ b/src/components/KitchenInventory/Orders/OrdersPage.jsx
@@ -4,21 +4,38 @@ import { useSelector } from 'react-redux';
 import { createPortal } from 'react-dom';
 import { toast } from 'react-toastify';
 import { FiChevronLeft, FiChevronRight, FiSearch, FiPlus } from 'react-icons/fi';
-import { fetchOrders, createOrder, updateOrderStatus, fetchSuppliers } from './mockOrdersData';
+
+import {
+  fetchOrders,
+  createOrder,
+  updateOrderStatus,
+  fetchSuppliers,
+  createSupplier,
+} from './ordersApi';
+
 import styles from './OrdersPage.module.css';
 
 const ORDERS_PER_PAGE = 5;
+
+/* -------------------------------------------------------------------------- */
+/*                                   MODAL                                    */
+/* -------------------------------------------------------------------------- */
 
 function Modal({ isOpen, toggle, size, className, children }) {
   const overlayRef = useRef(null);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) return undefined;
+
     const handleEscape = e => {
-      if (e.key === 'Escape') toggle();
+      if (e.key === 'Escape') {
+        toggle();
+      }
     };
+
     document.addEventListener('keydown', handleEscape);
     document.body.style.overflow = 'hidden';
+
     return () => {
       document.removeEventListener('keydown', handleEscape);
       document.body.style.overflow = '';
@@ -28,7 +45,9 @@ function Modal({ isOpen, toggle, size, className, children }) {
   if (!isOpen) return null;
 
   const handleOverlayClick = e => {
-    if (e.target === overlayRef.current) toggle();
+    if (e.target === overlayRef.current) {
+      toggle();
+    }
   };
 
   const handleOverlayKeyDown = e => {
@@ -41,7 +60,7 @@ function Modal({ isOpen, toggle, size, className, children }) {
   const sizeClass = size === 'lg' ? styles.modalLg : '';
 
   return createPortal(
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions -- Modal overlay backdrop
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       className={styles.modalOverlay}
       ref={overlayRef}
@@ -54,33 +73,78 @@ function Modal({ isOpen, toggle, size, className, children }) {
   );
 }
 
+Modal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  toggle: PropTypes.func.isRequired,
+  size: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+/* -------------------------------------------------------------------------- */
+/*                              MODAL HEADER                                  */
+/* -------------------------------------------------------------------------- */
+
 function ModalHeader({ toggle, children }) {
   return (
     <div className={styles.modalHeader}>
       <h3 className={styles.modalTitle}>{children}</h3>
-      <button type="button" className={styles.modalClose} onClick={toggle}>
+
+      <button type="button" className={styles.modalClose} onClick={toggle} aria-label="Close modal">
         &times;
       </button>
     </div>
   );
 }
 
+ModalHeader.propTypes = {
+  toggle: PropTypes.func.isRequired,
+  children: PropTypes.node,
+};
+
+/* -------------------------------------------------------------------------- */
+/*                               MODAL BODY                                   */
+/* -------------------------------------------------------------------------- */
+
 function ModalBody({ children }) {
   return <div className={styles.modalBody}>{children}</div>;
 }
+
+ModalBody.propTypes = {
+  children: PropTypes.node,
+};
+
+/* -------------------------------------------------------------------------- */
+/*                              MODAL FOOTER                                  */
+/* -------------------------------------------------------------------------- */
 
 function ModalFooter({ children }) {
   return <div className={styles.modalFooter}>{children}</div>;
 }
 
+ModalFooter.propTypes = {
+  children: PropTypes.node,
+};
+
+/* -------------------------------------------------------------------------- */
+/*                                STATUS BADGE                                */
+/* -------------------------------------------------------------------------- */
+
 const badgeClassForStatus = status => {
-  if (status === 'ordered') return styles.badgeOrdered;
-  if (status === 'received') return styles.badgeReceived;
+  if (status === 'Pending') {
+    return styles.badgeOrdered;
+  }
+
+  if (status === 'Ordered' || status === 'Shipped') {
+    return styles.badgeReceived;
+  }
+
   return styles.badgeStocked;
 };
 
 const StatusBadge = ({ status }) => {
   const cls = badgeClassForStatus(status);
+
   return (
     <span className={`${styles.badge} ${cls}`}>
       {status.charAt(0).toUpperCase() + status.slice(1)}
@@ -92,12 +156,18 @@ StatusBadge.propTypes = {
   status: PropTypes.string.isRequired,
 };
 
+/* -------------------------------------------------------------------------- */
+/*                                 STAT CARD                                  */
+/* -------------------------------------------------------------------------- */
+
 const StatCard = ({ label, value, bgColor, icon }) => (
   <div className={styles.statCard}>
     <div>
       <p className={styles.statLabel}>{label}</p>
+
       <p className={styles.statValue}>{value}</p>
     </div>
+
     <div className={styles.statIcon} style={{ '--stat-bg': bgColor }}>
       {icon}
     </div>
@@ -111,15 +181,22 @@ StatCard.propTypes = {
   icon: PropTypes.node,
 };
 
+/* -------------------------------------------------------------------------- */
+/*                                ORDER CARD                                  */
+/* -------------------------------------------------------------------------- */
+
 const OrderCard = ({ order, onStatusChange, darkMode }) => {
   const [confirmOpen, setConfirmOpen] = useState(false);
+
   const [confirmTarget, setConfirmTarget] = useState(null);
+
   const [detailsOpen, setDetailsOpen] = useState(false);
 
   const handleConfirm = () => {
     if (confirmTarget) {
       onStatusChange(order._id, confirmTarget);
     }
+
     setConfirmOpen(false);
     setConfirmTarget(null);
   };
@@ -130,97 +207,129 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
   };
 
   const getActionButton = () => {
-    if (order.status === 'ordered') {
+    if (order.status === 'Pending') {
       return (
         <button
+          type="button"
           className={`${styles.actionBtn} ${styles.actionReceive}`}
-          onClick={() => openConfirm('received')}
+          onClick={() => openConfirm('Ordered')}
         >
-          Mark as Received
+          Mark as Ordered
         </button>
       );
     }
-    if (order.status === 'received') {
+
+    if (order.status === 'Ordered') {
       return (
         <button
-          className={`${styles.actionBtn} ${styles.actionStock}`}
-          onClick={() => openConfirm('stocked')}
+          type="button"
+          className={`${styles.actionBtn} ${styles.actionReceive}`}
+          onClick={() => openConfirm('Shipped')}
         >
-          Mark as Stocked
+          Mark as Shipped
         </button>
       );
     }
+
+    if (order.status === 'Shipped') {
+      return (
+        <button
+          type="button"
+          className={`${styles.actionBtn} ${styles.actionStock}`}
+          onClick={() => openConfirm('Delivered')}
+        >
+          Mark as Delivered
+        </button>
+      );
+    }
+
     return null;
   };
 
-  const confirmLabel = confirmTarget === 'received' ? 'Mark as Received' : 'Mark as Stocked';
-  const confirmMessage =
-    confirmTarget === 'received'
-      ? `Mark order ${order.orderNumber} as received? This confirms delivery has arrived.`
-      : `Mark order ${order.orderNumber} as stocked? This confirms items are shelved in inventory.`;
+  const confirmLabel = confirmTarget ? `Mark as ${confirmTarget}` : '';
+
+  const displayOrderId = order._id || 'N/A';
+
+  const confirmMessage = confirmTarget
+    ? `Mark order ${displayOrderId} as ${confirmTarget.toLowerCase()}?`
+    : '';
 
   return (
     <>
       <div className={`${styles.orderCard} ${darkMode ? styles.cardDark : ''}`}>
         <div className={styles.orderHeader}>
           <div className={styles.orderIdRow}>
-            <span className={styles.orderId}>{order.orderNumber}</span>
+            <span className={styles.orderId}>{order._id || 'N/A'}</span>
+
             <StatusBadge status={order.status} />
           </div>
-          <span className={styles.orderTotal}>${order.total.toFixed(2)}</span>
+
+          <span className={styles.orderTotal}>${Number(order.totalAmount || 0).toFixed(2)}</span>
         </div>
 
         <div className={styles.supplier}>
           <span role="img" aria-label="supplier">
             🏢
           </span>{' '}
-          {order.supplier}
+          {order.supplier || order.supplierId?.name || 'N/A'}
         </div>
 
         <div className={styles.orderMeta}>
           <div>
             <p className={styles.metaLabel}>Order Date</p>
-            <p className={styles.metaValue}>📅 {new Date(order.orderDate).toLocaleDateString()}</p>
-          </div>
-          <div>
-            <p className={styles.metaLabel}>Expected Delivery</p>
+
             <p className={styles.metaValue}>
-              🚚 {new Date(order.expectedDelivery).toLocaleDateString()}
+              📅 {order.orderDate ? new Date(order.orderDate).toLocaleDateString() : 'N/A'}
             </p>
           </div>
+
+          <div>
+            <p className={styles.metaLabel}>Expected Delivery</p>
+
+            <p className={styles.metaValue}>
+              🚚{' '}
+              {order.expectedDeliveryDate
+                ? new Date(order.expectedDeliveryDate).toLocaleDateString()
+                : 'N/A'}
+            </p>
+          </div>
+
           <div>
             <p className={styles.metaLabel}>Items</p>
-            <p className={styles.metaValue}>📦 {order.items.length} items</p>
+
+            <p className={styles.metaValue}>📦 {order.items?.length || 0} items</p>
           </div>
         </div>
 
         <div className={styles.itemsSection}>
           <p className={styles.itemsSectionTitle}>Order Items:</p>
-          {order.items.map(item => (
-            <div key={item.name} className={styles.itemRow}>
+
+          {order.items?.map((item, index) => (
+            <div key={item._id || item.itemName || index} className={styles.itemRow}>
               <div className={styles.itemInfo}>
                 <div className={styles.itemIcon}>✓</div>
+
                 <div>
-                  <div className={styles.itemName}>{item.name}</div>
+                  <div className={styles.itemName}>{item.itemName || 'Unnamed item'}</div>
+
                   <div className={styles.itemQty}>
-                    {item.quantity} {item.unit} × ${item.unitPrice.toFixed(2)}
+                    {item.quantity} × ${Number(item.pricePerItem || 0).toFixed(2)}
                   </div>
                 </div>
               </div>
-              <span className={styles.itemPrice}>${item.total.toFixed(2)}</span>
+
+              <span className={styles.itemPrice}>
+                ${(Number(item.quantity || 0) * Number(item.pricePerItem || 0)).toFixed(2)}
+              </span>
             </div>
           ))}
         </div>
 
-        {order.notes && (
-          <div className={styles.notesBanner}>
-            <span>📝</span> {order.notes}
-          </div>
-        )}
-
         <div className={styles.actions}>
           {getActionButton()}
+
           <button
+            type="button"
             className={`${styles.actionBtn} ${styles.actionView}`}
             onClick={() => setDetailsOpen(true)}
           >
@@ -229,23 +338,32 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
         </div>
       </div>
 
+      {/* Confirmation Modal */}
       <Modal
         isOpen={confirmOpen}
         toggle={() => setConfirmOpen(false)}
         className={darkMode ? styles.modalDark : ''}
       >
         <ModalHeader toggle={() => setConfirmOpen(false)}>Confirm Status Change</ModalHeader>
+
         <ModalBody>{confirmMessage}</ModalBody>
+
         <ModalFooter>
-          <button className={styles.btnModalSecondary} onClick={() => setConfirmOpen(false)}>
+          <button
+            type="button"
+            className={styles.btnModalSecondary}
+            onClick={() => setConfirmOpen(false)}
+          >
             Cancel
           </button>
-          <button className={styles.btnModalPrimary} onClick={handleConfirm}>
+
+          <button type="button" className={styles.btnModalPrimary} onClick={handleConfirm}>
             {confirmLabel}
           </button>
         </ModalFooter>
       </Modal>
 
+      {/* Details Modal */}
       <Modal
         isOpen={detailsOpen}
         toggle={() => setDetailsOpen(false)}
@@ -253,81 +371,107 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
         className={darkMode ? styles.modalDark : ''}
       >
         <ModalHeader toggle={() => setDetailsOpen(false)}>
-          Order Details — {order.orderNumber}
+          Order Details — {order._id || 'N/A'}
         </ModalHeader>
+
         <ModalBody>
           <div className={styles.detailSection}>
             <p className={styles.detailLabel}>Status</p>
+
             <StatusBadge status={order.status} />
           </div>
+
           <div className={styles.detailSection}>
             <p className={styles.detailLabel}>Supplier</p>
-            <p className={styles.detailValue}>{order.supplier}</p>
+
+            <p className={styles.detailValue}>
+              {order.supplier || order.supplierId?.name || 'N/A'}
+            </p>
           </div>
+
           <div className={styles.detailRow}>
             <div className={styles.detailSection}>
               <p className={styles.detailLabel}>Order Date</p>
-              <p className={styles.detailValue}>{new Date(order.orderDate).toLocaleDateString()}</p>
-            </div>
-            <div className={styles.detailSection}>
-              <p className={styles.detailLabel}>Expected Delivery</p>
+
               <p className={styles.detailValue}>
-                {new Date(order.expectedDelivery).toLocaleDateString()}
+                {order.orderDate ? new Date(order.orderDate).toLocaleDateString() : 'N/A'}
               </p>
             </div>
-            {order.deliveredDate && (
+
+            <div className={styles.detailSection}>
+              <p className={styles.detailLabel}>Expected Delivery</p>
+
+              <p className={styles.detailValue}>
+                {order.expectedDeliveryDate
+                  ? new Date(order.expectedDeliveryDate).toLocaleDateString()
+                  : 'N/A'}
+              </p>
+            </div>
+
+            {order.actualDeliveryDate && (
               <div className={styles.detailSection}>
                 <p className={styles.detailLabel}>Delivered On</p>
+
                 <p className={styles.detailValue}>
-                  {new Date(order.deliveredDate).toLocaleDateString()}
+                  {new Date(order.actualDeliveryDate).toLocaleDateString()}
                 </p>
               </div>
             )}
           </div>
 
           <div className={styles.detailItemsHeader}>Order Items</div>
+
           <div className={styles.detailTableWrap}>
             <table className={styles.detailTable}>
               <thead>
                 <tr>
                   <th>Item</th>
                   <th>Qty</th>
-                  <th>Unit</th>
                   <th>Unit Price</th>
                   <th>Total</th>
                 </tr>
               </thead>
+
               <tbody>
-                {order.items.map(item => (
-                  <tr key={item.name}>
-                    <td>{item.name}</td>
+                {order.items?.map((item, index) => (
+                  <tr key={item._id || item.itemName || index}>
+                    <td>{item.itemName || 'Unnamed item'}</td>
+
                     <td>{item.quantity}</td>
-                    <td>{item.unit}</td>
-                    <td>${item.unitPrice.toFixed(2)}</td>
-                    <td>${item.total.toFixed(2)}</td>
+
+                    <td>${Number(item.pricePerItem || 0).toFixed(2)}</td>
+
+                    <td>
+                      $
+                      {Number(Number(item.quantity || 0) * Number(item.pricePerItem || 0)).toFixed(
+                        2,
+                      )}
+                    </td>
                   </tr>
                 ))}
               </tbody>
+
               <tfoot>
                 <tr>
-                  <td colSpan="4" className={styles.detailTotalLabel}>
+                  <td colSpan="3" className={styles.detailTotalLabel}>
                     Order Total
                   </td>
-                  <td className={styles.detailTotalValue}>${order.total.toFixed(2)}</td>
+
+                  <td className={styles.detailTotalValue}>
+                    ${Number(order.totalAmount || 0).toFixed(2)}
+                  </td>
                 </tr>
               </tfoot>
             </table>
           </div>
-
-          {order.notes && (
-            <div className={styles.detailNotes}>
-              <p className={styles.detailLabel}>Notes</p>
-              <p className={styles.detailValue}>{order.notes}</p>
-            </div>
-          )}
         </ModalBody>
+
         <ModalFooter>
-          <button className={styles.btnModalSecondary} onClick={() => setDetailsOpen(false)}>
+          <button
+            type="button"
+            className={styles.btnModalSecondary}
+            onClick={() => setDetailsOpen(false)}
+          >
             Close
           </button>
         </ModalFooter>
@@ -336,42 +480,282 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
   );
 };
 
+const orderItemShape = PropTypes.shape({
+  _id: PropTypes.string,
+  itemName: PropTypes.string.isRequired,
+  quantity: PropTypes.number.isRequired,
+  pricePerItem: PropTypes.number.isRequired,
+});
+
+const supplierReferenceShape = PropTypes.shape({
+  _id: PropTypes.string,
+  name: PropTypes.string,
+});
+
+const orderShape = PropTypes.shape({
+  _id: PropTypes.string,
+  status: PropTypes.oneOf(['Pending', 'Ordered', 'Shipped', 'Delivered', 'Cancelled']).isRequired,
+  supplierId: PropTypes.oneOfType([PropTypes.string, supplierReferenceShape]).isRequired,
+  orderDate: PropTypes.string,
+  expectedDeliveryDate: PropTypes.string,
+  actualDeliveryDate: PropTypes.string,
+  totalAmount: PropTypes.number,
+  items: PropTypes.arrayOf(orderItemShape),
+});
+
+OrderCard.propTypes = {
+  order: orderShape.isRequired,
+  onStatusChange: PropTypes.func.isRequired,
+  darkMode: PropTypes.bool.isRequired,
+};
+
+/* -------------------------------------------------------------------------- */
+/*                              NEW SUPPLIER MODAL                            */
+/* -------------------------------------------------------------------------- */
+
+const NewSupplierModal = ({ isOpen, onClose, onSubmit, darkMode }) => {
+  const [name, setName] = useState('');
+  const [contact, setContact] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [website, setWebsite] = useState('');
+  const [specialties, setSpecialties] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setName('');
+    setContact('');
+    setEmail('');
+    setPhone('');
+    setWebsite('');
+    setSpecialties('');
+  }, [isOpen]);
+
+  const handleSubmit = () => {
+    if (!name.trim() || !email.trim() || !phone.trim()) {
+      toast.error('Please fill in all required fields.');
+      return;
+    }
+
+    const supplierData = {
+      name: name.trim(),
+      contact: contact.trim(),
+      email: email.trim(),
+      phone: phone.trim(),
+      specialities: specialties
+        .split(',')
+        .map(item => item.trim())
+        .filter(Boolean),
+      website: website.trim(),
+      isActive: true,
+    };
+
+    onSubmit(supplierData);
+
+    setName('');
+    setContact('');
+    setEmail('');
+    setPhone('');
+    setWebsite('');
+    setSpecialties('');
+  };
+
+  return (
+    <Modal isOpen={isOpen} toggle={onClose} size="lg" className={darkMode ? styles.modalDark : ''}>
+      <ModalHeader toggle={onClose}>Add New Supplier</ModalHeader>
+
+      <ModalBody>
+        <div className={styles.formGroup}>
+          <label className={styles.label} htmlFor="supplierName">
+            Supplier Name <span className={styles.required}>*</span>
+          </label>
+
+          <input
+            id="supplierName"
+            type="text"
+            className={styles.input}
+            placeholder="Enter supplier name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </div>
+
+        <div className={styles.formRow}>
+          <div className={styles.formGroup}>
+            <label className={styles.label} htmlFor="supplierContact">
+              Contact Person
+            </label>
+
+            <input
+              id="supplierContact"
+              type="text"
+              className={styles.input}
+              placeholder="Contact name"
+              value={contact}
+              onChange={e => setContact(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className={styles.formRow}>
+          <div className={styles.formGroup}>
+            <label className={styles.label} htmlFor="supplierEmail">
+              Email
+            </label>
+
+            <input
+              id="supplierEmail"
+              type="email"
+              className={styles.input}
+              placeholder="supplier@example.com"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+            />
+          </div>
+
+          <div className={styles.formGroup}>
+            <label className={styles.label} htmlFor="supplierPhone">
+              Phone
+            </label>
+
+            <input
+              id="supplierPhone"
+              type="tel"
+              className={styles.input}
+              placeholder="Phone number"
+              value={phone}
+              onChange={e => setPhone(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className={styles.formGroup}>
+          <label className={styles.label} htmlFor="supplierWebsite">
+            Website
+          </label>
+
+          <input
+            id="supplierWebsite"
+            type="url"
+            className={styles.input}
+            placeholder="https://example.com"
+            value={website}
+            onChange={e => setWebsite(e.target.value)}
+          />
+        </div>
+
+        <div className={styles.formGroup}>
+          <label className={styles.label} htmlFor="supplierSpecialties">
+            Specialties
+          </label>
+
+          <input
+            id="supplierSpecialties"
+            type="text"
+            className={styles.input}
+            placeholder="Produce, Organic, Local"
+            value={specialties}
+            onChange={e => setSpecialties(e.target.value)}
+          />
+
+          <small>Separate multiple specialties with commas.</small>
+        </div>
+      </ModalBody>
+
+      <ModalFooter>
+        <button type="button" className={styles.btnModalSecondary} onClick={onClose}>
+          Cancel
+        </button>
+
+        <button type="button" className={styles.btnModalPrimary} onClick={handleSubmit}>
+          <FiPlus size={15} />
+          Add Supplier
+        </button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+NewSupplierModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  darkMode: PropTypes.bool.isRequired,
+};
+
+/* -------------------------------------------------------------------------- */
+/*                             NEW ORDER MODAL                                */
+/* -------------------------------------------------------------------------- */
+
 const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, darkMode }) => {
   const [supplierId, setSupplierId] = useState('');
+
   const [orderDate, setOrderDate] = useState('');
+
   const [deliveryDate, setDeliveryDate] = useState('');
-  const [notes, setNotes] = useState('');
+
   const [items, setItems] = useState([
-    { id: 1, name: '', quantity: '', unit: 'lbs', unitPrice: '' },
+    {
+      id: 1,
+      name: '',
+      quantity: '',
+      unit: 'lbs',
+      unitPrice: '',
+    },
   ]);
 
-  const today = new Date().toISOString().split('T')[0];
+  const getToday = () => new Date().toISOString().split('T')[0];
+
+  const today = getToday();
 
   useEffect(() => {
     if (isOpen) {
-      setOrderDate(today);
+      setOrderDate(getToday());
       setDeliveryDate('');
     }
-  }, [isOpen, today]);
+  }, [isOpen]);
 
   const handleOrderDateChange = value => {
     setOrderDate(value);
+
     if (deliveryDate && value && deliveryDate <= value) {
       setDeliveryDate('');
     }
   };
 
   const handleItemChange = (itemId, field, value) => {
-    setItems(items.map(item => (item.id === itemId ? { ...item, [field]: value } : item)));
+    setItems(currentItems =>
+      currentItems.map(item =>
+        item.id === itemId
+          ? {
+              ...item,
+              [field]: value,
+            }
+          : item,
+      ),
+    );
   };
 
   const addItem = () => {
-    setItems([...items, { id: Date.now(), name: '', quantity: '', unit: 'lbs', unitPrice: '' }]);
+    setItems(currentItems => [
+      ...currentItems,
+      {
+        id: Date.now(),
+        name: '',
+        quantity: '',
+        unit: 'lbs',
+        unitPrice: '',
+      },
+    ]);
   };
 
   const removeItem = itemId => {
-    if (items.length <= 1) return;
-    setItems(items.filter(item => item.id !== itemId));
+    if (items.length <= 1) {
+      return;
+    }
+
+    setItems(currentItems => currentItems.filter(item => item.id !== itemId));
   };
 
   const handleSubmit = () => {
@@ -379,53 +763,62 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
       toast.error('Please fill in all required fields.');
       return;
     }
+
     if (orderDate < today) {
       toast.error('Order date cannot be in the past.');
       return;
     }
+
     if (deliveryDate <= orderDate) {
       toast.error('Expected delivery must be after the order date.');
       return;
     }
-    const supplier = supplierList.find(s => s._id === supplierId);
-    const validItems = items.filter(i => i.name && i.quantity && i.unitPrice);
+
+    const validItems = items.filter(
+      item => item.name.trim() && Number(item.quantity) >= 1 && Number(item.unitPrice) >= 0,
+    );
+
     if (validItems.length === 0) {
       toast.error('Add at least one valid item.');
       return;
     }
 
-    const computed = validItems.map(item => ({
-      ...item,
-      quantity: Number(item.quantity),
-      unitPrice: Number(item.unitPrice),
-      total: Number(item.quantity) * Number(item.unitPrice),
-    }));
-
     onSubmit({
       supplierId,
-      supplier: supplier?.name || '',
+      status: 'Pending',
       orderDate: new Date(orderDate).toISOString(),
-      expectedDelivery: new Date(deliveryDate).toISOString(),
-      items: computed,
-      total: computed.reduce((sum, i) => sum + i.total, 0),
-      notes,
+      expectedDeliveryDate: new Date(deliveryDate).toISOString(),
+      items: validItems.map(item => ({
+        itemName: item.name.trim(),
+        quantity: Number(item.quantity),
+        pricePerItem: Number(item.unitPrice),
+      })),
     });
 
     setSupplierId('');
     setOrderDate(today);
     setDeliveryDate('');
-    setNotes('');
-    setItems([{ id: 1, name: '', quantity: '', unit: 'lbs', unitPrice: '' }]);
+    setItems([
+      {
+        id: 1,
+        name: '',
+        quantity: '',
+        unit: 'lbs',
+        unitPrice: '',
+      },
+    ]);
   };
 
   return (
     <Modal isOpen={isOpen} toggle={onClose} size="lg" className={darkMode ? styles.modalDark : ''}>
       <ModalHeader toggle={onClose}>New Purchase Order</ModalHeader>
+
       <ModalBody>
         <div className={styles.formGroup}>
           <label className={styles.label} htmlFor="supplier">
             Supplier <span className={styles.required}>*</span>
           </label>
+
           <select
             id="supplier"
             className={styles.select}
@@ -433,12 +826,19 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
             onChange={e => setSupplierId(e.target.value)}
           >
             <option value="">Select a supplier…</option>
-            {supplierList.map(s => (
-              <option key={s._id} value={s._id}>
-                {s.name} ({s.category})
+
+            {supplierList.map(supplier => (
+              <option key={supplier._id} value={supplier._id}>
+                {supplier.name}
               </option>
             ))}
           </select>
+
+          {supplierList.length === 0 && (
+            <small>
+              No suppliers are available. Create a supplier first from the Suppliers tab.
+            </small>
+          )}
         </div>
 
         <div className={styles.formRow}>
@@ -446,6 +846,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
             <label className={styles.label} htmlFor="orderDate">
               Order Date <span className={styles.required}>*</span>
             </label>
+
             <input
               id="orderDate"
               type="date"
@@ -455,10 +856,12 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
               onChange={e => handleOrderDateChange(e.target.value)}
             />
           </div>
+
           <div className={styles.formGroup}>
             <label className={styles.label} htmlFor="deliveryDate">
               Expected Delivery <span className={styles.required}>*</span>
             </label>
+
             <input
               id="deliveryDate"
               type="date"
@@ -474,13 +877,19 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
         <p className={styles.label}>
           Order Items <span className={styles.required}>*</span>
         </p>
+
         <div className={styles.itemsFormHeader}>
           <span className={styles.itemFormColName}>Item Name</span>
+
           <span className={styles.itemFormColSm}>Qty</span>
+
           <span className={styles.itemFormColSm}>Unit</span>
+
           <span className={styles.itemFormColSm}>Unit Price</span>
+
           <span />
         </div>
+
         {items.map(item => (
           <div key={item.id} className={styles.itemFormRow}>
             <input
@@ -489,6 +898,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
               value={item.name}
               onChange={e => handleItemChange(item.id, 'name', e.target.value)}
             />
+
             <input
               className={`${styles.input} ${styles.itemFormColSm}`}
               type="number"
@@ -498,20 +908,29 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
               value={item.quantity}
               onChange={e => handleItemChange(item.id, 'quantity', e.target.value)}
             />
+
             <select
               className={`${styles.select} ${styles.itemFormColSm}`}
               value={item.unit}
               onChange={e => handleItemChange(item.id, 'unit', e.target.value)}
             >
               <option value="lbs">lbs</option>
+
               <option value="kg">kg</option>
+
               <option value="bottles">bottles</option>
+
               <option value="dozen">dozen</option>
+
               <option value="bunches">bunches</option>
+
               <option value="gallons">gallons</option>
+
               <option value="containers">containers</option>
+
               <option value="pcs">pcs</option>
             </select>
+
             <input
               className={`${styles.input} ${styles.itemFormColSm}`}
               type="number"
@@ -521,39 +940,30 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
               value={item.unitPrice}
               onChange={e => handleItemChange(item.id, 'unitPrice', e.target.value)}
             />
+
             <button
               type="button"
               className={styles.removeItemBtn}
               onClick={() => removeItem(item.id)}
               disabled={items.length <= 1}
+              aria-label="Remove item"
             >
               ✕
             </button>
           </div>
         ))}
+
         <button type="button" className={styles.addItemBtn} onClick={addItem}>
           + Add Item
         </button>
-
-        <div className={styles.formGroup}>
-          <label className={styles.label} htmlFor="notes">
-            Notes
-          </label>
-          <textarea
-            id="notes"
-            className={styles.textarea}
-            rows="2"
-            placeholder="Optional notes…"
-            value={notes}
-            onChange={e => setNotes(e.target.value)}
-          />
-        </div>
       </ModalBody>
+
       <ModalFooter>
-        <button className={styles.btnModalSecondary} onClick={onClose}>
+        <button type="button" className={styles.btnModalSecondary} onClick={onClose}>
           Cancel
         </button>
-        <button className={styles.btnModalPrimary} onClick={handleSubmit}>
+
+        <button type="button" className={styles.btnModalPrimary} onClick={handleSubmit}>
           Create Order
         </button>
       </ModalFooter>
@@ -561,47 +971,63 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
   );
 };
 
-const orderItemShape = PropTypes.shape({
-  name: PropTypes.string,
-  quantity: PropTypes.string,
-  unitPrice: PropTypes.number,
-  total: PropTypes.number,
-});
-
-const orderShape = PropTypes.shape({
-  id: PropTypes.string,
-  status: PropTypes.string,
-  supplier: PropTypes.string,
-  orderDate: PropTypes.string,
-  expectedDelivery: PropTypes.string,
-  itemCount: PropTypes.number,
-  total: PropTypes.number,
-  urgent: PropTypes.string,
-  items: PropTypes.arrayOf(orderItemShape),
-});
-
-OrderCard.propTypes = {
-  order: orderShape,
-  onStatusChange: PropTypes.func,
+NewOrderModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  suppliers: PropTypes.arrayOf(
+    PropTypes.shape({
+      _id: PropTypes.string,
+      name: PropTypes.string,
+    }),
+  ).isRequired,
+  darkMode: PropTypes.bool.isRequired,
 };
+
+/* -------------------------------------------------------------------------- */
+/*                              ORDERS PAGE                                   */
+/* -------------------------------------------------------------------------- */
 
 function OrdersPage() {
   const darkMode = useSelector(state => state.theme?.darkMode ?? false);
 
   const [orders, setOrders] = useState([]);
+
   const [supplierList, setSupplierList] = useState([]);
+
   const [activeTab, setActiveTab] = useState('purchase-orders');
+
   const [searchQuery, setSearchQuery] = useState('');
+
   const [currentPage, setCurrentPage] = useState(1);
+
   const [loading, setLoading] = useState(true);
+
   const [newOrderOpen, setNewOrderOpen] = useState(false);
+
+  const [newSupplierOpen, setNewSupplierOpen] = useState(false);
 
   const loadOrders = useCallback(async () => {
     try {
       setLoading(true);
+
       const [orderRes, supplierRes] = await Promise.all([fetchOrders(), fetchSuppliers()]);
-      setOrders(orderRes.data);
-      setSupplierList(supplierRes.data);
+
+      console.log('orderRes:', orderRes);
+
+      console.log('orderRes.data:', orderRes.data);
+
+      console.log('Is orders array:', Array.isArray(orderRes.data));
+
+      console.log('supplierRes:', supplierRes);
+
+      console.log('supplierRes.data:', supplierRes.data);
+
+      console.log('Is suppliers array:', Array.isArray(supplierRes.data));
+
+      setOrders(Array.isArray(orderRes.data) ? orderRes.data : []);
+
+      setSupplierList(Array.isArray(supplierRes.data) ? supplierRes.data : []);
     } catch {
       toast.error('Failed to load orders.');
     } finally {
@@ -616,7 +1042,18 @@ function OrdersPage() {
   const handleStatusChange = async (orderId, newStatus) => {
     try {
       await updateOrderStatus(orderId, newStatus);
-      setOrders(prev => prev.map(o => (o._id === orderId ? { ...o, status: newStatus } : o)));
+
+      setOrders(prev =>
+        prev.map(order =>
+          order._id === orderId
+            ? {
+                ...order,
+                status: newStatus,
+              }
+            : order,
+        ),
+      );
+
       toast.success(`Order marked as ${newStatus}.`);
     } catch {
       toast.error('Failed to update order status.');
@@ -626,11 +1063,35 @@ function OrdersPage() {
   const handleCreateOrder = async orderData => {
     try {
       await createOrder(orderData);
+
       toast.success('Purchase order created.');
+
       setNewOrderOpen(false);
-      loadOrders();
+
+      await loadOrders();
     } catch {
       toast.error('Failed to create order.');
+    }
+  };
+
+  const handleCreateSupplier = async supplierData => {
+    try {
+      await createSupplier(supplierData);
+
+      toast.success('Supplier created successfully.');
+
+      setNewSupplierOpen(false);
+
+      /*
+       * Reload both orders and suppliers
+       * so the newly-created supplier
+       * immediately appears in the
+       * Suppliers tab and New Order
+       * dropdown.
+       */
+      await loadOrders();
+    } catch {
+      toast.error('Failed to create supplier.');
     }
   };
 
@@ -640,27 +1101,64 @@ function OrdersPage() {
     );
   };
 
-  const pendingCount = orders.filter(o => o.status === 'ordered').length;
-  const awaitingStock = orders.filter(o => o.status === 'received').length;
-  const monthlySpend = orders.reduce((sum, o) => sum + o.total, 0);
+  const pendingCount = orders.filter(
+    order => order.status === 'Pending' || order.status === 'Ordered',
+  ).length;
 
-  const filteredOrders = orders.filter(
-    order =>
-      order.orderNumber.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      order.supplier.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      order.items.some(i => i.name.toLowerCase().includes(searchQuery.toLowerCase())),
-  );
+  const awaitingStock = orders.filter(order => order.status === 'Delivered').length;
+
+  const now = new Date();
+
+  const monthlySpend = orders
+    .filter(order => {
+      const orderDate = new Date(order.orderDate);
+
+      return (
+        orderDate.getMonth() === now.getMonth() && orderDate.getFullYear() === now.getFullYear()
+      );
+    })
+    .reduce((sum, order) => sum + Number(order.totalAmount || 0), 0);
+
+  const filteredOrders = orders.filter(order => {
+    const query = searchQuery.trim().toLowerCase();
+
+    if (!query) {
+      return true;
+    }
+
+    const orderId = order._id?.toLowerCase() || '';
+
+    const supplierName = order.supplierId?.name?.toLowerCase() || '';
+
+    const itemMatches = order.items?.some(item => {
+      const itemName = item.itemName?.toLowerCase() || '';
+
+      return itemName.includes(query);
+    });
+
+    return orderId.includes(query) || supplierName.includes(query) || itemMatches;
+  });
 
   const sortedOrders = [...filteredOrders].sort((a, b) => {
-    const statusOrder = { ordered: 0, received: 1, stocked: 2 };
+    const statusOrder = {
+      Pending: 0,
+      Ordered: 1,
+      Shipped: 2,
+      Delivered: 3,
+      Cancelled: 4,
+    };
+
     if (statusOrder[a.status] !== statusOrder[b.status]) {
       return statusOrder[a.status] - statusOrder[b.status];
     }
+
     return new Date(b.orderDate) - new Date(a.orderDate);
   });
 
   const totalPages = Math.max(1, Math.ceil(sortedOrders.length / ORDERS_PER_PAGE));
+
   const safePage = Math.min(currentPage, totalPages);
+
   const paginatedOrders = sortedOrders.slice(
     (safePage - 1) * ORDERS_PER_PAGE,
     safePage * ORDERS_PER_PAGE,
@@ -672,10 +1170,12 @@ function OrdersPage() {
     if (loading) {
       return (
         <div className={`${styles.orderCard} ${styles.emptyState}`}>
-          <div className={styles.spinner} /> Loading orders…
+          <div className={styles.spinner} />
+          Loading orders…
         </div>
       );
     }
+
     if (paginatedOrders.length === 0) {
       return (
         <div className={`${styles.orderCard} ${styles.emptyState}`}>
@@ -683,6 +1183,7 @@ function OrdersPage() {
         </div>
       );
     }
+
     return (
       <>
         {paginatedOrders.map(order => (
@@ -697,14 +1198,22 @@ function OrdersPage() {
         {totalPages > 1 && (
           <div className={styles.pagination}>
             <button
+              type="button"
               className={styles.pageBtn}
               disabled={safePage <= 1}
-              onClick={() => setCurrentPage(p => p - 1)}
+              onClick={() => setCurrentPage(page => page - 1)}
             >
               <FiChevronLeft size={16} />
             </button>
-            {Array.from({ length: totalPages }, (_, i) => i + 1).map(page => (
+
+            {Array.from(
+              {
+                length: totalPages,
+              },
+              (_, i) => i + 1,
+            ).map(page => (
               <button
+                type="button"
                 key={page}
                 className={`${styles.pageBtn} ${page === safePage ? styles.pageBtnActive : ''}`}
                 onClick={() => setCurrentPage(page)}
@@ -712,10 +1221,12 @@ function OrdersPage() {
                 {page}
               </button>
             ))}
+
             <button
+              type="button"
               className={styles.pageBtn}
               disabled={safePage >= totalPages}
-              onClick={() => setCurrentPage(p => p + 1)}
+              onClick={() => setCurrentPage(page => page + 1)}
             >
               <FiChevronRight size={16} />
             </button>
@@ -729,6 +1240,7 @@ function OrdersPage() {
     <div className={containerClass}>
       <main className={styles.main}>
         <h1 className={styles.pageTitle}>Ordering & Procurement</h1>
+
         <p className={styles.pageSubtitle}>
           Manage purchase orders, supplier relationships, and procurement budget
         </p>
@@ -740,18 +1252,21 @@ function OrdersPage() {
             bgColor={darkMode ? '#3d2c00' : '#fff3e0'}
             icon="🕐"
           />
+
           <StatCard
             label="Awaiting Stock"
             value={awaitingStock}
             bgColor={darkMode ? '#1b4332' : '#e8f5e9'}
             icon="📦"
           />
+
           <StatCard
             label="Monthly Spend"
             value={`$${monthlySpend.toFixed(2)}`}
             bgColor={darkMode ? '#0d3b66' : '#e3f2fd'}
             icon="💰"
           />
+
           <StatCard
             label="Surplus Savings"
             value="$306"
@@ -762,11 +1277,21 @@ function OrdersPage() {
 
         <div className={styles.tabs}>
           {[
-            { id: 'purchase-orders', label: '📋 Purchase Orders' },
-            { id: 'suppliers', label: '🏢 Suppliers' },
-            { id: 'surplus', label: '↗️ Surplus Opportunities' },
+            {
+              id: 'purchase-orders',
+              label: '📋 Purchase Orders',
+            },
+            {
+              id: 'suppliers',
+              label: '🏢 Suppliers',
+            },
+            {
+              id: 'surplus',
+              label: '↗️ Surplus Opportunities',
+            },
           ].map(tab => (
             <button
+              type="button"
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
               className={`${styles.tab} ${activeTab === tab.id ? styles.tabActive : ''}`}
@@ -776,11 +1301,16 @@ function OrdersPage() {
           ))}
         </div>
 
+        {/* ---------------------------------------------------------------- */}
+        {/*                         PURCHASE ORDERS                          */}
+        {/* ---------------------------------------------------------------- */}
+
         {activeTab === 'purchase-orders' && (
           <>
             <div className={styles.toolbar}>
               <div className={styles.searchWrapper}>
                 <FiSearch className={styles.searchIcon} size={16} />
+
                 <input
                   type="text"
                   placeholder="Search by order #, supplier, or item…"
@@ -792,10 +1322,17 @@ function OrdersPage() {
                   className={`${styles.searchInput} ${darkMode ? styles.searchInputDark : ''}`}
                 />
               </div>
-              <button className={styles.btnPrimary} onClick={() => setNewOrderOpen(true)}>
-                <FiPlus size={16} /> New Order
+
+              <button
+                type="button"
+                className={styles.btnPrimary}
+                onClick={() => setNewOrderOpen(true)}
+              >
+                <FiPlus size={16} />
+                New Order
               </button>
-              <button className={styles.btnSecondary} onClick={handleAutoGenerate}>
+
+              <button type="button" className={styles.btnSecondary} onClick={handleAutoGenerate}>
                 🔄 Auto-Generate from Shortages
               </button>
             </div>
@@ -804,48 +1341,237 @@ function OrdersPage() {
           </>
         )}
 
+        {/* ---------------------------------------------------------------- */}
+        {/*                             SUPPLIERS                            */}
+        {/* ---------------------------------------------------------------- */}
+
         {activeTab === 'suppliers' && (
-          <div>
-            {supplierList.length > 0 ? (
-              supplierList.map(supplier => (
-                <div
-                  key={supplier._id}
-                  className={`${styles.orderCard} ${darkMode ? styles.cardDark : ''}`}
+          <section className={styles.suppliersSection} aria-labelledby="suppliers-heading">
+            <div className={styles.suppliersHeader}>
+              <div>
+                <h2 id="suppliers-heading" className={styles.sectionTitle}>
+                  Suppliers
+                </h2>
+
+                <p className={styles.sectionSubtitle}>
+                  Manage your suppliers and supplier information
+                </p>
+              </div>
+
+              <div className={styles.suppliersHeaderActions}>
+                <span className={styles.supplierCount}>
+                  {supplierList.length} {supplierList.length === 1 ? 'Supplier' : 'Suppliers'}
+                </span>
+
+                <button
+                  type="button"
+                  className={styles.btnPrimary}
+                  onClick={() => setNewSupplierOpen(true)}
                 >
-                  <div className={styles.supplierCardHeader}>
-                    <div className={styles.supplierCardName}>
-                      <span role="img" aria-label="supplier">
-                        🏢
-                      </span>{' '}
-                      {supplier.name}
-                    </div>
-                    {supplier.trusted && <span className={styles.trustedBadge}>Trusted</span>}
-                  </div>
-                  <div className={styles.supplierCardGrid}>
-                    <div className={styles.supplierCardField}>
-                      <p className={styles.metaLabel}>Category</p>
-                      <p className={styles.metaValue}>{supplier.category}</p>
-                    </div>
-                    <div className={styles.supplierCardField}>
-                      <p className={styles.metaLabel}>Contact</p>
-                      <p className={styles.metaValue}>{supplier.contact}</p>
-                    </div>
-                    <div className={styles.supplierCardField}>
-                      <p className={styles.metaLabel}>Phone</p>
-                      <p className={styles.metaValue}>{supplier.phone}</p>
-                    </div>
-                    <div className={styles.supplierCardField}>
-                      <p className={styles.metaLabel}>Email</p>
-                      <p className={styles.metaValue}>{supplier.email}</p>
-                    </div>
-                  </div>
-                </div>
-              ))
+                  <FiPlus size={16} />
+                  Add Supplier
+                </button>
+              </div>
+            </div>
+
+            {supplierList.length > 0 ? (
+              <div className={styles.supplierGrid}>
+                {supplierList.map(supplier => {
+                  const specialties = Array.isArray(supplier.specialities)
+                    ? supplier.specialities
+                    : [];
+
+                  const avgDeliveryDays =
+                    supplier.avgDeliveryDays ?? supplier.averageDeliveryDays ?? 'N/A';
+
+                  const totalOrders = supplier.totalOrders ?? supplier.orderCount ?? 0;
+
+                  const websiteUrl = supplier.websiteUrl || supplier.website || supplier.url;
+
+                  return (
+                    <article
+                      key={supplier._id}
+                      className={`${styles.supplierCard} ${darkMode ? styles.cardDark : ''}`}
+                    >
+                      <div className={styles.supplierCardHeader}>
+                        <div className={styles.supplierIdentity}>
+                          <div className={styles.supplierIcon} aria-hidden="true">
+                            🏢
+                          </div>
+
+                          <div>
+                            <h3 className={styles.supplierCardName}>{supplier.name}</h3>
+                          </div>
+                        </div>
+
+                        {supplier.trusted && <span className={styles.trustedBadge}>Trusted</span>}
+                      </div>
+
+                      <div className={styles.supplierDetails}>
+                        <div className={styles.supplierDetail}>
+                          <span className={styles.detailIcon} aria-hidden="true">
+                            👤
+                          </span>
+
+                          <div>
+                            <p className={styles.supplierDetailLabel}>Contact</p>
+
+                            <p className={styles.supplierDetailValue}>
+                              {supplier.contact || 'N/A'}
+                            </p>
+                          </div>
+                        </div>
+
+                        <div className={styles.supplierDetail}>
+                          <span className={styles.detailIcon} aria-hidden="true">
+                            ✉
+                          </span>
+
+                          <div>
+                            <p className={styles.supplierDetailLabel}>Email</p>
+
+                            <p className={styles.supplierDetailValue}>{supplier.email || 'N/A'}</p>
+                          </div>
+                        </div>
+
+                        <div className={styles.supplierDetail}>
+                          <span className={styles.detailIcon} aria-hidden="true">
+                            ☎
+                          </span>
+
+                          <div>
+                            <p className={styles.supplierDetailLabel}>Phone</p>
+
+                            <p className={styles.supplierDetailValue}>{supplier.phone || 'N/A'}</p>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className={styles.supplierStats}>
+                        <div className={styles.supplierStat}>
+                          <span className={styles.supplierStatIcon} aria-hidden="true">
+                            🚚
+                          </span>
+
+                          <div>
+                            <p className={styles.supplierStatLabel}>Avg Delivery</p>
+
+                            <p className={styles.supplierStatValue}>
+                              {avgDeliveryDays === 'N/A'
+                                ? 'N/A'
+                                : `${avgDeliveryDays} ${
+                                    Number(avgDeliveryDays) === 1 ? 'day' : 'days'
+                                  }`}
+                            </p>
+                          </div>
+                        </div>
+
+                        <div className={styles.supplierStat}>
+                          <span className={styles.supplierStatIcon} aria-hidden="true">
+                            📦
+                          </span>
+
+                          <div>
+                            <p className={styles.supplierStatLabel}>Total Orders</p>
+
+                            <p className={styles.supplierStatValue}>{totalOrders}</p>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className={styles.specialtiesSection}>
+                        <p className={styles.specialtiesLabel}>Specialties</p>
+
+                        {specialties.length > 0 ? (
+                          <div className={styles.specialtiesList}>
+                            {specialties.map((specialty, index) => (
+                              <span key={`${specialty}-${index}`} className={styles.specialtyTag}>
+                                {specialty}
+                              </span>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className={styles.noSpecialties}>No specialties listed</span>
+                        )}
+                      </div>
+
+                      <div className={styles.supplierActions}>
+                        <button
+                          type="button"
+                          className={`${styles.supplierActionBtn} ${styles.pricingBtn}`}
+                          onClick={() =>
+                            toast.info(
+                              `Pricing history for ${supplier.name} will be available soon.`,
+                            )
+                          }
+                        >
+                          View Pricing History
+                        </button>
+
+                        <button
+                          type="button"
+                          className={`${styles.supplierActionBtn} ${styles.editSupplierBtn}`}
+                          onClick={() =>
+                            toast.info(
+                              `Edit supplier information for ${supplier.name} will be available soon.`,
+                            )
+                          }
+                        >
+                          Edit Supplier Info
+                        </button>
+
+                        <button
+                          type="button"
+                          className={`${styles.supplierActionBtn} ${styles.newOrderBtn}`}
+                          onClick={() => {
+                            setActiveTab('purchase-orders');
+
+                            setNewOrderOpen(true);
+                          }}
+                        >
+                          <FiPlus size={15} />
+                          New Order
+                        </button>
+
+                        {websiteUrl && (
+                          <a
+                            href={websiteUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={styles.supplierWebsiteLink}
+                          >
+                            Visit Website
+                          </a>
+                        )}
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
             ) : (
-              <div className={`${styles.orderCard} ${styles.emptyState}`}>No suppliers found.</div>
+              <div className={`${styles.orderCard} ${styles.emptyState}`}>
+                <span className={styles.emptyStateIcon} aria-hidden="true">
+                  🏢
+                </span>
+
+                <p>No suppliers found.</p>
+
+                <button
+                  type="button"
+                  className={styles.btnPrimary}
+                  onClick={() => setNewSupplierOpen(true)}
+                >
+                  <FiPlus size={16} />
+                  Add Your First Supplier
+                </button>
+              </div>
             )}
-          </div>
+          </section>
         )}
+
+        {/* ---------------------------------------------------------------- */}
+        {/*                             SURPLUS                              */}
+        {/* ---------------------------------------------------------------- */}
 
         {activeTab === 'surplus' && (
           <div className={`${styles.orderCard} ${styles.emptyState}`}>
@@ -859,6 +1585,13 @@ function OrdersPage() {
         onClose={() => setNewOrderOpen(false)}
         onSubmit={handleCreateOrder}
         suppliers={supplierList}
+        darkMode={darkMode}
+      />
+
+      <NewSupplierModal
+        isOpen={newSupplierOpen}
+        onClose={() => setNewSupplierOpen(false)}
+        onSubmit={handleCreateSupplier}
         darkMode={darkMode}
       />
     </div>

--- a/src/components/KitchenInventory/Orders/OrdersPage.jsx
+++ b/src/components/KitchenInventory/Orders/OrdersPage.jsx
@@ -11,6 +11,7 @@ import {
   updateOrderStatus,
   fetchSuppliers,
   createSupplier,
+  updateSupplier,
 } from './ordersApi';
 
 import styles from './OrdersPage.module.css';
@@ -28,9 +29,7 @@ function Modal({ isOpen, toggle, size, className, children }) {
     if (!isOpen) return undefined;
 
     const handleEscape = e => {
-      if (e.key === 'Escape') {
-        toggle();
-      }
+      if (e.key === 'Escape') toggle();
     };
 
     document.addEventListener('keydown', handleEscape);
@@ -45,9 +44,7 @@ function Modal({ isOpen, toggle, size, className, children }) {
   if (!isOpen) return null;
 
   const handleOverlayClick = e => {
-    if (e.target === overlayRef.current) {
-      toggle();
-    }
+    if (e.target === overlayRef.current) toggle();
   };
 
   const handleOverlayKeyDown = e => {
@@ -60,12 +57,12 @@ function Modal({ isOpen, toggle, size, className, children }) {
   const sizeClass = size === 'lg' ? styles.modalLg : '';
 
   return createPortal(
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       className={styles.modalOverlay}
       ref={overlayRef}
       onClick={handleOverlayClick}
       onKeyDown={handleOverlayKeyDown}
+      role="presentation"
     >
       <div className={`${styles.modalContent} ${sizeClass} ${className || ''}`}>{children}</div>
     </div>,
@@ -89,7 +86,6 @@ function ModalHeader({ toggle, children }) {
   return (
     <div className={styles.modalHeader}>
       <h3 className={styles.modalTitle}>{children}</h3>
-
       <button type="button" className={styles.modalClose} onClick={toggle} aria-label="Close modal">
         &times;
       </button>
@@ -131,26 +127,16 @@ ModalFooter.propTypes = {
 /* -------------------------------------------------------------------------- */
 
 const badgeClassForStatus = status => {
-  if (status === 'Pending') {
-    return styles.badgeOrdered;
-  }
-
-  if (status === 'Ordered' || status === 'Shipped') {
-    return styles.badgeReceived;
-  }
-
+  if (status === 'Pending') return styles.badgeOrdered;
+  if (status === 'Ordered' || status === 'Shipped') return styles.badgeReceived;
   return styles.badgeStocked;
 };
 
-const StatusBadge = ({ status }) => {
-  const cls = badgeClassForStatus(status);
-
-  return (
-    <span className={`${styles.badge} ${cls}`}>
-      {status.charAt(0).toUpperCase() + status.slice(1)}
-    </span>
-  );
-};
+const StatusBadge = ({ status }) => (
+  <span className={`${styles.badge} ${badgeClassForStatus(status)}`}>
+    {status.charAt(0).toUpperCase() + status.slice(1)}
+  </span>
+);
 
 StatusBadge.propTypes = {
   status: PropTypes.string.isRequired,
@@ -164,10 +150,8 @@ const StatCard = ({ label, value, bgColor, icon }) => (
   <div className={styles.statCard}>
     <div>
       <p className={styles.statLabel}>{label}</p>
-
       <p className={styles.statValue}>{value}</p>
     </div>
-
     <div className={styles.statIcon} style={{ '--stat-bg': bgColor }}>
       {icon}
     </div>
@@ -187,16 +171,11 @@ StatCard.propTypes = {
 
 const OrderCard = ({ order, onStatusChange, darkMode }) => {
   const [confirmOpen, setConfirmOpen] = useState(false);
-
   const [confirmTarget, setConfirmTarget] = useState(null);
-
   const [detailsOpen, setDetailsOpen] = useState(false);
 
   const handleConfirm = () => {
-    if (confirmTarget) {
-      onStatusChange(order._id, confirmTarget);
-    }
-
+    if (confirmTarget) onStatusChange(order._id, confirmTarget);
     setConfirmOpen(false);
     setConfirmTarget(null);
   };
@@ -247,23 +226,24 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
   };
 
   const confirmLabel = confirmTarget ? `Mark as ${confirmTarget}` : '';
-
   const displayOrderId = order._id || 'N/A';
-
   const confirmMessage = confirmTarget
     ? `Mark order ${displayOrderId} as ${confirmTarget.toLowerCase()}?`
     : '';
+
+  const supplierName =
+    order.supplier ||
+    (typeof order.supplierId === 'object' ? order.supplierId?.name : null) ||
+    'N/A';
 
   return (
     <>
       <div className={`${styles.orderCard} ${darkMode ? styles.cardDark : ''}`}>
         <div className={styles.orderHeader}>
           <div className={styles.orderIdRow}>
-            <span className={styles.orderId}>{order._id || 'N/A'}</span>
-
+            <span className={styles.orderId}>{displayOrderId}</span>
             <StatusBadge status={order.status} />
           </div>
-
           <span className={styles.orderTotal}>${Number(order.totalAmount || 0).toFixed(2)}</span>
         </div>
 
@@ -271,13 +251,12 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
           <span role="img" aria-label="supplier">
             🏢
           </span>{' '}
-          {order.supplier || order.supplierId?.name || 'N/A'}
+          {supplierName}
         </div>
 
         <div className={styles.orderMeta}>
           <div>
             <p className={styles.metaLabel}>Order Date</p>
-
             <p className={styles.metaValue}>
               📅 {order.orderDate ? new Date(order.orderDate).toLocaleDateString() : 'N/A'}
             </p>
@@ -285,7 +264,6 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
 
           <div>
             <p className={styles.metaLabel}>Expected Delivery</p>
-
             <p className={styles.metaValue}>
               🚚{' '}
               {order.expectedDeliveryDate
@@ -296,7 +274,6 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
 
           <div>
             <p className={styles.metaLabel}>Items</p>
-
             <p className={styles.metaValue}>📦 {order.items?.length || 0} items</p>
           </div>
         </div>
@@ -308,10 +285,8 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
             <div key={item._id || item.itemName || index} className={styles.itemRow}>
               <div className={styles.itemInfo}>
                 <div className={styles.itemIcon}>✓</div>
-
                 <div>
                   <div className={styles.itemName}>{item.itemName || 'Unnamed item'}</div>
-
                   <div className={styles.itemQty}>
                     {item.quantity} × ${Number(item.pricePerItem || 0).toFixed(2)}
                   </div>
@@ -338,7 +313,6 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
         </div>
       </div>
 
-      {/* Confirmation Modal */}
       <Modal
         isOpen={confirmOpen}
         toggle={() => setConfirmOpen(false)}
@@ -363,7 +337,6 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
         </ModalFooter>
       </Modal>
 
-      {/* Details Modal */}
       <Modal
         isOpen={detailsOpen}
         toggle={() => setDetailsOpen(false)}
@@ -371,28 +344,23 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
         className={darkMode ? styles.modalDark : ''}
       >
         <ModalHeader toggle={() => setDetailsOpen(false)}>
-          Order Details — {order._id || 'N/A'}
+          Order Details — {displayOrderId}
         </ModalHeader>
 
         <ModalBody>
           <div className={styles.detailSection}>
             <p className={styles.detailLabel}>Status</p>
-
             <StatusBadge status={order.status} />
           </div>
 
           <div className={styles.detailSection}>
             <p className={styles.detailLabel}>Supplier</p>
-
-            <p className={styles.detailValue}>
-              {order.supplier || order.supplierId?.name || 'N/A'}
-            </p>
+            <p className={styles.detailValue}>{supplierName}</p>
           </div>
 
           <div className={styles.detailRow}>
             <div className={styles.detailSection}>
               <p className={styles.detailLabel}>Order Date</p>
-
               <p className={styles.detailValue}>
                 {order.orderDate ? new Date(order.orderDate).toLocaleDateString() : 'N/A'}
               </p>
@@ -400,7 +368,6 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
 
             <div className={styles.detailSection}>
               <p className={styles.detailLabel}>Expected Delivery</p>
-
               <p className={styles.detailValue}>
                 {order.expectedDeliveryDate
                   ? new Date(order.expectedDeliveryDate).toLocaleDateString()
@@ -411,7 +378,6 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
             {order.actualDeliveryDate && (
               <div className={styles.detailSection}>
                 <p className={styles.detailLabel}>Delivered On</p>
-
                 <p className={styles.detailValue}>
                   {new Date(order.actualDeliveryDate).toLocaleDateString()}
                 </p>
@@ -436,16 +402,10 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
                 {order.items?.map((item, index) => (
                   <tr key={item._id || item.itemName || index}>
                     <td>{item.itemName || 'Unnamed item'}</td>
-
                     <td>{item.quantity}</td>
-
                     <td>${Number(item.pricePerItem || 0).toFixed(2)}</td>
-
                     <td>
-                      $
-                      {Number(Number(item.quantity || 0) * Number(item.pricePerItem || 0)).toFixed(
-                        2,
-                      )}
+                      ${(Number(item.quantity || 0) * Number(item.pricePerItem || 0)).toFixed(2)}
                     </td>
                   </tr>
                 ))}
@@ -456,7 +416,6 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
                   <td colSpan="3" className={styles.detailTotalLabel}>
                     Order Total
                   </td>
-
                   <td className={styles.detailTotalValue}>
                     ${Number(order.totalAmount || 0).toFixed(2)}
                   </td>
@@ -496,6 +455,7 @@ const orderShape = PropTypes.shape({
   _id: PropTypes.string,
   status: PropTypes.oneOf(['Pending', 'Ordered', 'Shipped', 'Delivered', 'Cancelled']).isRequired,
   supplierId: PropTypes.oneOfType([PropTypes.string, supplierReferenceShape]).isRequired,
+  supplier: PropTypes.string,
   orderDate: PropTypes.string,
   expectedDeliveryDate: PropTypes.string,
   actualDeliveryDate: PropTypes.string,
@@ -510,10 +470,18 @@ OrderCard.propTypes = {
 };
 
 /* -------------------------------------------------------------------------- */
-/*                              NEW SUPPLIER MODAL                            */
+/*                           SUPPLIER FORM MODAL                              */
 /* -------------------------------------------------------------------------- */
 
-const NewSupplierModal = ({ isOpen, onClose, onSubmit, darkMode }) => {
+const SupplierFormModal = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  darkMode,
+  supplier,
+  title,
+  submitLabel,
+}) => {
   const [name, setName] = useState('');
   const [contact, setContact] = useState('');
   const [email, setEmail] = useState('');
@@ -524,13 +492,13 @@ const NewSupplierModal = ({ isOpen, onClose, onSubmit, darkMode }) => {
   useEffect(() => {
     if (!isOpen) return;
 
-    setName('');
-    setContact('');
-    setEmail('');
-    setPhone('');
-    setWebsite('');
-    setSpecialties('');
-  }, [isOpen]);
+    setName(supplier?.name || '');
+    setContact(supplier?.contact || '');
+    setEmail(supplier?.email || '');
+    setPhone(supplier?.phone || '');
+    setWebsite(supplier?.websiteUrl || supplier?.website || supplier?.url || '');
+    setSpecialties(Array.isArray(supplier?.specialities) ? supplier.specialities.join(', ') : '');
+  }, [isOpen, supplier]);
 
   const handleSubmit = () => {
     if (!name.trim() || !email.trim() || !phone.trim()) {
@@ -538,7 +506,7 @@ const NewSupplierModal = ({ isOpen, onClose, onSubmit, darkMode }) => {
       return;
     }
 
-    const supplierData = {
+    onSubmit({
       name: name.trim(),
       contact: contact.trim(),
       email: email.trim(),
@@ -548,29 +516,19 @@ const NewSupplierModal = ({ isOpen, onClose, onSubmit, darkMode }) => {
         .map(item => item.trim())
         .filter(Boolean),
       website: website.trim(),
-      isActive: true,
-    };
-
-    onSubmit(supplierData);
-
-    setName('');
-    setContact('');
-    setEmail('');
-    setPhone('');
-    setWebsite('');
-    setSpecialties('');
+      isActive: supplier?.isActive ?? true,
+    });
   };
 
   return (
     <Modal isOpen={isOpen} toggle={onClose} size="lg" className={darkMode ? styles.modalDark : ''}>
-      <ModalHeader toggle={onClose}>Add New Supplier</ModalHeader>
+      <ModalHeader toggle={onClose}>{title}</ModalHeader>
 
       <ModalBody>
         <div className={styles.formGroup}>
           <label className={styles.label} htmlFor="supplierName">
             Supplier Name <span className={styles.required}>*</span>
           </label>
-
           <input
             id="supplierName"
             type="text"
@@ -581,29 +539,25 @@ const NewSupplierModal = ({ isOpen, onClose, onSubmit, darkMode }) => {
           />
         </div>
 
-        <div className={styles.formRow}>
-          <div className={styles.formGroup}>
-            <label className={styles.label} htmlFor="supplierContact">
-              Contact Person
-            </label>
-
-            <input
-              id="supplierContact"
-              type="text"
-              className={styles.input}
-              placeholder="Contact name"
-              value={contact}
-              onChange={e => setContact(e.target.value)}
-            />
-          </div>
+        <div className={styles.formGroup}>
+          <label className={styles.label} htmlFor="supplierContact">
+            Contact Person
+          </label>
+          <input
+            id="supplierContact"
+            type="text"
+            className={styles.input}
+            placeholder="Contact name"
+            value={contact}
+            onChange={e => setContact(e.target.value)}
+          />
         </div>
 
         <div className={styles.formRow}>
           <div className={styles.formGroup}>
             <label className={styles.label} htmlFor="supplierEmail">
-              Email
+              Email <span className={styles.required}>*</span>
             </label>
-
             <input
               id="supplierEmail"
               type="email"
@@ -616,9 +570,8 @@ const NewSupplierModal = ({ isOpen, onClose, onSubmit, darkMode }) => {
 
           <div className={styles.formGroup}>
             <label className={styles.label} htmlFor="supplierPhone">
-              Phone
+              Phone <span className={styles.required}>*</span>
             </label>
-
             <input
               id="supplierPhone"
               type="tel"
@@ -634,7 +587,6 @@ const NewSupplierModal = ({ isOpen, onClose, onSubmit, darkMode }) => {
           <label className={styles.label} htmlFor="supplierWebsite">
             Website
           </label>
-
           <input
             id="supplierWebsite"
             type="url"
@@ -649,7 +601,6 @@ const NewSupplierModal = ({ isOpen, onClose, onSubmit, darkMode }) => {
           <label className={styles.label} htmlFor="supplierSpecialties">
             Specialties
           </label>
-
           <input
             id="supplierSpecialties"
             type="text"
@@ -658,7 +609,6 @@ const NewSupplierModal = ({ isOpen, onClose, onSubmit, darkMode }) => {
             value={specialties}
             onChange={e => setSpecialties(e.target.value)}
           />
-
           <small>Separate multiple specialties with commas.</small>
         </div>
       </ModalBody>
@@ -667,21 +617,34 @@ const NewSupplierModal = ({ isOpen, onClose, onSubmit, darkMode }) => {
         <button type="button" className={styles.btnModalSecondary} onClick={onClose}>
           Cancel
         </button>
-
         <button type="button" className={styles.btnModalPrimary} onClick={handleSubmit}>
           <FiPlus size={15} />
-          Add Supplier
+          {submitLabel}
         </button>
       </ModalFooter>
     </Modal>
   );
 };
 
-NewSupplierModal.propTypes = {
+SupplierFormModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   darkMode: PropTypes.bool.isRequired,
+  supplier: PropTypes.shape({
+    _id: PropTypes.string,
+    name: PropTypes.string,
+    contact: PropTypes.string,
+    email: PropTypes.string,
+    phone: PropTypes.string,
+    website: PropTypes.string,
+    websiteUrl: PropTypes.string,
+    url: PropTypes.string,
+    specialities: PropTypes.arrayOf(PropTypes.string),
+    isActive: PropTypes.bool,
+  }),
+  title: PropTypes.string.isRequired,
+  submitLabel: PropTypes.string.isRequired,
 };
 
 /* -------------------------------------------------------------------------- */
@@ -690,29 +653,21 @@ NewSupplierModal.propTypes = {
 
 const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, darkMode }) => {
   const [supplierId, setSupplierId] = useState('');
-
   const [orderDate, setOrderDate] = useState('');
-
   const [deliveryDate, setDeliveryDate] = useState('');
-
   const [items, setItems] = useState([
-    {
-      id: 1,
-      name: '',
-      quantity: '',
-      unit: 'lbs',
-      unitPrice: '',
-    },
+    { id: 1, name: '', quantity: '', unit: 'lbs', unitPrice: '' },
   ]);
 
   const getToday = () => new Date().toISOString().split('T')[0];
-
   const today = getToday();
 
   useEffect(() => {
     if (isOpen) {
+      setSupplierId('');
       setOrderDate(getToday());
       setDeliveryDate('');
+      setItems([{ id: Date.now(), name: '', quantity: '', unit: 'lbs', unitPrice: '' }]);
     }
   }, [isOpen]);
 
@@ -726,14 +681,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
 
   const handleItemChange = (itemId, field, value) => {
     setItems(currentItems =>
-      currentItems.map(item =>
-        item.id === itemId
-          ? {
-              ...item,
-              [field]: value,
-            }
-          : item,
-      ),
+      currentItems.map(item => (item.id === itemId ? { ...item, [field]: value } : item)),
     );
   };
 
@@ -741,7 +689,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
     setItems(currentItems => [
       ...currentItems,
       {
-        id: Date.now(),
+        id: Date.now() + Math.random(),
         name: '',
         quantity: '',
         unit: 'lbs',
@@ -751,10 +699,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
   };
 
   const removeItem = itemId => {
-    if (items.length <= 1) {
-      return;
-    }
-
+    if (items.length <= 1) return;
     setItems(currentItems => currentItems.filter(item => item.id !== itemId));
   };
 
@@ -786,27 +731,14 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
     onSubmit({
       supplierId,
       status: 'Pending',
-      orderDate: new Date(orderDate).toISOString(),
-      expectedDeliveryDate: new Date(deliveryDate).toISOString(),
+      orderDate: new Date(`${orderDate}T00:00:00`).toISOString(),
+      expectedDeliveryDate: new Date(`${deliveryDate}T00:00:00`).toISOString(),
       items: validItems.map(item => ({
         itemName: item.name.trim(),
         quantity: Number(item.quantity),
         pricePerItem: Number(item.unitPrice),
       })),
     });
-
-    setSupplierId('');
-    setOrderDate(today);
-    setDeliveryDate('');
-    setItems([
-      {
-        id: 1,
-        name: '',
-        quantity: '',
-        unit: 'lbs',
-        unitPrice: '',
-      },
-    ]);
   };
 
   return (
@@ -826,7 +758,6 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
             onChange={e => setSupplierId(e.target.value)}
           >
             <option value="">Select a supplier…</option>
-
             {supplierList.map(supplier => (
               <option key={supplier._id} value={supplier._id}>
                 {supplier.name}
@@ -846,7 +777,6 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
             <label className={styles.label} htmlFor="orderDate">
               Order Date <span className={styles.required}>*</span>
             </label>
-
             <input
               id="orderDate"
               type="date"
@@ -861,13 +791,12 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
             <label className={styles.label} htmlFor="deliveryDate">
               Expected Delivery <span className={styles.required}>*</span>
             </label>
-
             <input
               id="deliveryDate"
               type="date"
               className={styles.input}
               value={deliveryDate}
-              min={orderDate || today}
+              min={orderDate ? orderDate : today}
               disabled={!orderDate}
               onChange={e => setDeliveryDate(e.target.value)}
             />
@@ -880,13 +809,9 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
 
         <div className={styles.itemsFormHeader}>
           <span className={styles.itemFormColName}>Item Name</span>
-
           <span className={styles.itemFormColSm}>Qty</span>
-
           <span className={styles.itemFormColSm}>Unit</span>
-
           <span className={styles.itemFormColSm}>Unit Price</span>
-
           <span />
         </div>
 
@@ -902,7 +827,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
             <input
               className={`${styles.input} ${styles.itemFormColSm}`}
               type="number"
-              min="0"
+              min="1"
               step="1"
               placeholder="Qty"
               value={item.quantity}
@@ -915,19 +840,12 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
               onChange={e => handleItemChange(item.id, 'unit', e.target.value)}
             >
               <option value="lbs">lbs</option>
-
               <option value="kg">kg</option>
-
               <option value="bottles">bottles</option>
-
               <option value="dozen">dozen</option>
-
               <option value="bunches">bunches</option>
-
               <option value="gallons">gallons</option>
-
               <option value="containers">containers</option>
-
               <option value="pcs">pcs</option>
             </select>
 
@@ -962,7 +880,6 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
         <button type="button" className={styles.btnModalSecondary} onClick={onClose}>
           Cancel
         </button>
-
         <button type="button" className={styles.btnModalPrimary} onClick={handleSubmit}>
           Create Order
         </button>
@@ -992,20 +909,15 @@ function OrdersPage() {
   const darkMode = useSelector(state => state.theme?.darkMode ?? false);
 
   const [orders, setOrders] = useState([]);
-
   const [supplierList, setSupplierList] = useState([]);
-
   const [activeTab, setActiveTab] = useState('purchase-orders');
-
   const [searchQuery, setSearchQuery] = useState('');
-
   const [currentPage, setCurrentPage] = useState(1);
-
   const [loading, setLoading] = useState(true);
-
   const [newOrderOpen, setNewOrderOpen] = useState(false);
-
   const [newSupplierOpen, setNewSupplierOpen] = useState(false);
+  const [editSupplierOpen, setEditSupplierOpen] = useState(false);
+  const [editingSupplier, setEditingSupplier] = useState(null);
 
   const loadOrders = useCallback(async () => {
     try {
@@ -1013,22 +925,10 @@ function OrdersPage() {
 
       const [orderRes, supplierRes] = await Promise.all([fetchOrders(), fetchSuppliers()]);
 
-      console.log('orderRes:', orderRes);
-
-      console.log('orderRes.data:', orderRes.data);
-
-      console.log('Is orders array:', Array.isArray(orderRes.data));
-
-      console.log('supplierRes:', supplierRes);
-
-      console.log('supplierRes.data:', supplierRes.data);
-
-      console.log('Is suppliers array:', Array.isArray(supplierRes.data));
-
       setOrders(Array.isArray(orderRes.data) ? orderRes.data : []);
-
       setSupplierList(Array.isArray(supplierRes.data) ? supplierRes.data : []);
-    } catch {
+    } catch (error) {
+      console.error('Failed to load orders/suppliers:', error);
       toast.error('Failed to load orders.');
     } finally {
       setLoading(false);
@@ -1044,32 +944,32 @@ function OrdersPage() {
       await updateOrderStatus(orderId, newStatus);
 
       setOrders(prev =>
-        prev.map(order =>
-          order._id === orderId
-            ? {
-                ...order,
-                status: newStatus,
-              }
-            : order,
-        ),
+        prev.map(order => (order._id === orderId ? { ...order, status: newStatus } : order)),
       );
 
       toast.success(`Order marked as ${newStatus}.`);
-    } catch {
+    } catch (error) {
+      console.error('Failed to update order status:', error);
       toast.error('Failed to update order status.');
     }
   };
 
   const handleCreateOrder = async orderData => {
     try {
+      /*
+       * The supplier's Total Orders value is derived from the orders returned
+       * by the API. After creating an order we reload both resources so the
+       * supplier card immediately reflects the new order count.
+       */
       await createOrder(orderData);
 
       toast.success('Purchase order created.');
-
       setNewOrderOpen(false);
 
+      setCurrentPage(1);
       await loadOrders();
-    } catch {
+    } catch (error) {
+      console.error('Failed to create order:', error);
       toast.error('Failed to create order.');
     }
   };
@@ -1079,19 +979,29 @@ function OrdersPage() {
       await createSupplier(supplierData);
 
       toast.success('Supplier created successfully.');
-
       setNewSupplierOpen(false);
 
-      /*
-       * Reload both orders and suppliers
-       * so the newly-created supplier
-       * immediately appears in the
-       * Suppliers tab and New Order
-       * dropdown.
-       */
       await loadOrders();
-    } catch {
+    } catch (error) {
+      console.error('Failed to create supplier:', error);
       toast.error('Failed to create supplier.');
+    }
+  };
+
+  const handleUpdateSupplier = async supplierData => {
+    if (!editingSupplier?._id) return;
+
+    try {
+      await updateSupplier(editingSupplier._id, supplierData);
+
+      toast.success('Supplier updated successfully.');
+      setEditSupplierOpen(false);
+      setEditingSupplier(null);
+
+      await loadOrders();
+    } catch (error) {
+      console.error('Error updating supplier:', error);
+      toast.error('Failed to update supplier.');
     }
   };
 
@@ -1100,6 +1010,22 @@ function OrdersPage() {
       'Auto-generate from shortages will be available once the inventory module is connected.',
     );
   };
+
+  /*
+   * Calculate supplier order counts from the actual orders collection.
+   * This prevents the Suppliers tab from becoming stale when the backend
+   * supplier document does not yet contain a totalOrders/orderCount field.
+   */
+  const supplierOrderCounts = orders.reduce((counts, order) => {
+    const supplierId =
+      typeof order.supplierId === 'object' ? order.supplierId?._id : order.supplierId;
+
+    if (supplierId) {
+      counts[supplierId] = (counts[supplierId] || 0) + 1;
+    }
+
+    return counts;
+  }, {});
 
   const pendingCount = orders.filter(
     order => order.status === 'Pending' || order.status === 'Ordered',
@@ -1122,19 +1048,18 @@ function OrdersPage() {
   const filteredOrders = orders.filter(order => {
     const query = searchQuery.trim().toLowerCase();
 
-    if (!query) {
-      return true;
-    }
+    if (!query) return true;
 
     const orderId = order._id?.toLowerCase() || '';
 
-    const supplierName = order.supplierId?.name?.toLowerCase() || '';
+    const supplierName =
+      order.supplier?.toLowerCase() ||
+      (typeof order.supplierId === 'object' ? order.supplierId?.name?.toLowerCase() : '') ||
+      '';
 
-    const itemMatches = order.items?.some(item => {
-      const itemName = item.itemName?.toLowerCase() || '';
-
-      return itemName.includes(query);
-    });
+    const itemMatches = order.items?.some(item =>
+      (item.itemName?.toLowerCase() || '').includes(query),
+    );
 
     return orderId.includes(query) || supplierName.includes(query) || itemMatches;
   });
@@ -1156,7 +1081,6 @@ function OrdersPage() {
   });
 
   const totalPages = Math.max(1, Math.ceil(sortedOrders.length / ORDERS_PER_PAGE));
-
   const safePage = Math.min(currentPage, totalPages);
 
   const paginatedOrders = sortedOrders.slice(
@@ -1206,12 +1130,7 @@ function OrdersPage() {
               <FiChevronLeft size={16} />
             </button>
 
-            {Array.from(
-              {
-                length: totalPages,
-              },
-              (_, i) => i + 1,
-            ).map(page => (
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map(page => (
               <button
                 type="button"
                 key={page}
@@ -1277,18 +1196,9 @@ function OrdersPage() {
 
         <div className={styles.tabs}>
           {[
-            {
-              id: 'purchase-orders',
-              label: '📋 Purchase Orders',
-            },
-            {
-              id: 'suppliers',
-              label: '🏢 Suppliers',
-            },
-            {
-              id: 'surplus',
-              label: '↗️ Surplus Opportunities',
-            },
+            { id: 'purchase-orders', label: '📋 Purchase Orders' },
+            { id: 'suppliers', label: '🏢 Suppliers' },
+            { id: 'surplus', label: '↗️ Surplus Opportunities' },
           ].map(tab => (
             <button
               type="button"
@@ -1300,10 +1210,6 @@ function OrdersPage() {
             </button>
           ))}
         </div>
-
-        {/* ---------------------------------------------------------------- */}
-        {/*                         PURCHASE ORDERS                          */}
-        {/* ---------------------------------------------------------------- */}
 
         {activeTab === 'purchase-orders' && (
           <>
@@ -1340,10 +1246,6 @@ function OrdersPage() {
             {renderOrdersContent()}
           </>
         )}
-
-        {/* ---------------------------------------------------------------- */}
-        {/*                             SUPPLIERS                            */}
-        {/* ---------------------------------------------------------------- */}
 
         {activeTab === 'suppliers' && (
           <section className={styles.suppliersSection} aria-labelledby="suppliers-heading">
@@ -1384,7 +1286,28 @@ function OrdersPage() {
                   const avgDeliveryDays =
                     supplier.avgDeliveryDays ?? supplier.averageDeliveryDays ?? 'N/A';
 
-                  const totalOrders = supplier.totalOrders ?? supplier.orderCount ?? 0;
+                  /*
+                   * IMPORTANT:
+                   * Use the count from the orders currently loaded instead of
+                   * relying only on supplier.totalOrders/orderCount.
+                   *
+                   * Therefore:
+                   * Supplier A = 2 existing orders
+                   * Create another order for Supplier A
+                   * -> loadOrders()
+                   * -> supplierOrderCounts[A] = 3
+                   * -> Total Orders immediately shows 3
+                   */
+                  const backendTotalOrders = supplier.totalOrders ?? supplier.orderCount;
+
+                  const calculatedTotalOrders = supplierOrderCounts[supplier._id] ?? 0;
+
+                  const totalOrders = Object.prototype.hasOwnProperty.call(
+                    supplierOrderCounts,
+                    supplier._id,
+                  )
+                    ? calculatedTotalOrders
+                    : backendTotalOrders ?? 0;
 
                   const websiteUrl = supplier.websiteUrl || supplier.website || supplier.url;
 
@@ -1412,10 +1335,8 @@ function OrdersPage() {
                           <span className={styles.detailIcon} aria-hidden="true">
                             👤
                           </span>
-
                           <div>
                             <p className={styles.supplierDetailLabel}>Contact</p>
-
                             <p className={styles.supplierDetailValue}>
                               {supplier.contact || 'N/A'}
                             </p>
@@ -1426,10 +1347,8 @@ function OrdersPage() {
                           <span className={styles.detailIcon} aria-hidden="true">
                             ✉
                           </span>
-
                           <div>
                             <p className={styles.supplierDetailLabel}>Email</p>
-
                             <p className={styles.supplierDetailValue}>{supplier.email || 'N/A'}</p>
                           </div>
                         </div>
@@ -1438,10 +1357,8 @@ function OrdersPage() {
                           <span className={styles.detailIcon} aria-hidden="true">
                             ☎
                           </span>
-
                           <div>
                             <p className={styles.supplierDetailLabel}>Phone</p>
-
                             <p className={styles.supplierDetailValue}>{supplier.phone || 'N/A'}</p>
                           </div>
                         </div>
@@ -1452,10 +1369,8 @@ function OrdersPage() {
                           <span className={styles.supplierStatIcon} aria-hidden="true">
                             🚚
                           </span>
-
                           <div>
                             <p className={styles.supplierStatLabel}>Avg Delivery</p>
-
                             <p className={styles.supplierStatValue}>
                               {avgDeliveryDays === 'N/A'
                                 ? 'N/A'
@@ -1470,10 +1385,8 @@ function OrdersPage() {
                           <span className={styles.supplierStatIcon} aria-hidden="true">
                             📦
                           </span>
-
                           <div>
                             <p className={styles.supplierStatLabel}>Total Orders</p>
-
                             <p className={styles.supplierStatValue}>{totalOrders}</p>
                           </div>
                         </div>
@@ -1511,26 +1424,12 @@ function OrdersPage() {
                         <button
                           type="button"
                           className={`${styles.supplierActionBtn} ${styles.editSupplierBtn}`}
-                          onClick={() =>
-                            toast.info(
-                              `Edit supplier information for ${supplier.name} will be available soon.`,
-                            )
-                          }
-                        >
-                          Edit Supplier Info
-                        </button>
-
-                        <button
-                          type="button"
-                          className={`${styles.supplierActionBtn} ${styles.newOrderBtn}`}
                           onClick={() => {
-                            setActiveTab('purchase-orders');
-
-                            setNewOrderOpen(true);
+                            setEditingSupplier(supplier);
+                            setEditSupplierOpen(true);
                           }}
                         >
-                          <FiPlus size={15} />
-                          New Order
+                          Edit Supplier Info
                         </button>
 
                         {websiteUrl && (
@@ -1538,9 +1437,10 @@ function OrdersPage() {
                             href={websiteUrl}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className={styles.supplierWebsiteLink}
+                            className={`${styles.supplierActionBtn} ${styles.newOrderBtn}`}
                           >
-                            Visit Website
+                            <FiPlus size={15} />
+                            New Order
                           </a>
                         )}
                       </div>
@@ -1569,10 +1469,6 @@ function OrdersPage() {
           </section>
         )}
 
-        {/* ---------------------------------------------------------------- */}
-        {/*                             SURPLUS                              */}
-        {/* ---------------------------------------------------------------- */}
-
         {activeTab === 'surplus' && (
           <div className={`${styles.orderCard} ${styles.emptyState}`}>
             Surplus Opportunities section — Coming soon
@@ -1588,11 +1484,26 @@ function OrdersPage() {
         darkMode={darkMode}
       />
 
-      <NewSupplierModal
+      <SupplierFormModal
         isOpen={newSupplierOpen}
         onClose={() => setNewSupplierOpen(false)}
         onSubmit={handleCreateSupplier}
         darkMode={darkMode}
+        title="Add New Supplier"
+        submitLabel="Add Supplier"
+      />
+
+      <SupplierFormModal
+        isOpen={editSupplierOpen}
+        onClose={() => {
+          setEditSupplierOpen(false);
+          setEditingSupplier(null);
+        }}
+        onSubmit={handleUpdateSupplier}
+        darkMode={darkMode}
+        supplier={editingSupplier}
+        title="Edit Supplier Information"
+        submitLabel="Save Changes"
       />
     </div>
   );

--- a/src/components/KitchenInventory/Orders/OrdersPage.jsx
+++ b/src/components/KitchenInventory/Orders/OrdersPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { createPortal } from 'react-dom';
@@ -23,8 +23,6 @@ const ORDERS_PER_PAGE = 5;
 /* -------------------------------------------------------------------------- */
 
 function Modal({ isOpen, toggle, size, className, children }) {
-  const overlayRef = useRef(null);
-
   useEffect(() => {
     if (!isOpen) return undefined;
 
@@ -43,24 +41,10 @@ function Modal({ isOpen, toggle, size, className, children }) {
 
   if (!isOpen) return null;
 
-  const handleOverlayClick = e => {
-    if (e.target === overlayRef.current) toggle();
-  };
-
   const sizeClass = size === 'lg' ? styles.modalLg : '';
 
   return createPortal(
-    <div
-      className={styles.modalOverlay}
-      ref={overlayRef}
-      onClick={handleOverlayClick}
-      onKeyDown={e => {
-        if (e.key === 'Escape') {
-          toggle();
-        }
-      }}
-      role="presentation"
-    >
+    <div className={styles.modalOverlay}>
       <div className={`${styles.modalContent} ${sizeClass} ${className || ''}`}>{children}</div>
     </div>,
     document.body,
@@ -1275,13 +1259,27 @@ function OrdersPage() {
                     ? supplier.specialities
                     : [];
 
-                  const avgDeliveryDays =
-                    supplier.avgDeliveryDays ?? supplier.averageDeliveryDays ?? 'N/A';
+                  let avgDeliveryDays = supplier.avgDeliveryDays;
 
-                  const avgDeliveryDisplay =
-                    avgDeliveryDays === 'N/A'
-                      ? 'N/A'
-                      : `${avgDeliveryDays} ${Number(avgDeliveryDays) === 1 ? 'day' : 'days'}`;
+                  if (avgDeliveryDays == null) {
+                    avgDeliveryDays = supplier.averageDeliveryDays;
+                  }
+
+                  if (avgDeliveryDays == null) {
+                    avgDeliveryDays = 'N/A';
+                  }
+
+                  let avgDeliveryDisplay = 'N/A';
+
+                  if (avgDeliveryDays !== 'N/A') {
+                    let unit = 'days';
+
+                    if (Number(avgDeliveryDays) === 1) {
+                      unit = 'day';
+                    }
+
+                    avgDeliveryDisplay = `${avgDeliveryDays} ${unit}`;
+                  }
 
                   /*
                    * IMPORTANT:

--- a/src/components/KitchenInventory/Orders/OrdersPage.jsx
+++ b/src/components/KitchenInventory/Orders/OrdersPage.jsx
@@ -18,6 +18,11 @@ import styles from './OrdersPage.module.css';
 
 const ORDERS_PER_PAGE = 5;
 
+// Maximum values allowed for order items.
+// These values should match the corresponding server-side validation.
+const MAX_QUANTITY = 10000;
+const MAX_UNIT_PRICE = 100000;
+
 /* -------------------------------------------------------------------------- */
 /*                                   MODAL                                    */
 /* -------------------------------------------------------------------------- */
@@ -133,6 +138,7 @@ const StatCard = ({ label, value, bgColor, icon }) => (
       <p className={styles.statLabel}>{label}</p>
       <p className={styles.statValue}>{value}</p>
     </div>
+
     <div className={styles.statIcon} style={{ '--stat-bg': bgColor }}>
       {icon}
     </div>
@@ -157,6 +163,7 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
 
   const handleConfirm = () => {
     if (confirmTarget) onStatusChange(order._id, confirmTarget);
+
     setConfirmOpen(false);
     setConfirmTarget(null);
   };
@@ -207,7 +214,9 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
   };
 
   const confirmLabel = confirmTarget ? `Mark as ${confirmTarget}` : '';
+
   const displayOrderId = order._id || 'N/A';
+
   const confirmMessage = confirmTarget
     ? `Mark order ${displayOrderId} as ${confirmTarget.toLowerCase()}?`
     : '';
@@ -225,6 +234,7 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
             <span className={styles.orderId}>{displayOrderId}</span>
             <StatusBadge status={order.status} />
           </div>
+
           <span className={styles.orderTotal}>${Number(order.totalAmount || 0).toFixed(2)}</span>
         </div>
 
@@ -266,8 +276,10 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
             <div key={item._id || item.itemName || index} className={styles.itemRow}>
               <div className={styles.itemInfo}>
                 <div className={styles.itemIcon}>✓</div>
+
                 <div>
                   <div className={styles.itemName}>{item.itemName || 'Unnamed item'}</div>
+
                   <div className={styles.itemQty}>
                     {item.quantity} × ${Number(item.pricePerItem || 0).toFixed(2)}
                   </div>
@@ -342,6 +354,7 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
           <div className={styles.detailRow}>
             <div className={styles.detailSection}>
               <p className={styles.detailLabel}>Order Date</p>
+
               <p className={styles.detailValue}>
                 {order.orderDate ? new Date(order.orderDate).toLocaleDateString() : 'N/A'}
               </p>
@@ -349,6 +362,7 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
 
             <div className={styles.detailSection}>
               <p className={styles.detailLabel}>Expected Delivery</p>
+
               <p className={styles.detailValue}>
                 {order.expectedDeliveryDate
                   ? new Date(order.expectedDeliveryDate).toLocaleDateString()
@@ -359,6 +373,7 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
             {order.actualDeliveryDate && (
               <div className={styles.detailSection}>
                 <p className={styles.detailLabel}>Delivered On</p>
+
                 <p className={styles.detailValue}>
                   {new Date(order.actualDeliveryDate).toLocaleDateString()}
                 </p>
@@ -397,6 +412,7 @@ const OrderCard = ({ order, onStatusChange, darkMode }) => {
                   <td colSpan="3" className={styles.detailTotalLabel}>
                     Order Total
                   </td>
+
                   <td className={styles.detailTotalValue}>
                     ${Number(order.totalAmount || 0).toFixed(2)}
                   </td>
@@ -478,6 +494,7 @@ const SupplierFormModal = ({
     setEmail(supplier?.email || '');
     setPhone(supplier?.phone || '');
     setWebsite(supplier?.websiteUrl || supplier?.website || supplier?.url || '');
+
     setSpecialties(Array.isArray(supplier?.specialities) ? supplier.specialities.join(', ') : '');
   }, [isOpen, supplier]);
 
@@ -510,6 +527,7 @@ const SupplierFormModal = ({
           <label className={styles.label} htmlFor="supplierName">
             Supplier Name <span className={styles.required}>*</span>
           </label>
+
           <input
             id="supplierName"
             type="text"
@@ -524,6 +542,7 @@ const SupplierFormModal = ({
           <label className={styles.label} htmlFor="supplierContact">
             Contact Person
           </label>
+
           <input
             id="supplierContact"
             type="text"
@@ -539,6 +558,7 @@ const SupplierFormModal = ({
             <label className={styles.label} htmlFor="supplierEmail">
               Email <span className={styles.required}>*</span>
             </label>
+
             <input
               id="supplierEmail"
               type="email"
@@ -553,6 +573,7 @@ const SupplierFormModal = ({
             <label className={styles.label} htmlFor="supplierPhone">
               Phone <span className={styles.required}>*</span>
             </label>
+
             <input
               id="supplierPhone"
               type="tel"
@@ -568,6 +589,7 @@ const SupplierFormModal = ({
           <label className={styles.label} htmlFor="supplierWebsite">
             Website
           </label>
+
           <input
             id="supplierWebsite"
             type="url"
@@ -582,6 +604,7 @@ const SupplierFormModal = ({
           <label className={styles.label} htmlFor="supplierSpecialties">
             Specialties
           </label>
+
           <input
             id="supplierSpecialties"
             type="text"
@@ -590,6 +613,7 @@ const SupplierFormModal = ({
             value={specialties}
             onChange={e => setSpecialties(e.target.value)}
           />
+
           <small>Separate multiple specialties with commas.</small>
         </div>
       </ModalBody>
@@ -598,6 +622,7 @@ const SupplierFormModal = ({
         <button type="button" className={styles.btnModalSecondary} onClick={onClose}>
           Cancel
         </button>
+
         <button type="button" className={styles.btnModalPrimary} onClick={handleSubmit}>
           <FiPlus size={15} />
           {submitLabel}
@@ -636,11 +661,19 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
   const [supplierId, setSupplierId] = useState('');
   const [orderDate, setOrderDate] = useState('');
   const [deliveryDate, setDeliveryDate] = useState('');
+
   const [items, setItems] = useState([
-    { id: 1, name: '', quantity: '', unit: 'lbs', unitPrice: '' },
+    {
+      id: 1,
+      name: '',
+      quantity: '',
+      unit: 'lbs',
+      unitPrice: '',
+    },
   ]);
 
   const getToday = () => new Date().toISOString().split('T')[0];
+
   const today = getToday();
 
   useEffect(() => {
@@ -648,7 +681,16 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
       setSupplierId('');
       setOrderDate(getToday());
       setDeliveryDate('');
-      setItems([{ id: crypto.randomUUID(), name: '', quantity: '', unit: 'lbs', unitPrice: '' }]);
+
+      setItems([
+        {
+          id: crypto.randomUUID(),
+          name: '',
+          quantity: '',
+          unit: 'lbs',
+          unitPrice: '',
+        },
+      ]);
     }
   }, [isOpen]);
 
@@ -662,7 +704,14 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
 
   const handleItemChange = (itemId, field, value) => {
     setItems(currentItems =>
-      currentItems.map(item => (item.id === itemId ? { ...item, [field]: value } : item)),
+      currentItems.map(item =>
+        item.id === itemId
+          ? {
+              ...item,
+              [field]: value,
+            }
+          : item,
+      ),
     );
   };
 
@@ -681,6 +730,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
 
   const removeItem = itemId => {
     if (items.length <= 1) return;
+
     setItems(currentItems => currentItems.filter(item => item.id !== itemId));
   };
 
@@ -700,25 +750,87 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
       return;
     }
 
-    const validItems = items.filter(
-      item => item.name.trim() && Number(item.quantity) >= 1 && Number(item.unitPrice) >= 0,
-    );
+    /*
+     * Validate every item instead of filtering invalid items out.
+     *
+     * This prevents an invalid row from silently disappearing from
+     * the submitted order.
+     */
+    for (let index = 0; index < items.length; index += 1) {
+      const item = items[index];
+      const itemNumber = index + 1;
 
-    if (validItems.length === 0) {
-      toast.error('Add at least one valid item.');
-      return;
+      if (!item.name.trim()) {
+        toast.error(`Please enter an item name for item ${itemNumber}.`);
+        return;
+      }
+
+      if (item.quantity === '') {
+        toast.error(`Please enter a quantity for item ${itemNumber}.`);
+        return;
+      }
+
+      if (item.unitPrice === '') {
+        toast.error(`Please enter a unit price for item ${itemNumber}.`);
+        return;
+      }
+
+      const quantity = Number(item.quantity);
+      const unitPrice = Number(item.unitPrice);
+
+      /*
+       * Quantity validation:
+       * - Must be a finite number
+       * - Must be a whole number
+       * - Must be at least 1
+       * - Must not exceed MAX_QUANTITY
+       */
+      if (
+        !Number.isFinite(quantity) ||
+        !Number.isInteger(quantity) ||
+        quantity < 1 ||
+        quantity > MAX_QUANTITY
+      ) {
+        toast.error(
+          `Quantity for item ${itemNumber} must be a whole number between 1 and ${MAX_QUANTITY}.`,
+        );
+        return;
+      }
+
+      /*
+       * Unit price validation:
+       * - Must be a finite number
+       * - Must not be negative
+       * - Must not exceed MAX_UNIT_PRICE
+       */
+      if (!Number.isFinite(unitPrice) || unitPrice < 0 || unitPrice > MAX_UNIT_PRICE) {
+        toast.error(`Unit price for item ${itemNumber} must be between $0 and $${MAX_UNIT_PRICE}.`);
+        return;
+      }
+
+      /*
+       * Limit unit price to two decimal places.
+       */
+      const decimalPlaces = item.unitPrice.includes('.') ? item.unitPrice.split('.')[1].length : 0;
+
+      if (decimalPlaces > 2) {
+        toast.error(`Unit price for item ${itemNumber} cannot have more than 2 decimal places.`);
+        return;
+      }
     }
+
+    const validItems = items.map(item => ({
+      itemName: item.name.trim(),
+      quantity: Number(item.quantity),
+      pricePerItem: Number(item.unitPrice),
+    }));
 
     onSubmit({
       supplierId,
       status: 'Pending',
       orderDate: new Date(`${orderDate}T00:00:00`).toISOString(),
       expectedDeliveryDate: new Date(`${deliveryDate}T00:00:00`).toISOString(),
-      items: validItems.map(item => ({
-        itemName: item.name.trim(),
-        quantity: Number(item.quantity),
-        pricePerItem: Number(item.unitPrice),
-      })),
+      items: validItems,
     });
   };
 
@@ -739,6 +851,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
             onChange={e => setSupplierId(e.target.value)}
           >
             <option value="">Select a supplier…</option>
+
             {supplierList.map(supplier => (
               <option key={supplier._id} value={supplier._id}>
                 {supplier.name}
@@ -758,6 +871,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
             <label className={styles.label} htmlFor="orderDate">
               Order Date <span className={styles.required}>*</span>
             </label>
+
             <input
               id="orderDate"
               type="date"
@@ -772,6 +886,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
             <label className={styles.label} htmlFor="deliveryDate">
               Expected Delivery <span className={styles.required}>*</span>
             </label>
+
             <input
               id="deliveryDate"
               type="date"
@@ -809,6 +924,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
               className={`${styles.input} ${styles.itemFormColSm}`}
               type="number"
               min="1"
+              max={MAX_QUANTITY}
               step="1"
               placeholder="Qty"
               value={item.quantity}
@@ -834,6 +950,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
               className={`${styles.input} ${styles.itemFormColSm}`}
               type="number"
               min="0"
+              max={MAX_UNIT_PRICE}
               step="0.01"
               placeholder="$0.00"
               value={item.unitPrice}
@@ -852,6 +969,11 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
           </div>
         ))}
 
+        <small>
+          Quantity must be between 1 and {MAX_QUANTITY.toLocaleString()}. Unit price must be between
+          $0 and ${MAX_UNIT_PRICE.toLocaleString()}.
+        </small>
+
         <button type="button" className={styles.addItemBtn} onClick={addItem}>
           + Add Item
         </button>
@@ -861,6 +983,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
         <button type="button" className={styles.btnModalSecondary} onClick={onClose}>
           Cancel
         </button>
+
         <button type="button" className={styles.btnModalPrimary} onClick={handleSubmit}>
           Create Order
         </button>
@@ -908,7 +1031,8 @@ function OrdersPage() {
 
       setOrders(Array.isArray(orderRes.data) ? orderRes.data : []);
       setSupplierList(Array.isArray(supplierRes.data) ? supplierRes.data : []);
-    } catch {
+    } catch (error) {
+      console.error('Failed to load orders and suppliers:', error);
       toast.error('Failed to load orders.');
     } finally {
       setLoading(false);
@@ -924,7 +1048,14 @@ function OrdersPage() {
       await updateOrderStatus(orderId, newStatus);
 
       setOrders(prev =>
-        prev.map(order => (order._id === orderId ? { ...order, status: newStatus } : order)),
+        prev.map(order =>
+          order._id === orderId
+            ? {
+                ...order,
+                status: newStatus,
+              }
+            : order,
+        ),
       );
 
       toast.success(`Order marked as ${newStatus}.`);
@@ -946,6 +1077,7 @@ function OrdersPage() {
       setNewOrderOpen(false);
 
       setCurrentPage(1);
+
       await loadOrders();
     } catch {
       toast.error('Failed to create order.');
@@ -972,6 +1104,7 @@ function OrdersPage() {
       await updateSupplier(editingSupplier._id, supplierData);
 
       toast.success('Supplier updated successfully.');
+
       setEditSupplierOpen(false);
       setEditingSupplier(null);
 
@@ -1057,6 +1190,7 @@ function OrdersPage() {
   });
 
   const totalPages = Math.max(1, Math.ceil(sortedOrders.length / ORDERS_PER_PAGE));
+
   const safePage = Math.min(currentPage, totalPages);
 
   const paginatedOrders = sortedOrders.slice(
@@ -1172,9 +1306,18 @@ function OrdersPage() {
 
         <div className={styles.tabs}>
           {[
-            { id: 'purchase-orders', label: '📋 Purchase Orders' },
-            { id: 'suppliers', label: '🏢 Suppliers' },
-            { id: 'surplus', label: '↗️ Surplus Opportunities' },
+            {
+              id: 'purchase-orders',
+              label: '📋 Purchase Orders',
+            },
+            {
+              id: 'suppliers',
+              label: '🏢 Suppliers',
+            },
+            {
+              id: 'surplus',
+              label: '↗️ Surplus Opportunities',
+            },
           ].map(tab => (
             <button
               type="button"
@@ -1281,18 +1424,6 @@ function OrdersPage() {
                     avgDeliveryDisplay = `${avgDeliveryDays} ${unit}`;
                   }
 
-                  /*
-                   * IMPORTANT:
-                   * Use the count from the orders currently loaded instead of
-                   * relying only on supplier.totalOrders/orderCount.
-                   *
-                   * Therefore:
-                   * Supplier A = 2 existing orders
-                   * Create another order for Supplier A
-                   * -> loadOrders()
-                   * -> supplierOrderCounts[A] = 3
-                   * -> Total Orders immediately shows 3
-                   */
                   const backendTotalOrders = supplier.totalOrders ?? supplier.orderCount;
 
                   const calculatedTotalOrders = supplierOrderCounts[supplier._id] ?? 0;
@@ -1327,8 +1458,10 @@ function OrdersPage() {
                           <span className={styles.detailIcon} aria-hidden="true">
                             👤
                           </span>
+
                           <div>
                             <p className={styles.supplierDetailLabel}>Contact</p>
+
                             <p className={styles.supplierDetailValue}>
                               {supplier.contact || 'N/A'}
                             </p>
@@ -1339,8 +1472,10 @@ function OrdersPage() {
                           <span className={styles.detailIcon} aria-hidden="true">
                             ✉
                           </span>
+
                           <div>
                             <p className={styles.supplierDetailLabel}>Email</p>
+
                             <p className={styles.supplierDetailValue}>{supplier.email || 'N/A'}</p>
                           </div>
                         </div>
@@ -1349,8 +1484,10 @@ function OrdersPage() {
                           <span className={styles.detailIcon} aria-hidden="true">
                             ☎
                           </span>
+
                           <div>
                             <p className={styles.supplierDetailLabel}>Phone</p>
+
                             <p className={styles.supplierDetailValue}>{supplier.phone || 'N/A'}</p>
                           </div>
                         </div>
@@ -1361,8 +1498,10 @@ function OrdersPage() {
                           <span className={styles.supplierStatIcon} aria-hidden="true">
                             🚚
                           </span>
+
                           <div>
                             <p className={styles.supplierStatLabel}>Avg Delivery</p>
+
                             <p className={styles.supplierStatValue}>{avgDeliveryDisplay}</p>
                           </div>
                         </div>
@@ -1371,8 +1510,10 @@ function OrdersPage() {
                           <span className={styles.supplierStatIcon} aria-hidden="true">
                             📦
                           </span>
+
                           <div>
                             <p className={styles.supplierStatLabel}>Total Orders</p>
+
                             <p className={styles.supplierStatValue}>{totalOrders}</p>
                           </div>
                         </div>

--- a/src/components/KitchenInventory/Orders/OrdersPage.jsx
+++ b/src/components/KitchenInventory/Orders/OrdersPage.jsx
@@ -47,13 +47,6 @@ function Modal({ isOpen, toggle, size, className, children }) {
     if (e.target === overlayRef.current) toggle();
   };
 
-  const handleOverlayKeyDown = e => {
-    if (e.target === overlayRef.current && (e.key === 'Enter' || e.key === ' ')) {
-      e.preventDefault();
-      toggle();
-    }
-  };
-
   const sizeClass = size === 'lg' ? styles.modalLg : '';
 
   return createPortal(
@@ -61,7 +54,11 @@ function Modal({ isOpen, toggle, size, className, children }) {
       className={styles.modalOverlay}
       ref={overlayRef}
       onClick={handleOverlayClick}
-      onKeyDown={handleOverlayKeyDown}
+      onKeyDown={e => {
+        if (e.key === 'Escape') {
+          toggle();
+        }
+      }}
       role="presentation"
     >
       <div className={`${styles.modalContent} ${sizeClass} ${className || ''}`}>{children}</div>
@@ -928,7 +925,6 @@ function OrdersPage() {
       setOrders(Array.isArray(orderRes.data) ? orderRes.data : []);
       setSupplierList(Array.isArray(supplierRes.data) ? supplierRes.data : []);
     } catch (error) {
-      console.error('Failed to load orders/suppliers:', error);
       toast.error('Failed to load orders.');
     } finally {
       setLoading(false);
@@ -949,7 +945,6 @@ function OrdersPage() {
 
       toast.success(`Order marked as ${newStatus}.`);
     } catch (error) {
-      console.error('Failed to update order status:', error);
       toast.error('Failed to update order status.');
     }
   };
@@ -969,7 +964,6 @@ function OrdersPage() {
       setCurrentPage(1);
       await loadOrders();
     } catch (error) {
-      console.error('Failed to create order:', error);
       toast.error('Failed to create order.');
     }
   };
@@ -983,7 +977,6 @@ function OrdersPage() {
 
       await loadOrders();
     } catch (error) {
-      console.error('Failed to create supplier:', error);
       toast.error('Failed to create supplier.');
     }
   };
@@ -1000,7 +993,6 @@ function OrdersPage() {
 
       await loadOrders();
     } catch (error) {
-      console.error('Error updating supplier:', error);
       toast.error('Failed to update supplier.');
     }
   };

--- a/src/components/KitchenInventory/Orders/OrdersPage.jsx
+++ b/src/components/KitchenInventory/Orders/OrdersPage.jsx
@@ -664,7 +664,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
       setSupplierId('');
       setOrderDate(getToday());
       setDeliveryDate('');
-      setItems([{ id: Date.now(), name: '', quantity: '', unit: 'lbs', unitPrice: '' }]);
+      setItems([{ id: crypto.randomUUID(), name: '', quantity: '', unit: 'lbs', unitPrice: '' }]);
     }
   }, [isOpen]);
 
@@ -686,7 +686,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
     setItems(currentItems => [
       ...currentItems,
       {
-        id: Date.now() + Math.random(),
+        id: crypto.randomUUID(),
         name: '',
         quantity: '',
         unit: 'lbs',
@@ -793,7 +793,7 @@ const NewOrderModal = ({ isOpen, onClose, onSubmit, suppliers: supplierList, dar
               type="date"
               className={styles.input}
               value={deliveryDate}
-              min={orderDate ? orderDate : today}
+              min={orderDate || today}
               disabled={!orderDate}
               onChange={e => setDeliveryDate(e.target.value)}
             />
@@ -924,7 +924,7 @@ function OrdersPage() {
 
       setOrders(Array.isArray(orderRes.data) ? orderRes.data : []);
       setSupplierList(Array.isArray(supplierRes.data) ? supplierRes.data : []);
-    } catch (error) {
+    } catch {
       toast.error('Failed to load orders.');
     } finally {
       setLoading(false);
@@ -944,7 +944,7 @@ function OrdersPage() {
       );
 
       toast.success(`Order marked as ${newStatus}.`);
-    } catch (error) {
+    } catch {
       toast.error('Failed to update order status.');
     }
   };
@@ -963,7 +963,7 @@ function OrdersPage() {
 
       setCurrentPage(1);
       await loadOrders();
-    } catch (error) {
+    } catch {
       toast.error('Failed to create order.');
     }
   };
@@ -976,7 +976,7 @@ function OrdersPage() {
       setNewSupplierOpen(false);
 
       await loadOrders();
-    } catch (error) {
+    } catch {
       toast.error('Failed to create supplier.');
     }
   };
@@ -992,7 +992,7 @@ function OrdersPage() {
       setEditingSupplier(null);
 
       await loadOrders();
-    } catch (error) {
+    } catch {
       toast.error('Failed to update supplier.');
     }
   };
@@ -1278,6 +1278,11 @@ function OrdersPage() {
                   const avgDeliveryDays =
                     supplier.avgDeliveryDays ?? supplier.averageDeliveryDays ?? 'N/A';
 
+                  const avgDeliveryDisplay =
+                    avgDeliveryDays === 'N/A'
+                      ? 'N/A'
+                      : `${avgDeliveryDays} ${Number(avgDeliveryDays) === 1 ? 'day' : 'days'}`;
+
                   /*
                    * IMPORTANT:
                    * Use the count from the orders currently loaded instead of
@@ -1294,10 +1299,7 @@ function OrdersPage() {
 
                   const calculatedTotalOrders = supplierOrderCounts[supplier._id] ?? 0;
 
-                  const totalOrders = Object.prototype.hasOwnProperty.call(
-                    supplierOrderCounts,
-                    supplier._id,
-                  )
+                  const totalOrders = Object.hasOwn(supplierOrderCounts, supplier._id)
                     ? calculatedTotalOrders
                     : backendTotalOrders ?? 0;
 
@@ -1363,13 +1365,7 @@ function OrdersPage() {
                           </span>
                           <div>
                             <p className={styles.supplierStatLabel}>Avg Delivery</p>
-                            <p className={styles.supplierStatValue}>
-                              {avgDeliveryDays === 'N/A'
-                                ? 'N/A'
-                                : `${avgDeliveryDays} ${
-                                    Number(avgDeliveryDays) === 1 ? 'day' : 'days'
-                                  }`}
-                            </p>
+                            <p className={styles.supplierStatValue}>{avgDeliveryDisplay}</p>
                           </div>
                         </div>
 

--- a/src/components/KitchenInventory/Orders/OrdersPage.jsx
+++ b/src/components/KitchenInventory/Orders/OrdersPage.jsx
@@ -1032,7 +1032,6 @@ function OrdersPage() {
       setOrders(Array.isArray(orderRes.data) ? orderRes.data : []);
       setSupplierList(Array.isArray(supplierRes.data) ? supplierRes.data : []);
     } catch (error) {
-      console.error('Failed to load orders and suppliers:', error);
       toast.error('Failed to load orders.');
     } finally {
       setLoading(false);

--- a/src/components/KitchenInventory/Orders/OrdersPage.module.css
+++ b/src/components/KitchenInventory/Orders/OrdersPage.module.css
@@ -1334,13 +1334,15 @@
 }
 
 .containerDark .editSupplierBtn {
-  background-color: #16213e;
-  border-color: #3a3a5a;
-  color: #ccc;
+  background-color: #1c2541;
+  border-color: #6b7280;
+  color: #f1f5f9;
 }
 
 .containerDark .editSupplierBtn:hover {
-  background-color: #1c2541;
+  background-color: #26324f;
+  border-color: #9ca3af;
+  color: #fff;
 }
 
 .newOrderBtn {

--- a/src/components/KitchenInventory/Orders/OrdersPage.module.css
+++ b/src/components/KitchenInventory/Orders/OrdersPage.module.css
@@ -1,4 +1,5 @@
 /* Container */
+
 .container {
   min-height: 100vh;
   background-color: #f8f9fa;
@@ -11,6 +12,7 @@
 }
 
 /* Main Content */
+
 .main {
   max-width: 1200px;
   margin: 0 auto;
@@ -41,6 +43,7 @@
 }
 
 /* Stats Grid */
+
 .statsGrid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -108,6 +111,7 @@
 }
 
 /* Tabs */
+
 .tabs {
   display: flex;
   gap: 8px;
@@ -152,6 +156,7 @@
 }
 
 /* Toolbar */
+
 .toolbar {
   display: flex;
   gap: 12px;
@@ -249,6 +254,7 @@
 }
 
 /* Modal Buttons */
+
 .btnModalPrimary {
   padding: 8px 24px;
   background-color: #2e7d32;
@@ -295,6 +301,7 @@
 }
 
 /* Order Card */
+
 .orderCard {
   background-color: #fff;
   border-radius: 8px;
@@ -348,6 +355,7 @@
 }
 
 /* Status Badges */
+
 .badge {
   padding: 4px 10px;
   border-radius: 12px;
@@ -411,6 +419,7 @@
 }
 
 /* Order Meta */
+
 .orderMeta {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -433,6 +442,7 @@
 }
 
 /* Status Badges - Dark Mode */
+
 .modalDark .badgeOrdered {
   background-color: #3b2600;
   color: #ffcc80;
@@ -468,6 +478,7 @@
 }
 
 /* Items Section */
+
 .itemsSection {
   margin-top: 16px;
 }
@@ -541,6 +552,7 @@
 }
 
 /* Urgent Banner */
+
 .notesBanner {
   background-color: #e3f2fd;
   border: 1px solid #90caf9;
@@ -561,6 +573,7 @@
 }
 
 /* Actions */
+
 .actions {
   margin-top: 16px;
   display: flex;
@@ -611,6 +624,7 @@
 }
 
 /* Empty State */
+
 .emptyState {
   text-align: center;
   padding: 40px;
@@ -626,6 +640,7 @@
 }
 
 /* Loading Spinner */
+
 .spinner {
   width: 24px;
   height: 24px;
@@ -647,6 +662,7 @@
 }
 
 /* Pagination */
+
 .pagination {
   display: flex;
   justify-content: center;
@@ -710,6 +726,7 @@
 }
 
 /* New Order Form */
+
 .formRow {
   display: flex;
   gap: 16px;
@@ -753,6 +770,8 @@
   min-width: 0;
 }
 
+/* Add Item Button */
+
 .addItemBtn {
   background: none;
   border: 1px dashed #2e7d32;
@@ -762,11 +781,16 @@
   cursor: pointer;
   font-size: 13px;
   margin-bottom: 16px;
-  transition: background-color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s,
+    border-color 0.2s;
 }
 
 .addItemBtn:hover {
-  background-color: #e8f5e9;
+  background-color: #2e7d32;
+  color: #fff;
+  border-color: #2e7d32;
 }
 
 .containerDark .addItemBtn {
@@ -775,7 +799,9 @@
 }
 
 .containerDark .addItemBtn:hover {
-  background-color: #1b3a1b;
+  background-color: #4caf50;
+  color: #fff;
+  border-color: #4caf50;
 }
 
 .removeItemBtn {
@@ -816,6 +842,7 @@
 }
 
 /* Detail Modal */
+
 .detailSection {
   margin-bottom: 16px;
 }
@@ -985,6 +1012,7 @@
 }
 
 /* Suppliers Section */
+
 .suppliersSection {
   width: 100%;
 }
@@ -1033,16 +1061,16 @@
   color: #81c784;
 }
 
-
 /* Supplier Profile Grid */
+
 .supplierGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
 }
 
-
 /* Supplier Profile Card */
+
 .supplierCard {
   background-color: #fff;
   border-radius: 8px;
@@ -1068,8 +1096,8 @@
   box-shadow: 0 4px 12px rgb(0 0 0 / 40%);
 }
 
-
 /* Supplier Header */
+
 .supplierCardHeader {
   display: flex;
   justify-content: space-between;
@@ -1145,8 +1173,8 @@
   border-color: #2e5a2e;
 }
 
-
 /* Contact Details */
+
 .supplierDetails {
   display: grid;
   grid-template-columns: 1fr;
@@ -1201,8 +1229,8 @@
   color: #e0e0e0;
 }
 
-
 /* Supplier Stats */
+
 .supplierStats {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -1249,8 +1277,8 @@
   color: #e0e0e0;
 }
 
-
 /* Specialties */
+
 .specialtiesSection {
   padding: 16px 0;
 }
@@ -1294,8 +1322,8 @@
   font-size: 12px;
 }
 
-
 /* Supplier Actions */
+
 .supplierActions {
   display: flex;
   gap: 8px;
@@ -1377,8 +1405,8 @@
   color: #fff;
 }
 
-
 /* Supplier Responsive Layout */
+
 @media (width <= 900px) {
   .supplierGrid {
     grid-template-columns: 1fr;
@@ -1414,6 +1442,7 @@
 }
 
 /* Responsive */
+
 @media (width <= 768px) {
   .main {
     padding: 16px;
@@ -1460,6 +1489,7 @@
 }
 
 /* Modal Component */
+
 .modalOverlay {
   position: fixed;
   inset: 0;
@@ -1529,6 +1559,7 @@
 }
 
 /* Modal Dark Mode */
+
 .modalDark .modalContent {
   background-color: #16213e;
 }
@@ -1555,6 +1586,7 @@
 }
 
 /* Form Elements */
+
 .label {
   display: block;
   margin: 0 0 4px;
@@ -1625,4 +1657,19 @@
 
 .modalDark .modalBody .input[type='date'] {
   color-scheme: dark;
+}
+
+/* Mobile Tab Spacing */
+
+@media (width <= 600px) {
+  .tabs {
+    gap: 16px;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+
+  .tab {
+    padding: 12px;
+    flex-shrink: 0;
+  }
 }

--- a/src/components/KitchenInventory/Orders/OrdersPage.module.css
+++ b/src/components/KitchenInventory/Orders/OrdersPage.module.css
@@ -1260,7 +1260,7 @@
   border-radius: 12px;
   background-color: #f1f8e9;
   border: 1px solid #c5e1a5;
-  color: #558b2f;
+  color: #33691e;
   font-size: 11px;
 }
 

--- a/src/components/KitchenInventory/Orders/OrdersPage.module.css
+++ b/src/components/KitchenInventory/Orders/OrdersPage.module.css
@@ -432,6 +432,25 @@
   border-bottom-color: #2a2a4a;
 }
 
+/* Status Badges - Dark Mode */
+.modalDark .badgeOrdered {
+  background-color: #3b2600;
+  color: #ffcc80;
+  border: 1px solid #8d5f00;
+}
+
+.modalDark .badgeReceived {
+  background-color: #12351f;
+  color: #a5d6a7;
+  border: 1px solid #3f7f4f;
+}
+
+.modalDark .badgeStocked {
+  background-color: #102d4a;
+  color: #90caf9;
+  border: 1px solid #3d6f9e;
+}
+
 .metaLabel {
   color: #999;
   font-size: 12px;

--- a/src/components/KitchenInventory/Orders/OrdersPage.module.css
+++ b/src/components/KitchenInventory/Orders/OrdersPage.module.css
@@ -965,32 +965,159 @@
   border-color: #3a3a5a;
 }
 
-/* Supplier Card */
+/* Suppliers Section */
+.suppliersSection {
+  width: 100%;
+}
+
+.suppliersHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.sectionTitle {
+  margin: 0 0 4px;
+  font-size: 22px;
+  font-weight: 600;
+  color: #333;
+}
+
+.containerDark .sectionTitle {
+  color: #e0e0e0;
+}
+
+.sectionSubtitle {
+  margin: 0;
+  color: #666;
+  font-size: 14px;
+}
+
+.containerDark .sectionSubtitle {
+  color: #aaa;
+}
+
+.supplierCount {
+  padding: 6px 12px;
+  border-radius: 16px;
+  background-color: #e8f5e9;
+  color: #2e7d32;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.containerDark .supplierCount {
+  background-color: #1b3a1b;
+  color: #81c784;
+}
+
+
+/* Supplier Profile Grid */
+.supplierGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+
+/* Supplier Profile Card */
+.supplierCard {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+  padding: 20px;
+  transition:
+    box-shadow 0.2s,
+    transform 0.2s;
+  min-width: 0;
+}
+
+.supplierCard:hover {
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+  transform: translateY(-1px);
+}
+
+.containerDark .supplierCard {
+  background-color: #16213e;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 30%);
+}
+
+.containerDark .supplierCard:hover {
+  box-shadow: 0 4px 12px rgb(0 0 0 / 40%);
+}
+
+
+/* Supplier Header */
 .supplierCardHeader {
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.containerDark .supplierCardHeader {
+  border-bottom-color: #2a2a4a;
+}
+
+.supplierIdentity {
+  display: flex;
   align-items: center;
-  margin-bottom: 12px;
+  gap: 12px;
+  min-width: 0;
+}
+
+.supplierIcon {
+  width: 42px;
+  height: 42px;
+  flex: 0 0 42px;
+  border-radius: 50%;
+  background-color: #e8f5e9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+}
+
+.containerDark .supplierIcon {
+  background-color: #1b3a1b;
 }
 
 .supplierCardName {
+  margin: 0;
+  font-size: 16px;
   font-weight: 600;
-  font-size: 15px;
   color: #333;
+  overflow-wrap: anywhere;
 }
 
 .containerDark .supplierCardName {
   color: #e0e0e0;
 }
 
+.supplierCategory {
+  margin: 3px 0 0;
+  color: #777;
+  font-size: 12px;
+}
+
+.containerDark .supplierCategory {
+  color: #aaa;
+}
+
 .trustedBadge {
   background-color: #e8f5e9;
   color: #2e7d32;
   border: 1px solid #a5d6a7;
-  padding: 3px 10px;
+  padding: 4px 10px;
   border-radius: 12px;
   font-size: 11px;
-  font-weight: 500;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .containerDark .trustedBadge {
@@ -999,32 +1126,270 @@
   border-color: #2e5a2e;
 }
 
-.supplierCardGrid {
+
+/* Contact Details */
+.supplierDetails {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-  padding-top: 12px;
-  border-top: 1px solid #f0f0f0;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  padding: 16px 0;
+  border-bottom: 1px solid #f0f0f0;
 }
 
-.containerDark .supplierCardGrid {
-  border-top-color: #2a2a4a;
+.containerDark .supplierDetails {
+  border-bottom-color: #2a2a4a;
 }
 
-@media (width <= 768px) {
-  .supplierCardGrid {
-    grid-template-columns: repeat(2, 1fr);
-  }
+.supplierDetail {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
 }
 
-@media (width <= 480px) {
-  .supplierCardGrid {
+.detailIcon {
+  width: 30px;
+  height: 30px;
+  flex: 0 0 30px;
+  border-radius: 6px;
+  background-color: #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+}
+
+.containerDark .detailIcon {
+  background-color: #1c2541;
+}
+
+.supplierDetailLabel {
+  margin: 0 0 2px;
+  color: #999;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.supplierDetailValue {
+  margin: 0;
+  color: #333;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.containerDark .supplierDetailValue {
+  color: #e0e0e0;
+}
+
+
+/* Supplier Stats */
+.supplierStats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  padding: 16px 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.containerDark .supplierStats {
+  border-bottom-color: #2a2a4a;
+}
+
+.supplierStat {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border-radius: 6px;
+  background-color: #f8f9fa;
+}
+
+.containerDark .supplierStat {
+  background-color: #1c2541;
+}
+
+.supplierStatIcon {
+  font-size: 18px;
+}
+
+.supplierStatLabel {
+  margin: 0 0 2px;
+  color: #999;
+  font-size: 11px;
+}
+
+.supplierStatValue {
+  margin: 0;
+  color: #333;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.containerDark .supplierStatValue {
+  color: #e0e0e0;
+}
+
+
+/* Specialties */
+.specialtiesSection {
+  padding: 16px 0;
+}
+
+.specialtiesLabel {
+  margin: 0 0 8px;
+  color: #666;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.containerDark .specialtiesLabel {
+  color: #aaa;
+}
+
+.specialtiesList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.specialtyTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 9px;
+  border-radius: 12px;
+  background-color: #f1f8e9;
+  border: 1px solid #c5e1a5;
+  color: #558b2f;
+  font-size: 11px;
+}
+
+.containerDark .specialtyTag {
+  background-color: #263b20;
+  border-color: #3d5a32;
+  color: #aed581;
+}
+
+.noSpecialties {
+  color: #999;
+  font-size: 12px;
+}
+
+
+/* Supplier Actions */
+.supplierActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding-top: 4px;
+}
+
+.supplierActionBtn {
+  min-height: 36px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  text-decoration: none;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s,
+    color 0.2s;
+}
+
+.pricingBtn {
+  flex: 1 1 100%;
+  background-color: transparent;
+  border: 1px solid #2e7d32;
+  color: #2e7d32;
+}
+
+.pricingBtn:hover {
+  background-color: #e8f5e9;
+}
+
+.containerDark .pricingBtn {
+  border-color: #4caf50;
+  color: #81c784;
+}
+
+.containerDark .pricingBtn:hover {
+  background-color: #1b3a1b;
+}
+
+.editSupplierBtn {
+  flex: 1;
+  background-color: #fff;
+  border: 1px solid #bbb;
+  color: #555;
+}
+
+.editSupplierBtn:hover {
+  background-color: #f5f5f5;
+}
+
+.containerDark .editSupplierBtn {
+  background-color: #16213e;
+  border-color: #3a3a5a;
+  color: #ccc;
+}
+
+.containerDark .editSupplierBtn:hover {
+  background-color: #1c2541;
+}
+
+.newOrderBtn {
+  flex: 1;
+  background-color: #2e7d32;
+  border: 1px solid #2e7d32;
+  color: #fff;
+}
+
+.newOrderBtn:hover {
+  background-color: #1b5e20;
+  border-color: #1b5e20;
+  color: #fff;
+}
+
+
+/* Supplier Responsive Layout */
+@media (width <= 900px) {
+  .supplierGrid {
     grid-template-columns: 1fr;
   }
 }
 
-.supplierCardField {
-  min-width: 0;
+@media (width <= 600px) {
+  .suppliersHeader {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .supplierCount {
+    align-self: flex-start;
+  }
+
+  .supplierCard {
+    padding: 16px;
+  }
+
+  .supplierStats {
+    grid-template-columns: 1fr;
+  }
+
+  .supplierActions {
+    flex-direction: column;
+  }
+
+  .supplierActionBtn {
+    width: 100%;
+    flex: none;
+  }
 }
 
 /* Responsive */

--- a/src/components/KitchenInventory/Orders/ordersApi.js
+++ b/src/components/KitchenInventory/Orders/ordersApi.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const ORDERS_BASE_URL = '/api/kitchenandinventory/orders';
+const SUPPLIERS_BASE_URL = '/api/kitchenandinventory/suppliers';
+
+export const fetchOrders = () => axios.get(ORDERS_BASE_URL);
+
+export const createOrder = orderData => axios.post(ORDERS_BASE_URL, orderData);
+
+export const updateOrderStatus = (orderId, status) =>
+  axios.patch(`${ORDERS_BASE_URL}/${orderId}/status`, { status });
+
+export const fetchSuppliers = () => axios.get(SUPPLIERS_BASE_URL);
+
+export const createSupplier = supplierData => axios.post(SUPPLIERS_BASE_URL, supplierData);

--- a/src/components/KitchenInventory/Orders/ordersApi.js
+++ b/src/components/KitchenInventory/Orders/ordersApi.js
@@ -13,3 +13,6 @@ export const updateOrderStatus = (orderId, status) =>
 export const fetchSuppliers = () => axios.get(SUPPLIERS_BASE_URL);
 
 export const createSupplier = supplierData => axios.post(SUPPLIERS_BASE_URL, supplierData);
+
+export const updateSupplier = (supplierId, supplierData) =>
+  axios.put(`${SUPPLIERS_BASE_URL}/${supplierId}`, supplierData);

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1066,7 +1066,6 @@ export default (
           exact
           component={GardenManagement}
         />
-        <Route path="/kitchenandinventory/orders" component={OrdersPage} />
         <Route path="/kitchenandinventory/login" exact component={KitchenandInventoryLogin} />
         <ProtectedRoute path="/kitchenandinventory/recipes" exact component={RecipesLandingPage} />
         {/* ----- End of Kitchen and Inventory Portal Routes ----- */}
@@ -1075,7 +1074,8 @@ export default (
         <Route path="/subscribe" component={SubscribePage} />
         <Route path="/unsubscribe" component={UnsubscribePage} />
         <Route path="/collaboration" component={Collaboration} />
-        <ProtectedRoute path="/kitchenandinventory/orders" component={OrdersPage} />
+        <Route path="/kitchenandinventory/orders" component={OrdersPage} />
+        <Route path="/kitchenandinventory/suppliers" component={OrdersPage} />
         <Route path="/suggestedjobslist" component={SuggestedJobsList} />
         <ProtectedRoute path="/jobformbuilder" fallback component={JobFormBuilder} />
         <ProtectedRoute path="/materials/mostwastedmaterials" component={MostWastedMaterials} />


### PR DESCRIPTION
# Description
<img width="740" height="516" alt="Screenshot 2026-07-25 at 10 16 02 AM" src="https://github.com/user-attachments/assets/ec6ad7e6-5f2b-40fd-8e89-0c55c980cb4b" />

## Related PR
- Frontend: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5443
- Backend: https://github.com/OneCommunityGlobal/HGNRest/pull/2305

## Main changes explained:
- Created `Orders.js`, `Suppliers.js` as data models
- Created `OrdersController.js` and `SupplierController.js`as controllers
- Supplier profile cards display name, contact, email, phone, avg delivery days, total orders, reliability %, and specialty tags
- Three action buttons per supplier: View Pricing History, Edit Supplier Info, New Order
- New Order button anchors to the external supplier website URL stored in the database
- Purchase Orders tab with order cards showing status , items, and totals
- Stat cards: Pending Orders, Awaiting Stock, Monthly Spend, Surplus Savings
- Responsive design for laptop and tablet
- CSS modules for scoped styling

## How to test:
1. Check into current branch
2. Do `npm install` and `npm start` to run this PR locally
3. Clear site data/cache
4. Log as admin user
5. Navigate to `/kitchenandinventory/orders`
6. Verify Suppliers tab — all 4 supplier cards render with details
7. Click New Order — verify it opens external website
8. Check Purchase Orders tab — verify order cards and status
9. Toggle dark mode — verify all elements are readable
10. Resize browser to tablet width — verify responsive layout

## Result:

### Light Mode Video Demo
https://youtu.be/7G38mvRYQhA

https://github.com/user-attachments/assets/a4de108e-b659-4284-975b-37cef9a5c8a3