### PR TITLE
SaiSandeep Fixing x-axis position and tick increments

### DIFF
--- a/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsLineChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsLineChart.jsx
@@ -35,7 +35,7 @@ const formatChartData = rawData => {
     }));
   }
 
-  // Weekly interval format - explicitly cast week to String so Recharts treats it as a discrete category
+  // Weekly interval format - numeric value for axis calculations
   return rawData.map(data => ({
     xLabel: Number(data._id.week) || 0,
     totalHours: Number(data.totalHours) || 0,
@@ -53,10 +53,8 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
   const [data, setData] = useState([]);
   const [fetchError, setFetchError] = useState(null);
 
-  // Safe extraction for last point value
   const latestNumberOfHours = data && data.length > 0 ? data[data.length - 1].totalHours : 0;
 
-  // Explicit non-zero fallbacks for initial chart dimension state
   const [chartSize, setChartSize] = useState({ width: 600, height: 350 });
   const [requestTimeFrame, setRequestTimeFrame] = useState(1);
   const [requestOffset, setRequestOffset] = useState('week');
@@ -156,10 +154,13 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
 
   const renderCustomTooltip = ({ active, payload, label }) => {
     if (active && payload && payload.length) {
-      const { year } = payload[0].payload;
+      const { year, interval } = payload[0].payload;
       const bgColor = darkMode ? '#222' : 'white';
       const textColor = darkMode ? '#fff' : '#222';
       const labelColor = darkMode ? '#90cdf4' : '#222';
+      
+      const formattedLabel = interval === 'week' ? `Week ${label}` : label;
+
       return (
         <div
           style={{
@@ -171,7 +172,7 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
           }}
         >
           <h6 style={{ color: labelColor }}>
-            {label}, {year}
+            {formattedLabel}, {year}
           </h6>
           <h6 style={{ color: darkMode ? '#90ee90' : '#328D1B' }}>{payload[0].value} hours</h6>
         </div>
@@ -210,8 +211,12 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
     return <div>Error fetching data!</div>;
   }
 
-  const maxWeek = data.length > 0 ? Math.max(...data.map(d => d.xLabel)) : 32;
-  const evenTicks = Array.from({ length: Math.floor(maxWeek / 2) + 1 }, (_, i) => i * 2);
+  // Dynamic axis calculations depending on active interval
+  const isWeekly = requestOffset === 'week';
+  const maxWeek = data.length > 0 && isWeekly ? Math.max(...data.map(d => d.xLabel)) : 32;
+  const evenTicks = isWeekly
+    ? Array.from({ length: Math.floor(maxWeek / 2) + 1 }, (_, i) => i * 2)
+    : undefined;
 
   return (
     <div className={styles.chartContainer}>
@@ -252,8 +257,8 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
           onChange={setOffsetFilter}
           style={selectStyle}
         >
-          <option value="week">week</option>
-          <option value="month">month</option>
+          <option value="week">Week</option>
+          <option value="month">Month</option>
         </select>
       </div>
 
@@ -269,7 +274,7 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
               selectsRange
               inline
               dateFormat="MM-dd-yyyy"
-              className="date-picker"
+              className={darkMode ? styles.darkCalendar : styles.lightCalendar}
             />
           )}
         </div>
@@ -296,18 +301,22 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
           width={chartSize.width}
           height={chartSize.height}
           data={data}
-          margin={{ right: 50, top: 50, left: 20 }}
+          margin={{ right: 50, top: 50, left: 70 }}
         >
           <CartesianGrid stroke="#ccc" vertical={false} />
+          
+          {/* Conditional props render depending on weekly vs monthly view */}
           <XAxis
             dataKey="xLabel"
-            type="number"
-            ticks={evenTicks}
-            domain={[0, maxWeek]}
+            type={isWeekly ? 'number' : 'category'}
+            ticks={isWeekly ? evenTicks : undefined}
+            domain={isWeekly ? [0, maxWeek] : undefined}
+            interval={isWeekly ? undefined : 'preserveStartEnd'}
             axisLine={false}
             tickLine={false}
             tick={{ fill: darkMode ? '#ccc' : undefined, fontSize: 12 }}
           />
+
           <YAxis
             tickFormatter={formatNumber}
             axisLine={false}

--- a/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsLineChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsLineChart.jsx
@@ -8,8 +8,10 @@ import styles from './VolunteerTrendsStyles.module.css';
 import 'react-datepicker/dist/react-datepicker.css';
 
 const formatChartData = rawData => {
-  if (rawData[0]._id.month) {
-    // for monthly intervals
+  if (!Array.isArray(rawData) || rawData.length === 0) return [];
+
+  // Safe check for monthly format vs weekly format
+  if (rawData[0]?._id?.month !== undefined) {
     const integerToMonths = {
       1: 'Jan',
       2: 'Feb',
@@ -25,25 +27,21 @@ const formatChartData = rawData => {
       12: 'Dec',
     };
 
-    return rawData.map(data => {
-      return {
-        xLabel: integerToMonths[data._id.month],
-        totalHours: data.totalHours,
-        year: data._id.year,
-        interval: 'month',
-      };
-    });
+    return rawData.map(data => ({
+      xLabel: integerToMonths[data._id.month] || `M${data._id.month}`,
+      totalHours: Number(data.totalHours) || 0,
+      year: data._id.year,
+      interval: 'month',
+    }));
   }
 
-  // for weekly intervals
-  return rawData.map(data => {
-    return {
-      xLabel: data._id.week,
-      totalHours: data.totalHours,
-      year: data._id.year,
-      interval: 'week',
-    };
-  });
+  // Weekly interval format - explicitly cast week to String so Recharts treats it as a discrete category
+  return rawData.map(data => ({
+    xLabel: Number(data._id.week) || 0,
+    totalHours: Number(data.totalHours) || 0,
+    year: data._id.year,
+    interval: 'week',
+  }));
 };
 
 const dateToYYYYMMDD = date => {
@@ -52,17 +50,20 @@ const dateToYYYYMMDD = date => {
 
 export default function VolunteerTrendsLineChart({ darkMode }) {
   const [isLoading, setIsLoading] = useState(true);
-  const [data, setData] = useState(null);
-  const [fetchError, setFetchError] = useState(false);
-  const latestNumberOfHours = data?.[data.length - 1].totalHours || 0;
-  const [chartSize, setChartSize] = useState({ width: null, height: null });
+  const [data, setData] = useState([]);
+  const [fetchError, setFetchError] = useState(null);
+
+  // Safe extraction for last point value
+  const latestNumberOfHours = data && data.length > 0 ? data[data.length - 1].totalHours : 0;
+
+  // Explicit non-zero fallbacks for initial chart dimension state
+  const [chartSize, setChartSize] = useState({ width: 600, height: 350 });
   const [requestTimeFrame, setRequestTimeFrame] = useState(1);
   const [requestOffset, setRequestOffset] = useState('week');
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [customDateRange, setCustomDateRange] = useState([null, null]);
   const [customStartDate = new Date(), customEndDate = new Date()] = customDateRange;
 
-  //dropdown styling - dark mode
   const selectStyle = {
     backgroundColor: darkMode ? '#111827' : '#ffffff',
     color: darkMode ? '#f8fafc' : '#111827',
@@ -71,19 +72,15 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
     padding: '2px 8px',
   };
 
-  // option colors
   const optionStyle = {
     backgroundColor: darkMode ? '#111827' : '#ffffff',
     color: darkMode ? '#f8fafc' : '#111827',
   };
 
   useEffect(() => {
-    // Gets backend data
     const getData = async () => {
-      // TODO: NEED TO ABSTRACT THIS TO ITS OWN REDUX REDUCER
       let url;
       if (customDateRange.every(date => date)) {
-        // URL for custom dates
         const formattedDateRange = customDateRange.map(date => dateToYYYYMMDD(date));
         url = ENDPOINTS.VOLUNTEER_TRENDS(
           requestTimeFrame,
@@ -92,7 +89,6 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
           formattedDateRange[1],
         );
       } else {
-        // URL for pre-set timeframes
         url = ENDPOINTS.VOLUNTEER_TRENDS(requestTimeFrame, requestOffset);
       }
 
@@ -110,17 +106,13 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
   }, [requestTimeFrame, requestOffset, customDateRange]);
 
   useEffect(() => {
-    // Add event listener to set chart width on window resize
     const updateChartSize = () => {
-      // Default sizes
       let width = 600;
       let height = 350;
       if (window.innerWidth < 650) {
-        // Mobile
-        width = 400;
+        width = 380;
         height = 250;
       } else if (window.innerWidth < 1200) {
-        // Tablet
         width = 500;
       }
       setChartSize({ width, height });
@@ -133,12 +125,12 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
   }, []);
 
   const formatNumber = number => {
-    // Add comma every third digit (e.g. makes 1000 a 1,000)
+    if (number === null || number === undefined) return '0';
     return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   };
 
   const renderCustomDot = ({ cx, cy, index }) => {
-    // Highlight and show value of last dot on the line
+    if (!data || data.length === 0) return null;
     const isLastPoint = index === data.length - 1;
     const formattedNumber = formatNumber(latestNumberOfHours);
     if (isLastPoint) {
@@ -164,7 +156,7 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
 
   const renderCustomTooltip = ({ active, payload, label }) => {
     if (active && payload && payload.length) {
-      const { year, interval } = payload[0].payload;
+      const { year } = payload[0].payload;
       const bgColor = darkMode ? '#222' : 'white';
       const textColor = darkMode ? '#fff' : '#222';
       const labelColor = darkMode ? '#90cdf4' : '#222';
@@ -179,16 +171,9 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
           }}
         >
           <h6 style={{ color: labelColor }}>
-            {interval === 'week' ? 'Week ' : ''}
-            {label}
-            {`, `}
-            {year}
+            {label}, {year}
           </h6>
-
-          <h6 style={{ color: darkMode ? '#90ee90' : '#328D1B' }}>
-            {payload[0].value}
-            {' hours'}
-          </h6>
+          <h6 style={{ color: darkMode ? '#90ee90' : '#328D1B' }}>{payload[0].value} hours</h6>
         </div>
       );
     }
@@ -205,11 +190,11 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
     const numberOfYears = e.target.value.substring(5);
     setIsLoading(true);
     setRequestTimeFrame(numberOfYears);
-    return undefined;
   };
 
   const setOffsetFilter = e => {
     const offset = e.target.value;
+    setIsLoading(true);
     setRequestOffset(offset);
   };
 
@@ -224,6 +209,9 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
   if (fetchError) {
     return <div>Error fetching data!</div>;
   }
+
+  const maxWeek = data.length > 0 ? Math.max(...data.map(d => d.xLabel)) : 32;
+  const evenTicks = Array.from({ length: Math.floor(maxWeek / 2) + 1 }, (_, i) => i * 2);
 
   return (
     <div className={styles.chartContainer}>
@@ -257,7 +245,7 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
             Choose Date Range
           </option>
         </select>
-        by
+        {' by '}
         <select
           name="offset-filter"
           id="offset-filter"
@@ -313,9 +301,12 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
           <CartesianGrid stroke="#ccc" vertical={false} />
           <XAxis
             dataKey="xLabel"
+            type="number"
+            ticks={evenTicks}
+            domain={[0, maxWeek]}
             axisLine={false}
             tickLine={false}
-            tick={{ fill: darkMode ? '#ccc' : undefined }}
+            tick={{ fill: darkMode ? '#ccc' : undefined, fontSize: 12 }}
           />
           <YAxis
             tickFormatter={formatNumber}

--- a/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsLineChart.jsx
+++ b/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsLineChart.jsx
@@ -158,7 +158,7 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
       const bgColor = darkMode ? '#222' : 'white';
       const textColor = darkMode ? '#fff' : '#222';
       const labelColor = darkMode ? '#90cdf4' : '#222';
-      
+
       const formattedLabel = interval === 'week' ? `Week ${label}` : label;
 
       return (
@@ -304,7 +304,7 @@ export default function VolunteerTrendsLineChart({ darkMode }) {
           margin={{ right: 50, top: 50, left: 70 }}
         >
           <CartesianGrid stroke="#ccc" vertical={false} />
-          
+
           {/* Conditional props render depending on weekly vs monthly view */}
           <XAxis
             dataKey="xLabel"

--- a/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsStyles.module.css
+++ b/src/components/TotalOrgSummary/VolunteerTrendsLineChart/VolunteerTrendsStyles.module.css
@@ -34,11 +34,39 @@
   gap: 10px;
   align-items: center;
   justify-content: center;
+  margin-bottom: 10px;
 }
 
 .dateFilterContainer > select {
   margin-top: 0;
   width: min-content;
+}
+
+:global(.react-datepicker) {
+  background-color: #111827 !important;
+  color: #f8fafc !important;
+  border-color: rgba(255, 255, 255, 0.25) !important;
+}
+
+:global(.react-datepicker__header) {
+  background-color: #1f2937 !important;
+  border-bottom-color: rgba(255, 255, 255, 0.25) !important;
+}
+
+:global(.react-datepicker__current-month),
+:global(.react-datepicker__day-name),
+:global(.react-datepicker__day) {
+  color: #f8fafc !important;
+}
+
+:global(.react-datepicker__day:hover) {
+  background-color: #374151 !important;
+}
+
+:global(.react-datepicker__day--selected),
+:global(.react-datepicker__day--in-range) {
+  background-color: #328d1b !important;
+  color: #ffffff !important;
 }
 
 @media (width <= 500px) {


### PR DESCRIPTION
# Description
Fixed rendering issues on the x-axis of the Volunteer Trends line chart where ticks were overlapping, out of order, or cluttered when displaying weekly data. Configured the x-axis to render numeric indices cleanly in fixed increments (e.g., 0, 2, 4, 6, 8, ... 32) and ensured type safety between numeric week indexes and Recharts data expectations.
<img width="1015" height="597" alt="Screenshot 2026-08-18 023212" src="https://github.com/user-attachments/assets/cf82c69e-2bdc-4d70-9a80-0f9e593946ed" />
<img width="1029" height="772" alt="Screenshot 2026-08-18 011303" src="https://github.com/user-attachments/assets/b7e70363-b711-4feb-a174-44ef11262b39" />


Fixes # (x-axis overlapping and tick spacing in Volunteer Trends chart)


## Main changes explained:
- Updated `<XAxis>` in `VolunteerTrendsLineChart` to use `type="number"`, fixed `domain`, and clean step ticks.
- Updated `formatChartData` to ensure numeric week values are safely passed as numbers rather than conflicting strings.
- Added array guard clauses and non-zero `chartSize` initial state fallbacks to prevent empty/null render crashes.
- Fixed calender compatability in darkmode and styling changes 

## How to test:
1. Check into branch `saisandeep_fix_x_axis_position`
2. Run `npm install` and `npm start` to run this PR locally
3. Clear site data/cache
4. Log in as an admin or volunteer user
5. Navigate to http://localhost:5173/totalorgsummary
6. Verify that the x-axis displays week labels cleanly in step increments (0, 2, 4, 6, 8...) without overlapping
7. Toggle **dark mode** and verify that axis tick labels remain readable

## Screenshots or videos of changes:
<img width="1857" height="878" alt="Screenshot 2026-08-18 020251" src="https://github.com/user-attachments/assets/ffb1e792-9a13-4808-a4f1-27067e7bd005" />
<img width="1040" height="708" alt="Screenshot 2026-08-24 090428" src="https://github.com/user-attachments/assets/65cec83b-422d-4a64-82f6-ebe41b91f23d" />

