### PR TITLE
Ruthwik bug when navigating back from a task opened from the dashboard

### DIFF
--- a/src/components/Projects/WBS/SameFolderTasks/SameFolderTasks.jsx
+++ b/src/components/Projects/WBS/SameFolderTasks/SameFolderTasks.jsx
@@ -57,7 +57,7 @@ function SameFolderTasks(props) {
     };
 
     if (wbsId) {
-      setLoading(true);
+      // setLoading(true);
       fetchAllTasks();
       fetchWBSData();
     }
@@ -84,13 +84,16 @@ function SameFolderTasks(props) {
       const res = await axios.get(ENDPOINTS.TASKS(task.wbsId, task.level, task.mother));
       if (isMounted) {
         if (JSON.stringify(res?.data) === '{}') setAllTasks([]);
-        else setAllTasks(res?.data || []);
+        else {
+          console.log("DEBUG: ", res.data);
+          setAllTasks(res?.data || []);
+        }
       }
-      setLoading(false);
+      // setLoading(false);
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.log(error);
-      setLoading(false);
+      console.log("Fetch tasks err:", error);
+      // setLoading(false);
     }
   };
 


### PR DESCRIPTION
# Description
A bug in the navigation logic when attempting to navigate up a folder for a task results in the application crashing. See the video below.
https://github.com/user-attachments/assets/2caf25f3-d727-4ac8-a10e-9ec1d8976d78
It should ideally navigate back to the upper level folder for that task.

## Related PRS (if any):
No related PRs.
…

## Main changes explained:
A call to a setLoading function was being made without having defined it in the first place. This resulted in the useEffect hook attempting to call this function and crashing resulting in the error screen.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Go to dashboard and click on the task for any user.
6. Once the task view is opened up, click on the back button in the view to navigate to the folder in which the task was present. Verify that the page does not crash.
7. Continue navigating back and ensure no failures and the page loads correctly.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/fe8914b7-8969-4e71-98ad-4036080a04e1
