### PR TITLE
Mahathi - Improve Utilization Chart dark mode support

### DIFF
--- a/src/components/BMDashboard/UtilizationChart/UtilizationChart.jsx
+++ b/src/components/BMDashboard/UtilizationChart/UtilizationChart.jsx
@@ -239,118 +239,120 @@ function UtilizationChart() {
   );
 
   return (
-    <div className={`${styles.utilizationChartContainer} ${darkMode ? styles.darkMode : ''}`}>
-      <h2 className={styles.chartTitle}>Tool Utilization Analysis</h2>
+    <div className={`${styles.utilizationChartPage} ${darkMode ? styles.darkPage : ''}`}>
+      <div className={`${styles.utilizationChartContainer} ${darkMode ? styles.darkMode : ''}`}>
+        <h2 className={styles.chartTitle}>Tool Utilization Analysis</h2>
 
-      <div className={styles.filters}>
-        <select
-          value={toolFilter}
-          onChange={e => setToolFilter(e.target.value)}
-          className={styles.select}
-          aria-label="Filter by tool type"
-        >
-          <option value="ALL">All Tools</option>
-          {toolTypes.map(toolType => (
-            <option key={toolType._id} value={toolType._id}>
-              {toolType.name}
-            </option>
-          ))}
-        </select>
+        <div className={styles.filters}>
+          <select
+            value={toolFilter}
+            onChange={e => setToolFilter(e.target.value)}
+            className={styles.select}
+            aria-label="Filter by tool type"
+          >
+            <option value="ALL">All Tools</option>
+            {toolTypes.map(toolType => (
+              <option key={toolType._id} value={toolType._id}>
+                {toolType.name}
+              </option>
+            ))}
+          </select>
 
-        <select
-          value={projectFilter}
-          onChange={e => setProjectFilter(e.target.value)}
-          className={styles.select}
-          aria-label="Filter by project"
-        >
-          <option value="ALL">All Projects</option>
-          {projects.map(project => (
-            <option key={project.projectId} value={project.projectId}>
-              {project.projectName}
-            </option>
-          ))}
-        </select>
+          <select
+            value={projectFilter}
+            onChange={e => setProjectFilter(e.target.value)}
+            className={styles.select}
+            aria-label="Filter by project"
+          >
+            <option value="ALL">All Projects</option>
+            {projects.map(project => (
+              <option key={project.projectId} value={project.projectId}>
+                {project.projectName}
+              </option>
+            ))}
+          </select>
 
-        <DatePicker
-          selected={startDate}
-          onChange={date => setStartDate(date)}
-          placeholderText="Start Date"
-          maxDate={endDate || new Date()}
-          className={styles.datepickerWrapper}
-          aria-label="Start date"
+          <DatePicker
+            selected={startDate}
+            onChange={date => setStartDate(date)}
+            placeholderText="Start Date"
+            maxDate={endDate || new Date()}
+            className={styles.datepickerWrapper}
+            aria-label="Start date"
+          />
+
+          <DatePicker
+            selected={endDate}
+            onChange={date => setEndDate(date)}
+            placeholderText="End Date"
+            minDate={startDate || undefined}
+            maxDate={new Date()}
+            className={styles.datepickerWrapper}
+            aria-label="End date"
+          />
+
+          <button type="button" onClick={handleApplyClick} className={styles.button}>
+            Apply
+          </button>
+        </div>
+
+        <ForecastModeToggle value={forecastMode} onChange={handleForecastModeChange} />
+
+        {forecastMode === FORECAST_MODES.FORECAST_FULL && warningMessage && (
+          <div className={styles.warningBanner} role="alert">
+            {warningMessage}
+          </div>
+        )}
+
+        {!insightsLoading && insights.summary && <InsightsSummaryBar summary={insights.summary} />}
+
+        {chartLoading && (
+          <div className={styles.loadingContainer} role="status" aria-live="polite">
+            <div className={styles.spinner} />
+            <span className={styles.srOnly}>Loading utilization data...</span>
+          </div>
+        )}
+
+        {!chartLoading && chartError && (
+          <div className={styles.utilizationChartError} role="alert">
+            {chartError}
+          </div>
+        )}
+
+        {!chartLoading && !chartError && toolsData.length === 0 && (
+          <div className={styles.emptyMessage}>
+            No utilization data available for the selected filters.
+          </div>
+        )}
+
+        {!chartLoading && !chartError && toolsData.length > 0 && (
+          <div
+            role="img"
+            aria-label={`Horizontal bar chart showing utilization rates for ${toolsData.length} tool types`}
+          >
+            <Bar data={chartData} options={options} plugins={[trafficLightPlugin]} />
+          </div>
+        )}
+
+        <div aria-live="polite" className={styles.srOnly}>
+          {chartAnnouncement}
+        </div>
+
+        {!insightsLoading && !insightsError && (
+          <div className={styles.insightsPanelsGrid}>
+            <RecommendationPanel recommendations={insights.recommendations} />
+            <MaintenanceAlertPanel alerts={insights.maintenanceAlerts} />
+            <ResourceBalancingPanel suggestions={insights.resourceBalancing} />
+          </div>
+        )}
+
+        <ExportReportButton
+          tool={toolFilter}
+          project={projectFilter}
+          startDate={startDate}
+          endDate={endDate}
         />
-
-        <DatePicker
-          selected={endDate}
-          onChange={date => setEndDate(date)}
-          placeholderText="End Date"
-          minDate={startDate || undefined}
-          maxDate={new Date()}
-          className={styles.datepickerWrapper}
-          aria-label="End date"
-        />
-
-        <button type="button" onClick={handleApplyClick} className={styles.button}>
-          Apply
-        </button>
       </div>
-
-      <ForecastModeToggle value={forecastMode} onChange={handleForecastModeChange} />
-
-      {forecastMode === FORECAST_MODES.FORECAST_FULL && warningMessage && (
-        <div className={styles.warningBanner} role="alert">
-          {warningMessage}
-        </div>
-      )}
-
-      {!insightsLoading && insights.summary && <InsightsSummaryBar summary={insights.summary} />}
-
-      {chartLoading && (
-        <div className={styles.loadingContainer} role="status" aria-live="polite">
-          <div className={styles.spinner} />
-          <span className={styles.srOnly}>Loading utilization data...</span>
-        </div>
-      )}
-
-      {!chartLoading && chartError && (
-        <div className={styles.utilizationChartError} role="alert">
-          {chartError}
-        </div>
-      )}
-
-      {!chartLoading && !chartError && toolsData.length === 0 && (
-        <div className={styles.emptyMessage}>
-          No utilization data available for the selected filters.
-        </div>
-      )}
-
-      {!chartLoading && !chartError && toolsData.length > 0 && (
-        <div
-          role="img"
-          aria-label={`Horizontal bar chart showing utilization rates for ${toolsData.length} tool types`}
-        >
-          <Bar data={chartData} options={options} plugins={[trafficLightPlugin]} />
-        </div>
-      )}
-
-      <div aria-live="polite" className={styles.srOnly}>
-        {chartAnnouncement}
-      </div>
-
-      {!insightsLoading && !insightsError && (
-        <div className={styles.insightsPanelsGrid}>
-          <RecommendationPanel recommendations={insights.recommendations} />
-          <MaintenanceAlertPanel alerts={insights.maintenanceAlerts} />
-          <ResourceBalancingPanel suggestions={insights.resourceBalancing} />
-        </div>
-      )}
-
-      <ExportReportButton
-        tool={toolFilter}
-        project={projectFilter}
-        startDate={startDate}
-        endDate={endDate}
-      />
     </div>
   );
 }

