### PR TITLE
Mahathi - Improve Dark Mode Support for Lessons Learned Analytics

### DIFF
--- a/src/components/BMDashboard/WeeklyProjectSummary/GroupedBarGraphInjurySeverity/InjuryCategoryBarChart.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/GroupedBarGraphInjurySeverity/InjuryCategoryBarChart.css
@@ -1,9 +1,15 @@
 .injury-chart-container {
+  width: 100%;
   padding: 1rem;
+  box-sizing: border-box;
+}
+
+.injury-chart-header {
+  width: 100%;
 }
 
 .injury-chart-title {
-  color: #666666;
+  color: #4b5563;
   font-size: 1.5rem;
   font-weight: 600;
   margin-bottom: 1rem;
@@ -13,43 +19,528 @@
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
-  margin-bottom: 2rem;
+  align-items: flex-end;
+  margin-bottom: 1.5rem;
 }
 
-/* ------------------- DARK MODE STYLES ------------------- */
-.darkMode .injury-chart-title {
-  color: white;
+.filter {
+  flex: 1 1 180px;
+  min-width: 170px;
 }
 
-.darkMode .injury-chart-label {
-  color: white;
+.injury-chart-label {
+  display: block;
+  color: #374151;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 0.3rem;
 }
 
-.darkMode .injury-select__control {
-  background-color: #2b3e59 !important;
-  color: white !important;
-  border-color: #555 !important;
+.injury-select-container {
+  width: 100%;
+  font-size: 0.875rem;
 }
 
-.darkMode .injury-select__single-value,
-.darkMode .injury-select__multi-value__label,
-.darkMode .injury-select__input-container {
-  color: white !important;
+.injury-date-input {
+  width: 100%;
+  min-height: 38px;
+  padding: 0.5rem 0.65rem;
+  color: #111827;
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  box-sizing: border-box;
+  font-size: 0.875rem;
 }
 
-.darkMode .injury-select__menu {
-  background-color: #2b3e59 !important;
-  color: white !important;
+.injury-date-input::placeholder {
+  color: #6b7280;
 }
 
-.darkMode .injury-select__option:hover {
-  color: black !important;
+.injury-date-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 1px #3b82f6;
 }
 
-.darkMode .react-datepicker__input-container input {
-  background-color: #2b3e59 !important;
-  color: white !important;
-  border: 1px solid #555;
-  padding: 0.5rem;
+.injury-chart-visualization {
+  width: 100%;
+  min-width: 0;
+}
+
+.injury-chart-message,
+.injury-chart-empty {
+  color: #6b7280;
+  text-align: center;
+  font-style: italic;
+  padding: 1rem;
+}
+
+.injury-chart-error {
+  color: #b91c1c;
+  text-align: center;
+  padding: 1rem;
+}
+
+/* =========================================================
+   CUSTOM LEGEND
+   ========================================================= */
+
+.injury-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem 1rem;
+
+  width: calc(100% - 1rem);
+  max-height: 82px;
+
+  margin: 0.5rem auto 0;
+  padding: 0.65rem 0.75rem;
+
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  color: #374151;
+  background-color: #f8fafc;
+
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+
+  box-sizing: border-box;
+}
+
+.injury-chart-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+
+  max-width: 180px;
+  min-width: 0;
+
+  font-size: 0.75rem;
+}
+
+.injury-chart-legend-marker {
+  width: 10px;
+  height: 10px;
+  min-width: 10px;
+
+  display: inline-block;
+
+  border-radius: 2px;
+}
+
+.injury-chart-legend-text {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.injury-chart-legend {
+  scrollbar-width: thin;
+  scrollbar-color: #94a3b8 #f1f5f9;
+}
+
+.injury-chart-legend::-webkit-scrollbar {
+  width: 8px;
+}
+
+.injury-chart-legend::-webkit-scrollbar-track {
+  background-color: #f1f5f9;
   border-radius: 4px;
+}
+
+.injury-chart-legend::-webkit-scrollbar-thumb {
+  background-color: #94a3b8;
+  border: 2px solid #f1f5f9;
+  border-radius: 4px;
+}
+
+.injury-chart-legend::-webkit-scrollbar-thumb:hover {
+  background-color: #64748b;
+}
+
+/* =========================================================
+   DARK MODE
+   ========================================================= */
+
+.injury-chart-container.darkMode .injury-chart-title {
+  color: #f8fafc;
+}
+
+.injury-chart-container.darkMode .injury-chart-label {
+  color: #f3f4f6;
+}
+
+.injury-chart-container.darkMode .injury-chart-message,
+.injury-chart-container.darkMode .injury-chart-empty {
+  color: #cbd5e1;
+}
+
+.injury-chart-container.darkMode .injury-chart-error {
+  color: #fca5a5;
+}
+
+/* =========================================================
+   REACT SELECT - DARK MODE
+   ========================================================= */
+
+.injury-chart-container.darkMode .injury-select__control {
+  min-height: 38px;
+
+  color: #f8fafc !important;
+  background-color: #2b3e59 !important;
+
+  border-color: #536985 !important;
+  box-shadow: none !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__control:hover {
+  border-color: #7890ad !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__control--is-focused {
+  border-color: #60a5fa !important;
+  box-shadow: 0 0 0 1px #60a5fa !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__value-container {
+  background-color: transparent !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__placeholder {
+  color: #cbd5e1 !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__single-value {
+  color: #ffffff !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__input-container {
+  color: #ffffff !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__input {
+  color: #ffffff !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__input input {
+  color: #ffffff !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__indicator-separator {
+  background-color: #64748b !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__dropdown-indicator,
+.injury-chart-container.darkMode
+  .injury-select__clear-indicator {
+  color: #cbd5e1 !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__dropdown-indicator:hover,
+.injury-chart-container.darkMode
+  .injury-select__clear-indicator:hover {
+  color: #ffffff !important;
+}
+
+/* Selected values */
+
+.injury-chart-container.darkMode
+  .injury-select__multi-value {
+  background-color: #3b526f !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__multi-value__label {
+  color: #ffffff !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__multi-value__remove {
+  color: #dbeafe !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__multi-value__remove:hover {
+  color: #ffffff !important;
+  background-color: #b91c1c !important;
+}
+
+/* Dropdown itself */
+
+.injury-chart-container.darkMode
+  .injury-select__menu {
+  z-index: 50;
+
+  color: #f8fafc !important;
+  background-color: #263952 !important;
+
+  border: 1px solid #536985;
+
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 35%),
+    0 4px 6px -4px rgb(0 0 0 / 35%);
+}
+
+.injury-chart-container.darkMode
+  .injury-select__menu-list {
+  padding: 4px 0;
+  background-color: #263952 !important;
+}
+
+/* Normal option */
+
+.injury-chart-container.darkMode
+  .injury-select__option {
+  color: #f8fafc !important;
+  background-color: #263952 !important;
+
+  cursor: pointer;
+}
+
+/* Hover / keyboard focus */
+
+.injury-chart-container.darkMode
+  .injury-select__option--is-focused {
+  color: #ffffff !important;
+  background-color: #355173 !important;
+}
+
+/* Selected option */
+
+.injury-chart-container.darkMode
+  .injury-select__option--is-selected {
+  color: #ffffff !important;
+  background-color: #2563eb !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__option--is-selected.injury-select__option--is-focused {
+  color: #ffffff !important;
+  background-color: #1d4ed8 !important;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__menu-notice {
+  color: #cbd5e1 !important;
+}
+
+/* Dropdown scrollbar */
+
+.injury-chart-container.darkMode
+  .injury-select__menu-list {
+  scrollbar-width: thin;
+  scrollbar-color: #7890ad #263952;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__menu-list::-webkit-scrollbar {
+  width: 8px;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__menu-list::-webkit-scrollbar-track {
+  background-color: #263952;
+  border-radius: 4px;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__menu-list::-webkit-scrollbar-thumb {
+  background-color: #7890ad;
+
+  border: 2px solid #263952;
+  border-radius: 4px;
+}
+
+.injury-chart-container.darkMode
+  .injury-select__menu-list::-webkit-scrollbar-thumb:hover {
+  background-color: #94a3b8;
+}
+
+/* =========================================================
+   DATE INPUTS - DARK MODE
+   ========================================================= */
+
+.injury-chart-container.darkMode .injury-date-input {
+  color: #ffffff;
+
+  background-color: #2b3e59;
+
+  border: 1px solid #536985;
+
+  color-scheme: dark;
+}
+
+.injury-chart-container.darkMode
+  .injury-date-input::placeholder {
+  color: #cbd5e1;
+}
+
+.injury-chart-container.darkMode
+  .injury-date-input:hover {
+  border-color: #7890ad;
+}
+
+.injury-chart-container.darkMode
+  .injury-date-input:focus {
+  color: #ffffff;
+
+  background-color: #2b3e59;
+
+  border-color: #60a5fa;
+
+  box-shadow: 0 0 0 1px #60a5fa;
+}
+
+/* =========================================================
+   REACT DATEPICKER POPUP - DARK MODE
+   ========================================================= */
+
+.injury-chart-container.darkMode .react-datepicker {
+  color: #f8fafc;
+  background-color: #263952;
+
+  border-color: #536985;
+}
+
+.injury-chart-container.darkMode
+  .react-datepicker__header {
+  background-color: #2b3e59;
+
+  border-bottom-color: #536985;
+}
+
+.injury-chart-container.darkMode
+  .react-datepicker__current-month,
+.injury-chart-container.darkMode
+  .react-datepicker-time__header,
+.injury-chart-container.darkMode
+  .react-datepicker-year-header {
+  color: #ffffff;
+}
+
+.injury-chart-container.darkMode
+  .react-datepicker__day-name {
+  color: #cbd5e1;
+}
+
+.injury-chart-container.darkMode
+  .react-datepicker__day {
+  color: #f8fafc;
+}
+
+.injury-chart-container.darkMode
+  .react-datepicker__day:hover {
+  color: #ffffff;
+
+  background-color: #3b526f;
+}
+
+.injury-chart-container.darkMode
+  .react-datepicker__day--selected,
+.injury-chart-container.darkMode
+  .react-datepicker__day--keyboard-selected {
+  color: #ffffff;
+
+  background-color: #2563eb;
+}
+
+.injury-chart-container.darkMode
+  .react-datepicker__day--outside-month {
+  color: #7c8da3;
+}
+
+.injury-chart-container.darkMode
+  .react-datepicker__day--disabled {
+  color: #64748b;
+}
+
+.injury-chart-container.darkMode
+  .react-datepicker__navigation-icon::before {
+  border-color: #e2e8f0;
+}
+
+/* =========================================================
+   LEGEND - DARK MODE
+   ========================================================= */
+
+.injury-chart-container.darkMode
+  .injury-chart-legend {
+  color: #e2e8f0;
+
+  background-color: #263952;
+
+  border-color: #536985;
+
+  scrollbar-color: #7890ad #263952;
+}
+
+.injury-chart-container.darkMode
+  .injury-chart-legend-text {
+  color: #e2e8f0;
+}
+
+.injury-chart-container.darkMode
+  .injury-chart-legend::-webkit-scrollbar-track {
+  background-color: #263952;
+}
+
+.injury-chart-container.darkMode
+  .injury-chart-legend::-webkit-scrollbar-thumb {
+  background-color: #7890ad;
+
+  border-color: #263952;
+}
+
+.injury-chart-container.darkMode
+  .injury-chart-legend::-webkit-scrollbar-thumb:hover {
+  background-color: #94a3b8;
+}
+
+/* =========================================================
+   RESPONSIVE
+   ========================================================= */
+
+@media (max-width: 768px) {
+  .injury-chart-container {
+    padding: 0.75rem;
+  }
+
+  .injury-chart-title {
+    font-size: 1.15rem;
+  }
+
+  .injury-chart-filters {
+    gap: 0.75rem;
+  }
+
+  .filter {
+    flex: 1 1 100%;
+    min-width: 100%;
+  }
+
+  .injury-chart-legend {
+    justify-content: flex-start;
+
+    max-height: 100px;
+  }
+
+  .injury-chart-legend-item {
+    max-width: 150px;
+  }
 }

--- a/src/components/BMDashboard/WeeklyProjectSummary/GroupedBarGraphInjurySeverity/InjuryCategoryBarChart.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/GroupedBarGraphInjurySeverity/InjuryCategoryBarChart.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   BarChart,
   Bar,
@@ -21,11 +21,11 @@ import {
   fetchInjuryProjects,
 } from '../../../../actions/bmdashboard/injuryActions';
 
-// YYYY-MM-DD (no tz shift)
-const toYMD = d =>
-  d instanceof Date && !isNaN(d)
-    ? `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
-        d.getDate(),
+// YYYY-MM-DD without timezone shift
+const toYMD = date =>
+  date instanceof Date && !Number.isNaN(date.getTime())
+    ? `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(
+        date.getDate(),
       ).padStart(2, '0')}`
     : '';
 
@@ -40,6 +40,7 @@ function InjuryCategoryBarChart() {
     severities = [],
     injuryTypes = [],
   } = useSelector(state => state.bmInjury || {});
+
   const darkMode = useSelector(state => state.theme?.darkMode);
 
   const [projectNameFilter, setProjectNameFilter] = useState([]);
@@ -57,9 +58,10 @@ function InjuryCategoryBarChart() {
     const params = {
       startDate: toYMD(startDate),
       endDate: toYMD(endDate),
-      severities: severityFilter.map(s => s.value).join(','),
-      types: injuryTypeFilter.map(t => t.value).join(','),
+      severities: severityFilter.map(item => item.value).join(','),
+      types: injuryTypeFilter.map(item => item.value).join(','),
     };
+
     dispatch(fetchInjuryProjects(params));
   }, [dispatch, startDate, endDate, severityFilter, injuryTypeFilter]);
 
@@ -70,65 +72,137 @@ function InjuryCategoryBarChart() {
 
   const projectNameOptions = useMemo(() => {
     const seen = new Set();
-    const opts = [];
-    for (const p of projects) {
-      const name = p?.name ?? '';
-      if (!name || seen.has(name)) continue;
+    const options = [];
+
+    projects.forEach(project => {
+      const name = project?.name ?? '';
+
+      if (!name || seen.has(name)) return;
+
       seen.add(name);
-      opts.push({ value: name, label: name });
-    }
-    return opts.sort((a, b) => a.label.localeCompare(b.label));
+
+      options.push({
+        value: name,
+        label: name,
+      });
+    });
+
+    return options.sort((a, b) => a.label.localeCompare(b.label));
   }, [projects]);
 
   useEffect(() => {
     if (!projectNameFilter.length) return;
-    const valid = new Set(projectNameOptions.map(o => o.value));
-    const filtered = projectNameFilter.filter(p => valid.has(p.value));
-    if (filtered.length !== projectNameFilter.length) setProjectNameFilter(filtered);
+
+    const validProjectNames = new Set(projectNameOptions.map(option => option.value));
+
+    const filteredProjects = projectNameFilter.filter(project =>
+      validProjectNames.has(project.value),
+    );
+
+    if (filteredProjects.length !== projectNameFilter.length) {
+      setProjectNameFilter(filteredProjects);
+    }
   }, [projectNameOptions, projectNameFilter]);
 
-  const severityOptions = useMemo(() => sevList.map(s => ({ value: s, label: s })), [sevList]);
-  const typeOptions = useMemo(() => typeList.map(t => ({ value: t, label: t })), [typeList]);
+  const severityOptions = useMemo(
+    () =>
+      sevList.map(severity => ({
+        value: severity,
+        label: severity,
+      })),
+    [sevList],
+  );
+
+  const typeOptions = useMemo(
+    () =>
+      typeList.map(type => ({
+        value: type,
+        label: type,
+      })),
+    [typeList],
+  );
 
   useEffect(() => {
     const params = {
-      projectNames: projectNameFilter.length ? projectNameFilter.map(p => p.value).join(',') : '',
+      projectNames: projectNameFilter.length
+        ? projectNameFilter.map(project => project.value).join(',')
+        : '',
       startDate: toYMD(startDate),
       endDate: toYMD(endDate),
-      severities: severityFilter.map(s => s.value).join(','),
-      types: injuryTypeFilter.map(t => t.value).join(','),
+      severities: severityFilter.map(item => item.value).join(','),
+      types: injuryTypeFilter.map(item => item.value).join(','),
     };
+
     dispatch(fetchInjuryData(params));
   }, [dispatch, projectNameFilter, severityFilter, injuryTypeFilter, startDate, endDate]);
 
   const projectNameById = useMemo(() => {
-    const m = new Map();
-    for (const p of projects) m.set(String(p._id), p.name);
-    for (const r of data) {
-      const pid = String(r?.projectId ?? 'unknown');
-      if (!m.has(pid) && r?.projectName) m.set(pid, r.projectName);
-    }
-    return m;
+    const projectMap = new Map();
+
+    projects.forEach(project => {
+      projectMap.set(String(project._id), project.name);
+    });
+
+    data.forEach(record => {
+      const projectId = String(record?.projectId ?? 'unknown');
+
+      if (!projectMap.has(projectId) && record?.projectName) {
+        projectMap.set(projectId, record.projectName);
+      }
+    });
+
+    return projectMap;
   }, [projects, data]);
 
   const chartData = useMemo(() => {
-    const acc = Object.create(null);
-    for (const r of data) {
-      const workerCategory = r?.workerCategory ?? 'Unknown';
-      const pid = String(r?.projectId ?? 'unknown');
-      const total = Number(r?.totalInjuries) || 0;
-      if (!acc[workerCategory]) acc[workerCategory] = { workerCategory };
-      acc[workerCategory][pid] = (acc[workerCategory][pid] || 0) + total;
-    }
-    return Object.values(acc);
+    const accumulatedData = Object.create(null);
+
+    data.forEach(record => {
+      const workerCategory = record?.workerCategory ?? 'Unknown';
+      const projectId = String(record?.projectId ?? 'unknown');
+      const totalInjuries = Number(record?.totalInjuries) || 0;
+
+      if (!accumulatedData[workerCategory]) {
+        accumulatedData[workerCategory] = {
+          workerCategory,
+        };
+      }
+
+      accumulatedData[workerCategory][projectId] =
+        (accumulatedData[workerCategory][projectId] || 0) + totalInjuries;
+    });
+
+    return Object.values(accumulatedData);
   }, [data]);
 
   const seriesProjectIds = useMemo(() => {
-    const set = new Set(data.map(d => String(d?.projectId ?? 'unknown')));
-    return Array.from(set);
+    const projectIds = new Set(data.map(record => String(record?.projectId ?? 'unknown')));
+
+    return Array.from(projectIds);
   }, [data]);
 
   const showLabels = seriesProjectIds.length <= 4;
+
+  const axisColor = darkMode ? '#e2e8f0' : '#374151';
+  const tooltipBackground = darkMode ? '#263952' : '#ffffff';
+  const tooltipText = darkMode ? '#f8fafc' : '#111827';
+  const tooltipBorder = darkMode ? '#536985' : '#d1d5db';
+
+  const renderLegend = ({ payload }) => {
+    if (!payload?.length) return null;
+
+    return (
+      <div className={`injury-chart-legend ${darkMode ? 'injury-chart-legend-dark' : ''}`}>
+        {payload.map(entry => (
+          <div key={entry.value} className="injury-chart-legend-item" title={entry.value}>
+            <span className="injury-chart-legend-marker" style={{ backgroundColor: entry.color }} />
+
+            <span className="injury-chart-legend-text">{entry.value}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
 
   return (
     <div className={`injury-chart-container ${darkMode ? 'darkMode' : ''}`}>
@@ -140,14 +214,17 @@ function InjuryCategoryBarChart() {
             <label htmlFor="project-names-select" className="injury-chart-label">
               Projects
             </label>
+
             <Select
               inputId="project-names-select"
+              className="injury-select-container"
               classNamePrefix="injury-select"
               isMulti
               options={projectNameOptions}
               value={projectNameFilter}
-              onChange={setProjectNameFilter}
+              onChange={selected => setProjectNameFilter(selected || [])}
               placeholder="All names"
+              isSearchable
             />
           </div>
 
@@ -155,14 +232,17 @@ function InjuryCategoryBarChart() {
             <label htmlFor="severities-select" className="injury-chart-label">
               Severities
             </label>
+
             <Select
               inputId="severities-select"
+              className="injury-select-container"
               classNamePrefix="injury-select"
               isMulti
               options={severityOptions}
               value={severityFilter}
-              onChange={setSeverityFilter}
+              onChange={selected => setSeverityFilter(selected || [])}
               placeholder="All severities"
+              isSearchable
             />
           </div>
 
@@ -170,23 +250,27 @@ function InjuryCategoryBarChart() {
             <label htmlFor="injury-types-select" className="injury-chart-label">
               Injury types
             </label>
+
             <Select
               inputId="injury-types-select"
+              className="injury-select-container"
               classNamePrefix="injury-select"
               isMulti
               options={typeOptions}
               value={injuryTypeFilter}
-              onChange={setInjuryTypeFilter}
+              onChange={selected => setInjuryTypeFilter(selected || [])}
               placeholder="All types"
+              isSearchable
             />
           </div>
 
           <div className="filter">
-            <label htmlFor="start-date" className="injury-chart-label">
-              Start date
+            <label htmlFor="injury-start-date" className="injury-chart-label">
+              From
             </label>
+
             <DatePicker
-              id="start-date"
+              id="injury-start-date"
               selected={startDate}
               onChange={setStartDate}
               selectsStart
@@ -194,15 +278,17 @@ function InjuryCategoryBarChart() {
               endDate={endDate}
               maxDate={endDate || undefined}
               placeholderText="Start date"
+              className="injury-date-input"
             />
           </div>
 
           <div className="filter">
-            <label htmlFor="end-date" className="injury-chart-label">
-              End date
+            <label htmlFor="injury-end-date" className="injury-chart-label">
+              To
             </label>
+
             <DatePicker
-              id="end-date"
+              id="injury-end-date"
               selected={endDate}
               onChange={setEndDate}
               selectsEnd
@@ -210,53 +296,106 @@ function InjuryCategoryBarChart() {
               endDate={endDate}
               minDate={startDate || undefined}
               placeholderText="End date"
+              className="injury-date-input"
             />
           </div>
         </div>
       </div>
 
-      {loading && <p>Loading…</p>}
-      {!loading && error && <p className="error">Error: {String(error)}</p>}
+      {loading && <p className="injury-chart-message">Loading…</p>}
 
-      {!loading && !error && (
-        <ResponsiveContainer width="100%" height={420}>
-          <BarChart data={chartData} margin={{ top: 16, right: 24, bottom: 8, left: 8 }}>
-            <XAxis
-              dataKey="workerCategory"
-              interval={0}
-              angle={-45}
-              textAnchor="end"
-              height={80}
-              tick={{ fill: darkMode ? '#fff' : '#000' }}
-            />
-            <YAxis allowDecimals={false} />
-            <Tooltip
-              formatter={(value, name) => [
-                value,
-                projectNameById.get(String(name)) || 'Unknown Project',
-              ]}
-            />
-            <Legend
-              wrapperStyle={{ maxHeight: 72, overflowY: 'auto' }}
-              payload={seriesProjectIds.map(pid => ({
-                id: pid,
-                type: 'square',
-                value: projectNameById.get(pid) || 'Unknown Project',
-              }))}
-            />
-            {seriesProjectIds.map((pid, index) => (
-              <Bar key={pid} dataKey={pid} fill={index % 2 === 0 ? '#17c9d3' : '#000'}>
-                {showLabels && (
-                  <LabelList dataKey={pid} position="top" formatter={v => (v > 0 ? v : '')} />
-                )}
-              </Bar>
-            ))}
-          </BarChart>
-        </ResponsiveContainer>
+      {!loading && error && <p className="injury-chart-error">Error: {String(error)}</p>}
+
+      {!loading && !error && chartData.length > 0 && (
+        <div className="injury-chart-visualization">
+          <ResponsiveContainer width="100%" height={420}>
+            <BarChart
+              data={chartData}
+              margin={{
+                top: 16,
+                right: 24,
+                bottom: 8,
+                left: 8,
+              }}
+            >
+              <XAxis
+                dataKey="workerCategory"
+                interval={0}
+                angle={-45}
+                textAnchor="end"
+                height={80}
+                tick={{
+                  fill: axisColor,
+                  fontSize: 12,
+                }}
+                axisLine={{
+                  stroke: axisColor,
+                }}
+                tickLine={{
+                  stroke: axisColor,
+                }}
+              />
+
+              <YAxis
+                allowDecimals={false}
+                tick={{
+                  fill: axisColor,
+                  fontSize: 12,
+                }}
+                axisLine={{
+                  stroke: axisColor,
+                }}
+                tickLine={{
+                  stroke: axisColor,
+                }}
+              />
+
+              <Tooltip
+                formatter={(value, name) => [
+                  value,
+                  projectNameById.get(String(name)) || 'Unknown Project',
+                ]}
+                contentStyle={{
+                  backgroundColor: tooltipBackground,
+                  color: tooltipText,
+                  border: `1px solid ${tooltipBorder}`,
+                  borderRadius: '6px',
+                }}
+                itemStyle={{
+                  color: tooltipText,
+                }}
+                labelStyle={{
+                  color: tooltipText,
+                  fontWeight: 600,
+                }}
+              />
+
+              <Legend verticalAlign="bottom" content={renderLegend} />
+
+              {seriesProjectIds.map((projectId, index) => (
+                <Bar
+                  key={projectId}
+                  dataKey={projectId}
+                  name={projectNameById.get(projectId) || 'Unknown Project'}
+                  fill={index % 2 === 0 ? '#17c9d3' : '#64748b'}
+                >
+                  {showLabels && (
+                    <LabelList
+                      dataKey={projectId}
+                      position="top"
+                      formatter={value => (value > 0 ? value : '')}
+                      fill={axisColor}
+                    />
+                  )}
+                </Bar>
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
       )}
 
       {!loading && !error && chartData.length === 0 && (
-        <div className="empty">No data for selected filters.</div>
+        <div className="injury-chart-empty">No data for selected filters.</div>
       )}
     </div>
   );

--- a/src/components/BMDashboard/WeeklyProjectSummary/MostFrequentKeywords/MostFrequentKeywords.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/MostFrequentKeywords/MostFrequentKeywords.jsx
@@ -1,14 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import axios from 'axios';
-import DatePicker from 'react-datepicker';
-import 'react-datepicker/dist/react-datepicker.css';
 import * as d3 from 'd3';
-import styles from './MostFrequentKeywords.module.css';
+import DatePicker from 'react-datepicker';
 import Select from 'react-select';
+import 'react-datepicker/dist/react-datepicker.css';
+import styles from './MostFrequentKeywords.module.css';
 
 function MostFrequentKeywords() {
   const svgRef = useRef();
+
   const [projects, setProjects] = useState([]);
   const [selectedProject, setSelectedProject] = useState('');
   const [startDate, setStartDate] = useState(null);
@@ -16,15 +17,18 @@ function MostFrequentKeywords() {
   const [tags, setTags] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+
   const API_BASE = process.env.REACT_APP_APIENDPOINT;
   const darkMode = useSelector(state => state.theme.darkMode);
 
   const fetchProjects = async () => {
     try {
       const token = localStorage.getItem('token');
+
       const res = await axios.get(`${API_BASE}/projects`, {
         headers: { Authorization: token },
       });
+
       setProjects(res.data || []);
     } catch (err) {
       if (process.env.NODE_ENV !== 'production') {
@@ -36,16 +40,27 @@ function MostFrequentKeywords() {
 
   const fetchFrequentTags = async () => {
     if (!selectedProject) return;
+
     try {
       setIsLoading(true);
       setError('');
+
       const params = new URLSearchParams();
+
       params.append('projectId', selectedProject);
-      if (startDate) params.append('startDate', new Date(startDate).toISOString());
-      if (endDate) params.append('endDate', new Date(endDate).toISOString());
+
+      if (startDate) {
+        params.append('startDate', new Date(startDate).toISOString());
+      }
+
+      if (endDate) {
+        params.append('endDate', new Date(endDate).toISOString());
+      }
+
       params.append('limit', 7);
 
       const token = localStorage.getItem('token');
+
       const res = await axios.get(`${API_BASE}/tags/frequent?${params.toString()}`, {
         headers: { Authorization: token },
       });
@@ -56,6 +71,7 @@ function MostFrequentKeywords() {
         // eslint-disable-next-line no-console
         console.error('Tag fetch failed:', err);
       }
+
       setError('Failed to load tag data');
     } finally {
       setIsLoading(false);
@@ -73,22 +89,34 @@ function MostFrequentKeywords() {
   useEffect(() => {
     const timeout = setTimeout(() => {
       const svgEl = svgRef.current;
+
       if (!tags?.length || !svgEl) return;
 
       // eslint-disable-next-line testing-library/no-node-access
       const svg = d3.select(svgEl);
+
       svg.selectAll('*').remove();
 
       const container = svgEl.parentElement;
       const width = container?.clientWidth || 500;
       const height = 400;
+
       const centerX = width / 2;
       const centerY = height / 2;
       const padding = 50;
+
       const radius = Math.min(width - padding * 2, height - padding * 2) * 0.42;
 
       const ellipseRx = 48;
       const ellipseRy = 20;
+
+      const centerFill = darkMode ? '#2563EB' : '#3B82F6';
+      const lineColor = darkMode ? '#94A3B8' : '#555555';
+
+      const keywordFill = darkMode ? '#3B526F' : '#E0F2FE';
+      const keywordHoverFill = darkMode ? '#4F6B8E' : '#BFDBFE';
+
+      const keywordTextColor = darkMode ? '#F8FAFC' : '#111111';
 
       svg
         .attr('width', width)
@@ -102,14 +130,14 @@ function MostFrequentKeywords() {
         .attr('cy', centerY)
         .attr('rx', ellipseRx)
         .attr('ry', ellipseRy)
-        .attr('fill', '#3B82F6');
+        .attr('fill', centerFill);
 
       svg
         .append('text')
         .attr('x', centerX)
         .attr('y', centerY - 5)
         .attr('text-anchor', 'middle')
-        .attr('fill', 'white')
+        .attr('fill', '#FFFFFF')
         .attr('font-weight', 'bold')
         .attr('font-size', '10px')
         .text('Most Frequent');
@@ -119,19 +147,36 @@ function MostFrequentKeywords() {
         .attr('x', centerX)
         .attr('y', centerY + 9)
         .attr('text-anchor', 'middle')
-        .attr('fill', 'white')
+        .attr('fill', '#FFFFFF')
         .attr('font-weight', 'bold')
         .attr('font-size', '10px')
         .text('Keywords');
 
       const angleStep = (2.3 * Math.PI) / tags.length;
-      const angles = tags.map((_, i) => i * angleStep + Math.PI / 2 + 0.1);
+
+      const angles = tags.map((_, index) => index * angleStep + Math.PI / 2 + 0.1);
 
       const getEllipseSize = text => {
         const len = text.length;
-        if (len > 14) return { rx: 48, ry: 18 };
-        if (len > 10) return { rx: 40, ry: 16 };
-        return { rx: 32, ry: 16 };
+
+        if (len > 14) {
+          return {
+            rx: 48,
+            ry: 18,
+          };
+        }
+
+        if (len > 10) {
+          return {
+            rx: 40,
+            ry: 16,
+          };
+        }
+
+        return {
+          rx: 32,
+          ry: 16,
+        };
       };
 
       const ensureInBounds = (x, y) => ({
@@ -142,13 +187,15 @@ function MostFrequentKeywords() {
       const truncateText = (text, max = 14) =>
         text.length <= max ? text : `${text.slice(0, max - 1)}…`;
 
-      tags.forEach((tag, i) => {
-        const angle = angles[i];
+      tags.forEach((tag, index) => {
+        const angle = angles[index];
+
         const isLeftOrRight = Math.abs(Math.cos(angle)) > 0.9;
         const adjustedRadius = isLeftOrRight ? radius * 1.35 : radius;
 
         let x = centerX + adjustedRadius * Math.cos(angle);
         let y = centerY + adjustedRadius * Math.sin(angle);
+
         ({ x, y } = ensureInBounds(x, y));
 
         const xStart = centerX + ellipseRx * Math.cos(angle);
@@ -160,27 +207,43 @@ function MostFrequentKeywords() {
           .attr('y1', yStart)
           .attr('x2', x)
           .attr('y2', y)
-          .attr('stroke', '#555');
+          .attr('stroke', lineColor)
+          .attr('stroke-width', darkMode ? 1.25 : 1);
 
         const { rx, ry } = getEllipseSize(tag.tag);
+
         svg
           .append('ellipse')
           .attr('cx', x)
           .attr('cy', y)
           .attr('rx', rx)
           .attr('ry', ry)
-          .attr('fill', '#E0F2FE')
+          .attr('fill', keywordFill)
+          .attr('stroke', darkMode ? '#7890AD' : 'none')
+          .attr('stroke-width', darkMode ? 1 : 0)
           .style('cursor', 'pointer')
           .attr('tabindex', 0)
           .attr('role', 'button')
           .attr('aria-label', `Keyword: ${tag.tag}`)
           .on('mouseover', function() {
             // eslint-disable-next-line testing-library/no-node-access
-            d3.select(this).attr('fill', '#BFDBFE');
+            d3.select(this).attr('fill', keywordHoverFill);
           })
           .on('mouseout', function() {
             // eslint-disable-next-line testing-library/no-node-access
-            d3.select(this).attr('fill', '#E0F2FE');
+            d3.select(this).attr('fill', keywordFill);
+          })
+          .on('focus', function() {
+            // eslint-disable-next-line testing-library/no-node-access
+            d3.select(this)
+              .attr('fill', keywordHoverFill)
+              .attr('stroke-width', 2);
+          })
+          .on('blur', function() {
+            // eslint-disable-next-line testing-library/no-node-access
+            d3.select(this)
+              .attr('fill', keywordFill)
+              .attr('stroke-width', darkMode ? 1 : 0);
           })
           .on('click', () => {
             window.open(`/tags/${tag.tag}`, '_blank');
@@ -192,7 +255,9 @@ function MostFrequentKeywords() {
           .attr('y', y + 4)
           .attr('text-anchor', 'middle')
           .attr('font-size', '11px')
-          .attr('fill', '#111')
+          .attr('font-weight', darkMode ? 500 : 400)
+          .attr('fill', keywordTextColor)
+          .style('pointer-events', 'none')
           .text(truncateText(tag.tag))
           .append('title')
           .text(tag.tag);
@@ -200,36 +265,43 @@ function MostFrequentKeywords() {
     }, 100);
 
     return () => clearTimeout(timeout);
-  }, [tags]);
+  }, [tags, darkMode]);
+
+  const projectOptions = projects.map(project => ({
+    label: project.projectName,
+    value: project._id,
+  }));
+
+  const selectedProjectOption =
+    projectOptions.find(option => option.value === selectedProject) || null;
 
   return (
-    <div className={`${styles.mfkContainer} ${darkMode ? 'darkMode' : ''}`}>
+    <div className={`${styles.mfkContainer} ${darkMode ? styles.mfkDark : ''}`}>
       <h3 className={styles.mfkTitle}>📊 Most Frequent Keywords</h3>
+
       <div className={styles.mfkControls}>
         <div>
           <label htmlFor="project-select" className={styles.mfkLabel}>
             Project
           </label>
+
           <Select
             inputId="project-select"
             className={styles.mfkSelect}
             classNamePrefix="project-select"
-            options={projects.map(p => ({
-              label: p.projectName,
-              value: p._id,
-            }))}
-            value={projects
-              .map(p => ({ label: p.projectName, value: p._id }))
-              .find(opt => opt.value === selectedProject)}
+            options={projectOptions}
+            value={selectedProjectOption}
             onChange={selected => setSelectedProject(selected?.value || '')}
             placeholder="Select a project..."
             isSearchable
           />
         </div>
+
         <div>
           <label htmlFor="start-date" className={styles.mfkLabel}>
             From
           </label>
+
           <DatePicker
             id="start-date"
             selected={startDate}
@@ -238,10 +310,12 @@ function MostFrequentKeywords() {
             placeholderText="Start date"
           />
         </div>
+
         <div>
           <label htmlFor="end-date" className={styles.mfkLabel}>
             To
           </label>
+
           <DatePicker
             id="end-date"
             selected={endDate}
@@ -254,10 +328,13 @@ function MostFrequentKeywords() {
 
       <div className={styles.mfkChartContainer}>
         {isLoading && <div className={styles.mfkLoading}>Loading...</div>}
+
         {!isLoading && error && <div className={styles.mfkError}>{error}</div>}
+
         {!isLoading && !error && tags.length === 0 && (
           <div className={styles.mfkEmpty}>No tags found for this selection.</div>
         )}
+
         {!isLoading && !error && tags.length > 0 && <svg ref={svgRef} />}
       </div>
     </div>

--- a/src/components/BMDashboard/WeeklyProjectSummary/MostFrequentKeywords/MostFrequentKeywords.module.css
+++ b/src/components/BMDashboard/WeeklyProjectSummary/MostFrequentKeywords/MostFrequentKeywords.module.css
@@ -1,13 +1,14 @@
 .mfkContainer {
   padding: 1.25rem;
   font-family: 'Inter', sans-serif;
+  color: #111827;
 }
 
 .mfkTitle {
   font-size: 1.25rem;
   font-weight: 600;
   margin-bottom: 1rem;
-  color: #1e3a8a; /* Indigo-900 */
+  color: #1e3a8a;
 }
 
 .mfkControls {
@@ -23,31 +24,40 @@
   min-width: 220px;
 }
 
+.mfkLabel,
 .mfkControls label {
-  font-size: 0.875rem;
-  margin-bottom: 0.25rem;
   display: block;
-  color: #374151; /* Gray-700 */
+  margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
 }
 
-.mfkSelect{
+.mfkSelect {
   width: 100%;
   font-size: 0.9rem;
   border-radius: 0.375rem;
 }
+
 .mfkDatepicker {
   width: 100%;
   padding: 0.5rem;
   font-size: 0.9rem;
-  border: 1px solid #d1d5db; /* Gray-300 */
+  color: #111827;
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
   border-radius: 0.375rem;
 }
 
-.mfkSelect:focus,
 .mfkDatepicker:focus {
   outline: none;
-  border-color: #3b82f6; /* Blue-500 */
-  background-color: #fff;
+  border-color: #3b82f6;
+  background-color: #ffffff;
+  box-shadow: 0 0 0 1px #3b82f6;
+}
+
+.mfkDatepicker::placeholder {
+  color: #6b7280;
 }
 
 .mfkLoading,
@@ -55,8 +65,12 @@
 .mfkEmpty {
   text-align: center;
   margin-top: 1rem;
-  color: #6b7280; /* Gray-500 */
+  color: #6b7280;
   font-style: italic;
+}
+
+.mfkError {
+  color: #b91c1c;
 }
 
 .mfkChartContainer {
@@ -79,32 +93,290 @@
   display: block;
 }
 
+/* =========================================================
+   DARK MODE
+   Everything below is scoped to this component through
+   the mfkDark class.
+   ========================================================= */
 
-:global(.darkMode) .mfkTitle {
-  color: white;
+.mfkDark {
+  color: #f3f4f6;
 }
 
-:global(.darkMode) .mfkLabel {
-  color: white;
+.mfkDark .mfkTitle {
+  color: #f8fafc;
 }
 
-:global(.darkMode) :global(.project-select__control) {
+.mfkDark .mfkLabel,
+.mfkDark .mfkControls label {
+  color: #f3f4f6;
+}
+
+.mfkDark .mfkDatepicker {
+  color: #f8fafc;
+  background-color: #2b3e59;
+  border-color: #536985;
+  color-scheme: dark;
+}
+
+.mfkDark .mfkDatepicker::placeholder {
+  color: #cbd5e1;
+}
+
+.mfkDark .mfkDatepicker:hover {
+  border-color: #7890ad;
+}
+
+.mfkDark .mfkDatepicker:focus {
+  color: #ffffff;
+  background-color: #2b3e59;
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 1px #60a5fa;
+}
+
+.mfkDark .mfkLoading,
+.mfkDark .mfkEmpty {
+  color: #cbd5e1;
+}
+
+.mfkDark .mfkError {
+  color: #fca5a5;
+}
+
+/* =========================================================
+   REACT-SELECT DARK MODE
+   project-select comes from classNamePrefix="project-select"
+   ========================================================= */
+
+.mfkDark :global(.project-select__control) {
+  min-height: 38px;
+  color: #f8fafc !important;
   background-color: #2b3e59 !important;
-  color: white !important;
-  border-color: #555 !important;
+  border-color: #536985 !important;
+  box-shadow: none !important;
 }
 
-:global(.darkMode) :global(.project-select__single-value),
-:global(.darkMode) :global(.project-select__multi-value__label),
-:global(.darkMode) :global(.project-select__input-container) {
-  color: white !important;
+.mfkDark :global(.project-select__control:hover) {
+  border-color: #7890ad !important;
 }
 
-:global(.darkMode) :global(.project-select__menu) {
-  background-color: #2b3e59 !important;
-  color: white !important;
+.mfkDark :global(.project-select__control--is-focused) {
+  border-color: #60a5fa !important;
+  box-shadow: 0 0 0 1px #60a5fa !important;
 }
 
-:global(.darkMode) :global(.project-select__option:hover) {
-  color: black !important;
+.mfkDark :global(.project-select__value-container) {
+  background-color: transparent;
+}
+
+.mfkDark :global(.project-select__single-value) {
+  color: #ffffff !important;
+}
+
+.mfkDark :global(.project-select__placeholder) {
+  color: #cbd5e1 !important;
+}
+
+.mfkDark :global(.project-select__input-container) {
+  color: #ffffff !important;
+}
+
+.mfkDark :global(.project-select__input) {
+  color: #ffffff !important;
+}
+
+.mfkDark :global(.project-select__input input) {
+  color: #ffffff !important;
+}
+
+.mfkDark :global(.project-select__indicators) {
+  color: #cbd5e1;
+}
+
+.mfkDark :global(.project-select__dropdown-indicator) {
+  color: #cbd5e1 !important;
+}
+
+.mfkDark :global(.project-select__dropdown-indicator:hover) {
+  color: #ffffff !important;
+}
+
+.mfkDark :global(.project-select__indicator-separator) {
+  background-color: #64748b !important;
+}
+
+.mfkDark :global(.project-select__menu) {
+  z-index: 20;
+  color: #f8fafc !important;
+  background-color: #263952 !important;
+  border: 1px solid #536985;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 35%),
+    0 4px 6px -4px rgb(0 0 0 / 35%);
+}
+
+.mfkDark :global(.project-select__menu-list) {
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #263952;
+}
+
+/* Default dropdown option */
+.mfkDark :global(.project-select__option) {
+  color: #f8fafc !important;
+  background-color: #263952 !important;
+  cursor: pointer;
+}
+
+/* Hover / keyboard focused dropdown option */
+.mfkDark :global(.project-select__option--is-focused) {
+  color: #ffffff !important;
+  background-color: #355173 !important;
+}
+
+/* Currently selected dropdown option */
+.mfkDark :global(.project-select__option--is-selected) {
+  color: #ffffff !important;
+  background-color: #2563eb !important;
+}
+
+/* Selected + focused */
+.mfkDark
+  :global(.project-select__option--is-selected.project-select__option--is-focused) {
+  color: #ffffff !important;
+  background-color: #1d4ed8 !important;
+}
+
+.mfkDark :global(.project-select__menu-notice) {
+  color: #cbd5e1 !important;
+}
+
+/* Multi-select support if this Select is changed later */
+.mfkDark :global(.project-select__multi-value) {
+  background-color: #3b526f !important;
+}
+
+.mfkDark :global(.project-select__multi-value__label) {
+  color: #ffffff !important;
+}
+
+.mfkDark :global(.project-select__multi-value__remove) {
+  color: #e2e8f0 !important;
+}
+
+.mfkDark :global(.project-select__multi-value__remove:hover) {
+  color: #ffffff !important;
+  background-color: #b91c1c !important;
+}
+
+/* =========================================================
+   REACT-SELECT SCROLLBAR
+   Makes the dropdown scrollbar visible in dark mode.
+   ========================================================= */
+
+.mfkDark :global(.project-select__menu-list) {
+  scrollbar-width: thin;
+  scrollbar-color: #7890ad #263952;
+}
+
+.mfkDark :global(.project-select__menu-list::-webkit-scrollbar) {
+  width: 8px;
+}
+
+.mfkDark :global(.project-select__menu-list::-webkit-scrollbar-track) {
+  background: #263952;
+  border-radius: 4px;
+}
+
+.mfkDark :global(.project-select__menu-list::-webkit-scrollbar-thumb) {
+  background-color: #7890ad;
+  border: 2px solid #263952;
+  border-radius: 4px;
+}
+
+.mfkDark :global(.project-select__menu-list::-webkit-scrollbar-thumb:hover) {
+  background-color: #94a3b8;
+}
+
+/* =========================================================
+   REACT-DATEPICKER DARK MODE
+   Scoped so other DatePicker instances are unaffected.
+   ========================================================= */
+
+.mfkDark :global(.react-datepicker) {
+  color: #f8fafc;
+  background-color: #263952;
+  border-color: #536985;
+}
+
+.mfkDark :global(.react-datepicker__header) {
+  background-color: #2b3e59;
+  border-bottom-color: #536985;
+}
+
+.mfkDark :global(.react-datepicker__current-month),
+.mfkDark :global(.react-datepicker-time__header),
+.mfkDark :global(.react-datepicker-year-header) {
+  color: #ffffff;
+}
+
+.mfkDark :global(.react-datepicker__day-name) {
+  color: #cbd5e1;
+}
+
+.mfkDark :global(.react-datepicker__day) {
+  color: #f8fafc;
+}
+
+.mfkDark :global(.react-datepicker__day:hover) {
+  color: #ffffff;
+  background-color: #3b526f;
+}
+
+.mfkDark :global(.react-datepicker__day--selected),
+.mfkDark :global(.react-datepicker__day--keyboard-selected) {
+  color: #ffffff;
+  background-color: #2563eb;
+}
+
+.mfkDark :global(.react-datepicker__day--outside-month) {
+  color: #7c8da3;
+}
+
+.mfkDark :global(.react-datepicker__day--disabled) {
+  color: #64748b;
+}
+
+.mfkDark :global(.react-datepicker__triangle) {
+  color: #2b3e59;
+  fill: #2b3e59;
+}
+
+.mfkDark :global(.react-datepicker__navigation-icon::before) {
+  border-color: #e2e8f0;
+}
+
+/* =========================================================
+   RESPONSIVENESS
+   ========================================================= */
+
+@media (max-width: 768px) {
+  .mfkContainer {
+    padding: 0.75rem;
+  }
+
+  .mfkControls {
+    gap: 0.75rem;
+  }
+
+  .mfkControls > div {
+    flex: 1 1 100%;
+    min-width: 100%;
+  }
+
+  .mfkChartContainer {
+    height: 420px;
+    min-height: 420px;
+    padding: 5px;
+  }
 }


### PR DESCRIPTION
# Description
<img width="569" height="515" alt="Screenshot 2026-08-29 at 12 38 02 AM" src="https://github.com/user-attachments/assets/bddec582-b66a-4988-b7c3-3f8f3bf70329" />


## Related PRS (if any):
Old PR [PR3976](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3976)

## Main changes explained:
- Improved dark mode styling for the Most Frequent Keywords component.
- Improved project dropdown readability in dark mode.
- Added clearer hover, selected, focused, and scrollbar states for project options.
- Improved date input and date picker visibility.
- Updated keyword chart colors for better dark mode contrast.
- Updated the D3 visualization to redraw correctly when switching themes.
- Improved dark mode support for the Injury Severity chart.
- Improved Projects, Severities, and Injury Types dropdown readability.
- Updated date labels from Start date / End date to From / To for consistency.
- Improved chart axis, tooltip, data label, and legend readability.
- Improved the scrollable legend displayed below the chart.
- Preserved existing filtering and analytics behavior.


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to http://localhost:5173/bmdashboard/totalconstructionsummary
6. click on Lessons Learned
7. verify the feature works in [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI)

## Screenshots or videos of changes:

## Note:
This PR only addresses the Dark Mode readability and styling.
