### PR TITLE
Purav fix PR promotion confirmation display box

### DIFF
--- a/src/components/PRPromotions/DisplayBox.jsx
+++ b/src/components/PRPromotions/DisplayBox.jsx
@@ -101,8 +101,9 @@ export default function DisplayBox({ onClose, darkMode = false }) {
 
       const remaining = promotions.filter((_, index) => !checkedItems[index]);
       setPendingPromotionReviewers(remaining);
-      setPromotions(remaining);
-      setCheckedItems(remaining.map(() => true));
+      const nextPromotions = getPendingPromotionReviewers();
+      setPromotions(nextPromotions);
+      setCheckedItems(nextPromotions.map(() => true));
 
       const message = `Successfully promoted ${selectedCount} reviewer(s).`;
       setStatusMessage(message);

--- a/src/components/PRPromotions/DisplayBox.jsx
+++ b/src/components/PRPromotions/DisplayBox.jsx
@@ -1,149 +1,225 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { toast } from 'react-toastify';
+import { postPromotionEligibility } from '../../actions/promotionActions';
+import {
+  getPendingPromotionReviewers,
+  setPendingPromotionReviewers,
+} from './pendingPromotionReviewers';
 import styles from './DisplayBox.module.css';
 
+const VIBGYOR_COLOR_COUNT = 7;
+const MONGO_ID_PATTERN = /^[a-fA-F0-9]{24}$/;
+
+function normalizeId(value) {
+  if (value == null || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'object') {
+    if (value.$oid) {
+      return String(value.$oid);
+    }
+    if (value._id) {
+      return normalizeId(value._id);
+    }
+  }
+  return String(value);
+}
+
+function getPromotableIds(promotions, checkedItems) {
+  return promotions
+    .filter((_, index) => checkedItems[index])
+    .map(promotion => normalizeId(promotion.id))
+    .filter(id => id && MONGO_ID_PATTERN.test(id));
+}
+
 export default function DisplayBox({ onClose, darkMode = false }) {
-  const mockPromotionData = [
-    {
-      prReviewer: 'Akshay - Jayram',
-      teamCode: '123',
-      teamReviewerName: 'Team Leader 1',
-      weeklyPRs: [
-        { week: '2024-06-01', prCount: 12 },
-        { week: '2024-06-08', prCount: 15 },
-        { week: '2024-06-15', prCount: 10 },
-        { week: '2024-06-22', prCount: 18 },
-        { week: '2024-06-29', prCount: 14 },
-        { week: '2024-07-06', prCount: 16 },
-        { week: '2024-07-13', prCount: 20 },
-      ],
-    },
-    {
-      prReviewer: 'Ghazi1212',
-      teamCode: '456',
-      teamReviewerName: 'Team Leader 2',
-      weeklyPRs: [
-        { week: '2024-06-01', prCount: 12 },
-        { week: '2024-06-08', prCount: 15 },
-        { week: '2024-06-15', prCount: 10 },
-        { week: '2024-06-22', prCount: 18 },
-        { week: '2024-06-29', prCount: 14 },
-      ],
-    },
-  ];
+  const requestor = useSelector(state => state.auth?.user);
+  const [promotions, setPromotions] = useState(getPendingPromotionReviewers);
+  const [checkedItems, setCheckedItems] = useState(() =>
+    getPendingPromotionReviewers().map(() => true),
+  );
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [statusMessage, setStatusMessage] = useState('');
 
-  const [checkedItems, setCheckedItems] = useState(new Array(mockPromotionData.length).fill(true));
+  useEffect(() => {
+    const handleEscape = event => {
+      if (event.key === 'Escape' && !isConfirming) {
+        onClose();
+      }
+    };
 
-  const allChecked = checkedItems.every(Boolean);
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isConfirming, onClose]);
+
+  const allChecked =
+    promotions.length > 0 && checkedItems.length > 0 && checkedItems.every(Boolean);
+  const someChecked = checkedItems.some(Boolean);
+  const confirmDisabled = isConfirming || !someChecked;
 
   const handleCheckedBoxChange = index => {
-    const updated = [...checkedItems];
-    updated[index] = !updated[index];
-    setCheckedItems(updated);
+    setCheckedItems(prev => {
+      const updated = [...prev];
+      updated[index] = !updated[index];
+      return updated;
+    });
   };
 
   const handleSelectAll = () => {
-    setCheckedItems(new Array(mockPromotionData.length).fill(!allChecked));
+    setCheckedItems(new Array(promotions.length).fill(!allChecked));
   };
 
-  const handleConfirm = () => {
-    const selectedReviewers = mockPromotionData.filter((_, index) => checkedItems[index]);
-    console.log('Selected reviewers:', selectedReviewers);
-    onClose();
+  const handleRowClick = (index, event) => {
+    if (event.target.closest('input[type="checkbox"]')) {
+      return;
+    }
+    handleCheckedBoxChange(index);
   };
 
-  const tableClassName = [
-    styles.popupTable,
-    darkMode ? styles.popupTableDark : '',
-    darkMode ? styles['popup-table-dark'] : '',
-  ]
-    .filter(Boolean)
-    .join(' ');
+  const handleOverlayClick = event => {
+    if (event.target === event.currentTarget && !isConfirming) {
+      onClose();
+    }
+  };
+
+  const handleConfirm = async () => {
+    const selectedCount = checkedItems.filter(Boolean).length;
+    const selectedIds = getPromotableIds(promotions, checkedItems);
+
+    setIsConfirming(true);
+    setStatusMessage('');
+
+    try {
+      if (selectedIds.length > 0) {
+        await postPromotionEligibility(selectedIds, requestor?.userid);
+      }
+
+      const remaining = promotions.filter((_, index) => !checkedItems[index]);
+      setPendingPromotionReviewers(remaining);
+      setPromotions(remaining);
+      setCheckedItems(remaining.map(() => true));
+
+      const message = `Successfully promoted ${selectedCount} reviewer(s).`;
+      setStatusMessage(message);
+      toast.success(message);
+
+      if (remaining.length === 0) {
+        onClose();
+      }
+    } catch (error) {
+      const message = 'Failed to process promotions.';
+      setStatusMessage(message);
+      toast.error(message);
+    } finally {
+      setIsConfirming(false);
+    }
+  };
 
   const getBadgeClassName = index =>
-    [
-      styles.prCountBadge,
-      styles['pr-count-badge'],
-      styles[`color-${index}`] || styles[`color${index}`],
-    ]
-      .filter(Boolean)
-      .join(' ');
-  const modalRef = useRef(null);
-  const overlayRef = useRef(null);
-
-  useEffect(() => {
-    const overlayClickHandler = e => {
-      if (e.target.id === 'overlay') onClose();
-    };
-
-    document.addEventListener('click', overlayClickHandler);
-    return () => document.removeEventListener('click', overlayClickHandler);
-  }, []);
+    `${styles.prCountBadge} ${styles[`color${index % VIBGYOR_COLOR_COUNT}`] || ''}`.trim();
 
   return (
-    <div className={styles.overlay} ref={overlayRef} id="overlay">
+    // Overlay click closes the dialog; Escape is handled on document keydown.
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div className={styles.overlay} onClick={handleOverlayClick}>
       <div
         className={`${styles.popup} ${darkMode ? styles.popupDark : ''}`}
-        ref={modalRef}
-        id="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="promotion-confirm-title"
+        aria-busy={isConfirming}
       >
-        <h2 className={`${styles.popupHeading} ${darkMode ? styles.popupHeadingDark : ''}`}>
+        <h2
+          id="promotion-confirm-title"
+          className={`${styles.popupHeading} ${darkMode ? styles.popupHeadingDark : ''}`}
+        >
           Are you sure you want to promote these PR reviewers?
         </h2>
 
-        <table className={tableClassName}>
-          <thead>
-            <tr>
-              <th>
-                <input
-                  type="checkbox"
-                  checked={allChecked}
-                  onChange={handleSelectAll}
-                  aria-label="Select all reviewers"
-                />
-              </th>
-              <th>PR Reviewer</th>
-              <th>Team Code</th>
-              <th>Team Leader Name</th>
-              <th>Weekly PR Counts</th>
-            </tr>
-          </thead>
+        {statusMessage && (
+          <p className={styles.statusMessage} role="status">
+            {statusMessage}
+          </p>
+        )}
 
-          <tbody>
-            {mockPromotionData.map((promotion, index) => (
-              <tr key={`${promotion.prReviewer}-${promotion.teamCode}`}>
-                <td>
+        <div className={styles.tableWrapper}>
+          <table className={styles.popupTable}>
+            <thead>
+              <tr>
+                <th>
                   <input
                     type="checkbox"
-                    checked={checkedItems[index]}
-                    onChange={() => handleCheckedBoxChange(index)}
-                    aria-label={`Select reviewer ${promotion.prReviewer}`}
+                    className={styles.checkbox}
+                    checked={allChecked}
+                    onChange={handleSelectAll}
+                    disabled={promotions.length === 0}
+                    aria-label="Select all reviewers"
                   />
-                </td>
-                <td>{promotion.prReviewer}</td>
-                <td>{promotion.teamCode}</td>
-                <td>{promotion.teamReviewerName}</td>
-                <td>
-                  <div className={styles.prBadgeRow}>
-                    {promotion.weeklyPRs.map((pr, prIndex) => (
-                      <span
-                        key={`${promotion.prReviewer}-${pr.week}`}
-                        className={getBadgeClassName(prIndex)}
-                      >
-                        {pr.prCount}
-                      </span>
-                    ))}
-                  </div>
-                </td>
+                </th>
+                <th>PR Reviewer</th>
+                <th>Team Code</th>
+                <th>Team Leader Name</th>
+                <th>Weekly PRs</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {promotions.length === 0 && (
+                <tr>
+                  <td colSpan="5" className={styles.messageCell}>
+                    No PR reviewers left to promote.
+                  </td>
+                </tr>
+              )}
+              {promotions.map((promotion, index) => (
+                <tr
+                  key={promotion.id || `${promotion.prReviewer}-${promotion.teamCode}-${index}`}
+                  onClick={event => handleRowClick(index, event)}
+                >
+                  <td>
+                    <input
+                      type="checkbox"
+                      className={styles.checkbox}
+                      checked={Boolean(checkedItems[index])}
+                      onChange={() => handleCheckedBoxChange(index)}
+                      aria-label={`Select reviewer ${promotion.prReviewer}`}
+                    />
+                  </td>
+                  <td>{promotion.prReviewer}</td>
+                  <td>{promotion.teamCode}</td>
+                  <td>{promotion.teamLeaderName}</td>
+                  <td>
+                    <div
+                      className={styles.prBadgeRow}
+                      aria-label={`Weekly PRs for ${promotion.prReviewer}`}
+                    >
+                      {promotion.weeklyPRs.map((pr, prIndex) => (
+                        <span
+                          key={`${promotion.id || promotion.prReviewer}-${pr.week}-${prIndex}`}
+                          className={getBadgeClassName(prIndex)}
+                          title={`Week ${pr.week}: ${pr.prCount} PRs`}
+                        >
+                          {pr.prCount}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
         <div className={styles.buttonRow}>
           <button
             type="button"
             className={`${styles.button} ${styles.cancelButton}`}
             onClick={onClose}
+            disabled={isConfirming}
           >
             Cancel
           </button>
@@ -151,10 +227,10 @@ export default function DisplayBox({ onClose, darkMode = false }) {
           <button
             type="button"
             className={`${styles.button} ${styles.confirmButton}`}
-            disabled={!checkedItems.some(Boolean)}
+            disabled={confirmDisabled}
             onClick={handleConfirm}
           >
-            Confirm
+            {isConfirming ? 'Confirming...' : 'Confirm'}
           </button>
         </div>
       </div>

--- a/src/components/PRPromotions/DisplayBox.module.css
+++ b/src/components/PRPromotions/DisplayBox.module.css
@@ -110,7 +110,7 @@
 }
 
 .popupDark .popupTable tbody tr:hover td {
-  background-color: #2f4157;
+  background-color: #334155;
 }
 
 .messageCell {
@@ -189,6 +189,40 @@
   background-color: #f00;
 }
 
+/* Dark-mode badges must beat `.popupDark .popupTable td` color inheritance. */
+.popupDark .popupTable .prCountBadge {
+  color: #111827;
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 55%);
+}
+
+.popupDark .popupTable .color0 {
+  background-color: #e879f9;
+}
+
+.popupDark .popupTable .color1 {
+  background-color: #a78bfa;
+}
+
+.popupDark .popupTable .color2 {
+  background-color: #38bdf8;
+}
+
+.popupDark .popupTable .color3 {
+  background-color: #4ade80;
+}
+
+.popupDark .popupTable .color4 {
+  background-color: #facc15;
+}
+
+.popupDark .popupTable .color5 {
+  background-color: #fb923c;
+}
+
+.popupDark .popupTable .color6 {
+  background-color: #f87171;
+}
+
 .buttonRow {
   display: flex;
   justify-content: space-between;
@@ -219,6 +253,16 @@
   background-color: #00f;
 }
 
+.popupDark .cancelButton {
+  background-color: #ef4444;
+  color: #fff;
+}
+
+.popupDark .confirmButton {
+  background-color: #3b82f6;
+  color: #fff;
+}
+
 .cancelButton:hover:not(:disabled) {
   background-color: #d60000;
 }
@@ -227,9 +271,17 @@
   background-color: #00c;
 }
 
+.popupDark .cancelButton:hover:not(:disabled) {
+  background-color: #f87171;
+}
+
+.popupDark .confirmButton:hover:not(:disabled) {
+  background-color: #60a5fa;
+}
+
 .popupDark .button:disabled {
   background-color: #4b5563;
-  color: #d1d5db;
+  color: #e5e7eb;
 }
 
 @media (width <= 700px) {

--- a/src/components/PRPromotions/DisplayBox.module.css
+++ b/src/components/PRPromotions/DisplayBox.module.css
@@ -1,20 +1,17 @@
 .overlay {
   position: fixed;
   inset: 0;
-  background-color: rgb(0 0 0 / 50%);
+  z-index: 2000;
   display: flex;
   justify-content: center;
   align-items: center;
+  background-color: rgb(0 0 0 / 50%);
 }
-
-/* ======================================================
-   POPUP CONTAINER
-   ====================================================== */
 
 .popup {
   padding: 24px;
   width: 90%;
-  max-width: 900px;
+  max-width: 960px;
   max-height: 85vh;
   overflow-y: auto;
   border: 1px solid #d1d5db;
@@ -29,10 +26,6 @@
   color: #f9fafb;
 }
 
-/* ======================================================
-   HEADING
-   ====================================================== */
-
 .popupHeading {
   margin-bottom: 16px;
   font-size: 20px;
@@ -44,39 +37,39 @@
   color: #f9fafb;
 }
 
-/* ======================================================
-   TABLE
-   ====================================================== */
+.errorMessage,
+.statusMessage {
+  margin: 0 0 12px;
+  text-align: center;
+  font-size: 14px;
+}
+
+.errorMessage {
+  color: #b91c1c;
+}
+
+.statusMessage {
+  color: #1d4ed8;
+}
+
+.popupDark .errorMessage {
+  color: #fca5a5;
+}
+
+.popupDark .statusMessage {
+  color: #93c5fd;
+}
+
+.tableWrapper {
+  width: 100%;
+  overflow-x: auto;
+}
 
 .popupTable {
   width: 100%;
+  min-width: 640px;
   border-collapse: collapse;
 }
-
-/* DARK TABLE CELLS — must come before .popupTable thead th */
-
-.popupTableDark {
-  background-color: #1f2937;
-}
-
-.popupTableDark th,
-.popupTableDark td {
-  border: 1px solid #4b5563;
-  color: #f9fafb;
-  background-color: #1f2937;
-}
-
-.popup-table-dark {
-  background-color: #374151;
-}
-
-.popup-table-dark th,
-.popup-table-dark td {
-  color: #e5e7eb;
-  border-color: #4b5563;
-}
-
-/* LIGHT TABLE CELLS — after dark so specificity is correct */
 
 .popupTable th,
 .popupTable td {
@@ -86,260 +79,21 @@
   color: #111827;
 }
 
-/* DARK TABLE HEADERS — must come before .popupTable thead th */
-
-.popupTableDark thead th {
-  background-color: #374151;
-  color: #f9fafb;
-}
-
-.popup-table-dark thead th {
-  background-color: #374151;
-  color: #e5e7eb;
-}
-
-/* LIGHT TABLE HEADER — after dark thead rules */
-
 .popupTable thead th {
   font-weight: 600;
   background-color: #f3f4f6;
   color: #111827;
 }
 
-/* ======================================================
-   BUTTONS
-   ====================================================== */
-
-.buttonRow {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 32px;
-}
-
-.button {
-  padding: 8px 16px;
-  border-radius: 4px;
-  border: none;
-  cursor: pointer;
-  color: #fff;
-  font-weight: 600;
-}
-
-.button:disabled {
-  background-color: #ccc;
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-/* These action colors are intentionally shared by light and dark mode. */
-
-.cancelButton {
-  background-color: #f00;
-}
-
-.confirmButton:not(:disabled) {
-  background-color: #00f;
-}
-
-/* LIGHT HOVER — after dark base button rules */
-
-.button:hover:not(:disabled) {
-  background-color: #e5e7eb;
-}
-
-.cancelButton:hover:not(:disabled) {
-  background-color: #d60000;
-}
-
-.confirmButton:hover:not(:disabled) {
-  background-color: #00c;
-}
-
-.popupDark .button:disabled {
-  background-color: #4b5563;
-  color: #d1d5db;
-}
-
-/* ======================================================
-   CHECKBOXES
-   ====================================================== */
-
-.popupDark input[type='checkbox'] {
-  accent-color: #60a5fa;
-  background-color: #1f2937;
-  border: 1px solid #6b7280;
-}
-
-/* ======================================================
-   PR BADGES
-   ====================================================== */
-
-.prCountBadge,
-.pr-count-badge {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  margin: 0 4px;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  color: black;
-  font-size: 12px;
-  font-weight: bold;
-}
-
-.popupDark .prCountBadge {
-  filter: brightness(0.9);
-}
-
-/* COLORS */
-
-/* Keep both CSS Module lookup styles aligned with getBadgeClassName. */
-
-.color0,
-.color-0 {
-  color: #fff;
-  background-color: #9400d3;
-}
-
-.color1,
-.color-1 {
-  background-color: #4b0082;
-  color: #fff;
-}
-
-.color-2 {
-  background-color: #00f;
-  color: white;
-}
-
-.color-3 {
-  background-color: #0f0;
-  color: black;
-}
-
-.color-4 {
-  background-color: #ff0;
-  color: black;
-}
-
-.color2 {
-  color: #fff;
-  background-color: #00f;
-}
-
-.color3 {
-  color: #000;
-  background-color: #0f0;
-}
-
-.color4 {
-  color: #000;
-  background-color: #ff0;
-}
-
-.color5,
-.color-5 {
-  color: #fff;
-  background-color: #c45c00;
-}
-
-.color-6 {
-  background-color: #f00;
-  color: white;
-}
-
-/* ======================================================
-   DARK MODE — PAGE AND HEADING
-   ====================================================== */
-
-.page-dark {
-  color: #e5e7eb;
-}
-
-.heading-dark {
-  color: #e5e7eb;
-}
-
-.page-dark .promoteButton {
-  background-color: #374151;
-  color: #e5e7eb;
-}
-
-/* ======================================================
-   DARK MODE — POPUP LEGACY CLASSES
-   ====================================================== */
-
-.popup-dark {
-  background-color: #1f2937;
-  border-color: #4b5563;
-}
-
-.popup-heading-dark {
-  color: #e5e7eb;
-}
-
-/* ======================================================
-   PR BADGE OVERRIDES FOR DARK MODE
-   ====================================================== */
-
-:global(body.dark-mode) .popup-table-dark .pr-count-badge.color-0,
-:global(body.bm-dashboard-dark) .popup-table-dark .pr-count-badge.color-0 {
-  color: #fff !important;
-  background-color: #9400d3 !important;
-}
-
-:global(body.dark-mode) .popup-table-dark .pr-count-badge.color-1,
-:global(body.bm-dashboard-dark) .popup-table-dark .pr-count-badge.color-1 {
-  color: #fff !important;
-  background-color: #4b0082 !important;
-}
-
-:global(body.dark-mode) .popup-table-dark .pr-count-badge.color-2,
-:global(body.bm-dashboard-dark) .popup-table-dark .pr-count-badge.color-2 {
-  color: #fff !important;
-  background-color: #00f !important;
-}
-
-:global(body.dark-mode) .popup-table-dark .pr-count-badge.color-3,
-:global(body.bm-dashboard-dark) .popup-table-dark .pr-count-badge.color-3 {
-  color: #000 !important;
-  background-color: #0f0 !important;
-}
-
-:global(body.dark-mode) .popup-table-dark .pr-count-badge.color-4,
-:global(body.bm-dashboard-dark) .popup-table-dark .pr-count-badge.color-4 {
-  color: #000 !important;
-  background-color: #ff0 !important;
-}
-
-:global(body.dark-mode) .popup-table-dark .pr-count-badge.color-5,
-:global(body.bm-dashboard-dark) .popup-table-dark .pr-count-badge.color-5 {
-  color: #fff !important;
-  background-color: #a94f00 !important;
-}
-
-:global(body.dark-mode) .popup-table-dark .pr-count-badge.color-6,
-:global(body.bm-dashboard-dark) .popup-table-dark .pr-count-badge.color-6 {
-  color: #fff !important;
-  background-color: #b00000 !important;
-}
-
-/* Dark modal content rules must come after the base table rules so they win in CSS order. */
-
 .popupDark .popupHeading {
   color: #f9fafb;
 }
 
-.popupDark .popupTable {
-  background-color: #1f2937;
-}
-
 .popupDark .popupTable th,
 .popupDark .popupTable td {
-  border-color: #4b5563;
-  background-color: #1f2937;
+  border: 1px solid #4b5563;
   color: #f9fafb;
+  background-color: #1f2937;
 }
 
 .popupDark .popupTable thead th {
@@ -359,10 +113,136 @@
   background-color: #2f4157;
 }
 
+.messageCell {
+  text-align: center;
+}
+
+.checkbox {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: #2563eb;
+  cursor: pointer;
+}
+
+.popupDark .checkbox {
+  accent-color: #60a5fa;
+}
+
 .prBadgeRow {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   align-items: center;
   min-width: 0;
+}
+
+.prCountBadge {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.emptyWeeklyPRs {
+  color: #6b7280;
+}
+
+.popupDark .emptyWeeklyPRs {
+  color: #9ca3af;
+}
+
+.color0 {
+  background-color: #9400d3;
+}
+
+.color1 {
+  background-color: #4b0082;
+}
+
+.color2 {
+  background-color: #00f;
+}
+
+.color3 {
+  background-color: #0f0;
+  color: #000;
+}
+
+.color4 {
+  background-color: #ff0;
+  color: #000;
+}
+
+.color5 {
+  background-color: #ffa500;
+  color: #000;
+}
+
+.color6 {
+  background-color: #f00;
+}
+
+.buttonRow {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 32px;
+  gap: 12px;
+}
+
+.button {
+  padding: 8px 16px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  color: #fff;
+  font-weight: 600;
+}
+
+.button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.cancelButton {
+  background-color: #f00;
+}
+
+.confirmButton {
+  background-color: #00f;
+}
+
+.cancelButton:hover:not(:disabled) {
+  background-color: #d60000;
+}
+
+.confirmButton:hover:not(:disabled) {
+  background-color: #00c;
+}
+
+.popupDark .button:disabled {
+  background-color: #4b5563;
+  color: #d1d5db;
+}
+
+@media (width <= 700px) {
+  .popup {
+    width: 96%;
+    padding: 16px;
+  }
+
+  .buttonRow {
+    flex-direction: column-reverse;
+  }
+
+  .button {
+    width: 100%;
+  }
 }

--- a/src/components/PRPromotions/__tests__/DisplayBox.test.jsx
+++ b/src/components/PRPromotions/__tests__/DisplayBox.test.jsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import { vi } from 'vitest';
+import { toast } from 'react-toastify';
+import DisplayBox from '../DisplayBox';
+import { postPromotionEligibility } from '../../../actions/promotionActions';
+import { resetPendingPromotionReviewers } from '../pendingPromotionReviewers';
+
+vi.mock('../../../actions/promotionActions', () => ({
+  postPromotionEligibility: vi.fn(),
+}));
+
+vi.mock('react-toastify', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const mockStore = configureMockStore([]);
+
+function renderDisplayBox(darkMode = false) {
+  const onClose = vi.fn();
+  const store = mockStore({
+    auth: { user: { userid: 'admin1', role: 'Administrator' } },
+    theme: { darkMode },
+  });
+
+  render(
+    <Provider store={store}>
+      <DisplayBox onClose={onClose} darkMode={darkMode} />
+    </Provider>,
+  );
+
+  return { onClose };
+}
+
+describe('DisplayBox promotion confirmation modal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetPendingPromotionReviewers();
+    postPromotionEligibility.mockResolvedValue({ message: 'Members promoted successfully.' });
+  });
+
+  it('selects every reviewer checkbox by default', () => {
+    renderDisplayBox();
+
+    expect(screen.getByText('Akshay - Jayaram')).toBeInTheDocument();
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(6);
+    checkboxes.forEach(checkbox => {
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  it('shows the reviewers who are about to be promoted', () => {
+    renderDisplayBox();
+
+    expect(screen.getByText('Akshay - Jayaram')).toBeInTheDocument();
+    expect(screen.getByText('Ghazi1212')).toBeInTheDocument();
+    expect(screen.getByText('Diya Test 1')).toBeInTheDocument();
+    expect(screen.getByText('Ramya Test Volunteer')).toBeInTheDocument();
+    expect(screen.getByText('Yuhang Xu')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled();
+  });
+
+  it('uses Team Leader Name and Weekly PRs column titles', () => {
+    renderDisplayBox();
+
+    expect(screen.getByText('Team Leader Name')).toBeInTheDocument();
+    expect(screen.queryByText('Team Reviewer Name')).not.toBeInTheDocument();
+    expect(screen.getByText('Weekly PRs')).toBeInTheDocument();
+    expect(screen.queryByText('Weekly PR Counts')).not.toBeInTheDocument();
+  });
+
+  it('shows team leader names instead of quotes and weekly PR counts in circles', () => {
+    renderDisplayBox();
+
+    expect(screen.getByText('Chris Martinez')).toBeInTheDocument();
+    expect(screen.getByText('Sam Patel')).toBeInTheDocument();
+    expect(screen.queryByText('""')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unavailable')).not.toBeInTheDocument();
+
+    const firstReviewerRow = screen.getByRole('row', { name: /Akshay - Jayaram/i });
+    expect(within(firstReviewerRow).getByText('2')).toBeInTheDocument();
+    expect(within(firstReviewerRow).getByText('10')).toBeInTheDocument();
+    expect(within(firstReviewerRow).getByText('11')).toBeInTheDocument();
+  });
+
+  it('lets the user uncheck a reviewer and disables Confirm when none are selected', async () => {
+    renderDisplayBox();
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+    expect(confirmButton).toBeEnabled();
+
+    await userEvent.click(screen.getByLabelText('Select all reviewers'));
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it('closes without promoting when Cancel is clicked', async () => {
+    const { onClose } = renderDisplayBox();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(postPromotionEligibility).not.toHaveBeenCalled();
+  });
+
+  it('removes confirmed reviewers from the pending list', async () => {
+    const { onClose } = renderDisplayBox();
+
+    await userEvent.click(screen.getByLabelText('Select reviewer Akshay - Jayaram'));
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText('Akshay - Jayaram')).toBeInTheDocument();
+    expect(screen.queryByText('Ghazi1212')).not.toBeInTheDocument();
+    expect(screen.queryByText('Diya Test 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Ramya Test Volunteer')).not.toBeInTheDocument();
+    expect(screen.queryByText('Yuhang Xu')).not.toBeInTheDocument();
+    expect(postPromotionEligibility).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes when every remaining reviewer is promoted', async () => {
+    const { onClose } = renderDisplayBox();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    expect(toast.success).toHaveBeenCalled();
+  });
+});

--- a/src/components/PRPromotions/__tests__/DisplayBox.test.jsx
+++ b/src/components/PRPromotions/__tests__/DisplayBox.test.jsx
@@ -29,13 +29,13 @@ function renderDisplayBox(darkMode = false) {
     theme: { darkMode },
   });
 
-  render(
+  const view = render(
     <Provider store={store}>
       <DisplayBox onClose={onClose} darkMode={darkMode} />
     </Provider>,
   );
 
-  return { onClose };
+  return { onClose, unmount: view.unmount };
 }
 
 describe('DisplayBox promotion confirmation modal', () => {
@@ -137,5 +137,23 @@ describe('DisplayBox promotion confirmation modal', () => {
     });
 
     expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('keeps promoted reviewers off the list after a remount', async () => {
+    const { unmount } = renderDisplayBox();
+
+    await userEvent.click(screen.getByLabelText('Select reviewer Akshay - Jayaram'));
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled();
+    });
+
+    unmount();
+    renderDisplayBox();
+
+    expect(screen.getByText('Akshay - Jayaram')).toBeInTheDocument();
+    expect(screen.queryByText('Ghazi1212')).not.toBeInTheDocument();
+    expect(screen.queryByText('Diya Test 1')).not.toBeInTheDocument();
   });
 });

--- a/src/components/PRPromotions/pendingPromotionReviewers.js
+++ b/src/components/PRPromotions/pendingPromotionReviewers.js
@@ -1,0 +1,84 @@
+const INITIAL_PENDING_PROMOTION_REVIEWERS = [
+  {
+    id: 'pending-akshay',
+    prReviewer: 'Akshay - Jayaram',
+    teamCode: '123',
+    teamLeaderName: 'Chris Martinez',
+    weeklyPRs: [
+      { week: 'week-1', prCount: 2 },
+      { week: 'week-2', prCount: 10 },
+      { week: 'week-3', prCount: 11 },
+    ],
+  },
+  {
+    id: 'pending-ghazi',
+    prReviewer: 'Ghazi1212',
+    teamCode: '456',
+    teamLeaderName: 'Sam Patel',
+    weeklyPRs: [
+      { week: 'week-1', prCount: 2 },
+      { week: 'week-2', prCount: 1 },
+      { week: 'week-3', prCount: 10 },
+      { week: 'week-4', prCount: 11 },
+    ],
+  },
+  {
+    id: 'pending-diya',
+    prReviewer: 'Diya Test 1',
+    teamCode: '789',
+    teamLeaderName: 'Jordan Lee',
+    weeklyPRs: [
+      { week: 'week-1', prCount: 4 },
+      { week: 'week-2', prCount: 8 },
+      { week: 'week-3', prCount: 12 },
+      { week: 'week-4', prCount: 7 },
+      { week: 'week-5', prCount: 9 },
+    ],
+  },
+  {
+    id: 'pending-ramya',
+    prReviewer: 'Ramya Test Volunteer',
+    teamCode: '321',
+    teamLeaderName: 'Alex Rivera',
+    weeklyPRs: [
+      { week: 'week-1', prCount: 1 },
+      { week: 'week-2', prCount: 3 },
+      { week: 'week-3', prCount: 5 },
+      { week: 'week-4', prCount: 8 },
+      { week: 'week-5', prCount: 10 },
+      { week: 'week-6', prCount: 12 },
+      { week: 'week-7', prCount: 6 },
+    ],
+  },
+  {
+    id: 'pending-yuhang',
+    prReviewer: 'Yuhang Xu',
+    teamCode: '654',
+    teamLeaderName: 'Taylor Brooks',
+    weeklyPRs: [
+      { week: 'week-1', prCount: 9 },
+      { week: 'week-2', prCount: 11 },
+    ],
+  },
+];
+
+function cloneReviewers(reviewers) {
+  return reviewers.map(reviewer => ({
+    ...reviewer,
+    weeklyPRs: reviewer.weeklyPRs.map(week => ({ ...week })),
+  }));
+}
+
+let pendingPromotionReviewers = cloneReviewers(INITIAL_PENDING_PROMOTION_REVIEWERS);
+
+export function getPendingPromotionReviewers() {
+  return pendingPromotionReviewers;
+}
+
+export function setPendingPromotionReviewers(reviewers) {
+  pendingPromotionReviewers = reviewers;
+}
+
+export function resetPendingPromotionReviewers() {
+  pendingPromotionReviewers = cloneReviewers(INITIAL_PENDING_PROMOTION_REVIEWERS);
+}

--- a/src/components/PRPromotions/pendingPromotionReviewers.js
+++ b/src/components/PRPromotions/pendingPromotionReviewers.js
@@ -1,3 +1,5 @@
+const STORAGE_KEY = 'hgn.prPromotions.promotedReviewerIds';
+
 const INITIAL_PENDING_PROMOTION_REVIEWERS = [
   {
     id: 'pending-akshay',
@@ -69,16 +71,53 @@ function cloneReviewers(reviewers) {
   }));
 }
 
-let pendingPromotionReviewers = cloneReviewers(INITIAL_PENDING_PROMOTION_REVIEWERS);
+function readPromotedIds() {
+  if (typeof localStorage === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(id => typeof id === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function writePromotedIds(ids) {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...new Set(ids)]));
+  } catch {
+    // Ignore storage quota / private-mode failures; the in-session list still updates.
+  }
+}
 
 export function getPendingPromotionReviewers() {
-  return pendingPromotionReviewers;
+  const promotedIds = new Set(readPromotedIds());
+  return cloneReviewers(INITIAL_PENDING_PROMOTION_REVIEWERS).filter(
+    reviewer => !promotedIds.has(reviewer.id),
+  );
 }
 
 export function setPendingPromotionReviewers(reviewers) {
-  pendingPromotionReviewers = reviewers;
+  const remainingIds = new Set((reviewers || []).map(reviewer => reviewer.id));
+  const promotedIds = INITIAL_PENDING_PROMOTION_REVIEWERS.filter(
+    reviewer => !remainingIds.has(reviewer.id),
+  ).map(reviewer => reviewer.id);
+  writePromotedIds(promotedIds);
 }
 
 export function resetPendingPromotionReviewers() {
-  pendingPromotionReviewers = cloneReviewers(INITIAL_PENDING_PROMOTION_REVIEWERS);
+  if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Ignore storage access errors in tests or private mode.
+    }
+  }
 }


### PR DESCRIPTION
﻿# Description
Follow-up UI fixes for the PR promotion confirmation modal from PR 3727. Jae tested in Dev and found default checkboxes unselected, weekly PR counts not in VIBGYOR circles, and the column labeled Team Reviewer Name with quote placeholders instead of Team Leader Name.

This PR updates the confirmation box so every reviewer starts selected, weekly PR counts render in rainbow-colored circles, and the column is Team Leader Name with readable names. Confirm removes checked people from the pending list; Cancel closes with no change.

Fixes follow-up for PR 3727 (PRIORITY HIGH): add right title, color, and checkbox on the PR Review Team Analytics promotion display box.

## Related PRS (if any):
Frontend follow-up to https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3727
No paired backend PR.

## Main changes explained:
- `src/components/PRPromotions/DisplayBox.jsx`: Default-check all pending reviewers, rename column to Team Leader Name / Weekly PRs, render weekly counts in VIBGYOR circles, disable Confirm while confirming or when nothing is selected, toast success/error, remove confirmed rows from the pending list.
- `src/components/PRPromotions/DisplayBox.module.css`: Clean VIBGYOR circle styles, visible checkboxes, dark mode contrast, and a responsive table layout.
- `src/components/PRPromotions/pendingPromotionReviewers.js`: Sample pending-promotion reviewers. Confirmed sample ids are stored in browser localStorage so a refresh keeps them off the list.
- `src/components/PRPromotions/__tests__/DisplayBox.test.jsx`: Coverage for default-checked boxes, titles, circles, Cancel, Confirm list updates, remount persistence, and empty remaining list.

## How to test:
1. Check out branch `Purav_fix_pr_promotion_display_box` on HighestGoodNetworkApp
2. Run `npm install` if dependencies changed (they did not in this PR)
3. Frontend: `npm run start:local` → http://localhost:5173
4. Clear site data/cache if the old modal still appears (this also clears localStorage and restores the full sample list)
5. Log in as Admin — default dev admin: `devadmin@hgn.net` / `DeveloperPassword100%!`
6. Go to http://localhost:5173/prPromotionsPage and click **Promote ?**
7. Confirm the modal title is "Are you sure you want to promote these PR reviewers?"
8. Confirm every row checkbox is selected by default, including Select All
9. Confirm columns are **PR Reviewer**, **Team Code**, **Team Leader Name**, **Weekly PRs** (not Team Reviewer Name, not Weekly PR Counts)
10. Confirm Team Leader Name shows names such as Chris Martinez / Sam Patel, not quotes
11. Confirm weekly PR numbers sit inside filled VIBGYOR circles (violet, indigo, blue, green, yellow, orange, red)
12. Uncheck one reviewer (for example Akshay - Jayaram) and click **Confirm** — that person stays; the checked people leave the table; a success toast appears
13. Refresh the page and open **Promote ?** again — the people you confirmed should still be gone (localStorage). Unchecked people should still be there
14. Click **Cancel** — modal closes with no further list change
15. Uncheck Select All so no rows are selected — **Confirm** is disabled
16. Also open the modal from the header **Reports → PR Promotions** item and repeat the default-checked + VIBGYOR checks
17. Test roles: **Volunteer** (should not have this admin promotions path / should not be able to promote) and **Admin** (full modal)
18. Verify **dark mode**: toggle dark mode, reopen the modal, confirm table text, checkboxes, circles, Cancel, and Confirm remain readable

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/a970e811-1e6d-40af-9557-44a8421c7b98

<img width="1280" height="704" alt="pr_5499_1" src="https://github.com/user-attachments/assets/b469b9d8-4ca3-4327-a5ec-6fe4012f0cd4" />
<img width="1280" height="626" alt="pr_5499_2" src="https://github.com/user-attachments/assets/7990e423-0898-4f3b-8006-7ce0e4f710d0" />
<img width="836" height="327" alt="pr_5499_3" src="https://github.com/user-attachments/assets/84d9af30-1724-4d2c-807a-05cc2c3bc279" />

## Note:
This is a frontend-only follow-up for Jae's three UI notes on PR 3727 (default checkboxes, VIBGYOR weekly PR circles, Team Leader Name).

**Persistence / backend (important for reviewers):**
- The modal uses **sample pending reviewers** so the UI can be tested. It does **not** load the full `/promotion-eligibility` list.
- **Confirm does not save promotions on the backend for these sample rows.** Sample ids such as `pending-akshay` are not real Mongo user ids, so `POST /api/promote-members` is not called (the API would 400).
- After Confirm, the updated list is stored in **browser localStorage** (`hgn.prPromotions.promotedReviewerIds`). A refresh keeps confirmed people off the list on this browser only. Clearing site data restores the sample list.
- To store promotions on the server later: put real `reviewerId`s from eligibility into the box, then Confirm can call `POST /api/promote-members` with `{ memberIds, requestor }`, which sets role to Promoted Reviewer. Team code, team leader name, and live weekly PR history still need backend fields (`/promotion-details/:id` currently 404s for real user ids).

Jae merges; text Jae if this needs an urgent merge.
