### PR TITLE
Anthony/ 🔥 for Permission Change Related Header and Changing Role on User Profile

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -46,6 +46,7 @@ export const loginUser = credentials => dispatch => {
         dispatch(setCurrentUser({ new: true, userId: res.data.userId }));
         return { success: true, new: true };
       }
+      localStorage.setItem('justLoggedIn', true);
       localStorage.setItem(tokenKey, res.data.token);
       httpService.setjwt(res.data.token);
       const decoded = jwtDecode(res.data.token);

--- a/src/components/Auth/PermissionWatcher.jsx
+++ b/src/components/Auth/PermissionWatcher.jsx
@@ -9,16 +9,24 @@ import { getUserProfile } from '../../actions/userProfile';
 
 function PermissionWatcher() {
   const dispatch = useDispatch();
-  const { isAuthenticated, forceLogoutAt } = useSelector(state => state.auth || {});
+  const { isAuthenticated, forceLogoutAt, user } = useSelector(state => state.auth || {});
   const userProfile = useSelector(state => state.userProfile);
   const isAcknowledged = userProfile?.permissions?.isAcknowledged !== false;
   const [isPermAckLoading, setIsPermAckLoading] = useState(false);
+  const currentUser = user.userid === userProfile._id;
   // Get seconds remaining until force logout
   const secondsRemaining = useCountdown(forceLogoutAt);
+  const [justLoggedIn, setJustLoggedIn] = useState(!!localStorage.getItem('justLoggedIn'));
+
+  useEffect(() => {
+    if (justLoggedIn) {
+      handleAcknowledge();
+    }
+  }, [currentUser]);
 
   // Start the force logout countdown when conditions are met
   useEffect(() => {
-    if (isAuthenticated && !isAcknowledged && !forceLogoutAt) {
+    if (isAuthenticated && !isAcknowledged && !forceLogoutAt && currentUser && !justLoggedIn) {
       // eslint-disable-next-line no-console
       console.log('Starting force logout countdown due to unacknowledged permission changes');
       dispatch(startForceLogout(20000)); // 20 seconds countdown
@@ -50,6 +58,10 @@ function PermissionWatcher() {
         .then(() => {
           setIsPermAckLoading(false);
           dispatch(getUserProfile(_id));
+          if (justLoggedIn) {
+            localStorage.removeItem('justLoggedIn');
+            setJustLoggedIn(false);
+          }
         })
         .catch(error => {
           // eslint-disable-next-line no-console
@@ -68,13 +80,16 @@ function PermissionWatcher() {
     return null;
   }
   return (
-    !isAcknowledged && (
+    !isAcknowledged &&
+    currentUser &&
+    !justLoggedIn && (
       <PopUpBar
-        message={`Permissions changed—logging out in ${secondsRemaining}s. Timer will be stopped; please restart after login.`}
+        message={`Heads up, there have been permission changes made to your account. You will be logged out in ${secondsRemaining}s to automatically apply these new permissions. \n
+          Your timer will be stopped as part of this logout, please restart after logging back in.`}
         onClickClose={handleAcknowledge}
         textColor="red"
         isLoading={isPermAckLoading}
-        button={false}
+        permissionsChanged={!isAcknowledged}
       />
     )
   );

--- a/src/components/Auth/PermissionWatcher.jsx
+++ b/src/components/Auth/PermissionWatcher.jsx
@@ -13,7 +13,7 @@ function PermissionWatcher() {
   const userProfile = useSelector(state => state.userProfile);
   const isAcknowledged = userProfile?.permissions?.isAcknowledged !== false;
   const [isPermAckLoading, setIsPermAckLoading] = useState(false);
-  const currentUser = user.userid === userProfile._id;
+  const currentUser = user?.userid === userProfile?._id;
   // Get seconds remaining until force logout
   const secondsRemaining = useCountdown(forceLogoutAt);
   const [justLoggedIn, setJustLoggedIn] = useState(!!localStorage.getItem('justLoggedIn'));

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1072,16 +1072,6 @@ export function Header(props) {
           />
         ))}
       <PermissionWatcher props={props} />
-      {props.auth.isAuthenticated && props.userProfile?.permissions?.isAcknowledged === false && (
-        <PopUpBar
-          firstName={viewingUser?.firstName || firstName}
-          lastName={viewingUser?.lastName}
-          message="Heads Up, there were permission changes made to this account"
-          onClickClose={handlePermissionChangeAck}
-          textColor="black_text"
-          isLoading={isAckLoading}
-        />
-      )}
       <div>
         <Modal
           isOpen={popup}
@@ -1097,8 +1087,10 @@ export function Header(props) {
       </div>
       {props.auth.isAuthenticated && isModalVisible && (
         <div className={`${darkMode ? 'bg-oxford-blue' : ''} ${styles.cardWrapper}`}>
-          <Card color="primary" className={styles.headerCard}>
-            <div className="close-button"><Button close onClick={closeModal} /></div>
+          <Card color="primary" className={`${styles.headerCard} ${styles.dashboardHeader}`}>
+            <div className="close-button" style={{ paddingRight: '5px'}}>
+              <Button close onClick={closeModal} />
+            </div>
             <div className={`${styles.cardContent}`}>{modalContent}</div>
           </Card>
         </div>

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -112,6 +112,10 @@
   position: relative;
 }
 
+.headerCard.dashboardHeader {
+  flex-direction: row-reverse;
+}
+
 .cardWrapper {
   padding: 1rem 0;
   width: 100%;

--- a/src/components/PopUpBar/PopUpBar.jsx
+++ b/src/components/PopUpBar/PopUpBar.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import DOMPurify from 'dompurify';
 import parse from 'html-react-parser';
 import styles from './PopUpBar.module.css';
+import { Button } from 'reactstrap';
 
 function PopUpBar({
   firstName = window.viewingUser?.firstName,
@@ -13,6 +14,7 @@ function PopUpBar({
   isLoading = false,
   button = true,
   isMeetingNotification = false,
+  permissionsChanged = false,
 }) {
   const defaultTemplate =
     `You are currently functioning as ${firstName} ${lastName}, ` +
@@ -24,6 +26,7 @@ function PopUpBar({
     styles.popupContainer,
     textColor === 'black_text' ? styles.blackText : '',
     isMeetingNotification ? styles.meetingNotification : '',
+    permissionsChanged ? styles.permissionsChanged : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -41,11 +44,7 @@ function PopUpBar({
           {isMeetingNotification ? parse(DOMPurify.sanitize(displayText)) : displayText}
         </p>
       )}
-      {button && (
-        <button type="button" className={styles.closeButton} onClick={onClickClose}>
-          X
-        </button>
-      )}
+      {button && <Button close onClick={onClickClose} style={{ paddingRight: '5px' }} />}
     </div>
   );
 }

--- a/src/components/PopUpBar/PopUpBar.module.css
+++ b/src/components/PopUpBar/PopUpBar.module.css
@@ -91,6 +91,17 @@
   padding: 0;
 }
 
+.popupContainer.permissionsChanged {
+  align-items: flex-start;
+  gap: 0px;
+  padding: 0px;
+}
+
+.popupContainer.permissionsChanged > .popupMessage {
+  white-space: pre-line;
+  padding: 5px 40px;
+}
+
 @media (width <= 768px) {
   .meetingNotification .popupMessage {
     font-size: 0.8rem;

--- a/src/components/PopUpBar/__tests__/PopUpBar.test.jsx
+++ b/src/components/PopUpBar/__tests__/PopUpBar.test.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import { render, screen, fireEvent } from '@testing-library/react';
+import { Button } from 'reactstrap';
 import PopUpBar from '../PopUpBar';
 
 // render Component
@@ -37,7 +38,7 @@ describe('Test Suite for PopUpBar', () => {
     const onClickClose = vi.fn();
     renderComponent({ onClickClose });
 
-    const closeButton = screen.getByText('X');
+    const closeButton = screen.getByRole('button', { name: /close/i });
     fireEvent.click(closeButton);
 
     expect(onClickClose).toHaveBeenCalled();

--- a/src/components/UserProfile/Badges.jsx
+++ b/src/components/UserProfile/Badges.jsx
@@ -184,7 +184,10 @@ export const Badges = (props) => {
           </div>
         </CardHeader>
         <CardBody style={{ overflow: 'auto' }}>
-          <FeaturedBadges personalBestMaxHrs={props.userProfile.personalBestMaxHrs} badges={props.userProfile.badgeCollection} />
+          {props.userProfile.badgeCollection.length > 0 ?
+            <FeaturedBadges personalBestMaxHrs={props.userProfile.personalBestMaxHrs} badges={props.userProfile.badgeCollection} /> :
+            ''
+          }
         </CardBody>
         <CardFooter style={{ display: 'flex', alignItems: 'center' }}>
           <span

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.jsx
@@ -496,6 +496,7 @@ const BasicInformationTab = props => {
   const [desktopDisplay, setDesktopDisplay] = useState(window.innerWidth > 1024);
   const [errorOccurred, setErrorOccurred] = useState(false);
   const [showRolePermsModal, setShowRolePermsModal] = useState(false);
+  const [newRole, setNewRole] = useState(userProfile.role);
   const dispatch = useDispatch();
   const rolesAllowedToEditStatusFinalDay = ['Administrator', 'Owner'];
   const canEditStatus = dispatch(hasPermission('interactWithPauseUserButton'));
@@ -552,6 +553,22 @@ const BasicInformationTab = props => {
   const handleResize = () => {
     setDesktopDisplay(window.innerWidth > 1024);
   };
+
+  const updateSelectedRole = selectedRole => {
+    setNewRole(selectedRole);
+    const retrievedRole = roles.find(role => role.roleName === selectedRole);
+    const remainingAddedPermissions = userProfile.permissions.frontPermissions.some(permission => !retrievedRole.permissions.includes(permission));
+    const remainingRemovedPermissions = retrievedRole.permissions.some(permission => userProfile.permissions.removedDefaultPermissions.includes(permission));
+
+    if(remainingAddedPermissions || remainingRemovedPermissions) {
+      setShowRolePermsModal(true)
+    } else {
+      setUserProfile({ 
+        ...userProfile, 
+        role: selectedRole,
+      })
+    }
+  }
 
   useEffect(() => {
     window.addEventListener('resize', handleResize);
@@ -725,15 +742,38 @@ const BasicInformationTab = props => {
       </Col>
       <Col md={desktopDisplay ? '6' : ''} className={darkMode ? 'bg-yinmn-blue' : ''}>
         {canEditRole ? (
-          <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-            <Button
-              color="primary"
-              style={darkMode ? boxStyleDark : boxStyle}
-              onClick={() => setShowRolePermsModal(true)}
+          <FormGroup>
+            <select
+              id="role"
+              name="role"
+              className={`form-control ${darkMode ? 'bg-darkmode-liblack border-0 text-light' : ''}`}
+              value={newRole || ''}   // make sure this is a string
+              onChange={e => {
+                updateSelectedRole(e.target.value)
+              }}
             >
-              Manage Role & Permissions
-            </Button>
-          </div>
+              {/* Optional placeholder when no role selected */}
+              {!userProfile.role && <option value="">Select role</option>}
+
+              {canAddDeleteEditOwners && (
+                <option value="Owner" style={desktopDisplay ? { marginLeft: '5px' } : {}}>
+                  Owner
+                </option>
+              )}
+  
+              {(roles || [])
+                .map(r => (typeof r === 'string' ? r : r.roleName)) // normalize
+                .filter(Boolean)
+                .map(roleName => {
+                  if (roleName === 'Owner') return null; // skip Owner in this list
+                  return (
+                    <option key={roleName} value={roleName}>
+                      {roleName}
+                    </option>
+                  );
+                })}
+            </select>
+          </FormGroup>
           
         ) : (
           <p className={`text-right ${darkMode ? 'text-light' : ''}`}>{userProfile.role}</p>
@@ -1025,6 +1065,7 @@ const BasicInformationTab = props => {
       <RoleChangePermissionsModal
         isOpen={showRolePermsModal}
         onClose={() => setShowRolePermsModal(false)}
+        newRole={newRole}
         roles={roles}
         userProfile={userProfile}
         setUserProfile={setUserProfile}

--- a/src/components/UserProfile/BasicInformationTab/BasicInformationTab.module.css
+++ b/src/components/UserProfile/BasicInformationTab/BasicInformationTab.module.css
@@ -83,3 +83,32 @@
 .darkModeText {
   color: white;
 }
+
+.darkMode.roleModal.button {
+  border-color: #2563eb !important;
+  background-color: #2563eb !important;
+}
+
+.darkMode.roleModal.button:hover {
+  color: #fff;
+  background-color: #1d4ed8 !important;
+  border-color: #1d4ed8 !important;
+}
+
+.roleModal.button {
+  color: #007bff;
+  background-color: #f8f9fa;
+  border-color: #007bff;
+}
+
+.roleModal.button:hover {
+  color: #fff;
+  background-color: #007bff;
+  border-color: #007bff;
+}
+
+.roleModal.button:disabled {
+  color: #007bff;
+  border-color: #007bff;
+  background-color: transparent;
+}

--- a/src/components/UserProfile/BasicInformationTab/__tests__/BasicInformationTab.test.jsx
+++ b/src/components/UserProfile/BasicInformationTab/__tests__/BasicInformationTab.test.jsx
@@ -504,7 +504,7 @@ it('Test case 9: Renders the role  component with a combo box  when canEditRole 
     </Provider>,
   );
   expect(screen.getByText("Role")).toBeInTheDocument(); // Label
-  expect(screen.getByRole('button', { name: 'Manage Role & Permissions' })).toBeInTheDocument(); // Role Modal button
+  expect(screen.getByRole('combobox')).toBeInTheDocument(); // combo box
 });
 it('Test case 10 : Does not render a combo box for role component   when canEditRole is false', () => {
   testProps.canEditRole=false;

--- a/src/components/UserProfile/RoleChangePermissionsModal.jsx
+++ b/src/components/UserProfile/RoleChangePermissionsModal.jsx
@@ -131,6 +131,8 @@ function RoleChangePermissionsModal(props) {
     if(!selectedRole2) return
     const roleDefaults = roleNameToDefaults[selectedRole2.roleName] || [];
     const removedDefaults = getRemovedDefaults(selectedRole2.roleName)
+    const remainingAddedPermissions = userCustomPermissions.filter(perms => { return !roleDefaults.includes(perms) })?.length;
+    const remainingRemovedPermissions = removedDefaults.filter(perms => { return roleDefaults.includes(perms) })?.length;
     return (
       <div key={selectedRole2.roleName} style={{ border: '1px solid #ccc', borderRadius: 4, marginBottom: 8 }}>
         <div style={{ padding: '8px 12px' }}>
@@ -145,11 +147,18 @@ function RoleChangePermissionsModal(props) {
             </div>
           }
           {userProfile?.role !== selectedRole && <h5>Changing User&apos;s Role from {userProfile?.role} to {selectedRole}</h5>}
-          {userProfile?.role !== selectedRole && 
+          {userProfile?.role !== selectedRole && (remainingAddedPermissions > 0 || remainingRemovedPermissions > 0) &&
             <div style={{ display: 'flex' }}>
               <div style={{padding: '10px 0'}}>
                 These permissions were modified and do not match the new role&apos;s. 
                 Which of these permissions do you wish to keep?
+              </div>
+            </div>
+          }
+          {userProfile?.role !== selectedRole && (remainingAddedPermissions === 0 && remainingRemovedPermissions === 0) &&
+            <div style={{ display: 'flex' }}>
+              <div style={{padding: '10px 0'}}>
+                There are added/removed pemissions remaining but they match the default permissions of the currently selected new role, so nothing to check in this case
               </div>
             </div>
           }

--- a/src/components/UserProfile/RoleChangePermissionsModal.jsx
+++ b/src/components/UserProfile/RoleChangePermissionsModal.jsx
@@ -18,6 +18,7 @@ function RoleChangePermissionsModal(props) {
   const {
     isOpen,
     onClose,
+    newRole,
     roles = [],
     userProfile,
     loadUserProfile,
@@ -35,21 +36,20 @@ function RoleChangePermissionsModal(props) {
     return map;
   }, [roles]);
 
-  const initialSelectedRole = userProfile?.role || '';
   const initialCustomPerms = userProfile?.permissions?.frontPermissions || [];
   const initialRemovedDefaults = userProfile?.permissions?.removedDefaultPermissions || [];
 
-  const [selectedRole, setSelectedRole] = useState(initialSelectedRole);
+  const [selectedRole, setSelectedRole] = useState(newRole);
   const [userCustomPermissions, setUserCustomPermissions] = useState(initialCustomPerms);
   const [removedDefaultsByRole, setRemovedDefaultsByRole] = useState({});
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    setSelectedRole(initialSelectedRole);
+    setSelectedRole(newRole);
     setUserCustomPermissions(initialCustomPerms);
     setRemovedDefaultsByRole(prev => ({
       ...prev,
-      [initialSelectedRole]: initialRemovedDefaults,
+      [newRole]: initialRemovedDefaults,
     }));
   }, [isOpen]);
 
@@ -102,13 +102,15 @@ function RoleChangePermissionsModal(props) {
       await axios.patch(permissionURL, permissionData)
 
       loadUserProfile();
+      setSaving(false);
+      setKeptFrontPermissions([]); // reset all permissions to unchecked if modal is retriggered after saving
+      setKeptRemovedPermissions([]);
       toast.success('Your changes have been saved, you can verify it in Permissions Management');
       onClose();
     } catch (err) {
+      setSaving(false);
       const errorData = `: ${err.response.data}`
       toast.error(`Failed to update role/permissions${err?.response?.data ? errorData : ''}`);
-    } finally {
-      setSaving(false);
     }
   };
 
@@ -132,14 +134,25 @@ function RoleChangePermissionsModal(props) {
     return (
       <div key={selectedRole2.roleName} style={{ border: '1px solid #ccc', borderRadius: 4, marginBottom: 8 }}>
         <div style={{ padding: '8px 12px' }}>
-          {userProfile?.role === selectedRole && <h4>User&apos;s Current Role</h4>}
-          {userProfile?.role !== selectedRole && <h5>Changing User&apos;s Role from {userProfile?.role} to {selectedRole}</h5>}
-          <div style={{ display: 'flex' }}>
-            <div style={{padding: '10px 0'}}>
-              These permissions were modified and do not match the new role&apos;s. 
-              Which of these permissions do you wish to keep?
+          {userProfile?.role === selectedRole &&
+            <div>
+              <h4>User&apos;s Current Role</h4>
+              <br></br>
+              <div>
+                To change just the user's permissions, utilize Permissions Management under Other Links if you have the
+                authority to modify individual user permissions.
+              </div>
             </div>
-          </div>
+          }
+          {userProfile?.role !== selectedRole && <h5>Changing User&apos;s Role from {userProfile?.role} to {selectedRole}</h5>}
+          {userProfile?.role !== selectedRole && 
+            <div style={{ display: 'flex' }}>
+              <div style={{padding: '10px 0'}}>
+                These permissions were modified and do not match the new role&apos;s. 
+                Which of these permissions do you wish to keep?
+              </div>
+            </div>
+          }
           {userCustomPermissions
             .some(perms => {
               return !roleDefaults.includes(perms)
@@ -201,11 +214,11 @@ function RoleChangePermissionsModal(props) {
     <Modal isOpen={isOpen} toggle={onClose} className={darkMode ? 'dark-mode text-light' : ''} size="lg">
       <ModalHeader toggle={onClose} style={{}} className={darkMode ? 'bg-space-cadet' : ''}>
         <div style={{display: 'flex', gap: '10px'}}>
-          Manage Role & Permissions
+          You Are About to Change The Role & Permissions For This Person
           <EditableInfoModal
             role={authRole}
             areaName={'roleChangeInfo'}
-            areaTitle="Role Change"
+            areaTitle="Role Change Modal"
             fontSize={20}
             darkMode={darkMode}
           />
@@ -214,7 +227,7 @@ function RoleChangePermissionsModal(props) {
       <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
         <div style={{ marginBottom: 12 }}>
           <label htmlFor="roleSelect" className={darkMode ? 'text-light' : ''}>
-            Role
+            New Role
           </label>
           <Input
             type="select"
@@ -247,11 +260,11 @@ function RoleChangePermissionsModal(props) {
         </div>
       </ModalBody>
       <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
-        <Button onClick={onClose} style={boxStyling} disabled={saving}>
+        <Button color="secondary" onClick={onClose} style={boxStyling} disabled={saving}>
           Cancel
         </Button>
-        <Button color="success" onClick={handleConfirm} style={boxStyling} disabled={saving || userProfile?.role === selectedRole}>
-          {saving ? 'Saving...' : 'Confirm'}
+        <Button onClick={handleConfirm} className={`${darkMode ? styles.darkMode : ''} ${styles.roleModal} ${styles.button}`} disabled={saving || userProfile?.role === selectedRole}>
+          {saving ? 'Saving...' : 'Save Changes'}
         </Button>
       </ModalFooter>
     </Modal>

--- a/src/components/UserProfile/UserProfile.scss
+++ b/src/components/UserProfile/UserProfile.scss
@@ -103,10 +103,6 @@
   font-weight: 600;
 }
 
-.profile-tabs .nav-tabs {
-  margin-bottom: 5%;
-}
-
 .profile-tabs .nav-tabs .nav-link {
   font-weight: 600;
   border: none;
@@ -161,7 +157,7 @@
 }
 
 .profileEditButtonContainer {
-  margin-top: 20px;
+  margin-top: 15px;
 }
 
 .profileEditButton {
@@ -466,6 +462,10 @@ button.btn.btn-outline-primary {
   grid-column: 1;
   grid-row: 3;
   background-color: transparent;
+}
+
+#myTabContent {
+  padding: 10px 0px 5px 5px;
 }
 
 /* Mobile & Tablet Layout */

--- a/src/components/UserProfile/UserProfileEdit/SaveButton.jsx
+++ b/src/components/UserProfile/UserProfileEdit/SaveButton.jsx
@@ -47,10 +47,6 @@ const SaveButton = props => {
       setIsLoading(false);
       setIsErr(false);
       setSaved();
-
-      setTimeout(() => {
-        setModal(true);
-      }, 1000); 
     } catch (err) {
       setIsErr(true);
       setIsLoading(false);


### PR DESCRIPTION
# Description
Fixed 2nd success message modal popup when closing the first quickly after changing a user's role on their profile page. Fixed getting the permissions changed logout header when viewing the dashboard of another user or some other pages of another user. Some styling changes on User Profile for details container for Basic Information and other sections.
Readded the dropdown list for Role on User Profile, triggering the modal to check added/removed permissions if there are any that differ from new Role, otherwise just new role is selected allowing user to Save Changes.

## Related PRS (if any):
This frontend PR is related to no backend PR.
…

## Main changes explained:
- Updated authActions.js by adding a line to add justLoggedIn localStorage item on user login to prevent forced logout.
- Updated PermissionWatcher to also have a currentUser condition, preventing the "Heads up..." popup (also adjusted the message to cover what was originally separated into two PopUpBar elements), and the forced logout situation for wrong users, and to only trigger if user was currently logged in at time of their permissions being updated. Prevents forced logout if user just logged in after such changes. 
- Updated Header.jsx by removing Popup Bar element, whole header handling to PermissionWatcher.jsx
- Updated Header.module.css by adding a class styling so text in blue header (mostly for Volunteer/Manager accounts that have not clicked the X yet) is always left of the X.
- Updated PopUpBar.jsx by adding handling for styling of the permissions change related header, and aligning the X to be same spot as the blue header related to some roles.
- Updated PopUpBar.module.css with new styling so the permission change header retains how it looked with being two separate PopUpBar elements.
- Updated Badges.jsx so when user has no badges to display, the section does not have a horizontal scrollbar on smaller screens
- Updated RoleChangePermissionsModal.jsx by changing mostly text as per request regarding changes and added a different message for if user's current role was selected after the modal was triggered.
- Updated UserProfile.scss with removing one class, adjusting other styling for less white space between section links below badge section and the section content.
- Updated BasicInformationTab.jsx with restoring the dropdown list to the Role part of Basic Information, and largely setup for it to only trigger the role change modal if new selected role's default permissions do not match all of the modified permissions of the user assigned through Permissions Management -> Manage Individual User Permissions.
- Updated BasicInformationTab.module.css with new styling selectors, to get the Save Changes button of the role change modal to better match the look of Save Changes at the bottom of User Profile.
- Updated SaveButton.jsx by removing a setTimeout in handleSave that resets the setModal to true, causing a 2nd success message modal to popup if you closed the 1st modal within a second of it appearing. (Another issue was that the 2nd success modal caused you to lose the scrollbar, requiring a refresh, but possibly due to issue resolved by below fix)

…

## How to test:
1. check into current branch
2. do `npm install` or `yarn install` and `...` to run this PR locally
3. Clear site data/cache
4. login as Owner
5. go to dashboard→ go to a user (can use Anthony Test or Anthony Test2 to test) → click name to go to that account's profile page
6. Scroll down to the user's basic information, modify one of the values and click save changes
7. Verify that after closing the modal quickly, no 2nd modal pops up
8. You can double check the 2nd modal pop up on the dev site, by repeating step 7 and seeing it appear.

### Check Role dropdown list/Role Change Modal
1. Pick a user that you'd like to test
2. Go to Other Links → Permissions Management → Manage Individual User Permissions, check the permissions of the user you picked
3. Compare their permissions to their role to see if they only have the role's default permissions or had changed permissions
4. Go to the user's profile page
5. Scroll down to Role, click the list and select a role
6. If the user has no permissions changed, verify that you can freely keep changing the role
7. Test Save Changes to check that on refresh, the user's role is updated correctly
9. If the user has modified permissions, select different roles, and verify that the role change modal appears as normal with added/removed permissions to check respectively based on the role.
10. Click outside the modal to close it, and try a different role to repeat step 8.
11. Click Save Changes on the role change modal with however many checked/unchecked permissions as you desire and verify if the role is successfully changed, 
12. (Owner Only or user with the permission to view the permission change log table) Go to Other Links → Permissions Management verify that a change log was created.

### Forced logout Headers Route 1
1. Click the R icon to the right of the user's name on User Profile (Assuming you're continuing right from above steps. Also, this step is included because sometimes a role change does trigger the permission change headers, possibly due to some permission changes occurring, but does not seem to be consistent, or was also due sometimes to the 2nd success message modal)

### Forced logout Headers Route 2
1. Go to Other Links -> Permission Management -> Manage User Permissions, filter to a user you're testing (either my test accounts or yours if you have a spare that you can log into to verify from the permissions modified user), and add/remove a permission, or multiple if you'd like.
2. Save changes
3. Either go to the user's profile, then click the R to go to their People Report page (this is one such page where the permission headers can appear when viewing information about another user, you can verify this bug by repeated the process on the dev site)
4. Or go to Dashboard -> find the user -> click the green or red dot to the left of their name -> click yes to view their dashboard -> verify that no permission change header appears for you

### Bonus step if you have a 2nd account that you can log into
1. If you did route 2 using your 2nd account -> logout of your owner account -> login on your spare account -> verify that the permission change header does not for that account.
2. Modify permission of the spare account, using the dev site while staying logged in on your spare on the localhost site. Verify that on refresh or changing the view to some pages, would cause the permission change header to appear and then subsequently log you out. (Not all pages have the check for if user has their permission changes acknowledged or not, so some pages would not cause the user to be logged out, this should repeatable by following the same steps on dev, with your spare visiting those same pages after a permission change while logged in)

## Screenshots or videos of changes:
<img width="1316" height="317" alt="Adjusted X of the permission change header to align with X of blue header" src="https://github.com/user-attachments/assets/fb50a070-d6b0-4e1b-b4a5-0a5241ff9d5f" />

<img width="595" height="699" alt="Restored drop down list for changing role on user profile page" src="https://github.com/user-attachments/assets/fb1bc65e-204b-4cbc-8683-2f0239411744" />

<img width="794" height="527" alt="Changed top title of role change modal on user profile" src="https://github.com/user-attachments/assets/b811cef8-fca2-49de-9bc6-6ea8d2d14330" />

<img width="1161" height="527" alt="Added text paragraph for role change modal if an admin selected the user&#39;s current role" src="https://github.com/user-attachments/assets/f16c3422-9ee8-45a0-9f67-4aca152f262b" />

### Videos:
[Demo for Forced Logout on Admin/Owner view and People Report Page of Another User](https://www.youtube.com/watch?v=J64O58-NGZ4)

[Demo of Changing Roles with Modal and Dropdown List](https://www.youtube.com/watch?v=4B_EY24_ASs)

(Above video is outdated for edge case in the modal where no added/removed permissions are shown for some selected roles)
<img width="1117" height="621" alt="Added handling for if switching selected role to a role with no permissions to check in role modal" src="https://github.com/user-attachments/assets/7a5954dd-0cc0-48ef-b162-8319cb5a3a68" />


## Note:
If you do a role change without the modal popping up, you can click Save Changes to update the user's role, but their added/removed permissions would be retained, thereby triggering the modal if you change the user's role again to a role that does meet the conditions to trigger it. 

I confirmed with Jae that it's ok to leave for the time being, so do not worry about that, if needed it'll be addressed in a separate hotfix or PR.