### PR TITLE
Amaan - Fix Lesson List styling

### DIFF
--- a/src/components/BMDashboard/LessonList/LessonListForm.module.css
+++ b/src/components/BMDashboard/LessonList/LessonListForm.module.css
@@ -149,12 +149,12 @@
 
 /* Dark mode */
 .darkMode {
-  background-color: #1B2A41;
+  background-color: #1b2a41;
   color: #f8f9fa;
 }
 
 .darkMode .formContainer {
-  background-color: #1C2541;
+  background-color: #1c2541;
   border-radius: 8px;
   padding: 1rem;
 }
@@ -180,8 +180,8 @@
 }
 
 .tagContainerDark {
-  background-color: #1C2541;
-  border: 1px solid #3A506B;
+  background-color: #1c2541;
+  border: 1px solid #3a506b;
   border-radius: 6px;
 }
 
@@ -238,9 +238,18 @@
 }
 
 .lightMode {
-  background-color: #ffffff;
+  background-color: #e8f4f9;
   color: #212529;
 }
+
+/* Match the dark-mode page container with a distinct light dashboard surface. */
+.lightMode .formContainer {
+  background-color: #ffffff;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
 .lightMode label {
   color: #212529 !important;
 }

--- a/src/components/BMDashboard/LessonList/LessonListForm.module.css
+++ b/src/components/BMDashboard/LessonList/LessonListForm.module.css
@@ -43,15 +43,30 @@
 }
 
 .singleForm {
+  /* Align each filter label with its dropdown within a consistent group width. */
   display: flex !important;
+  align-items: center;
   gap: 5px;
   text-align: center !important;
   margin-right: 40px;
-  width: 200px;
+  width: 320px;
+  max-width: 100%;
+}
+
+/* Keep the Filter and Sort labels the same width beside their matching selects. */
+.singleForm :global(.form-label) {
+  flex: 0 0 50px;
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 0;
+  text-align: left;
 }
 
 .singleFormSelect {
+  /* Keep the Filter and Sort dropdowns at the same compact width. */
   background-color: #f2f2f266 !important;
+  width: 200px;
+  max-width: 100%;
 }
 
 .tagContainer {


### PR DESCRIPTION
# Description
Phase 2 follow-up for the Lesson List page related to the previously merged PR #4528.

<img width="539" height="607" alt="image" src="https://github.com/user-attachments/assets/20dabdbf-473c-4005-b670-1c45a862e83a" />

The current Lesson List page has inconsistent page-level styling between light mode and dark mode. Dark mode displays the Lesson List content inside a clearly defined container, while light mode does not provide the same visual separation from the surrounding page. The Expand All and Collapse All functionality was also tested and confirmed to work smoothly in both light and dark modes without console errors.

This Phase 2 follow-up improves the Lesson List styling to provide a more consistent container structure across light and dark modes while preserving smooth Expand All and Collapse All functionality and all existing Lesson List behavior.

## Related PRS (if any):
Related frontend PR: #4528 – Fix Expand/Collapse All functionality

Related historical PR: #3107

PR #4528 is already merged into development. This PR is a new Phase 2 follow-up and does not modify the historical PR branch.

## Main changes explained:
- Improve the Lesson List page styling for better consistency across light and dark modes.
- Provide clearer visual separation between the page background and the main Lesson List content.
- Improve the main content container with consistent spacing, border radius, and border styling.
- Improve the sizing and alignment of page controls for a more consistent layout.
- Preserve existing Lesson List functionality, including filtering, sorting, tags, Expand All, Collapse All, editing, deleting, liking, exporting, and data loading.


## How to test:
1. Check out the current PR branch:
   `amaan-fix-lesson-list-dark-mode`
2. Run `npm install` if dependencies are not already installed.
3. Run `npm run start:local`.
4. Clear site data/cache if needed.
5. Log in with an account that can access the Lesson List page.
6. Navigate to:
   `http://localhost:5173/bmdashboard/lessonlist`
7. Verify the Lesson List light-mode page displays a clearly defined inner container against the surrounding page background.
8. Verify the container padding, border radius, and border display correctly.
9. Switch to dark mode and verify the existing dark-mode container styling remains unchanged.
10. Verify Filter, Sort, Tags, Export Data, Expand All, Collapse All, and lesson-card interactions continue to function correctly in both light and dark mode.

## Screenshots or videos of changes:
Before:
<img width="468" height="266" alt="image" src="https://github.com/user-attachments/assets/5c58bc73-9606-46c8-b1a0-fa9eb6abdb09" />

<img width="468" height="242" alt="image" src="https://github.com/user-attachments/assets/642e4f5e-d41b-4d11-b843-6acf77483216" />

After:
<img width="1502" height="859" alt="image" src="https://github.com/user-attachments/assets/b6932e68-a60a-4b19-a323-4267ace37960" />

<img width="1490" height="859" alt="image" src="https://github.com/user-attachments/assets/f309620e-7a9e-4aa1-bc77-849348a83b35" />



## Note:
This is a new Phase 2 follow-up to the already merged PR #4528. Additional verified Lesson List Phase 2 UI fixes may be added to this PR as testing continues.