### PR TITLE
Som Ramnani - refactor(FaqSection): fix dark mode & add copy contact email functionality

### DIFF
--- a/src/components/CommunityPortal/Activities/FaqSection.jsx
+++ b/src/components/CommunityPortal/Activities/FaqSection.jsx
@@ -90,7 +90,10 @@ function FaqSection() {
   });
 
   return (
-    <div className={styles.faqContainer}>
+    <div
+      className={`${styles.faqContainer} ${darkMode ? styles.faqContainerDark : ''}`}
+      data-testid="faq-section"
+    >
       <h2 className={styles.faqTitle}>Frequently Asked Questions</h2>
       <p className={styles.faqSubtitle}>
         These are the most frequently asked questions about One Community.
@@ -98,7 +101,7 @@ function FaqSection() {
 
       <input
         type="text"
-        className={`${styles.faqSearch} ${darkMode ? styles.faqSearchDark : ''}`}
+        className={styles.faqSearch}
         placeholder="Search FAQs..."
         value={searchTerm}
         onChange={handleSearchChange}
@@ -111,7 +114,7 @@ function FaqSection() {
             type="button"
             className={`${styles.faqCategory} ${
               selectedCategory === category ? styles.active : ''
-            } ${darkMode ? styles.faqCategoryDark : ''}`}
+            }`}
             onClick={() => handleCategoryClick(category)}
           >
             {category}
@@ -129,7 +132,7 @@ function FaqSection() {
             <div key={faq.id} className={styles.faqItem}>
               <button
                 type="button"
-                className={`${styles.faqQuestion} ${darkMode ? styles.faqQuestionDark : ''}`}
+                className={styles.faqQuestion}
                 onClick={() => toggleFaq(faq.id)}
                 aria-expanded={openIndex === faq.id}
               >

--- a/src/components/CommunityPortal/Activities/FaqSection.module.css
+++ b/src/components/CommunityPortal/Activities/FaqSection.module.css
@@ -129,22 +129,61 @@
   color: gray;
 }
 
-.faqSearchDark {
+.faqContainerDark {
+  color: #d8dee9;
+  background-color: #1b2a41;
+}
+
+.faqContainerDark .faqTitle,
+.faqContainerDark .faqQuestion,
+.faqContainerDark .faqContact {
+  color: #f5f7fa;
+}
+
+.faqContainerDark .faqSubtitle,
+.faqContainerDark .noResults {
+  color: #b7c1d1;
+}
+
+.faqContainerDark .faqItem {
+  border-bottom-color: #4a5a77;
+}
+
+.faqContainerDark .faqAnswer {
+  color: #d8dee9;
+}
+
+.faqContainerDark .faqSearch {
   background-color: #2b3e59;
-  color: #ffffff;
+  color: #fff;
   border-color: #4a5a77;
 }
 
-.faqSearchDark::placeholder {
-  color: #8899aa;
+.faqContainerDark .faqSearch::placeholder {
+  color: #89a;
 }
 
-.faqCategoryDark {
+.faqContainerDark .faqCategory {
   background-color: #2b3e59;
-  color: #ffffff;
+  color: #fff;
   border: 1px solid #4a5a77;
 }
 
-.faqQuestionDark {
-  color: #ffffff;
+.faqContainerDark .faqCategory:hover,
+.faqContainerDark .faqCategory.active {
+  background-color: #3b4f6b;
+  color: #fff;
+  border-color: #7aa2d6;
+}
+
+.faqContainerDark .contactLink {
+  color: #90caf9;
+}
+
+.faqContainerDark .contactLink:hover {
+  color: #bbdefb;
+}
+
+.faqContainerDark .copiedMessage {
+  color: #81c784;
 }

--- a/src/components/CommunityPortal/Activities/__tests__/FaqSection.test.jsx
+++ b/src/components/CommunityPortal/Activities/__tests__/FaqSection.test.jsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import FaqSection from '../FaqSection';
+import styles from '../FaqSection.module.css';
+
+const mockStore = configureMockStore([]);
+const mockWriteText = vi.fn();
+
+const renderFaqSection = (darkMode = false) => {
+  const store = mockStore({ theme: { darkMode } });
+  return render(
+    <Provider store={store}>
+      <FaqSection />
+    </Provider>,
+  );
+};
+
+beforeAll(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText: mockWriteText },
+  });
+});
+
+beforeEach(() => {
+  mockWriteText.mockReset();
+  mockWriteText.mockResolvedValue(undefined);
+});
+
+describe('FaqSection', () => {
+  it('only applies the dark container class when dark mode is enabled', () => {
+    const { unmount } = renderFaqSection();
+    expect(screen.getByTestId('faq-section')).not.toHaveClass(styles.faqContainerDark);
+
+    unmount();
+    renderFaqSection(true);
+    expect(screen.getByTestId('faq-section')).toHaveClass(styles.faqContainerDark);
+  });
+
+  it('expands and collapses an answer in dark mode', () => {
+    renderFaqSection(true);
+    const question = screen.getByRole('button', { name: /what is one community/i });
+
+    expect(question).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(question);
+
+    expect(question).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText(/global nonprofit organization/i)).toBeInTheDocument();
+
+    fireEvent.click(question);
+    expect(question).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('filters FAQs by search text and category', () => {
+    renderFaqSection();
+
+    fireEvent.change(screen.getByPlaceholderText(/search faqs/i), {
+      target: { value: 'virtual and physical' },
+    });
+    expect(screen.getByText('Where is One Community located?')).toBeInTheDocument();
+    expect(screen.queryByText('What is One Community?')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/search faqs/i), {
+      target: { value: '' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Events' }));
+    expect(
+      screen.getByText('What kind of events does One Community organize?'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Where is One Community located?')).not.toBeInTheDocument();
+  });
+
+  it('copies the contact email and confirms the action', async () => {
+    renderFaqSection();
+
+    fireEvent.click(screen.getByRole('button', { name: /contact us/i }));
+
+    expect(mockWriteText).toHaveBeenCalledWith('onecommunityglobal@gmail.com');
+    expect(await screen.findByText('Copied!')).toBeInTheDocument();
+  });
+});

--- a/src/components/CommunityPortal/Activities/activityId/ActivityFAQs.jsx
+++ b/src/components/CommunityPortal/Activities/activityId/ActivityFAQs.jsx
@@ -2,8 +2,11 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { debounce } from 'lodash';
 import { FaSearch, FaChevronDown, FaChevronUp } from 'react-icons/fa';
+import { toast } from 'react-toastify';
 import { getAllFAQs } from '~/components/Faq/api';
 import styles from './ActivityFAQs.module.css';
+
+const CONTACT_EMAIL = 'onecommunityglobal@gmail.com';
 
 function normalizeFaqFromApi(faq) {
   return {
@@ -97,6 +100,13 @@ function ActivityFAQs() {
   const handleSearchChange = e => {
     const query = e.target.value;
     setSearchQuery(query);
+  };
+
+  const handleContactClick = () => {
+    navigator.clipboard
+      .writeText(CONTACT_EMAIL)
+      .then(() => toast.success('Email copied!'))
+      .catch(() => toast.error('Failed to copy email.'));
   };
 
   // Determine empty state message
@@ -193,9 +203,9 @@ function ActivityFAQs() {
       <div className={styles.footer}>
         <p className={styles.footerText}>
           Still have questions? Feel free to{' '}
-          <a href="#contact" className={styles.footerLink}>
+          <button type="button" className={styles.footerLink} onClick={handleContactClick}>
             contact
-          </a>{' '}
+          </button>{' '}
           with us!
         </p>
       </div>

--- a/src/components/CommunityPortal/Activities/activityId/ActivityFAQs.module.css
+++ b/src/components/CommunityPortal/Activities/activityId/ActivityFAQs.module.css
@@ -213,16 +213,24 @@
   color: #1976d2;
   text-decoration: none;
   cursor: pointer;
-  transition: color 0.3s ease;
+  transition: color 0.3s ease, background-color 0.3s ease;
   background: none;
   border: none;
-  padding: 0;
+  border-radius: 3px;
+  padding: 0 2px;
   font: inherit;
 }
 
 .footerLink:hover {
   color: #1565c0;
   text-decoration: underline;
+}
+
+.footerLink:focus-visible {
+  color: #0d47a1;
+  text-decoration: underline;
+  outline: 2px solid #1976d2;
+  outline-offset: 2px;
 }
 
 @media (width <= 768px) {
@@ -346,11 +354,20 @@
 }
 
 :global(body.dark-mode) .footerLink {
-  color: #64b5f6;
+  color: #90caf9 !important;
+  font-weight: 600;
+  text-decoration: underline;
 }
 
-:global(body.dark-mode) .footerLink:hover {
-  color: #90caf9;
+:global(body.dark-mode) .footerLink:hover,
+:global(body.dark-mode) .footerLink:focus-visible {
+  color: #fff !important;
+  background-color: #1565c0;
+  text-decoration: underline;
+}
+
+:global(body.dark-mode) .footerLink:focus-visible {
+  outline-color: #90caf9;
 }
 
 :global(body.dark-mode) .loading,

--- a/src/components/CommunityPortal/Activities/activityId/ActivityFAQs.module.css
+++ b/src/components/CommunityPortal/Activities/activityId/ActivityFAQs.module.css
@@ -214,6 +214,10 @@
   text-decoration: none;
   cursor: pointer;
   transition: color 0.3s ease;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
 }
 
 .footerLink:hover {
@@ -353,4 +357,3 @@
 :global(body.dark-mode) .error {
   color: #b0b0b0;
 }
-

--- a/src/components/CommunityPortal/Activities/activityId/__tests__/ActivityFAQs.test.jsx
+++ b/src/components/CommunityPortal/Activities/activityId/__tests__/ActivityFAQs.test.jsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'react-toastify';
+import { getAllFAQs } from '~/components/Faq/api';
+import ActivityFAQs from '../ActivityFAQs';
+
+vi.mock('~/components/Faq/api', () => ({
+  getAllFAQs: vi.fn(),
+}));
+
+vi.mock('react-toastify', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockWriteText = vi.fn();
+
+const renderActivityFAQs = () =>
+  render(
+    <MemoryRouter initialEntries={['/communityportal/activity/activity-1/faq']}>
+      <Route path="/communityportal/activity/:activityid/faq">
+        <ActivityFAQs />
+      </Route>
+    </MemoryRouter>,
+  );
+
+beforeAll(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText: mockWriteText },
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWriteText.mockReset();
+  mockWriteText.mockResolvedValue(undefined);
+  getAllFAQs.mockResolvedValue({
+    data: [
+      {
+        _id: 'faq-1',
+        question: 'How do I join?',
+        answer: 'Choose an activity and register.',
+        category: 'Participation',
+      },
+    ],
+  });
+});
+
+describe('ActivityFAQs', () => {
+  it('copies the code-provided contact email and shows a success toast', async () => {
+    renderActivityFAQs();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'contact' }));
+
+    expect(mockWriteText).toHaveBeenCalledWith('onecommunityglobal@gmail.com');
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Email copied!'));
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast when copying fails', async () => {
+    mockWriteText.mockRejectedValueOnce(new Error('Clipboard unavailable'));
+    renderActivityFAQs();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'contact' }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to copy email.'));
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/CommunityPortal/Activities/activityId/__tests__/ActivityFAQs.test.jsx
+++ b/src/components/CommunityPortal/Activities/activityId/__tests__/ActivityFAQs.test.jsx
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { toast } from 'react-toastify';
 import { getAllFAQs } from '~/components/Faq/api';
 import ActivityFAQs from '../ActivityFAQs';
+import styles from '../ActivityFAQs.module.css';
 
 vi.mock('~/components/Faq/api', () => ({
   getAllFAQs: vi.fn(),
@@ -54,7 +55,11 @@ describe('ActivityFAQs', () => {
   it('copies the code-provided contact email and shows a success toast', async () => {
     renderActivityFAQs();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'contact' }));
+    const contactButton = await screen.findByRole('button', { name: 'contact' });
+    expect(contactButton.tagName).toBe('BUTTON');
+    expect(contactButton).toHaveClass(styles.footerLink);
+
+    fireEvent.click(contactButton);
 
     expect(mockWriteText).toHaveBeenCalledWith('onecommunityglobal@gmail.com');
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Email copied!'));

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -83,6 +83,7 @@ import SkillsOverviewPage from './components/HGNHelpSkillsDashboard/SkillsOvervi
 import CommunityMembersPage from './components/HGNHelpSkillsDashboard/CommunityMembersPage';
 import UserProfilePage from './components/HGNHelpSkillsDashboard/UserProfilePage';
 import FeedbackModal from './components/HGNHelpSkillsDashboard/FeedbackModal';
+import Activity from './components/CommunityPortal/Activities/activityId/Activity';
 import ActivityAttendance from './components/CommunityPortal/Activities/ActivityAttendance';
 import ActivityAgenda from './components/CommunityPortal/Activities/ActivityAgenda';
 import EventList from './components/CommunityPortal/Event/EventList/EventList';
@@ -872,6 +873,11 @@ export default (
           path="/communityportal/profile/:userId"
           fallback
           component={UserProfile}
+        />
+        <CPProtectedRoute
+          path="/communityportal/activity/:activityid/faq"
+          exact
+          render={() => <Activity initialTab="FAQs" />}
         />
         <CPProtectedRoute
           path="/communityportal/ActivityAttendance"


### PR DESCRIPTION
# Description
<img width="820" height="373" alt="Screenshot 2026-08-20 at 12 11 48 PM" src="https://github.com/user-attachments/assets/740b486c-46be-4058-b8f8-cff8f3e598d2" />
<img width="821" height="630" alt="Screenshot 2026-08-20 at 12 12 24 PM" src="https://github.com/user-attachments/assets/f37ca6e1-be8a-4827-b8fa-8af71a6643b6" />

## Related PRS (if any):
This PR is related to [PR#3241](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3241).


## Main changes explained:
- Updated `FaqSection.jsx` to apply dark mode through a single container-level CSS Module class instead of adding separate dark-mode classes to individual elements.
- Updated `FaqSection.module.css` with scoped dark-mode styles for FAQ questions, answers, search fields, category filters, borders, contact links, and empty states.
- Updated `ActivityFAQs.jsx` to replace the inactive contact link with a button that copies `onecommunityglobal@gmail.com` to the clipboard.
- Added success and failure notifications using the existing `react-toastify` system. A successful copy displays “Email copied!”, while a clipboard failure displays “Failed to copy email.”
- Updated `ActivityFAQs.module.css` so the contact button retains the appearance of a link in both light and dark modes.
- Added `FaqSection.test.jsx` to cover theme selection, accordion behavior, searching, category filtering, and contact interaction.
- Added `ActivityFAQs.test.jsx` to verify that the correct email is copied and that the appropriate success or error toast is displayed.

## How to test:
1. Check into `som-fix/activity-faqs-dark-mode`
2. Do `npm install` and  start the app locally.
3. Clear site data/cache
4. Log in as admin user
5. Navigate to `/communityportal/activity/1/faq` or replace 1 with an available activity ID.
6. Confirm that the FAQ page loads correctly. Expand questions and test the search and category filters.
7. Enable dark mode and confirm that all FAQ content—including questions, answers, filters, search fields, and contact text—is clearly visible.
8. Click contact and confirm that an “Email copied!” toast appears. Paste the clipboard contents and verify that it contains onecommunityglobal@gmail.com.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/8d278816-5bec-4166-94f3-09756efbd2df


## Note:
- This PR focuses only on the FAQ dark-mode improvements and contact email copy functionality.
- Activity-specific FAQ fetching remains unchanged and can be addressed in a separate PR.
- The legacy `FaqSection` component is currently not mounted by an active route, but its dark-mode styling and tests were updated for future use.
- The contact button currently copies the code-provided `onecommunityglobal@gmail.com` address rather than an event-specific email.
- No backend or API changes are included.
