### PR TITLE
Bosu fix: correct HGN help access restrictions frontend

### DIFF
--- a/src/components/HGNForm/questionpages/FollowupQuestions.jsx
+++ b/src/components/HGNForm/questionpages/FollowupQuestions.jsx
@@ -200,8 +200,7 @@ function FollowupQuestions() {
   };
   const groupedData = groupFormDataByPage(newVolunteer, user.userid);
 
-  // TODO: Add logic to send groupedData to backend
-  const handleFormSubmission = e => {
+  const handleFormSubmission = async e => {
     e.preventDefault();
     const mernWorkExp = newVolunteer.followup_mern_work_experience;
     const mernWorkExpWordCount = getWordCount(mernWorkExp);
@@ -214,15 +213,16 @@ function FollowupQuestions() {
     }
 
     dispatch(setformData(newVolunteer));
-    axios
-      .post(ENDPOINTS.HGN_FORM_SUBMIT, groupedData)
-      .then(res => {
-        if (res.status === 201) toast.success('Form submitted successfully!');
-      })
-      .catch(error => {
-        if (error.response.status === 500) toast.error('Error submitting form. Please try again.');
-      });
-    navigate.push('/hgnform/page6');
+    try {
+      const res = await axios.post(ENDPOINTS.HGN_FORM_SUBMIT, groupedData);
+      if (res.status === 201) {
+        toast.success('Form submitted successfully!');
+        // Only leave this page once the submission is confirmed saved.
+        navigate.push('/hgnform/page6');
+      }
+    } catch (error) {
+      toast.error(error.response?.data?.error || 'Error submitting form. Please try again.');
+    }
   };
 
   const handleBack = () => {

--- a/src/components/LandingPage/HelpModal.jsx
+++ b/src/components/LandingPage/HelpModal.jsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import PropTypes from 'prop-types';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Modal } from 'react-bootstrap';
 import { connect, useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
@@ -13,8 +13,11 @@ function HelpModal({ show, onHide, auth }) {
   const [options, setOptions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [teams, setTeams] = useState([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // null = not yet determined (loading or unknown due to a failed request); true/false = backend result
+  const [eligible, setEligible] = useState(null);
+  const [eligibilityLoading, setEligibilityLoading] = useState(true);
+  const [eligibilityError, setEligibilityError] = useState(false);
 
   const darkMode = useSelector(state => state.theme.darkMode);
 
@@ -36,18 +39,27 @@ function HelpModal({ show, onHide, auth }) {
   }, []);
 
   useEffect(() => {
-    if (!userId) return;
+    if (!userId) {
+      setEligibilityLoading(false);
+      return;
+    }
 
-    const fetchUserProfile = async () => {
+    const fetchEligibility = async () => {
+      setEligibilityLoading(true);
+      setEligibilityError(false);
       try {
-        const profileResponse = await axios.get(ENDPOINTS.USER_PROFILE(userId));
-        setTeams(profileResponse.data?.teams || []);
+        const eligibilityResponse = await axios.get(ENDPOINTS.HELP_REQUEST_ELIGIBILITY);
+        setEligible(Boolean(eligibilityResponse.data?.eligible));
       } catch {
-        setTeams([]);
+        // A failed eligibility check is not proof of ineligibility; keep eligible unknown (null).
+        setEligible(null);
+        setEligibilityError(true);
+      } finally {
+        setEligibilityLoading(false);
       }
     };
 
-    fetchUserProfile();
+    fetchEligibility();
   }, [userId]);
 
   const handleSelect = option => {
@@ -70,7 +82,6 @@ function HelpModal({ show, onHide, auth }) {
 
     try {
       await axios.post(ENDPOINTS.HELP_REQUEST_CREATE, {
-        userId,
         topic: selectedOption,
         description: `Help request for: ${selectedOption}`,
       });
@@ -96,18 +107,6 @@ function HelpModal({ show, onHide, auth }) {
     localStorage.setItem('openSuggestionsModal', 'true');
     onHide();
   };
-
-  /* ---------------- Access Logic ---------------- */
-  const role = auth?.user?.role?.trim().toLowerCase() || '';
-
-  const allowedRoles = useMemo(() => new Set(['owner', 'administrator']), []);
-
-  const isSoftwareDevMember = useMemo(() => {
-    return (
-      allowedRoles.has(role) ||
-      teams.some(team => team.teamName?.trim().toLowerCase() === 'software development team')
-    );
-  }, [allowedRoles, teams, role]);
 
   const renderContent = () => {
     if (loading) return <div>Loading categories...</div>;
@@ -181,9 +180,16 @@ function HelpModal({ show, onHide, auth }) {
       <Modal.Body>
         <div className={styles.selectContainer}>{renderContent()}</div>
 
-        {!isSoftwareDevMember && (
+        {!eligibilityLoading && eligibilityError && (
           <div className="alert alert-warning mt-3">
-            Only members of the Software Development Team can submit requests.
+            Unable to verify your eligibility right now. Please try again later.
+          </div>
+        )}
+
+        {!eligibilityLoading && !eligibilityError && eligible === false && (
+          <div className="alert alert-warning mt-3">
+            You must complete the HGN questionnaire and belong to an eligible HGN team or role to
+            submit a help request.
           </div>
         )}
 
@@ -203,7 +209,7 @@ function HelpModal({ show, onHide, auth }) {
         <Button
           variant="primary"
           onClick={handleSubmit}
-          disabled={!selectedOption || !isSoftwareDevMember || isSubmitting}
+          disabled={!selectedOption || eligibilityLoading || eligible !== true || isSubmitting}
         >
           {isSubmitting ? 'Submitting...' : 'Submit'}
         </Button>

--- a/src/components/LandingPage/__tests__/HelpModal.test.jsx
+++ b/src/components/LandingPage/__tests__/HelpModal.test.jsx
@@ -1,0 +1,144 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import axios from 'axios';
+import { ENDPOINTS } from '~/utils/URL';
+import HelpModal from '../HelpModal';
+
+vi.mock('axios');
+vi.mock('react-toastify');
+
+const mockStore = configureMockStore([]);
+
+const makeStore = () =>
+  mockStore({
+    theme: { darkMode: false },
+    auth: { user: { userid: 'user1', role: 'Volunteer' } },
+  });
+
+const renderHelpModal = (store, props = {}) =>
+  render(
+    <Provider store={store}>
+      <HelpModal show onHide={vi.fn()} {...props} />
+    </Provider>,
+  );
+
+describe('HelpModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockGet = ({ categories = [{ name: 'HTML Semantics' }], eligibility } = {}) => {
+    axios.get.mockImplementation(url => {
+      if (url === ENDPOINTS.HELP_CATEGORIES) {
+        return Promise.resolve({ data: categories });
+      }
+      if (typeof eligibility === 'function') {
+        return eligibility(url);
+      }
+      return Promise.resolve({ data: eligibility });
+    });
+  };
+
+  it('loads help categories from the categories endpoint', async () => {
+    mockGet({ eligibility: { eligible: true, questionnaireCompleted: true } });
+    const store = makeStore();
+    renderHelpModal(store);
+
+    await screen.findByText('Select an option');
+    expect(axios.get).toHaveBeenCalledWith(ENDPOINTS.HELP_CATEGORIES);
+  });
+
+  it('calls the authenticated eligibility endpoint without a userId, never sending userId to the backend', async () => {
+    mockGet({ eligibility: { eligible: true, questionnaireCompleted: true } });
+    const store = makeStore();
+    renderHelpModal(store);
+
+    await screen.findByText(/^Select an option$/);
+    expect(axios.get).toHaveBeenCalledWith(ENDPOINTS.HELP_REQUEST_ELIGIBILITY);
+  });
+
+  it('does not show the ineligible warning while eligibility is still loading', async () => {
+    let resolveEligibility;
+    axios.get.mockImplementation(url => {
+      if (url === ENDPOINTS.HELP_CATEGORIES) {
+        return Promise.resolve({ data: [] });
+      }
+      return new Promise(resolve => {
+        resolveEligibility = () => resolve({ data: { eligible: false } });
+      });
+    });
+    const store = makeStore();
+    renderHelpModal(store);
+
+    expect(screen.queryByText(/must complete the HGN questionnaire/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
+
+    resolveEligibility();
+    await screen.findByText(/must complete the HGN questionnaire/i);
+  });
+
+  it('enables Submit and hides the warning for an eligible user', async () => {
+    mockGet({ eligibility: { eligible: true, questionnaireCompleted: true } });
+    const store = makeStore();
+    renderHelpModal(store);
+
+    await waitFor(() =>
+      expect(screen.queryByText(/must complete the HGN questionnaire/i)).not.toBeInTheDocument(),
+    );
+  });
+
+  it('shows the ineligible warning and disables Submit for an ineligible user', async () => {
+    mockGet({ eligibility: { eligible: false, questionnaireCompleted: false } });
+    const store = makeStore();
+    renderHelpModal(store);
+
+    await screen.findByText(/must complete the HGN questionnaire/i);
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
+  });
+
+  it('shows a neutral error (not an ineligibility message) when the eligibility request fails', async () => {
+    axios.get.mockImplementation(url => {
+      if (url === ENDPOINTS.HELP_CATEGORIES) {
+        return Promise.resolve({ data: [] });
+      }
+      return Promise.reject(new Error('network error'));
+    });
+    const store = makeStore();
+    renderHelpModal(store);
+
+    await screen.findByText(/unable to verify your eligibility/i);
+    expect(screen.queryByText(/must complete the HGN questionnaire/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
+  });
+
+  it('still shows the Suggestions link regardless of eligibility state', async () => {
+    mockGet({ eligibility: { eligible: false, questionnaireCompleted: false } });
+    const store = makeStore();
+    renderHelpModal(store);
+
+    expect(screen.getByText(/if you have any suggestions/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'here' })).toBeInTheDocument();
+  });
+
+  it('submits a help request without sending userId in the body for an eligible user', async () => {
+    mockGet({ eligibility: { eligible: true, questionnaireCompleted: true } });
+    axios.post.mockResolvedValue({ data: { _id: 'hr1' } });
+    const store = makeStore();
+    renderHelpModal(store);
+
+    await screen.findByText('Select an option');
+    fireEvent.click(screen.getByText('Select an option'));
+    fireEvent.click(await screen.findByText('HTML Semantics'));
+
+    const submitButton = await screen.findByRole('button', { name: /submit/i });
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled());
+    expect(axios.post).toHaveBeenCalledWith(
+      ENDPOINTS.HELP_REQUEST_CREATE,
+      expect.not.objectContaining({ userId: expect.anything() }),
+    );
+  });
+});

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -636,6 +636,7 @@ export const ENDPOINTS = {
   LB_LISTING_BOOK: `${APIEndpoint}/lb/listing/availability/booking`,
   HELP_CATEGORIES: `${APIEndpoint}/help-categories`,
   HELP_REQUEST_CREATE: `${APIEndpoint}/helprequest/create`,
+  HELP_REQUEST_ELIGIBILITY: `${APIEndpoint}/helprequest/eligibility`,
   APPLICANT_SOURCES: `${APIEndpoint}/applicant-analytics/applicant-sources`,
 
   OPT_STATUS_BREAKDOWN: (startDate, endDate, role) => {


### PR DESCRIPTION
## Description

Fixes the HGN Questionnaire Dashboard access restriction issue on `/hgnhelp`.

Previously, valid users could still be blocked from submitting HGN Help requests because access eligibility was determined using incomplete client-side role/team logic. The questionnaire submission flow could also navigate to the success page before confirming that the questionnaire response was successfully saved.

This update moves HGN Help eligibility to the backend as the authoritative source, properly handles eligibility loading/error states, and ensures questionnaire submission completes successfully before navigating to the confirmation page.

Fixes: (PRIORITY URGENT) HGN Questionnaire Dashboard - Fix Access Restriction Too Strict on `/hgnhelp`

## Related PRS (if any):

- Related original frontend PR: #3360
- This frontend PR is related to backend PR #BACKEND_PR_NUMBER.
- Both frontend and backend PRs should be tested together.

## Main changes explained:

- Updated `HelpModal.jsx` to retrieve HGN Help eligibility from the backend instead of relying on client-side role and team checks.
- Added handling for eligibility loading, eligible, ineligible, and request-error states.
- Updated the HGN Help eligibility API endpoint configuration.
- Removed `userId` from help request and eligibility calls so user identity is determined securely by the backend from authentication.
- Updated questionnaire submission in `FollowupQuestions.jsx` to wait for a successful server response before navigating to the confirmation page.
- Added focused tests for HGN Help eligibility and request behavior.
- Preserved existing help categories, Suggestions functionality, modal behavior, notifications, and dark mode.

## How to test:

1. Checkout the frontend branch:
   `Bosu-fix-hgnhelp-access-restriction`

2. Checkout backend PR #BACKEND_PR_NUMBER and run both applications locally.

3. Run the frontend:
   `nvm use 20`
   `npm install`
   `npm run start:local`

4. Log in with an Owner/Admin/Core Team/Software Development Team test account.

5. Navigate to `/hgnhelp` before completing the HGN questionnaire and verify:
   - Eligibility returns false.
   - The main Submit button is disabled.
   - The user receives the eligibility message.

6. Navigate to `/hgnform`, complete the questionnaire, and submit it.

7. Verify the questionnaire request returns HTTP `201` before navigating to the success page.

8. Return to `/hgnhelp` and verify:
   - Eligibility returns `true`.
   - `questionnaireCompleted` returns `true`.
   - The main Submit button is enabled.

9. Select a help category and submit the request.

10. Verify `/api/helprequest/create` returns HTTP `201` and the success notification is displayed.

11. Verify the request payload does not contain a client-provided `userId`.

12. Verify the Suggestions link and existing Suggestions submission functionality still work.

13. Verify the functionality in both light and dark mode.

## Screenshots or videos of changes:

<img width="1510" height="620" alt="Screenshot 2026-08-16 at 12 09 21 AM" src="https://github.com/user-attachments/assets/f0c718ec-2719-4d9f-8fbb-daa3fa5d965a" />


## Note:

This frontend PR requires the related backend PR for the complete eligibility and authentication flow. The backend is now responsible for determining the authenticated user's eligibility.