### PR TITLE
Roshini Seelamsetty: Create permission to see and interact with the deadline tracking details

### DIFF
--- a/src/components/PermissionsManagement/Permissions.json
+++ b/src/components/PermissionsManagement/Permissions.json
@@ -325,6 +325,11 @@
                 "label": "View and Interact with Task \"X\" on Dashboards",
                 "key": "canDeleteTask",
                 "description": "Gives the user permission to DELETE tasks from the Management Dashboard showing all their team members."
+              },
+              {
+                "label": "View and Interact with Task Deadlines Boxes",
+                "key": "viewAndInteractWithTaskDeadlinesBoxes",
+                "description": "Gives the user permission to view and interact with task deadline tracking boxes on the Dashboard Tasks tab."
               }
             ]
           }

--- a/src/components/TeamMemberTasks/TeamMemberTask.jsx
+++ b/src/components/TeamMemberTasks/TeamMemberTask.jsx
@@ -154,7 +154,9 @@ const TeamMemberTask = React.memo(
     const rolesAllowedToSeeDeadlineCount = ['Manager', 'Mentor', 'Administrator', 'Owner'];
     const isAllowedToResolveTasks =
       rolesAllowedToResolveTasks.includes(userRole) || dispatch(hasPermission('resolveTask'));
-    const isAllowedToSeeDeadlineCount = rolesAllowedToSeeDeadlineCount.includes(userRole);
+    const isAllowedToSeeDeadlineCount =
+      rolesAllowedToSeeDeadlineCount.includes(userRole) ||
+      dispatch(hasPermission('viewAndInteractWithTaskDeadlinesBoxes'));
 
     const canGetWeeklySummaries = dispatch(hasPermission('getWeeklySummaries'));
     const canSeeReports =


### PR DESCRIPTION
# Description

<img width="758" height="544" alt="Screenshot 2026-08-28 at 08 25 55" src="https://github.com/user-attachments/assets/1bcbf50c-6727-4390-9a6c-31017e66572c" />


## Related PRS (if any):
This frontend PR is related to the [#2325 ](https://github.com/OneCommunityGlobal/HGNRest/pull/2325)

## Main Changes

- Updated `Permissions.json` to add:
  - Label: `View and Interact with Task Deadlines Boxes`
  - Permission key: `viewAndInteractWithTaskDeadlinesBoxes`
- Updated `TeamMemberTask.jsx` to allow deadline tracking interaction when the user has the new permission.
- Preserved existing role-based access for Administrator, Owner, Manager, and Mentor users.

## How to Test

1. Check out the current branch.
2. Run `npm install`.
3. Run `npm start`.
4. Clear site data/cache and log in.
5. Navigate to **Other Links → Permissions Management**.
6. Open **Project Management → Work Breakdown Structures → Tasks**.
7. Verify that **View and Interact with Task Deadlines Boxes** appears.

## Validation

- Focused tests passed: 16 tests
- Full test suite passed: 2,197 tests


