### PR TITLE
HANDIKA: Fix dark mode styling for applicant volunteer ratio chart

### DIFF
--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
@@ -112,15 +112,6 @@ function ApplicantVolunteerRatio() {
 
   const legendTextColor = darkMode ? '#e0e0e0' : '#333';
 
-  if (loading) {
-    return (
-      <div className={`${styles.page} ${darkMode ? styles.dark : ''}`}>
-        <h2 className={styles.heading}>Number of People Hired vs. Total Applications</h2>
-        <div className={styles.statusMessage}>Loading...</div>
-      </div>
-    );
-  }
-
   if (error) {
     return (
       <div className={`${styles.page} ${darkMode ? styles.dark : ''}`}>
@@ -178,6 +169,7 @@ function ApplicantVolunteerRatio() {
           <Select
             id="role-select"
             isMulti
+            closeMenuOnSelect={false}
             options={allRoles}
             value={selectedRoles}
             onChange={setSelectedRoles}
@@ -221,7 +213,12 @@ function ApplicantVolunteerRatio() {
         </button>
       </div>
 
-      {chartData.length > 0 ? (
+      {loading ? (
+        <div className={styles.loadingContainer} role="status" aria-label="Loading chart data">
+          <div className={styles.loadingSpinner} aria-hidden="true" />
+          <span>Loading chart data...</span>
+        </div>
+      ) : chartData.length > 0 ? (
         <div className={styles.chartContainer}>
           <ResponsiveContainer width="100%" height={350}>
             <BarChart

--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
@@ -43,6 +43,24 @@ function SelectOption(props) {
 
 const roleSelectComponents = { MultiValue: LimitedMultiValue, Option: SelectOption };
 
+function ChartTooltip({ active, payload, label, darkMode }) {
+  if (!active || !payload?.length) return null;
+
+  return (
+    <div
+      className={`${styles.chartTooltipContent} ${darkMode ? styles.chartTooltipContentDark : ''}`}
+    >
+      <p className={styles.chartTooltipRole}>{label}</p>
+      {payload.map(entry => (
+        <p key={entry.dataKey} className={styles[`chartTooltip${entry.dataKey}`]}>
+          {entry.name}: {entry.value}
+          {entry.dataKey === 'hiredPercentage' ? '%' : ''}
+        </p>
+      ))}
+    </div>
+  );
+}
+
 function ApplicantVolunteerRatio() {
   const darkMode = useSelector(state => state.theme.darkMode);
 
@@ -328,20 +346,35 @@ function ApplicantVolunteerRatio() {
                 label={{ value: 'Role', angle: -90, position: 'insideLeft' }}
               />
 
-              <Tooltip />
+              <Tooltip
+                content={<ChartTooltip darkMode={darkMode} />}
+                cursor={{ fill: darkMode ? '#52677d' : '#f0f0f0', opacity: 0.35 }}
+              />
 
               {viewMode === 'count' ? (
                 <>
-                  <Bar dataKey="applicants" fill="#1976d2">
+                  <Bar
+                    dataKey="applicants"
+                    fill="#1976d2"
+                    activeBar={{ fill: darkMode ? '#60a5fa' : '#1565c0' }}
+                  >
                     <LabelList dataKey="applicants" position="right" />
                   </Bar>
 
-                  <Bar dataKey="hired" fill="#43a047">
+                  <Bar
+                    dataKey="hired"
+                    fill="#43a047"
+                    activeBar={{ fill: darkMode ? '#86efac' : '#2e7d32' }}
+                  >
                     <LabelList dataKey="hired" position="right" />
                   </Bar>
                 </>
               ) : (
-                <Bar dataKey="hiredPercentage" fill="#43a047">
+                <Bar
+                  dataKey="hiredPercentage"
+                  fill="#43a047"
+                  activeBar={{ fill: darkMode ? '#86efac' : '#2e7d32' }}
+                >
                   <LabelList
                     dataKey="hiredPercentage"
                     position="right"

--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
@@ -2,10 +2,46 @@ import { useState, useMemo, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, LabelList, ResponsiveContainer } from 'recharts';
 import DatePicker from 'react-datepicker';
-import Select from 'react-select';
+import Select, { components } from 'react-select';
 import { getAllApplicantVolunteerRatios } from '../../services/applicantVolunteerRatioService';
 import styles from './ApplicantVolunteerRatio.module.css';
 import 'react-datepicker/dist/react-datepicker.css';
+
+function LimitedMultiValue(props) {
+  const { index, getValue } = props;
+  const hiddenValueCount = getValue().length - 2;
+
+  if (index < 2) return <components.MultiValue {...props} />;
+
+  if (index === 2) {
+    return (
+      <span className={styles.selectedCount} title={`${hiddenValueCount} more selected`}>
+        + {hiddenValueCount}
+      </span>
+    );
+  }
+
+  return null;
+}
+
+function SelectOption(props) {
+  const { children, isSelected } = props;
+
+  return (
+    <components.Option {...props}>
+      <span className={styles.optionContent}>
+        <span>{children}</span>
+        {isSelected && (
+          <span className={styles.optionCheck} aria-hidden="true">
+            ✓
+          </span>
+        )}
+      </span>
+    </components.Option>
+  );
+}
+
+const roleSelectComponents = { MultiValue: LimitedMultiValue, Option: SelectOption };
 
 function ApplicantVolunteerRatio() {
   const darkMode = useSelector(state => state.theme.darkMode);
@@ -227,9 +263,11 @@ function ApplicantVolunteerRatio() {
             id="role-select"
             isMulti
             closeMenuOnSelect={false}
+            hideSelectedOptions={false}
             options={allRoles}
             value={selectedRoles}
             onChange={setSelectedRoles}
+            components={roleSelectComponents}
             placeholder="Select roles..."
             classNamePrefix="applicant-role-select"
             styles={roleSelectStyles}

--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
@@ -282,14 +282,9 @@ function ApplicantVolunteerRatio() {
         <button
           type="button"
           onClick={() => setViewMode('count')}
-          style={{
-            padding: '6px 12px',
-            cursor: 'pointer',
-            backgroundColor: viewMode === 'count' ? '#1976d2' : '#e0e0e0',
-            color: viewMode === 'count' ? '#fff' : '#000',
-            border: 'none',
-            borderRadius: '4px',
-          }}
+          className={`${styles.toggleButton} ${
+            viewMode === 'count' ? styles.toggleButtonActive : ''
+          }`}
         >
           Count View
         </button>
@@ -297,14 +292,9 @@ function ApplicantVolunteerRatio() {
         <button
           type="button"
           onClick={() => setViewMode('percentage')}
-          style={{
-            padding: '6px 12px',
-            cursor: 'pointer',
-            backgroundColor: viewMode === 'percentage' ? '#1976d2' : '#e0e0e0',
-            color: viewMode === 'percentage' ? '#fff' : '#000',
-            border: 'none',
-            borderRadius: '4px',
-          }}
+          className={`${styles.toggleButton} ${
+            viewMode === 'percentage' ? styles.toggleButtonActive : ''
+          }`}
         >
           Percentage View
         </button>

--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx
@@ -111,6 +111,63 @@ function ApplicantVolunteerRatio() {
   }, [darkMode]);
 
   const legendTextColor = darkMode ? '#e0e0e0' : '#333';
+  const roleSelectStyles = useMemo(
+    () => ({
+      control: (base, state) => ({
+        ...base,
+        backgroundColor: darkMode ? '#243b55' : base.backgroundColor,
+        borderColor: state.isFocused ? '#60a5fa' : darkMode ? '#52677d' : base.borderColor,
+        boxShadow: state.isFocused ? '0 0 0 1px #60a5fa' : base.boxShadow,
+        ':hover': {
+          borderColor: darkMode ? '#60a5fa' : '#2684ff',
+        },
+      }),
+      menu: base => ({
+        ...base,
+        backgroundColor: darkMode ? '#243b55' : base.backgroundColor,
+        border: darkMode ? '1px solid #52677d' : base.border,
+      }),
+      menuPortal: base => ({ ...base, zIndex: 10000 }),
+      option: (base, state) => ({
+        ...base,
+        backgroundColor: state.isSelected
+          ? darkMode
+            ? '#2563eb'
+            : base.backgroundColor
+          : state.isFocused && darkMode
+          ? '#3a506b'
+          : base.backgroundColor,
+        color: darkMode ? '#f9fafb' : base.color,
+        ':active': {
+          backgroundColor: darkMode ? '#1d4ed8' : base[':active']?.backgroundColor,
+        },
+      }),
+      multiValue: base => ({
+        ...base,
+        backgroundColor: darkMode ? '#3a506b' : base.backgroundColor,
+      }),
+      multiValueLabel: base => ({
+        ...base,
+        color: darkMode ? '#f9fafb' : base.color,
+      }),
+      multiValueRemove: base => ({
+        ...base,
+        color: darkMode ? '#dbeafe' : base.color,
+        ':hover': {
+          backgroundColor: darkMode ? '#dc2626' : '#ffbdad',
+          color: '#fff',
+        },
+      }),
+      input: base => ({ ...base, color: darkMode ? '#f9fafb' : base.color }),
+      placeholder: base => ({ ...base, color: darkMode ? '#9ca3af' : base.color }),
+      dropdownIndicator: base => ({ ...base, color: darkMode ? '#cbd5e1' : base.color }),
+      indicatorSeparator: base => ({
+        ...base,
+        backgroundColor: darkMode ? '#52677d' : base.backgroundColor,
+      }),
+    }),
+    [darkMode],
+  );
 
   if (error) {
     return (
@@ -174,8 +231,10 @@ function ApplicantVolunteerRatio() {
             value={selectedRoles}
             onChange={setSelectedRoles}
             placeholder="Select roles..."
-            classNamePrefix="custom-select"
+            classNamePrefix="applicant-role-select"
+            styles={roleSelectStyles}
             menuPortalTarget={typeof document !== 'undefined' ? document.body : undefined}
+            menuPosition="fixed"
           />
         </div>
       </div>

--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
@@ -40,6 +40,38 @@
   max-width: 420px;
 }
 
+.selectedCount {
+  align-self: center;
+  flex: 0 0 auto;
+  padding: 3px 7px;
+  border-radius: 3px;
+  background-color: #e5e7eb;
+  color: #374151;
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.dark .selectedCount {
+  background-color: #3a506b;
+  color: #f9fafb;
+}
+
+.optionContent {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+}
+
+.optionCheck {
+  flex: 0 0 auto;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
 .label {
   font-weight: 500;
   margin-bottom: 0;

--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
@@ -35,7 +35,9 @@
 .filterGroupInline {
   display: flex;
   flex-direction: column;
+  width: 100%;
   min-width: 220px;
+  max-width: 420px;
 }
 
 .label {

--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
@@ -58,6 +58,31 @@
   color: #f9fafb;
 }
 
+/* View toggle buttons */
+.toggleButton {
+  padding: 6px 12px;
+  cursor: pointer;
+  background-color: #e0e0e0;
+  color: #000;
+  border: none;
+  border-radius: 4px;
+}
+
+.toggleButtonActive {
+  background-color: #1976d2;
+  color: #fff;
+}
+
+.dark .toggleButton {
+  background-color: #3a506b;
+  color: #f9fafb;
+  border: 1px solid #52677d;
+}
+
+.dark .toggleButtonActive {
+  background-color: #2563eb;
+}
+
 .optionContent {
   display: flex;
   align-items: center;

--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
@@ -55,6 +55,121 @@
   margin: 0 4px;
 }
 
+.page :global(.react-datepicker__navigation-icon::before) {
+  border-color: #08060d !important;
+}
+
+.page :global(.react-datepicker__navigation-icon) {
+  font-size: initial !important;
+}
+
+.page :global(.react-datepicker__day--disabled:hover) {
+  background-color: transparent !important;
+  cursor:not-allowed;
+}
+
+.page :global(.react-datepicker__day--disabled) {
+  color: #9ca3af !important;
+}
+
+.page :global(.react-datepicker__day--keyboard-selected) {
+  background-color: #ffffff;
+  color: #000000;
+}
+
+.page :global(.react-datepicker__day--in-selecting-range:not(.react-datepicker__day--in-range)) {
+  color: #000000 !important;
+  background-color: #f0f0f0;
+}
+
+.page :global(.react-datepicker__day--in-range) {
+  color: #000000 !important;
+}
+
+.page :global(.react-datepicker__day--in-range.react-datepicker__day--in-selecting-range) {
+  background-color: #3b82f6 !important;
+  color: #ffffff !important;
+}
+
+.page :global(.react-datepicker__day--in-range.react-datepicker__day--outside-month) {
+  color: #ffffff !important;
+}
+
+.page :global(.react-datepicker__month--selecting-range .react-datepicker__day--in-range:not(.react-datepicker__day--in-selecting-range)) {
+  color: #000000 !important;
+}
+
+/* Date picker dark mode. */
+:global(.dark-mode) .page :global(.react-datepicker__input-container input) {
+  background-color: #243b55 !important;
+  color: #f9fafb !important;
+  border: 1px solid #52677d !important;
+  color-scheme: dark;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker) {
+  background-color: #1b2a41;
+  color: #f9fafb;
+  border-color: #374151;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__header) {
+  background-color: #111827;
+  border-bottom: 1px solid #374151;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__current-month),
+:global(.dark-mode) .page :global(.react-datepicker__day-name),
+:global(.dark-mode) .page :global(.react-datepicker__day),
+:global(.dark-mode) .page :global(.react-datepicker__time-name) {
+  color: #f9fafb;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__day:hover) {
+  background-color: #374151;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__day--disabled) {
+  color: #9ca3af !important;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__day--keyboard-selected) {
+  background-color: #1b2a41;
+  color: #ffffff;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__day--in-selecting-range:not(.react-datepicker__day--in-range)) {
+  color: #ffffff !important;
+  background-color: #ffffff1b;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__day--in-range) {
+  color: #ffffff !important;
+  background-color: #3b82f6;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__day--in-range.react-datepicker__day--in-selecting-range) {
+  background-color: #3b82f6 !important;
+  color: #ffffff !important;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__day--in-range.react-datepicker__day--outside-month) {
+  color: #ffffff !important;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__month--selecting-range .react-datepicker__day--in-range:not(.react-datepicker__day--in-selecting-range)) {
+  color: #ffffff !important;
+  background-color: #ffffff1b;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__day--disabled) {
+  color: #6b7280;
+}
+
+:global(.dark-mode) .page :global(.react-datepicker__triangle) {
+  display: none;
+}
+
 /* Validation Error */
 .validationError {
   color: #fc0;
@@ -83,171 +198,4 @@
   text-align: center;
   padding: 40px 0;
   color: inherit;
-}
-
-/* Dark Mode Global Overrides */
-.dark :global(.react-datepicker__input-container input) {
-  background-color: #0b2434;
-  border-color: #2b4a6b;
-  color: #fff;
-}
-
-.dark :global(.react-datepicker) {
-  background-color: #0b2434;
-  border-color: #2b4a6b;
-}
-
-.dark :global(.react-datepicker__header) {
-  background-color: #0b2434;
-  border-bottom-color: #2b4a6b;
-}
-
-.dark :global(.react-datepicker__current-month),
-.dark :global(.react-datepicker__day-name),
-.dark :global(.react-datepicker__day) {
-  color: #fff;
-}
-
-.dark :global(.react-datepicker__day:hover) {
-  background-color: rgb(255 255 255 / 10%);
-}
-
-.dark :global(.react-datepicker__day--selected) {
-  background-color: rgb(67 160 71 / 22%);
-}
-
-/* React Select Dark Mode Overrides */
-.dark :global(.custom-select__control) {
-  background-color: #0b2434 !important;
-  border-color: #2b4a6b !important;
-  color: #fff !important;
-}
-
-.dark :global(.custom-select__menu) {
-  background-color: #0b2434 !important;
-  color: #fff !important;
-}
-
-/* Target menu when it's portaled to body in dark mode */
-:global(.dark-mode-body) :global(.custom-select__menu) {
-  background-color: #0b2434 !important;
-  color: #fff !important;
-}
-
-.dark :global(.custom-select__option) {
-  background-color: transparent !important;
-  color: #fff !important;
-}
-
-:global(.dark-mode-body) :global(.custom-select__option) {
-  background-color: transparent !important;
-  color: #fff !important;
-}
-
-.dark :global(.custom-select__option--is-focused) {
-  background-color: rgb(255 255 255 / 6%) !important;
-}
-
-:global(.dark-mode-body) :global(.custom-select__option--is-focused) {
-  background-color: rgb(255 255 255 / 6%) !important;
-}
-
-.dark :global(.custom-select__option--is-selected) {
-  background-color: rgb(67 160 71 / 22%) !important;
-}
-
-:global(.dark-mode-body) :global(.custom-select__option--is-selected) {
-  background-color: rgb(67 160 71 / 22%) !important;
-}
-
-.dark :global(.custom-select__multi-value) {
-  background-color: rgb(255 255 255 / 6%) !important;
-}
-
-.dark :global(.custom-select__multi-value__label) {
-  color: #fff !important;
-}
-
-.dark :global(.custom-select__multi-value__remove) {
-  color: #fff !important;
-}
-
-.dark :global(.custom-select__multi-value__remove:hover) {
-  background-color: rgb(255 255 255 / 10%) !important;
-  color: #fff !important;
-}
-
-.dark :global(.custom-select__placeholder) {
-  color: rgb(224 224 224 / 90%) !important;
-}
-
-.dark :global(.custom-select__single-value) {
-  color: #fff !important;
-}
-
-.dark :global(.custom-select__input-container) {
-  color: #fff !important;
-}
-
-.dark :global(.custom-select__dropdown-indicator) {
-  color: #fff !important;
-}
-
-.dark :global(.custom-select__clear-indicator) {
-  color: #fff !important;
-}
-
-.dark :global(.custom-select__indicator-separator) {
-  background-color: rgb(255 255 255 / 6%) !important;
-}
-
-/* Body Dark Mode */
-:global(.dark-mode-body),
-:global(.dark-mode-body) body,
-:global(.dark-mode-body) #root,
-:global(.dark-mode-body) .App {
-  background-color: #1b2a41 !important;
-  color: #e0e0e0 !important;
-}
-
-:global(.dark-mode-body) .header-wrapper,
-:global(.dark-mode-body) .content-wrapper,
-:global(.dark-mode-body) .page,
-:global(.dark-mode-body) .container,
-:global(.dark-mode-body) .container-fluid {
-  background-color: #1b2a41 !important;
-  color: #e0e0e0 !important;
-}
-
-:global(.dark-mode-body) .recharts-wrapper,
-:global(.dark-mode-body) .recharts-surface {
-  background-color: #1b2a41 !important;
-}
-
-/* Recharts Tooltip Dark Mode */
-.dark :global(.recharts-tooltip-wrapper) {
-  z-index: 100;
-}
-
-.dark :global(.recharts-default-tooltip) {
-  background-color: #1e293b !important;
-  border: 1px solid #475569 !important;
-  border-radius: 4px;
-  padding: 8px;
-}
-
-.dark :global(.recharts-tooltip-label) {
-  color: #f1f5f9 !important;
-  font-weight: 600;
-  margin-bottom: 4px;
-}
-
-.dark :global(.recharts-tooltip-item) {
-  color: #e2e8f0 !important;
-}
-
-.dark :global(.recharts-tooltip-item-name),
-.dark :global(.recharts-tooltip-item-separator),
-.dark :global(.recharts-tooltip-item-value) {
-  color: #e2e8f0 !important;
 }

--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
@@ -300,6 +300,10 @@
   display: none;
 }
 
+:global(.dark-mode) .page :global(.react-datepicker__navigation-icon::before) {
+  border-color: #fff !important;
+}
+
 /* Validation Error */
 .validationError {
   color: #fc0;

--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
@@ -187,6 +187,42 @@
   color: red;
 }
 
+/* Loading indicator */
+.loadingContainer {
+  min-height: 350px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.loadingSpinner {
+  width: 48px;
+  height: 48px;
+  border: 5px solid #e5e7eb;
+  border-top-color: #1976d2;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.dark .loadingSpinner {
+  border-color: #52677d;
+  border-top-color: #60a5fa;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loadingSpinner {
+    animation-duration: 1.6s;
+  }
+}
+
 /* Chart Container */
 .chartContainer {
   width: 100%;

--- a/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
+++ b/src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css
@@ -83,6 +83,77 @@
   background-color: #2563eb;
 }
 
+/* Chart hover tooltip */
+.chartTooltip :global(.recharts-default-tooltip) {
+  background-color: #fff !important;
+  border: 1px solid #ccc !important;
+  color: #333 !important;
+}
+
+.chartTooltip :global(.recharts-tooltip-label),
+.chartTooltip :global(.recharts-tooltip-item) {
+  color: #333 !important;
+}
+
+.dark .chartTooltip :global(.recharts-default-tooltip) {
+  background-color: #243b55 !important;
+  border-color: #52677d !important;
+  color: #f9fafb !important;
+}
+
+.dark .chartTooltip :global(.recharts-tooltip-label),
+.dark .chartTooltip :global(.recharts-tooltip-item) {
+  color: #f9fafb !important;
+}
+
+.chartTooltipContent {
+  padding: 10px 12px;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  color: #333;
+}
+
+.chartTooltipContent p {
+  margin: 0;
+}
+
+.chartTooltipRole {
+  margin-bottom: 6px !important;
+  color: #333;
+  font-weight: 700;
+}
+
+.chartTooltipContentDark {
+  background-color: #243b55;
+  border-color: #52677d;
+  color: #f9fafb;
+}
+
+.chartTooltipContentDark .chartTooltipRole {
+  color: #dbeafe;
+}
+
+/* The tooltip can be rendered outside the component's dark wrapper. */
+:global(.dark-mode) .chartTooltipContent {
+  background-color: #243b55;
+  border-color: #52677d;
+  color: #f9fafb;
+}
+
+:global(.dark-mode) .chartTooltipContent .chartTooltipRole {
+  color: #dbeafe;
+}
+
+.chartTooltipContent .chartTooltipapplicants {
+  color: #1976d2 !important;
+}
+
+.chartTooltipContent .chartTooltiphired,
+.chartTooltipContent .chartTooltiphiredPercentage {
+  color: #43a047 !important;
+}
+
 .optionContent {
   display: flex;
   align-items: center;


### PR DESCRIPTION
# Description
Fix dark mode styling for ApplicationVolunteerRatio chart.
<img width="723" height="334" alt="image" src="https://github.com/user-attachments/assets/e29adbe7-d52b-43c1-b1ab-88d1fb8a7eac" />

## Related PRS (if any):
To test this frontend PR, use the [PR 2330](https://github.com/OneCommunityGlobal/HGNRest/pull/2330) on the backend side.

## Main changes explained:
- Update src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.jsx for updating the date pickers, multi-select components, and tooltip.
- Update src/components/ApplicantVolunteerRatio/ApplicantVolunteerRatio.module.css for updating the dark mode styles.

## How to test:
1. check into `handika/fix-dark-mode-styling-for-ApplicantVolunteerRatio-chart` branch
2. do `npm install` and `npm run start:local` to run this PR locally
3. Clear site data/cache
4. log in as `owner` user
5. go to `/applicant-volunteer-ratio`
6. verify the dark mode styles for this `/applicant-volunteer-ratio` page.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/2de72262-f1ca-4567-b8a9-655245aa5ac9

## Note:
None


