### PR TITLE
Bosu - fix: enable HGN questionnaire profile navigation

### DIFF
--- a/src/components/HGNHelpSkillsDashboard/UserCard.jsx
+++ b/src/components/HGNHelpSkillsDashboard/UserCard.jsx
@@ -2,10 +2,11 @@ import styles from './style/UserCard.module.css';
 import avatar from './style/avatar.png';
 import emailIcon from './style/email_icon.png';
 import slackIcon from './style/slack_icon.png';
+import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
 function UserCard({ user }) {
-  const { name, email, slack, score, topSkills, skills } = user;
+  const { userId, name, email, slack, score, topSkills, skills } = user;
   const darkMode = useSelector(state => state.theme.darkMode);
 
   const normalizedSkills = Array.isArray(topSkills)
@@ -23,7 +24,16 @@ function UserCard({ user }) {
     <div className={`${styles.userCard} ${darkMode ? styles.darkMode : ''}`}>
       <img src={avatar} alt="Avatar" className={`${styles.avatar}`} />
       <div className={`${styles.info}`}>
-        <div className={`${styles.userName}`}>{name}</div>
+        {userId ? (
+          <Link
+            to={`/hgnhelp/profile/${userId}`}
+            className={`${styles.userName} ${styles.profileLink}`}
+          >
+            {name}
+          </Link>
+        ) : (
+          <div className={`${styles.userName}`}>{name}</div>
+        )}
         {email && (
           <div className={`${styles.contactLine}`}>
             <img src={emailIcon} alt="Email" className={`${styles.contactIcon}`} />

--- a/src/components/HGNHelpSkillsDashboard/UserProfilePage.jsx
+++ b/src/components/HGNHelpSkillsDashboard/UserProfilePage.jsx
@@ -333,6 +333,25 @@ function SkillsTabbedSection({ skillsData }) {
 }
 
 // Main UserProfilePage
+const normalizeSkillInfo = skillInfo => {
+  const toSkills = section =>
+    Object.entries(section || {})
+      .filter(([, score]) => !Number.isNaN(Number(score)))
+      .map(([name, score]) => ({
+        id: name,
+        name,
+        score: Number(score),
+        question: name,
+      }));
+
+  return {
+    Frontend: toSkills(skillInfo?.frontend),
+    Backend: toSkills(skillInfo?.backend),
+    DevOps: [],
+    SWPractices: [],
+  };
+};
+
 function UserProfilePage() {
   const { userId } = useParams();
   const [userProfile, setUserProfile] = useState(null);
@@ -345,7 +364,7 @@ function UserProfilePage() {
 
       try {
         setLoading(true);
-        const response = await axios.get(ENDPOINTS.USER_PROFILE(userId));
+        const response = await axios.get(ENDPOINTS.SKILLS_PROFILE(userId));
         setUserProfile(response.data);
         setLoading(false);
       } catch (err) {
@@ -363,12 +382,26 @@ function UserProfilePage() {
   return (
     <div className={`${styles.userProfilePage}`}>
       <div>
-        <div>User Profile Page Placeholder</div>
+        <h2>{userProfile?.name?.displayName || 'User Profile'}</h2>
+        {userProfile?.teams?.length > 0 && (
+          <div>
+            <h3>Teams</h3>
+            {userProfile.teams.map(team => (
+              <div key={team.id}>{team.role ? `${team.name} (${team.role})` : team.name}</div>
+            ))}
+          </div>
+        )}
+        {userProfile?.skillInfo?.general?.leadership_experience && (
+          <p>Leadership experience: {userProfile.skillInfo.general.leadership_experience}</p>
+        )}
+        {userProfile?.skillInfo?.followUp?.additional_info && (
+          <p>Additional experience: {userProfile.skillInfo.followUp.additional_info}</p>
+        )}
       </div>
 
-      {userProfile?.skills && (
+      {userProfile?.skillInfo && (
         <div className={`${styles.skillsSection}`}>
-          <SkillsTabbedSection skillsData={userProfile.skills} />
+          <SkillsTabbedSection skillsData={normalizeSkillInfo(userProfile.skillInfo)} />
         </div>
       )}
     </div>

--- a/src/components/HGNHelpSkillsDashboard/__tests__/ProfileRoute.test.jsx
+++ b/src/components/HGNHelpSkillsDashboard/__tests__/ProfileRoute.test.jsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import axios from 'axios';
+import UserCard from '../UserCard';
+import UserProfilePage from '../UserProfilePage';
+import { ENDPOINTS } from '~/utils/URL';
+
+vi.mock('axios');
+
+const mockStore = configureMockStore([]);
+const store = mockStore({ theme: { darkMode: false } });
+
+const renderProfile = (userId = 'user-123') =>
+  render(
+    <MemoryRouter initialEntries={[`/hgnhelp/profile/${userId}`]}>
+      <Provider store={store}>
+        <Route path="/hgnhelp/profile/:userId">
+          <UserProfilePage />
+        </Route>
+      </Provider>
+    </MemoryRouter>,
+  );
+
+describe('HGN Help profile route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('links a user name with userId, not the questionnaire response _id', () => {
+    render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <UserCard
+            user={{
+              _id: 'questionnaire-response-id',
+              userId: 'actual-user-profile-id',
+              name: 'Member One',
+              score: 8,
+            }}
+          />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Member One' })).toHaveAttribute(
+      'href',
+      '/hgnhelp/profile/actual-user-profile-id',
+    );
+  });
+
+  it('does not create a profile URL when userId is missing', () => {
+    render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <UserCard
+            user={{
+              _id: 'questionnaire-response-id',
+              name: 'Member Without Id',
+              score: 8,
+            }}
+          />
+        </Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole('link', { name: 'Member Without Id' })).not.toBeInTheDocument();
+    expect(screen.getByText('Member Without Id')).toBeInTheDocument();
+  });
+
+  it('loads the skills profile endpoint with the route userId and renders supported data', async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        userId: 'user-123',
+        name: { displayName: 'Member One' },
+        teams: [{ id: 'team-1', name: 'Software Development Team', role: 'Member' }],
+        skillInfo: {
+          frontend: { React: '8' },
+          backend: { MongoDB: '7' },
+          general: { leadership_experience: 'Led a volunteer team' },
+          followUp: { additional_info: 'Experienced with mentoring contributors' },
+        },
+      },
+    });
+
+    renderProfile();
+
+    await screen.findByText('Member One');
+    expect(axios.get).toHaveBeenCalledWith(ENDPOINTS.SKILLS_PROFILE('user-123'));
+    expect(screen.getByText('Software Development Team (Member)')).toBeInTheDocument();
+    expect(screen.getByText(/Leadership experience: Led a volunteer team/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Additional experience: Experienced with mentoring contributors/),
+    ).toBeInTheDocument();
+    expect(screen.getByText('React')).toBeInTheDocument();
+  });
+
+  it('handles empty optional profile data safely', async () => {
+    axios.get.mockResolvedValue({
+      data: { name: { displayName: 'Member Without Details' }, teams: [], skillInfo: {} },
+    });
+
+    renderProfile('user-empty');
+
+    expect(await screen.findByText('Member Without Details')).toBeInTheDocument();
+    expect(screen.queryByText('Teams')).not.toBeInTheDocument();
+  });
+
+  it('renders an API error without crashing', async () => {
+    axios.get.mockRejectedValue(new Error('Request failed'));
+
+    renderProfile('user-error');
+
+    await screen.findByText('Error: Failed to load user profile data');
+  });
+});

--- a/src/components/HGNHelpSkillsDashboard/style/UserCard.module.css
+++ b/src/components/HGNHelpSkillsDashboard/style/UserCard.module.css
@@ -48,6 +48,16 @@
   word-break: break-word;
 }
 
+.profileLink {
+  text-decoration: none;
+}
+
+.profileLink:hover,
+.profileLink:focus {
+  color: inherit;
+  text-decoration: underline;
+}
+
 .contactLine {
   display: flex;
   align-items: center;


### PR DESCRIPTION
# Description

Fixes the HGN Questionnaire Dashboard profile route accessibility issue.

The route `/hgnhelp/profile/:userId` existed, but users displayed in the HGN community list did not have a working navigation path to their questionnaire profile. During investigation, it was also identified that the profile page needed to use the HGN skills profile endpoint to retrieve the user's questionnaire skills, experience information, and team details.

The frontend now provides profile navigation from community user cards using the actual user profile ID supplied by the backend and loads the combined HGN skills profile data.

## Related PRs

1. This frontend PR is related to backend PR **#2315**.
2. The backend PR exposes the actual `UserProfile` ID as `userId` in ranked and community questionnaire responses.
3. Both PRs should be tested together.

## Main changes explained

1. Updated `UserCard.jsx` to make the user's name link to `/hgnhelp/profile/:userId`.
2. Updated profile navigation to use `user.userId` instead of the HGN questionnaire response document `_id`.
3. Added safe handling so users without a valid `userId` do not generate an invalid profile URL.
4. Updated `UserProfilePage.jsx` to use `ENDPOINTS.SKILLS_PROFILE(userId)` so the page receives questionnaire skills, experience/follow-up information, and team data.
5. Preserved existing email and Slack functionality on user cards.
6. Added focused tests for profile routing, correct user ID usage, missing IDs, profile API data, empty optional data, and API error handling.

## How to test

1. Checkout this frontend branch.

2. Checkout the related backend PR branch.

3. Run the backend locally.

4. Run the frontend with:

   `npm run start:local`

5. Log in with an authorized test account.

6. Navigate to `/hgnhelp/community`, or access the community list through the HGN questionnaire flow.

7. Click a user's name.

8. Verify the browser navigates to:

   `/hgnhelp/profile/<userId>`

9. Verify the profile displays the selected user's:

   * Name
   * Skills
   * Experience/follow-up information
   * Team information when available

10. Open DevTools → Network and verify the profile request uses:

    `/api/skills/profile/<userId>`

11. Verify the endpoint returns the selected user's real profile instead of the `Unknown User` placeholder.

12. Test multiple users, including a user with team information and a user without team information.

13. Refresh the profile route directly and confirm it continues to load correctly.

14. Verify the profile displays correctly in dark mode.

## Validation performed

* Focused frontend tests: **5/5 passed**
* ESLint on changed frontend files: **passed**
* `git diff --check`: **passed**
* Production frontend build with `npm run build`: **passed**
* Manual local profile navigation: **passed**
* Multiple-user profile testing: **passed**
* Skills data rendering: **passed**
* Experience data rendering: **passed**
* Team data rendering: **passed**

## Screenshots or videos of changes


Uploading Screen Recording 2026-08-22 at 11.52.29 AM.mov…


## Note

The duplicate existing `/hgnhelp` route definitions were investigated but were not modified because they are not required for this profile-route fix. No unrelated routing, dependency, or backend changes are included in this frontend PR.
