### PR TITLE
Bosu - fix PR quality distribution tooltip and member count

### DIFF
--- a/src/components/PRAnalyticsDashboard/ReviewsInsight/PRQualityGraph.jsx
+++ b/src/components/PRAnalyticsDashboard/ReviewsInsight/PRQualityGraph.jsx
@@ -7,7 +7,13 @@ import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 Chart.register(ChartDataLabels);
 
-function PRQualityGraph({ selectedTeams, qualityData, isDataViewActive, orderedTeamIds }) {
+function PRQualityGraph({
+  selectedTeams,
+  qualityData,
+  isDataViewActive,
+  orderedTeamIds,
+  teamData,
+}) {
   const darkMode = useSelector(state => state.theme.darkMode);
 
   if (!selectedTeams || selectedTeams.length === 0) {
@@ -67,9 +73,8 @@ function PRQualityGraph({ selectedTeams, qualityData, isDataViewActive, orderedT
         displayColors: false,
         enabled: true,
         callbacks: {
-          title: items =>
-            items && items[0] ? `${items[0].label}: ${items[0].formattedValue}` : '',
-          label: ctx => (isDataViewActive ? `${ctx.raw.toFixed(1)}%` : ctx.raw),
+          title: () => '',
+          label: ctx => `${ctx.label}: ${isDataViewActive ? `${ctx.raw.toFixed(1)}%` : ctx.raw}`,
         },
       },
       datalabels: {
@@ -101,6 +106,14 @@ function PRQualityGraph({ selectedTeams, qualityData, isDataViewActive, orderedT
               }`}
             >
               {team}
+              <span
+                className={`${sharedStyles.riTeamMemberCount} ${
+                  darkMode ? sharedStyles.darkModeForeground : ''
+                }`}
+              >
+                {' '}
+                ({teamData[team]?.memberCount || 0} members)
+              </span>
             </h3>
             <Pie data={generateChartData(team)} options={options} />
           </div>
@@ -127,6 +140,11 @@ PRQualityGraph.propTypes = {
   ),
   isDataViewActive: PropTypes.bool,
   orderedTeamIds: PropTypes.arrayOf(PropTypes.string),
+  teamData: PropTypes.objectOf(
+    PropTypes.shape({
+      memberCount: PropTypes.number,
+    }),
+  ),
 };
 
 PRQualityGraph.defaultProps = {
@@ -134,6 +152,7 @@ PRQualityGraph.defaultProps = {
   qualityData: {},
   isDataViewActive: false,
   orderedTeamIds: [],
+  teamData: {},
 };
 
 export default PRQualityGraph;

--- a/src/components/PRAnalyticsDashboard/ReviewsInsight/ReviewsInsight.jsx
+++ b/src/components/PRAnalyticsDashboard/ReviewsInsight/ReviewsInsight.jsx
@@ -247,6 +247,7 @@ function ReviewsInsight() {
             qualityData={qualityData}
             isDataViewActive={dataViewActive}
             orderedTeamIds={orderedTeamIds}
+            teamData={teamData}
           />
         </div>
       )}

--- a/src/components/PRAnalyticsDashboard/ReviewsInsight/ReviewsInsight.module.css
+++ b/src/components/PRAnalyticsDashboard/ReviewsInsight/ReviewsInsight.module.css
@@ -237,6 +237,11 @@
   border: none;
 }
 
+.riTeamMemberCount {
+  font-size: 0.8em;
+  font-weight: normal;
+}
+
 /* Shared */
 .riGraph {
   border: 1px solid #ccc;

--- a/src/components/PRAnalyticsDashboard/ReviewsInsight/__tests__/PRQualityGraph.test.jsx
+++ b/src/components/PRAnalyticsDashboard/ReviewsInsight/__tests__/PRQualityGraph.test.jsx
@@ -1,0 +1,102 @@
+import { vi } from 'vitest';
+
+vi.mock('react-redux', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useSelector: vi.fn(() => false),
+  };
+});
+
+let lastPieOptions;
+vi.mock('react-chartjs-2', () => ({
+  Pie: ({ options }) => {
+    lastPieOptions = options;
+    return <div data-testid="pie-chart" />;
+  },
+}));
+
+import { render, screen } from '@testing-library/react';
+import PRQualityGraph from '../PRQualityGraph';
+
+const renderWithStore = ui => render(ui);
+
+const selectedTeams = [{ value: 'Team A', label: 'Team A' }];
+const qualityData = {
+  'Team A': {
+    NotApproved: 0,
+    LowQuality: 1,
+    Sufficient: 1,
+    Exceptional: 0,
+  },
+};
+const teamData = {
+  'Team A': {
+    memberCount: 5,
+  },
+};
+
+describe('PRQualityGraph', () => {
+  it('labels every category in the tooltip in Number mode', () => {
+    renderWithStore(
+      <PRQualityGraph
+        selectedTeams={selectedTeams}
+        qualityData={qualityData}
+        isDataViewActive={false}
+        orderedTeamIds={['Team A']}
+        teamData={teamData}
+      />,
+    );
+
+    const { tooltip } = lastPieOptions.plugins;
+    expect(tooltip.callbacks.title()).toBe('');
+    expect(tooltip.callbacks.label({ label: 'Not Approved', raw: 0 })).toBe('Not Approved: 0');
+    expect(tooltip.callbacks.label({ label: 'Low Quality', raw: 1 })).toBe('Low Quality: 1');
+    expect(tooltip.callbacks.label({ label: 'Sufficient', raw: 1 })).toBe('Sufficient: 1');
+    expect(tooltip.callbacks.label({ label: 'Exceptional', raw: 0 })).toBe('Exceptional: 0');
+  });
+
+  it('labels every category in the tooltip in Data View (percentage) mode', () => {
+    renderWithStore(
+      <PRQualityGraph
+        selectedTeams={selectedTeams}
+        qualityData={qualityData}
+        isDataViewActive
+        orderedTeamIds={['Team A']}
+        teamData={teamData}
+      />,
+    );
+
+    const { tooltip } = lastPieOptions.plugins;
+    expect(tooltip.callbacks.label({ label: 'Not Approved', raw: 0 })).toBe('Not Approved: 0.0%');
+    expect(tooltip.callbacks.label({ label: 'Low Quality', raw: 50 })).toBe('Low Quality: 50.0%');
+  });
+
+  it('renders the team member count from teamData', () => {
+    renderWithStore(
+      <PRQualityGraph
+        selectedTeams={selectedTeams}
+        qualityData={qualityData}
+        isDataViewActive={false}
+        orderedTeamIds={['Team A']}
+        teamData={teamData}
+      />,
+    );
+
+    expect(screen.getByText(/5 members/)).toBeInTheDocument();
+  });
+
+  it('defaults to 0 members when teamData is missing for a team', () => {
+    renderWithStore(
+      <PRQualityGraph
+        selectedTeams={selectedTeams}
+        qualityData={qualityData}
+        isDataViewActive={false}
+        orderedTeamIds={['Team A']}
+        teamData={{}}
+      />,
+    );
+
+    expect(screen.getByText(/0 members/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Description

Finishes the follow-up fixes for the PR Review Team Analytics Dashboard PR Insights frontend.

This fixes two regressions in the PR Quality Distribution section:

1. Pie-chart tooltips were only showing the first quality category as a key-value pair. Other hovered values were displayed without their category names.
2. Team member counts were no longer displayed with each team's PR Quality Distribution chart.

Related original/follow-up work:
- PR #4389
- PR #3839
- PR #1624

## Main changes explained

1. Updated `PRQualityGraph.jsx` so every tooltip entry displays its quality category and corresponding value.
2. Preserved Number mode and Data View percentage formatting.
3. Passed the existing `teamData` from `ReviewsInsight.jsx` into `PRQualityGraph`.
4. Restored each team's member count next to the team name without introducing any new backend/API request.
5. Added scoped styling for the team member count.
6. Added focused unit tests covering:
   - all tooltip category labels in Number mode
   - percentage formatting in Data View mode
   - team member count rendering
   - safe fallback when member-count data is unavailable

## How to test

1. Checkout this branch:
   `Bosu-fix-pr-review-quality-distribution`
2. Use Node 20.
3. Run the frontend locally with:
   `npm run start:local`
4. Log in with an Admin/Owner test account.
5. Navigate to:
   `PR Dashboard -> PR Reviews Insights`
   or `/pull-request-analytics/reviews-insight`
6. Set Duration to `All Time`.
7. Select `All Teams`.
8. In the PR Quality Distribution section, confirm each team displays its member count.
9. Hover over a pie chart and confirm all four quality categories display as key-value pairs:
   - Not Approved
   - Low Quality
   - Sufficient
   - Exceptional
10. Confirm zero-value categories are also shown in the tooltip.
11. Toggle Data View and confirm the same categories are shown with percentage values.
12. Select individual teams and other duration filters and confirm charts/member counts continue to update correctly.
13. Verify the page in dark mode and at narrower browser widths.

## Testing completed

- Focused PR Quality Graph unit tests passed.
- PR Analytics Dashboard focused tests passed.
- ESLint passed for modified JavaScript/test files.
- `git diff --check` passed.
- Manually verified Number mode.
- Manually verified Data View percentage mode.
- Manually verified zero-value tooltip entries.
- Manually verified team member counts.
- Manually verified team filtering.
- Manually verified dark mode and responsive behavior.

## Backend changes

None.

The existing frontend data already contains `memberCount`, so no API or backend changes were necessary.

## Screenshots / Videos


https://github.com/user-attachments/assets/9f66c5b0-94df-4f57-9b79-d1f247acf414

<img width="1512" height="908" alt="Screenshot 2026-08-29 at 6 54 20 PM" src="https://github.com/user-attachments/assets/aaca0208-f3c4-440a-b9b3-b3ee289b85e8" />
