### PR TITLE
Akshay Fix HGN Help Modal Dark Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ Use this space to show useful examples of how a project can be used. Additional 
 
 _For more examples, please refer to the [Documentation](https://example.com)_
 
+### HGN Help request behavior
+
+The `/hgnhelp` route displays the HGN Help request modal. Owners, administrators, and volunteers on the HGN Software Development Team can submit a request after selecting a help category. Other volunteers see an eligibility warning and cannot submit.
+
+After a successful submission, the success toast is displayed, the modal closes, and the user is intentionally returned to `/dashboard`. This redirect is explicit application behavior, not an automatic result of the modal overlay. The suggestion `here` link also closes the help modal and returns to the dashboard to open the suggestion flow.
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ## One Community Global Code of Conduct

--- a/src/components/LandingPage/HelpModal.jsx
+++ b/src/components/LandingPage/HelpModal.jsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import PropTypes from 'prop-types';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Modal } from 'react-bootstrap';
 import { connect, useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
@@ -100,14 +100,13 @@ function HelpModal({ show, onHide, auth }) {
   /* ---------------- Access Logic ---------------- */
   const role = auth?.user?.role?.trim().toLowerCase() || '';
 
-  const allowedRoles = useMemo(() => new Set(['owner', 'administrator']), []);
-
-  const isSoftwareDevMember = useMemo(() => {
-    return (
-      allowedRoles.has(role) ||
-      teams.some(team => team.teamName?.trim().toLowerCase() === 'software development team')
+  const isSoftwareDevMember =
+    ['owner', 'administrator'].includes(role) ||
+    teams.some(team =>
+      ['software development team', 'hgn software development team'].includes(
+        team.teamName?.trim().toLowerCase(),
+      ),
     );
-  }, [allowedRoles, teams, role]);
 
   const renderContent = () => {
     if (loading) return <div>Loading categories...</div>;
@@ -191,7 +190,7 @@ function HelpModal({ show, onHide, auth }) {
           If you have any suggestions please click{' '}
           <button
             type="button"
-            className="p-0 border-0 align-baseline"
+            className={`${styles.suggestionsLink} ${darkMode ? styles.suggestionsLinkDark : ''}`}
             onClick={handleSuggestionsClick}
           >
             here

--- a/src/components/LandingPage/HelpModal.module.css
+++ b/src/components/LandingPage/HelpModal.module.css
@@ -1,14 +1,14 @@
 /* stylelint-disable  */
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
 
-.helpModal .modalDialog {
+.helpModal :global(.modal-dialog) {
   max-width: 992px;
   margin: 1.75rem auto;
   width: 100%;
   padding: 0 15px;
 }
 
-.helpModal .modalContent {
+.helpModal :global(.modal-content) {
   width: 100%;
   min-height: 416px;
   background: #fff;
@@ -19,12 +19,12 @@
   overflow: hidden;
 }
 
-.helpModal .modalHeader {
+.helpModal :global(.modal-header) {
   border: none;
   padding: 48px 80px 24px;
 }
 
-.helpModal .modalTitle {
+.helpModal :global(.modal-title) {
   font-family: Roboto;
   font-weight: 700;
   font-size: 32px;
@@ -117,32 +117,66 @@
   padding-left: 5px;
 }
 
+.suggestionsLink {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #0d6efd;
+  font: inherit;
+  text-decoration: underline;
+  vertical-align: baseline;
+}
+
+.suggestionsLink:hover {
+  color: #0a58ca;
+}
+
+.suggestionsLink:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
+}
+
 /* ============================================
    DARK MODE STYLES
    ============================================ */
 
-.darkMode .modalContent {
+.darkMode :global(.modal-content) {
   background-color: #2b3e59 !important;
   border: 1px solid #4a5a77 !important;
   box-shadow: 0 4px 8px rgb(0 0 0 / 40%) !important;
+  color: #fff;
 }
 
-.darkMode .modalHeader {
+.darkMode :global(.modal-header) {
   border-bottom: 1px solid #4a5a77 !important;
 }
 
-.darkMode .modalTitle {
+.darkMode :global(.modal-title) {
   color: #fff !important;
 }
 
-.darkMode p button {
-  font-size: 18px;
-  color: #ddb55e !important;
-  text-decoration: underline;
+.darkMode :global(.modal-footer) {
+  border-top-color: #4a5a77;
 }
 
-.darkMode p button:hover {
-  color: #f5a926 !important;
+.darkMode :global(.close) {
+  color: #fff;
+  text-shadow: none;
+  opacity: 0.8;
+}
+
+.darkMode :global(.close:hover),
+.darkMode :global(.close:focus) {
+  color: #fff;
+  opacity: 1;
+}
+
+.suggestionsLinkDark {
+  color: #ddb55e;
+}
+
+.suggestionsLinkDark:hover {
+  color: #f5a926;
 }
 
 .selectButtonDark {
@@ -187,7 +221,7 @@
 }
 
 @media (width <= 992px) {
-  .helpModal .modalBody {
+  .helpModal :global(.modal-body) {
     padding: 0 20px;
   }
 

--- a/src/components/LandingPage/__tests__/HelpModal.test.jsx
+++ b/src/components/LandingPage/__tests__/HelpModal.test.jsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import axios from 'axios';
+import { ENDPOINTS } from '~/utils/URL';
+import HelpModal from '../HelpModal';
+import styles from '../HelpModal.module.css';
+
+vi.mock('axios');
+
+test('supports an HGN software team volunteer in dark mode', async () => {
+  const userId = 'test-user';
+  axios.get.mockImplementation(url => {
+    if (url === ENDPOINTS.HELP_CATEGORIES) {
+      return Promise.resolve({ data: [{ name: 'Software Support' }] });
+    }
+    return Promise.resolve({
+      data: { teams: [{ teamName: 'HGN Software Development Team' }] },
+    });
+  });
+
+  const store = configureStore({
+    reducer: {
+      auth: () => ({ user: { userid: userId, role: 'Volunteer' } }),
+      theme: () => ({ darkMode: true }),
+    },
+  });
+
+  render(
+    <Provider store={store}>
+      <HelpModal show onHide={vi.fn()} />
+    </Provider>,
+  );
+
+  const suggestionsLink = await screen.findByRole('button', { name: 'here' });
+  expect(suggestionsLink).toHaveClass(styles.suggestionsLink, styles.suggestionsLinkDark);
+
+  await userEvent.click(screen.getByRole('button', { name: 'Select an option' }));
+  await userEvent.click(screen.getByRole('option', { name: 'Software Support' }));
+
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled());
+  expect(axios.get).toHaveBeenCalledWith(ENDPOINTS.USER_PROFILE(userId));
+});


### PR DESCRIPTION

<img width="547" height="770" alt="image" src="https://github.com/user-attachments/assets/3f811d14-8f5f-4ad3-900b-91d7ae54f643" />

# Description

Finishes follow-up fixes for PR #4636 on `/hgnhelp`. The HGN Help request modal needs complete dark-mode coverage, including the suggestion `here` link, and verification that submit eligibility behaves correctly for administrators, owners, Software Development Team volunteers, and other volunteers.

Fixes Priority High task 10: HGN Help modal dark mode and submission eligibility follow-up.

## Related PRS (if any):

1. Follow-up to frontend PR #4636.
2. Related frontend PR #4291.
3. Connected data-collection work: frontend PR #3070 and backend PR #1204.

## Main changes explained:

1. Update the HGN Help request modal so every interactive element remains readable in dark mode.
2. Correct the `here` link dark-mode presentation.
3. Verify and, if needed, correct submit eligibility for permitted user roles and Software Development Team volunteers.
4. Add focused regression coverage for the corrected behavior.

## How to test:

1. Check out `Akshay_fix_hgn_help_modal_dark_mode`.
2. Run `npm install`, then `npm run start:local`.
3. Clear site data/cache and log in as an Admin or Owner.
4. Open `http://localhost:5173/hgnhelp` (use the port printed by Vite if different).
5. Verify the modal, dropdown, suggestion text, `here` link, warning, and Submit button in light and dark modes.
6. Confirm an Admin or Owner can select a help category and submit.
7. Log in as a volunteer on the Software Development Team and confirm submission is enabled after selecting a category.
8. Log in as a volunteer outside the Software Development Team and confirm submission remains disabled with the eligibility warning.
9. Follow the `here` link, submit the suggestion form, and confirm the expected success toast.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/49bd1409-b3a8-4e8e-aafd-b1adb89a52ce

## Note:

Draft PR. Implementation and final validation are in progress.
