### PR TITLE
Som Ramnani - fix(reset-timer-button): fix poor layout of the pop up window

### DIFF
--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -783,18 +783,11 @@ function Timer({ authUser, darkMode, isPopout }) {
       toggle={() => setConfirmationResetModal(!confirmationResetModal)}
       centered
       size="md"
-      className={cs(fontColor, darkMode ? 'dark-mode' : '')}
+      className={cs(fontColor, darkMode ? css.resetConfirmationModal : '')}
     >
-      <ModalHeader
-        className={darkMode ? 'bg-space-cadet' : ''}
-        toggle={() => setConfirmationResetModal(false)}
-      >
-        Reset Time
-      </ModalHeader>
-      <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
-        Are you sure you want to reset your time?
-      </ModalBody>
-      <ModalFooter className={darkMode ? 'bg-yinmn-blue' : ''}>
+      <ModalHeader toggle={() => setConfirmationResetModal(false)}>Reset Time</ModalHeader>
+      <ModalBody>Are you sure you want to reset your time?</ModalBody>
+      <ModalFooter>
         <Button
           color="primary"
           onClick={() => {

--- a/src/components/Timer/Timer.module.css
+++ b/src/components/Timer/Timer.module.css
@@ -94,6 +94,26 @@
   color: white;
 }
 
+.resetConfirmationModal :global(.modal-content),
+.resetConfirmationModal :global(.modal-header),
+.resetConfirmationModal :global(.modal-body),
+.resetConfirmationModal :global(.modal-footer) {
+  background-color: #343a40;
+  color: white;
+  border-color: #343a40;
+}
+
+.resetConfirmationModal :global(.close) {
+  color: white;
+  opacity: 0.85;
+  text-shadow: none;
+}
+
+.resetConfirmationModal :global(.close:hover) {
+  color: white;
+  opacity: 1;
+}
+
 .hideTimer {
   display: none;
 }

--- a/src/components/Timer/__test__/TimerResetModal.test.jsx
+++ b/src/components/Timer/__test__/TimerResetModal.test.jsx
@@ -1,0 +1,69 @@
+/* eslint-disable testing-library/no-node-access */
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import css from '../Timer.module.css';
+
+const websocketMocks = vi.hoisted(() => ({
+  sendJsonMessage: vi.fn(),
+}));
+
+vi.mock('react-redux', async importOriginal => {
+  const actual = await importOriginal();
+  return { ...actual, connect: () => Component => Component, useDispatch: () => vi.fn() };
+});
+
+vi.mock('react-use-websocket', () => ({
+  default: () => ({
+    sendMessage: vi.fn(),
+    sendJsonMessage: websocketMocks.sendJsonMessage,
+    lastJsonMessage: null,
+    getWebSocket: vi.fn(),
+  }),
+  ReadyState: { CONNECTING: 1, OPEN: 1, CLOSING: 2, CLOSED: 3 },
+}));
+
+import Timer from '../Timer';
+
+describe('Timer reset confirmation modal', () => {
+  beforeEach(() => {
+    window.focus = vi.fn();
+    HTMLMediaElement.prototype.play = vi.fn(() => Promise.resolve());
+    HTMLMediaElement.prototype.pause = vi.fn();
+  });
+
+  afterEach(() => {
+    websocketMocks.sendJsonMessage.mockClear();
+  });
+
+  const openResetModal = darkMode => {
+    render(<Timer authUser={{ userid: 'test-user', role: 'Owner' }} darkMode={darkMode} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reset timer' }));
+    return screen.getByText('Reset Time').closest('.modal');
+  };
+
+  it('uses the scoped charcoal theme in dark mode and resets the timer', async () => {
+    const modal = openResetModal(true);
+    const modalDialog = modal.querySelector('.modal-dialog');
+
+    await waitFor(() => expect(modal).toHaveClass('show'));
+    expect(modalDialog).toHaveClass(css.resetConfirmationModal, 'text-light');
+    expect(modalDialog.querySelector('.bg-yinmn-blue')).toBeNull();
+    expect(screen.getByText('Are you sure you want to reset your time?')).toBeVisible();
+    expect(screen.getByLabelText('Close')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, reset time!' }));
+
+    expect(websocketMocks.sendJsonMessage).toHaveBeenCalledWith({ action: 'CLEAR_TIMER' }, false);
+    await waitFor(() => expect(screen.queryByText('Reset Time')).not.toBeInTheDocument());
+  });
+
+  it('leaves the light-mode reset dialog unthemed', async () => {
+    const modal = openResetModal(false);
+    const modalDialog = modal.querySelector('.modal-dialog');
+
+    await waitFor(() => expect(modal).toHaveClass('show'));
+    expect(modalDialog).not.toHaveClass(css.resetConfirmationModal, 'text-light');
+    expect(modalDialog.querySelector('.bg-yinmn-blue')).toBeNull();
+  });
+});


### PR DESCRIPTION
# Description
<img width="819" height="913" alt="Screenshot 2026-09-01 at 1 41 18 PM" src="https://github.com/user-attachments/assets/fa444d2e-9ccc-4db4-9724-c2aafb51a1e8" />

## Related PRS (if any):
This PR is related to the development backend

## Main changes explained:
- Updated `Timer.jsx` to replace the Reset Time dialog’s dark-mode blue utility classes with a scoped reset-dialog theme, while preserving its light-mode appearance and reset behavior.
- Updated `Timer.module.css` to add a charcoal (`#343a40`) theme for the Reset Time dialog’s header, body, footer, borders, text, and close button.
- Created `TimerResetModal.test.jsx` to verify that the reset dialog opens correctly, uses the charcoal dark-mode theme without the blue background, remains default in light mode, and sends the reset action successfully.


## How to test:
1. Check into the current branch `som-feat/scroll-to-top-button`
2. Run `npm install` and start the app locally.
3. Clear site data/cache.
4. Log in as an admin user.
5. From the dashboard header, open the timer and click the Reset Timer button.
6. Verify the Reset Time confirmation dialog in light mode:
      - The dialog remains centered.
      - The confirmation text, close button, and “Yes, reset time!” button are visible.
7. Enable [dark mode](https://docs.google.com/document/d/11OXJfBBedK6vV-XvqWR8A9lOH0BsfnaHx01h1NZZXfI), then repeat the reset-timer flow.
8. Verify the dark-mode Reset Time dialog:
    - No large blue background appears.
    - The header, body, and footer use a consistent charcoal background.
    - Text and the close button are clearly visible.
    - The reset action still works correctly.

## Screenshots or videos of changes:

**Light Mode:**

<img width="1429" height="782" alt="PR#5488 3-Light-Mode" src="https://github.com/user-attachments/assets/67a62963-e6b9-4840-b7b6-9530534f255f" />

**Dark Mode:**

<img width="1435" height="776" alt="PR#5488 2-Dark-Mode" src="https://github.com/user-attachments/assets/3ab8f8e4-411c-41f1-9f62-6ba87fb14e96" />

**Demo:**
https://github.com/user-attachments/assets/6faac91b-f08a-4f77-a7b9-129057b80c60

## Note:
- This PR only updates the Reset Time confirmation dialog’s dark-mode styling.
- The separate timer pop-out control layout issues are not included in this PR.


