### PR TITLE
Gayatri - 🔥 Invalid Team Code error when selecting a suggested QST team code …

### DIFF
--- a/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
+++ b/src/components/UserProfile/QuickSetupModal/QuickSetupModal.jsx
@@ -40,12 +40,12 @@ function QuickSetupModal(props) {
     })
     .map(code => {
       if (typeof code === 'string') {
-        return { value: code, label: code };
+        return { value: code.trim(), label: code.trim() };
       }
 
       return {
-        value: code.value || '',
-        label: code.label || code.value || '',
+        value: (code.value || '').trim(),
+        label: (code.label || code.value || '').trim(),
       };
     });
 

--- a/src/components/UserProfile/QuickSetupModal/__test__/QuickSetupModal.test.jsx
+++ b/src/components/UserProfile/QuickSetupModal/__test__/QuickSetupModal.test.jsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import QuickSetupModal from '../QuickSetupModal';
-import { getAllTitle } from '../../../../actions/title';
+import { getAllTitle, addTitle } from '../../../../actions/title';
 import {
   mockTeamsData,
   mockUserProfile,
@@ -13,7 +13,6 @@ import {
 } from '../__mock__/mockData';
 import hasPermission from '~/utils/permissions';
 import { vi } from 'vitest';
-
 vi.mock('react-redux', async importOriginal => {
   const actual = await importOriginal();
   return {
@@ -23,25 +22,23 @@ vi.mock('react-redux', async importOriginal => {
 });
 vi.mock('../../../../actions/title', () => ({
   getAllTitle: vi.fn(),
+  addTitle: vi.fn(),
+  editTitle: vi.fn(),
 }));
-
 vi.mock('../../../../utils/permissions', () => ({
   __esModule: true,
   default: vi.fn(permission => mockUserPermissions[permission]),
 }));
-
 const mockStore = configureMockStore([]);
-
 describe('QuickSetupModal Component', () => {
   let store;
-
   beforeEach(() => {
     store = mockStore({
       theme: { darkMode: false },
     });
     getAllTitle.mockResolvedValue({ data: mockTitles });
+    addTitle.mockResolvedValue({ status: 200, data: {} });
   });
-
   test('renders "Add New QST" button when user has addTitle permission', async () => {
     // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(async () => {
@@ -51,13 +48,54 @@ describe('QuickSetupModal Component', () => {
         </Provider>,
       );
     });
-
     const addButton = screen.getByText('Add New QST');
     expect(addButton).toBeInTheDocument();
     expect(addButton).toBeEnabled();
   });
-
   test('opens AddNewTitleModal when "Add New QST" button is clicked', async () => {
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <QuickSetupModal
+            userProfile={mockUserProfile}
+            hasPermission={() => true}
+            teamsData={mockTeamsData}
+          />
+        </Provider>,
+      );
+    });
+    fireEvent.click(screen.getByText('Add New QST'));
+    await waitFor(() => {
+      expect(screen.getByText('Add A New Title')).toBeInTheDocument();
+    });
+  });
+  test('renders Edit and Save buttons conditionally', async () => {
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <QuickSetupModal userProfile={mockUserProfile} hasPermission={() => true} />
+        </Provider>,
+      );
+    });
+    const editButton = screen.getByText('Edit');
+    expect(editButton).toBeInTheDocument();
+    fireEvent.click(editButton);
+    const saveButton = screen.getByText('Save');
+    expect(saveButton).toBeInTheDocument();
+  });
+
+  test('accepts a team code selected from the dropdown even when the source data has trailing whitespace', async () => {
+    // Simulate real-world data where a team code stored in Redux state has
+    // accidental leading/trailing whitespace (e.g. from spreadsheet import).
+    store = mockStore({
+      theme: { darkMode: false },
+      teamCodes: {
+        teamCodes: ['17GADCC '],
+      },
+    });
+
     // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(async () => {
       render(
@@ -72,28 +110,50 @@ describe('QuickSetupModal Component', () => {
     });
 
     fireEvent.click(screen.getByText('Add New QST'));
-
     await waitFor(() => {
       expect(screen.getByText('Add A New Title')).toBeInTheDocument();
     });
-  });
 
-  test('renders Edit and Save buttons conditionally', async () => {
-    // eslint-disable-next-line testing-library/no-unnecessary-act
-    await act(async () => {
-      render(
-        <Provider store={store}>
-          <QuickSetupModal userProfile={mockUserProfile} hasPermission={() => true} />
-        </Provider>,
-      );
+    // Fill required fields so the Confirm button becomes enabled.
+        const inputs = screen.getAllByRole('textbox');
+    const titleNameInput = inputs.find(input => input.id === 'titleName');
+    const mediaFolderInput = inputs.find(input => input.id === 'mediafolder');
+
+    fireEvent.change(titleNameInput, {
+      target: { value: 'Test Title' },
+    });
+    fireEvent.change(mediaFolderInput, {
+      target: { value: 'https://example.com/folder' },
     });
 
-    const editButton = screen.getByText('Edit');
-    expect(editButton).toBeInTheDocument();
+    // Type into the Team Code autocomplete field to trigger suggestions.
+    const teamCodeInputs = screen.getAllByRole('textbox');
+    const teamCodeInput = teamCodeInputs.find(
+      input => input.id !== 'titleName' && input.id !== 'titleCode' && input.id !== 'mediafolder',
+    );
+    fireEvent.change(teamCodeInput, { target: { value: '17' } });
+    fireEvent.focus(teamCodeInput);
 
-    fireEvent.click(editButton);
+    // Select the suggested code from the dropdown — it should be trimmed,
+    // not padded with the trailing whitespace present in the source data.
+    await waitFor(() => {
+      expect(screen.getByText('17GADCC')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('17GADCC'));
 
-    const saveButton = screen.getByText('Save');
-    expect(saveButton).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Confirm'));
+
+    // The bug: this used to show "Invalid team code" even though the exact
+    // code was just selected from the suggestion list. After the fix, no
+    // such warning should appear, and the save action should be called
+    // with the trimmed value.
+    await waitFor(() => {
+      expect(screen.queryByText(/invalid team code/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/team code not exists/i)).not.toBeInTheDocument();
+    });
+
+    expect(addTitle).toHaveBeenCalledWith(
+      expect.objectContaining({ teamCode: '17GADCC' }),
+    );
   });
 });


### PR DESCRIPTION
# Description
Fixes an urgent bug in the Quick Setup Title (QST) "Edit Title" modal where selecting a valid, actively-suggested team code and clicking Confirm incorrectly showed "Invalid team code. Please provide a valid team code."

## Root Cause
`QSTTeamCodes` in QuickSetupModal.jsx is built from Redux state (`stateTeamCodes`). If any team code in that state has leading/trailing whitespace (common with admin-entered or spreadsheet-sourced data), the dropdown's fuzzy search still matched and displayed it correctly as a suggestion. However, the code was stored with its whitespace intact, while the confirm-time validation trimmed only the *selected* value before comparing it against the untrimmed array — causing an exact-match failure even though it was the exact code that had just been suggested.

## Fix
Trim both `value` and `label` when building `QSTTeamCodes`, for both the string and object code formats, so whitespace never causes a mismatch between what's suggested and what's validated.

## How to test
1. Check into this branch and run `npm install` and `yarn start:skip-tests`
2. Open a user's profile → Edit Title (QST) modal
3. Type into the Team Code field to trigger the autocomplete suggestions
4. Select a suggested code and click Confirm
5. Confirm it saves successfully with no "Invalid team code" error

## Testing
Added a new unit test simulating a team code with trailing whitespace, verifying the full select → confirm flow succeeds and the submitted payload contains the trimmed value. All existing tests (2198 total) and lint pass.
