### PR TITLE
Jaden: fix config.name bug and inline styles in PR Grading Test (DONE Jaden)

### DIFF
--- a/src/components/PRGradingScreen/PRGradingTest.jsx
+++ b/src/components/PRGradingScreen/PRGradingTest.jsx
@@ -96,7 +96,7 @@ const PRGradingTest = () => {
   const existingTeamNames = allTeams.map(t => t.name);
 
   return (
-    <Container style={{ padding: '40px 20px' }} className={darkMode ? 'dark-mode' : ''}>
+    <Container className={`${styles.container} ${darkMode ? 'dark-mode' : ''}`}>
       <Row className="justify-content-center">
         <Col md={8}>
           <Card className={darkMode ? 'bg-dark text-light border-secondary' : ''}>
@@ -104,7 +104,7 @@ const PRGradingTest = () => {
               <div className="d-flex justify-content-between align-items-center">
                 <div>
                   <h2 className={darkMode ? 'text-light' : ''}>PR Grading Screen Test</h2>
-                  <p className="mb-0" style={{ color: darkMode ? '#9ca3af' : undefined }}>
+                  <p className={`mb-0 ${darkMode ? styles.subtitleDark : styles.subtitle}`}>
                     Select a team configuration to test the component
                   </p>
                 </div>
@@ -139,19 +139,9 @@ const PRGradingTest = () => {
                         <button
                           type="button"
                           onClick={e => handleDeleteConfig(e, team.id)}
-                          style={{
-                            position: 'absolute',
-                            top: '8px',
-                            right: '8px',
-                            background: 'transparent',
-                            border: 'none',
-                            color: darkMode ? '#f87171' : '#dc3545',
-                            fontWeight: 'bold',
-                            fontSize: '1rem',
-                            cursor: 'pointer',
-                            lineHeight: 1,
-                            padding: '0 4px',
-                          }}
+                          className={`${styles.deleteButton} ${
+                            darkMode ? styles.deleteButtonDark : ''
+                          }`}
                           title="Delete configuration"
                         >
                           ✕

--- a/src/components/PRGradingScreen/PRGradingTest.module.css
+++ b/src/components/PRGradingScreen/PRGradingTest.module.css
@@ -45,3 +45,33 @@
 .teamConfigButtonDark:hover small {
   color: #e5e7eb;
 }
+
+.deleteButton {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-weight: bold;
+  font-size: 1rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 4px;
+  color: #dc3545;
+}
+
+.deleteButtonDark {
+  color: #f87171;
+}
+
+.container {
+  padding: 40px 20px;
+}
+
+.subtitle {
+  color: #4b5563;
+}
+
+.subtitleDark {
+  color: #9ca3af;
+}

--- a/src/components/PRGradingScreen/index.jsx
+++ b/src/components/PRGradingScreen/index.jsx
@@ -20,7 +20,7 @@ const PRGradingScreenContainer = () => {
     }));
 
     const teamData = {
-      teamName: config.teamName,
+      teamName: config.name,
       dateRange: {
         start: new Date().toLocaleDateString(),
         end: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toLocaleDateString(),


### PR DESCRIPTION
Jaden: fix config.name bug and inline styles in PR Grading Test (DONE Jaden)- #5468

## Description
Implements Task #1334 - PR Review Team Analytics Dashboard: PR Grading Screen fixes.

## Main changes explained
- Fixed `config.teamName` -> `config.name` in `PRGradingScreen/index.jsx`: team objects use `name` (not `teamName`), so navigating to a DB-backed config was passing `undefined` as the team name to `PRGradingScreen`
- Moved all inline styles out of `PRGradingTest.jsx` into `PRGradingTest.module.css`: delete button positioning/color, container padding, and subtitle color

## Related PRs
- Builds on PR #4935 (Sayali: Create Test Configuration button and modal)
- Relates to backend PR OneCommunityGlobal/HGNRest#2088

## How to test
1. Check out branch `Jaden_Task1334_PRGrading_ConfigCreation_PageNotFound`
2. Run backend PR HGNRest#2088 branch: `npm run build && npm run start`
3. Run frontend: `npm install && npm run start:local`
4. Log in as admin and navigate to `/pr-grading-test`
5. Click a DB config - verify PR Grading Screen receives the correct team name (not undefined)
6. Toggle dark mode - verify delete button, container, and subtitle still styled correctly

<img width="1710" height="945" alt="pic" src="https://github.com/user-attachments/assets/a7dae4fd-3e8d-44dd-8fb5-e0bd9672764f" />