### PR TITLE
Mahathi - fix: restore supplier performance and tools stoppage charts

### DIFF
--- a/src/components/BMDashboard/WeeklyProjectSummary/SupplierPerformanceGraph.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/SupplierPerformanceGraph.jsx
@@ -165,7 +165,7 @@ const SupplierPerformanceDashboard = function({ height = 420, onDataLoaded }) {
             <option value="all">ALL Projects</option>
             {projects.map(project => (
               <option key={project._id} value={project._id}>
-                {project._id}
+                {project.projectName}
               </option>
             ))}
           </Input>

--- a/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/WeeklyProjectSummary.jsx
@@ -21,7 +21,8 @@ import MostFrequentKeywords from './MostFrequentKeywords/MostFrequentKeywords';
 import LessonsLearntChart from '../LessonsLearnt/LessonsLearntChart';
 import DistributionLaborHours from './DistributionLaborHours/DistributionLaborHours';
 import ActualVsPlannedCost from './ActualVsPlannedCost/ActualVsPlannedCost';
-
+import SupplierPerformanceGraph from './SupplierPerformanceGraph';
+import ToolsStoppageHorizontalBarChart from './Tools/ToolsStoppageHorizontalBarChart/ToolsStoppageHorizontalBarChart';
 import styles from './WeeklyProjectSummary.module.css';
 import ToolStatusDonutChart from './ToolStatusDonutChart/ToolStatusDonutChart';
 import InjurySeverityChart from '../Injuries/InjurySeverityChart';
@@ -289,15 +290,26 @@ function WeeklyProjectSummary() {
       {
         title: 'Tools and Equipment Tracking',
         key: 'Tools and Equipment Tracking',
-        className: 'half',
-        content: [
-          <div key="donut" className={`${styles.weeklyProjectSummaryCard} ${styles.normalCard}`}>
-            <ToolStatusDonutChart />
-          </div>,
-          <div key="bar" className={`${styles.weeklyProjectSummaryCard} ${styles.normalCard}`}>
-            <ToolsHorizontalBarChart darkMode={darkMode} />
-          </div>,
-        ],
+        className: 'full',
+        content: (
+          <div className={styles.toolsTrackingGrid}>
+            <div className={`${styles.weeklyProjectSummaryCard} ${styles.normalCard}`}>
+              <ToolStatusDonutChart />
+            </div>
+
+            <div className={`${styles.weeklyProjectSummaryCard} ${styles.normalCard}`}>
+              <ToolsHorizontalBarChart darkMode={darkMode} />
+            </div>
+
+            <div className={`${styles.weeklyProjectSummaryCard} ${styles.normalCard}`}>
+              <SupplierPerformanceGraph />
+            </div>
+
+            <div className={`${styles.weeklyProjectSummaryCard} ${styles.normalCard}`}>
+              <ToolsStoppageHorizontalBarChart />
+            </div>
+          </div>
+        ),
       },
       {
         title: 'Lessons Learned',


### PR DESCRIPTION
# Description
<img width="532" height="433" alt="Screenshot 2026-08-15 at 3 34 43 PM" src="https://github.com/user-attachments/assets/809e2b61-cbc6-4660-bf35-057d3946103f" />


## Related PRS (if any):
This frontend PR is related to the [#2306](https://github.com/OneCommunityGlobal/HGNRest/pull/2306) backend PR.
Previous Related PR [https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4442](url)


## Main changes explained:
1. Restored the Supplier Performance chart in the Tools and Equipment Tracking section.
2. Restored the Tools Stoppage chart that had also been removed from the current dashboard layout.
3. Reorganized the Tools and Equipment Tracking section into a cleaner responsive layout
4. Updated the Supplier Performance project dropdown to display project names instead of MongoDB project IDs.
5. Verified the Supplier Performance date filters work correctly with current development data.

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to /bmdashboard/totalconstructionsummary
6. Open the tools and equipment tracking section
7. verify that the supplier's performance chart returns data for 30days, 6months and one year filter.
8. verify that the project selection dropdown now shows the project name instead of project ID
<img width="1160" height="580" alt="Screenshot 2026-08-15 at 3 54 09 PM" src="https://github.com/user-attachments/assets/0fd56e9f-dc67-451b-910b-580fc2ad5ca9" />