--- a/src/components/BMDashboard/UtilizationChart/UtilizationChart.module.css
+++ b/src/components/BMDashboard/UtilizationChart/UtilizationChart.module.css
@@ -1,4 +1,14 @@
-/* ============ BASE CONTAINER & VARIABLES ============ */
+.utilizationChartPage {
+  min-height: 100vh;
+  padding: 2rem 1rem;
+  background-color: #fff;
+  transition: background-color 0.3s ease;
+}
+
+.darkPage {
+  background-color: #0d1b2a;
+}
+
 .utilizationChartContainer {
   padding: 2rem;
   max-width: 1200px;


### PR DESCRIPTION
# Description

Improve dark mode support for the Utilization Chart page.
<img width="523" height="612" alt="Screenshot 2026-08-29 at 11 52 06 PM" src="https://github.com/user-attachments/assets/eb4b8508-b08f-4103-ab3d-f084fea16953" />

In dark mode, the Utilization Chart content and chart area were displayed with dark mode styling, but the page background surrounding the chart remained white. This created inconsistent styling and poor visual contrast between the analytics visualization and the rest of the page.

This PR updates the Utilization Chart page so that the surrounding page background also responds to the application's dark mode state. A dark navy background is used instead of pure black to provide better contrast with the existing dark blue Utilization Chart container while maintaining consistency with the application's dark theme.

The implementation preserves the existing Utilization Chart functionality, including utilization analytics, forecasting, filters, insights, maintenance alerts, resource balancing, and report export functionality.

## Related PRS (if any):

This change is frontend-only and does not require a related backend PR.
Old PR [https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3996](url)

## Main changes explained:

- Update `UtilizationChart.module.css` to add scoped page-level light and dark mode background styles.
- Add a dark navy page background to prevent the area surrounding the Utilization Chart from remaining white in dark mode.
- Preserve the existing dark mode CSS variables and styling used by the Utilization Chart container, filters, analytics panels, and other components.
- Update `UtilizationChart.jsx` to add a page-level wrapper around the existing Utilization Chart container.
- Conditionally apply the new dark page class using the existing Redux `darkMode` state.
- Preserve the existing `darkMode` class on the Utilization Chart container so current dark mode behavior continues to work.
- Preserve existing utilization analytics, forecasting, filtering, insights, alerts, resource balancing, and export functionality.
- Maintain existing light mode behavior.

## How to test:

1. Checkout this branch:

   `git checkout mahathi/fix-utilization-chart-dark-mode`

2. Install dependencies if needed:

   `npm install`

3. Start the frontend application [ http://localhost:5173/utilizationchart ](url)
4. Clear the browser site data/cache if necessary and refresh the application.

5. Log in with a user account that has access to the Utilization Chart page.

6. Navigate to the Utilization Chart page.

7. Verify the page in **light mode**:
   - The surrounding page background remains light.
   - The Utilization Chart and its controls display correctly.
   - Filters and chart functionality continue to work as expected.

8. Switch the application to **dark mode**.

9. Verify that:
   - The area surrounding the Utilization Chart no longer remains white.
   - The surrounding page uses the new dark navy background.
   - The Utilization Chart container remains visually distinct from the surrounding page.
   - Chart labels, axes, grid lines, and data labels remain readable.
   - Tool and project filters remain readable and functional.
   - Date filters remain readable and functional.
   - Forecast controls and analytics sections continue to display correctly.
   - Insights, alerts, resource balancing, and export functionality remain unaffected.
   - There are no unexpected light/white page areas around the Utilization Chart.

10. Toggle between light and dark mode and verify that the page background updates correctly without affecting the existing Utilization Chart functionality.

## Note:

This change is intentionally scoped to the Utilization Chart page.

The existing Utilization Chart already contains comprehensive dark mode styling for the chart container and its analytics components. This PR preserves that implementation and adds a page-level dark mode wrapper to address the remaining white background outside the chart.

A dark navy background (`#0d1b2a`) is used instead of pure black to provide better visual contrast with the existing dark blue chart container and create a more consistent dark mode appearance.