### PR TITLE
Purav-takeover-job-application-form-issues

### DIFF
--- a/src/components/Collaboration/Collaboration.jsx
+++ b/src/components/Collaboration/Collaboration.jsx
@@ -160,6 +160,7 @@ function Collaboration() {
         jobDescription: ad.description || '',
         requirements: ad.requirements || [],
         category: ad.category || 'General',
+        jobDetailsLink: ad.jobDetailsLink || '',
       },
     });
   };

--- a/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
+++ b/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
@@ -152,6 +152,21 @@ function resolveNavigationJobTitle(jobDataFromRedirect, location) {
   );
 }
 
+function resolveJobDetailsLink(jobData, jobsList, title) {
+  const fromNav = jobData?.jobDetailsLink;
+  if (fromNav && String(fromNav).trim()) return String(fromNav).trim();
+  const t = String(title || '')
+    .trim()
+    .toLowerCase();
+  if (!t || !jobsList?.length) return '';
+  const match = jobsList.find(j => {
+    const jobTitle = String(j.title || '').toLowerCase();
+    const jobPosition = String(j.position || '').toLowerCase();
+    return jobTitle === t || jobPosition === t;
+  });
+  return (match?.jobDetailsLink && String(match.jobDetailsLink).trim()) || '';
+}
+
 function notifyInitialFormSelection(navTitle, formMatch, chosen) {
   if (!navTitle || formMatch) return;
   if (chosen) {
@@ -655,6 +670,7 @@ function JobApplicationForm() {
 
   const [forms, setForms] = useState([]);
   const [selectedJob, setSelectedJob] = useState('');
+  const [jobsData, setJobsData] = useState([]);
   const [answers, setAnswers] = useState([]);
   const [jobTitleInput, setJobTitleInput] = useState('');
   const [filteredForm, setFilteredForm] = useState(null);
@@ -759,17 +775,19 @@ function JobApplicationForm() {
 
   const fetchJobData = async jobId => {
     try {
-      const response = await axios.get(`${ENDPOINTS.GET_JOB}/${jobId}`);
-      if (response.data) {
+      const response = await axios.get(`${ENDPOINTS.APIEndpoint()}/jobs/${jobId}`);
+      const job = response.data?.job || response.data;
+      if (job) {
         setJobDataFromRedirect({
-          jobId: response.data._id,
-          jobTitle: response.data.title,
-          jobDescription: response.data.description || '',
-          requirements: response.data.requirements || [],
-          category: response.data.category || 'General',
+          jobId: job._id,
+          jobTitle: job.title,
+          jobDescription: job.description || '',
+          requirements: job.requirements || [],
+          category: job.category || 'General',
+          jobDetailsLink: job.jobDetailsLink || '',
         });
-        if (response.data.title) {
-          setJobTitleInput(response.data.title);
+        if (job.title) {
+          setJobTitleInput(job.title);
         }
       }
     } catch (error) {
@@ -804,6 +822,15 @@ function JobApplicationForm() {
 
     async function fetchForms() {
       try {
+        try {
+          const jobsRes = await axios.get(`${ENDPOINTS.APIEndpoint()}/jobs?limit=1000`);
+          if (!cancelled && jobsRes.data?.jobs) {
+            setJobsData(Array.isArray(jobsRes.data.jobs) ? jobsRes.data.jobs : []);
+          }
+        } catch {
+          /* Job listings are only used for optional details links; form load can continue. */
+        }
+
         const res = await axios.get(ENDPOINTS.GET_ALL_JOB_FORMS);
         if (cancelled) return;
         const formsArr = parseFormsResponse(res);
@@ -929,8 +956,12 @@ function JobApplicationForm() {
     });
   }, [answers, visibleQuestions]);
 
-  const handleShowDescription = e => {
-    e.preventDefault();
+  const currentJobDetailsLink = useMemo(
+    () => resolveJobDetailsLink(jobDataFromRedirect, jobsData, bannerJobTitle || selectedJob),
+    [jobDataFromRedirect, jobsData, bannerJobTitle, selectedJob],
+  );
+
+  const handleKnowMoreClick = () => {
     setShowDescription(true);
   };
 
@@ -1177,11 +1208,18 @@ function JobApplicationForm() {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
 
-      toast.success('Application submitted successfully.');
+      toast.success('Application submitted successfully. A confirmation email will be sent.');
       resetFormAfterSubmit();
     } catch (err) {
-      const message = err.response?.data?.message || err.message || 'Failed to submit application.';
-      toast.error(message, { autoClose: 7000 });
+      if (err.response?.status === 409) {
+        toast.error(err.response?.data?.message || 'Application already submitted', {
+          autoClose: 7000,
+        });
+      } else {
+        const message =
+          err.response?.data?.message || err.message || 'Failed to submit application.';
+        toast.error(message, { autoClose: 7000 });
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -1214,7 +1252,13 @@ function JobApplicationForm() {
             </button>
           </div>
           <div className={styles.headerRight}>
-            <select className={styles.jobSelect} value={selectedJob} onChange={handleJobChange}>
+            <select
+              className={styles.jobSelect}
+              value={selectedJob}
+              onChange={handleJobChange}
+              aria-label="Select a position"
+            >
+              <option value="">Select a position</option>
               {forms.map(form => (
                 <option key={form._id || form.id} value={form.title}>
                   {form.title}
@@ -1228,9 +1272,20 @@ function JobApplicationForm() {
             Job Application – {(bannerJobTitle || selectedJob || 'this role').trim()}
           </h1>
           <p className={styles.formSubtitle}>
-            <a href="#learnMore" onClick={handleShowDescription}>
-              Click to know more about this position
-            </a>
+            {currentJobDetailsLink ? (
+              <a href={currentJobDetailsLink} target="_blank" rel="noopener noreferrer">
+                Click to know more about this position
+              </a>
+            ) : (
+              <button
+                type="button"
+                className={styles.linkButton}
+                onClick={handleKnowMoreClick}
+                aria-haspopup="dialog"
+              >
+                Click to know more about this position
+              </button>
+            )}
           </p>
           {showDescription && filteredForm && (
             <div className={styles.popupOverlay}>
@@ -1645,38 +1700,49 @@ function JobApplicationForm() {
                         ))}
                       </fieldset>
                     )}
-                    {qt === 'radio' && q.options && q.options.length > 0 && (
+                    {qt === 'radio' &&
+                      q.options &&
+                      q.options.length > 0 &&
+                      !isIndividualOrgQuestion && (
+                        <fieldset
+                          className={styles.optionFieldset}
+                          aria-labelledby={`${formKey}-heading`}
+                        >
+                          {q.options.map(opt => (
+                            <label key={String(opt)}>
+                              <input
+                                type="radio"
+                                name={`question-${formKey}`}
+                                value={opt}
+                                checked={answers[idx] === opt}
+                                onChange={() => handleAnswerChange(idx, opt)}
+                              />{' '}
+                              {opt}
+                            </label>
+                          ))}
+                        </fieldset>
+                      )}
+                    {isIndividualOrgQuestion ? (
                       <fieldset
                         className={styles.optionFieldset}
                         aria-labelledby={`${formKey}-heading`}
                       >
-                        {q.options.map(opt => (
-                          <label key={String(opt)}>
-                            <input
-                              type="radio"
-                              name={`question-${formKey}`}
-                              value={opt}
-                              checked={answers[idx] === opt}
-                              onChange={() => handleAnswerChange(idx, opt)}
-                            />{' '}
-                            {opt}
-                          </label>
-                        ))}
+                        {(q.options?.length ? q.options : ['Individual', 'Organization']).map(
+                          opt => (
+                            <label key={String(opt)}>
+                              <input
+                                type="radio"
+                                name={`question-${formKey}`}
+                                value={opt}
+                                checked={answers[idx] === opt}
+                                onChange={() => handleAnswerChange(idx, opt, label)}
+                                required={req}
+                              />{' '}
+                              {opt}
+                            </label>
+                          ),
+                        )}
                       </fieldset>
-                    )}
-                    {isIndividualOrgQuestion ? (
-                      <select
-                        className={styles.selectField}
-                        value={Array.isArray(answers[idx]) ? '' : answers[idx] || ''}
-                        onChange={e => handleAnswerChange(idx, e.target.value, label)}
-                        required={req}
-                        aria-required={req}
-                        aria-labelledby={`${formKey}-heading`}
-                      >
-                        <option value="">Select an option</option>
-                        <option value="Individual">Individual</option>
-                        <option value="Organization">Organization</option>
-                      </select>
                     ) : (
                       qt === 'dropdown' && (
                         <select
@@ -1718,7 +1784,8 @@ function JobApplicationForm() {
                       'radio',
                       'dropdown',
                     ].includes(qt) &&
-                      !isFileUploadQuestion(q) && (
+                      !isFileUploadQuestion(q) &&
+                      !isIndividualOrgQuestion && (
                         <input
                           type="text"
                           placeholder="Type your response here"

--- a/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
+++ b/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
@@ -137,8 +137,9 @@ function pickInitialForm(formsArr, navState) {
   if (navState?.jobTitle) {
     const matched = findFormForJobTitle(formsArr, navState.jobTitle);
     if (matched) return matched;
+    return formsArr.find(f => f.questions?.length) || formsArr[0];
   }
-  return formsArr.find(f => f.questions?.length) || formsArr[0];
+  return null;
 }
 
 function parseFormsResponse(res) {
@@ -190,7 +191,7 @@ function getInitialFormState(chosen, navTitle) {
     };
   }
   return {
-    selectedJob: chosen.title,
+    selectedJob: '',
     filteredForm: chosen,
     answers: initialAnswersForQuestions(getVisibleQuestionsForForm(chosen)),
     bannerJobTitle: navTitle || chosen.title,
@@ -965,6 +966,15 @@ function JobApplicationForm() {
 
   const handleJobChange = next => {
     setSelectedJob(next);
+    if (!next) {
+      setBannerJobTitle('');
+      setFilteredForm(null);
+      setAnswers([]);
+      setQuestionFiles({});
+      questionFileInputRefs.current = {};
+      setFieldErrors({});
+      return;
+    }
     setBannerJobTitle(next);
   };
 

--- a/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
+++ b/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
@@ -665,6 +665,90 @@ FileUploadField.defaultProps = {
   required: false,
 };
 
+function JobPositionSelect({ value, forms, onChange }) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef(null);
+  const label = value || 'Select a position';
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDoc = event => {
+      if (!wrapRef.current?.contains(event.target)) setOpen(false);
+    };
+    const onKey = event => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDoc);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const choose = next => {
+    onChange(next);
+    setOpen(false);
+  };
+
+  return (
+    <div className={styles.jobSelectWrap} ref={wrapRef}>
+      <button
+        type="button"
+        className={styles.jobSelect}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label="Select a position"
+        onClick={() => setOpen(isOpen => !isOpen)}
+      >
+        <span className={styles.jobSelectLabel}>{label}</span>
+      </button>
+      {open && (
+        <ul className={styles.jobSelectMenu} role="listbox" aria-label="Positions">
+          <li
+            role="option"
+            aria-selected={!value}
+            className={!value ? styles.jobSelectOptionActive : undefined}
+          >
+            <button type="button" onClick={() => choose('')}>
+              Select a position
+            </button>
+          </li>
+          {forms.map(form => (
+            <li
+              key={form._id || form.id}
+              role="option"
+              aria-selected={value === form.title}
+              className={value === form.title ? styles.jobSelectOptionActive : undefined}
+            >
+              <button type="button" onClick={() => choose(form.title)}>
+                {form.title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+JobPositionSelect.propTypes = {
+  value: PropTypes.string,
+  forms: PropTypes.arrayOf(
+    PropTypes.shape({
+      _id: PropTypes.string,
+      id: PropTypes.string,
+      title: PropTypes.string,
+    }),
+  ),
+  onChange: PropTypes.func.isRequired,
+};
+
+JobPositionSelect.defaultProps = {
+  value: '',
+  forms: [],
+};
+
 function JobApplicationForm() {
   const routerLocation = useLocation();
 
@@ -879,8 +963,7 @@ function JobApplicationForm() {
     setFieldErrors({});
   }, [selectedJob, forms]);
 
-  const handleJobChange = e => {
-    const next = e.target.value;
+  const handleJobChange = next => {
     setSelectedJob(next);
     setBannerJobTitle(next);
   };
@@ -1170,7 +1253,15 @@ function JobApplicationForm() {
 
     setIsSubmitting(true);
     try {
+      const answersPayload = visibleQuestions.map((q, idx) => ({
+        questionId: q._id,
+        answer: serializeAnswerForSubmit(q, idx, answers, questionFiles),
+      }));
+
       const formData = new FormData();
+      formData.append('respondent', applicantName.trim());
+      formData.append('email', applicantEmail.trim());
+      formData.append('answers', JSON.stringify(answersPayload));
       formData.append(
         'payload',
         JSON.stringify({
@@ -1187,10 +1278,7 @@ function JobApplicationForm() {
             hoursPerWeek,
             roleSkills,
           },
-          answers: visibleQuestions.map((q, idx) => ({
-            questionId: q._id,
-            answer: serializeAnswerForSubmit(q, idx, answers, questionFiles),
-          })),
+          answers: answersPayload,
         }),
       );
 
@@ -1211,14 +1299,15 @@ function JobApplicationForm() {
       toast.success('Application submitted successfully. A confirmation email will be sent.');
       resetFormAfterSubmit();
     } catch (err) {
+      const apiMessage = err.response?.data?.message || err.response?.data?.error;
       if (err.response?.status === 409) {
-        toast.error(err.response?.data?.message || 'Application already submitted', {
+        toast.error(apiMessage || 'Application already submitted', {
           autoClose: 7000,
         });
       } else {
-        const message =
-          err.response?.data?.message || err.message || 'Failed to submit application.';
-        toast.error(message, { autoClose: 7000 });
+        toast.error(apiMessage || err.message || 'Failed to submit application.', {
+          autoClose: 7000,
+        });
       }
     } finally {
       setIsSubmitting(false);
@@ -1252,19 +1341,7 @@ function JobApplicationForm() {
             </button>
           </div>
           <div className={styles.headerRight}>
-            <select
-              className={styles.jobSelect}
-              value={selectedJob}
-              onChange={handleJobChange}
-              aria-label="Select a position"
-            >
-              <option value="">Select a position</option>
-              {forms.map(form => (
-                <option key={form._id || form.id} value={form.title}>
-                  {form.title}
-                </option>
-              ))}
-            </select>
+            <JobPositionSelect value={selectedJob} forms={forms} onChange={handleJobChange} />
           </div>
         </section>
         <section className={styles.formContainer}>
@@ -1724,7 +1801,7 @@ function JobApplicationForm() {
                       )}
                     {isIndividualOrgQuestion ? (
                       <fieldset
-                        className={styles.optionFieldset}
+                        className={`${styles.optionFieldset} ${styles.optionFieldsetInline}`}
                         aria-labelledby={`${formKey}-heading`}
                       >
                         {(q.options?.length ? q.options : ['Individual', 'Organization']).map(

--- a/src/components/Collaboration/JobApplicationForm/JobApplicationForm.module.css
+++ b/src/components/Collaboration/JobApplicationForm/JobApplicationForm.module.css
@@ -36,7 +36,7 @@
   width: min(960px, 92vw);
   max-width: 100%;
   padding: clamp(0.75rem, 2vw, 1.25rem);
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   flex-wrap: wrap;
   box-sizing: border-box;
@@ -45,36 +45,99 @@
 
 .headerLeft {
   display: flex;
-  gap: 10px;
+  align-items: center;
+  gap: 8px;
+  flex: 0 1 auto;
 }
 
 .headerRight {
   display: flex;
   align-items: center;
-  flex-shrink: 1;
+  flex: 0 1 auto;
   min-width: 0;
 }
 
 .jobTitleInput {
-  padding: 5px;
+  padding: 5px 8px;
   border: 1px solid #ccc;
   border-radius: 5px;
+  width: 12rem;
+  max-width: 100%;
+}
+
+.jobSelectWrap {
+  position: relative;
+  min-width: 0;
+  max-width: min(16rem, 100%);
 }
 
 .jobSelect {
-  padding: 6px 36px 6px 8px;
+  display: flex;
+  align-items: center;
+  width: max-content;
+  max-width: 16rem;
+  padding: 6px 28px 6px 8px;
   border: 1px solid #ccc;
   border-radius: 5px;
-  min-width: 150px;
-  max-width: 300px;
-  width: auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  background-color: #fff;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
   appearance: none;
   background-image: url("data:image/svg+xml;utf8,<svg fill='%23666' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>");
   background-repeat: no-repeat;
-  background-position: right 10px center;
+  background-position: right 8px center;
   background-size: 16px;
+}
+
+.jobSelectLabel {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.jobSelectMenu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 30;
+  margin: 0;
+  padding: 4px 0;
+  list-style: none;
+  width: max-content;
+  min-width: 100%;
+  max-width: min(20rem, 80vw);
+  max-height: 16rem;
+  overflow: auto;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  box-shadow: 0 8px 20px rgb(0 0 0 / 15%);
+}
+
+.jobSelectMenu button {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  font-size: 0.85rem;
+  line-height: 1.3;
+  text-align: left;
+  padding: 6px 10px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  cursor: pointer;
+}
+
+.jobSelectOptionActive button,
+.jobSelectMenu button:hover {
+  background: #1a73e8;
+  color: #fff;
 }
 
 .goButton {
@@ -240,13 +303,26 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 8px;
+}
+
+.optionFieldsetInline {
+  flex-flow: row wrap;
+  align-items: center;
+  gap: 6px 18px;
 }
 
 .optionFieldset label {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: flex-start;
+  width: auto;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
+  line-height: 1.25;
+  gap: 6px;
   font-weight: 400;
   cursor: pointer;
 }
@@ -285,7 +361,7 @@
   font-size: medium;
 }
 
-.formGroup input,
+.formGroup input:not([type='radio'], [type='checkbox']),
 .formGroup select,
 .formGroup textarea {
   padding: 10px;
@@ -298,6 +374,23 @@
   width: 100%;
   max-width: 100%;
   min-width: 0;
+}
+
+.optionFieldset input[type='radio'],
+.optionFieldset input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  min-height: 16px;
+  max-width: 16px;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+  flex: 0 0 auto;
+  accent-color: #1a73e8;
 }
 
 .formGroup textarea {
@@ -636,7 +729,7 @@
 
 .darkMode .jobTitleInput,
 .darkMode .jobSelect,
-.darkMode input,
+.darkMode input:not([type='radio'], [type='checkbox']),
 .darkMode select,
 .darkMode textarea {
   background: #181a1b;
@@ -645,17 +738,35 @@
   transition: background 0.3s, color 0.3s, box-shadow 0.3s;
 }
 
+.darkMode .optionFieldset input[type='radio'],
+.darkMode .optionFieldset input[type='checkbox'] {
+  background: none;
+  border: 0;
+  accent-color: #7ec8ff;
+}
+
 .darkMode .jobSelect {
   background-image: url("data:image/svg+xml;utf8,<svg fill='lightgray' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>");
   background-repeat: no-repeat;
-  background-position: right 12px center;
-  background-size: 18px 18px;
-  padding-right: 36px;
+  background-position: right 8px center;
+  background-size: 16px;
 }
 
 .darkMode .jobSelect:focus,
 .darkMode .jobSelect:active {
   background-image: url("data:image/svg+xml;utf8,<svg fill='white' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'><path d='M7 15l5-5 5 5z'/></svg>");
+}
+
+.darkMode .jobSelectMenu {
+  background: #181a1b;
+  border-color: #444;
+  color: #f1f1f1;
+}
+
+.darkMode .jobSelectOptionActive button,
+.darkMode .jobSelectMenu button:hover {
+  background: #1a73e8;
+  color: #fff;
 }
 
 .darkMode input[type='date'],

--- a/src/components/Collaboration/JobApplicationForm/JobApplicationForm.module.css
+++ b/src/components/Collaboration/JobApplicationForm/JobApplicationForm.module.css
@@ -36,7 +36,7 @@
   width: min(960px, 92vw);
   max-width: 100%;
   padding: clamp(0.75rem, 2vw, 1.25rem);
-  justify-content: flex-start;
+  justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
   box-sizing: border-box;
@@ -53,7 +53,9 @@
 .headerRight {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   flex: 0 1 auto;
+  margin-left: auto;
   min-width: 0;
 }
 
@@ -102,7 +104,8 @@
 .jobSelectMenu {
   position: absolute;
   top: calc(100% + 4px);
-  left: 0;
+  right: 0;
+  left: auto;
   z-index: 30;
   margin: 0;
   padding: 4px 0;

--- a/src/components/Collaboration/JobApplicationForm/JobApplicationForm.module.css
+++ b/src/components/Collaboration/JobApplicationForm/JobApplicationForm.module.css
@@ -71,8 +71,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   background-image: url("data:image/svg+xml;utf8,<svg fill='%23666' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>");
   background-repeat: no-repeat;
   background-position: right 10px center;
@@ -185,6 +183,17 @@
   text-align: left;
 }
 
+.linkButton {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #007bff;
+  text-decoration: none;
+  cursor: pointer;
+  font-size: inherit;
+  font-family: inherit;
+}
+
 .formSubtitle {
   text-align: center;
   margin-bottom: 20px;
@@ -229,6 +238,17 @@
   margin: 0;
   padding: 0;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.optionFieldset label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 400;
+  cursor: pointer;
 }
 
 .formProfileDetailGroup {
@@ -905,6 +925,7 @@
     grid-column: auto;
   }
 }
+
 /* User Requirements Section */
 .userRequirementsSection {
   margin: 20px 0;


### PR DESCRIPTION
# Description

Takes over and finishes the frontend work for the Job Application Page (`/job-application`) form functionality issues (Priority High, Sayantan / WIP Sohail Uddin Syed). Built from latest `development` with only the job-application feature changes on top (not a merge of the stale PR branch).

Fixes required-field indicators, Individual/Organization radios, form reset, know-more link, compact position dropdown, 409 duplicate-submit toast, multipart resume + second-file upload, and submit payload matching the live backend.

Fixes # (Priority High) — Job Application Page form functionality issues. Related previous PR: #4168.

## Related PRs (if any):

| Repo | Branch | PR | Role |
|------|--------|-----|------|
| **HighestGoodNetworkApp (this PR)** | `Purav-fix-job-application-form-issues` | *(this PR)* | Takeover frontend — rebased on current `development` |
| HighestGoodNetworkApp (superseded) | `fix-job-form-issues-frontend` | [#5469](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5469) | Original frontend PR (Sohail → Purav takeover) |
| **HGNRest (paired)** | `Purav-job-form-issues-backend` | [#2333](https://github.com/OneCommunityGlobal/HGNRest/pull/2333) | Takeover backend — **required for end-to-end testing** |
| HGNRest (superseded) | `job-form-issues-backend` | [#2318](https://github.com/OneCommunityGlobal/HGNRest/pull/2318) | Original backend PR |

**To test end-to-end:** check out `Purav-fix-job-application-form-issues` on HighestGoodNetworkApp and `Purav-job-form-issues-backend` on HGNRest.

## Main changes explained:

- `JobApplicationForm.jsx` — required fields (Name, Email, profile, and required questions) show `*`
- `JobApplicationForm.jsx` — Individual/Organization is radio buttons, left-aligned on one row
- `JobApplicationForm.jsx` — all form fields reset after a successful submit
- `JobApplicationForm.jsx` — "Click to know more about this position" opens `jobDetailsLink` in a new tab when present; otherwise opens the inline description modal (button, not invalid `#` anchor)
- `Collaboration.jsx` — passes `jobDetailsLink` through navigation state from the job board
- `JobApplicationForm.jsx` — submit uses multipart `respondent`, `email`, `answers`, `payload`, `resume`, and `questionFile_{questionId}` for the second upload
- `JobApplicationForm.jsx` — 409 from backend shows "Application already submitted"
- `JobApplicationForm.jsx` / `JobApplicationForm.module.css` — compact `JobPositionSelect` (dynamic width, wrapped long titles) beside search + Go instead of a stretched native `<select>`
- `JobApplicationForm.module.css` — `linkButton` and radio/checkbox styles so extras are not styled as full-width text fields

## How to test:

1. Check out `Purav-fix-job-application-form-issues` on **HighestGoodNetworkApp** and `Purav-job-form-issues-backend` on **HGNRest**
2. Run `npm install` if dependencies changed
3. Backend: `npm run build` then `npm start` (HGNRest, port 4500). Frontend: `npm run start:local` → http://localhost:5173
4. Point frontend `.env` `REACT_APP_APIENDPOINT` at local API if testing uploads/email against this backend
5. Clear site data/cache
6. Log in as **Admin** (`devadmin@hgn.net` / `DeveloperPassword100%!`) and as a **Volunteer** (personal test account)
7. Dashboard → Collaboration → click a job role → `/job-application`
8. Confirm required `*` on Name, Email, and required questions
9. Confirm Individual / Organization radios sit on one row under the question
10. Confirm search + Go + position dropdown sit on one row; open the dropdown and confirm the list is compact (long titles wrap, not full-header width)
11. Submit with empty Name or Email — toast lists missing fields
12. Fill a complete application, attach resume and the question-14 second file, submit — expect **201**, success toast, fields cleared
13. Submit again with the same email — **409** and "Application already submitted"
14. "Click to know more about this position" — new tab if `jobDetailsLink` exists, otherwise the description modal
15. Network → POST `/api/jobforms/:formId/responses` — multipart includes `resume` and `questionFile_*` when a second file is attached
16. Verify **dark mode** on the same page (labels, radios, dropdown menu, know-more link)
17. Admin: Requirements Status preview still visible; Volunteer: form usable without admin preview

## Screenshots or videos of changes:

<img width="1279" height="705" alt="pr_5502_2333_1" src="https://github.com/user-attachments/assets/9584f1bc-e698-404d-bf95-b99c5d7ded7d" />
<img width="1274" height="704" alt="pr_5502_2333_2" src="https://github.com/user-attachments/assets/e7cf73a1-a745-4b3e-968c-b99fd821c44c" />
<img width="1195" height="507" alt="pr_5502_2333_3" src="https://github.com/user-attachments/assets/a721efbc-9f4c-4648-a3f9-1eedeb9a250c" />


https://github.com/user-attachments/assets/5d1f0c70-ba95-477d-8383-46ad133c7490




## Note:

- Must be tested with backend branch `Purav-job-form-issues-backend` (https://github.com/OneCommunityGlobal/HGNRest/pull/2333). Older `job-form-issues-backend` used `upload.single('resume')` and will 500 on a second file.
- Local confirmation email typically does not send unless `NODE_ENV=production` and `sendEmail` is on.
- Please close #5469 in favor of this PR once reviewers are ready. Jae merges; do not merge this PR yourself.
