### PR TITLE
Fixed existing issues present in Total Org Summary

### DIFF
--- a/src/components/TotalOrgSummary/HoursCompleted/HoursCompletedBarChart.jsx
+++ b/src/components/TotalOrgSummary/HoursCompleted/HoursCompletedBarChart.jsx
@@ -56,8 +56,8 @@ export default function HoursCompletedBarChart({ isLoading, data, darkMode, comp
     return raw > 1 ? raw : raw * 100;
   };
 
-  const taskPercentage = normalizePercentage(taskHours.submittedToCommittedHoursPercentage);
-  const projectPercentage = normalizePercentage(projectHours.submittedToCommittedHoursPercentage);
+  const taskPercentage = normalizePercentage(taskHours.percentageOfTotal);
+  const projectPercentage = normalizePercentage(projectHours.percentageOfTotal);
   const taskChangePercentage = normalizePercentage(taskHours.comparisonPercentage);
   const projectChangePercentage = normalizePercentage(projectHours.comparisonPercentage);
   const stats = [
@@ -190,6 +190,14 @@ export default function HoursCompletedBarChart({ isLoading, data, darkMode, comp
             const formatted = `${normalized.toFixed(1)}%`;
             return `${formatted} of Committed Hours Submitted (Tasks)`;
           })()}
+
+          {(() => {
+            const raw = data.projectHours.percentageOfTotal ?? 0;
+            const normalized = raw > 1 ? raw : raw * 100;
+            const formatted = `${normalized.toFixed(1)}%`;
+            return ` | ${formatted} of Committed Hours (Projects)`;
+          })()}
+
           {(() => {
             const raw = data.hoursSubmittedToTasksComparisonPercentage;
             if (raw === undefined || raw === null) {


### PR DESCRIPTION
# Description
<img width="782" height="543" alt="Screenshot 2026-09-01 at 2 20 02 PM" src="https://github.com/user-attachments/assets/25f94a35-8321-4d17-ac9e-b37fc7e62292" />


## Related PRS (if any):
This frontend PR is related to the [#2328](https://github.com/OneCommunityGlobal/HGNRest/pull/2328) backend PR.
…

## Main changes explained:

1. Updated HoursCompletedBarChart.jsx to display the Projects percentage alongside the Tasks percentage in the subtitle, so both categories are visible together.
2. Updated HoursCompletedBarChart.jsx to use percentageOfTotal instead of submittedToCommittedHoursPercentage for the bar label calculations. percentageOfTotal represents each category's share of total logged hours and always sums to 100%, making the bar labels consistent with the footer breakdown.

…

## How to test:

1. check out to the current branch
2. do npm install and run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Dashboard → Total Org Summary → Volunteer Workload and Task Completion Analysis → Hours Completed / Task Completed charts → Date range selected: 6/26/2026 - 8/21/2026
6. verify the following.,
  a. With the date range 6/26/2026 – 8/21/2026, the subtitle should read something like x% of Total Logged Hours (Tasks) | y% of Total Logged Hours (Projects) - both values visible, not just Tasks.
  b. The percentage in parentheses on each bar should match the footer split. Previously bars showed (0.00%) and (1.00%) while the footer showed 31.3% and 68.7%. After the fix, the bar labels should show the correct percentages respectively not 0% or 1%.
  c. Previously showed 1275 completed tasks for the date range 6/26/2026 – 8/21/2026. After the fix, re-run with the same date range and verify the count drops significantly to a number that is realistic for that ~2 month window.
  The tester flagged that 1275 tasks against 25.32 hours works out to ~0.02 hours per task, which is unrealistic. The fixed count should be the correct number for the selected period.