### PR TITLE
Ansh - 🔥 Badge Management edit crash for legacy badges

### DIFF
--- a/src/components/Badge/EditBadgePopup.jsx
+++ b/src/components/Badge/EditBadgePopup.jsx
@@ -12,6 +12,7 @@ import {
   FormText,
   FormFeedback,
   UncontrolledTooltip,
+  Alert,
 } from 'reactstrap';
 import { connect } from 'react-redux';
 import './Badge.module.css';
@@ -81,9 +82,9 @@ function EditBadgePopup(props) {
   useEffect(() => {
     setBadgeValues(props.badgeValues);
     setBadgeId(props.badgeValues ? props.badgeValues._id : null);
-    setBadgeName(props.badgeValues ? props.badgeValues.badgeName : '');
-    setImageUrl(props.badgeValues ? props.badgeValues.imageUrl : '');
-    setDescription(props.badgeValues ? props.badgeValues.description : '');
+    setBadgeName(props.badgeValues?.badgeName ?? '');
+    setImageUrl(props.badgeValues?.imageUrl ?? '');
+    setDescription(props.badgeValues?.description ?? '');
     setRanking(props.badgeValues ? props.badgeValues.ranking : 0);
     setType(props.badgeValues ? props.badgeValues.type : 'Custom');
     setCategory(props.badgeValues ? props.badgeValues.category : 'Unspecified');
@@ -100,11 +101,10 @@ function EditBadgePopup(props) {
     return pattern.test(badgeRanking);
   };
 
-  const enableButton =
-    badgeName.length === 0 ||
-    imageUrl.length === 0 ||
-    description.length === 0 ||
-    !validRanking(ranking);
+  const hasMissingRequiredFields =
+    badgeName.length === 0 || imageUrl.length === 0 || description.length === 0;
+
+  const enableButton = hasMissingRequiredFields || !validRanking(ranking);
 
   const closePopup = () => {
     props.setEditPopup(false);
@@ -192,6 +192,12 @@ function EditBadgePopup(props) {
         Edit Badge
       </ModalHeader>
       <ModalBody className={darkMode ? 'bg-yinmn-blue' : ''}>
+        {hasMissingRequiredFields && (
+          <Alert color="warning">
+            This badge is missing required information. Please complete all required fields before
+            saving.
+          </Alert>
+        )}
         <Form id="badgeEdit">
           <FormGroup>
             <Label for="badgeName" className={fontColor}>

--- a/src/components/Badge/__tests__/EditBadgePopup.test.jsx
+++ b/src/components/Badge/__tests__/EditBadgePopup.test.jsx
@@ -179,4 +179,31 @@ describe('EditBadgePopup Component', () => {
     expect(options).toEqual(expectedCategories);
     expect(screen.getByLabelText('Hours'));
   });
+  test('handles null required fields without crashing and shows warning', () => {
+    const badgeWithNullFields = {
+      ...mockBadgeValues,
+      type: 'Custom',
+      imageUrl: null,
+      description: null,
+    };
+
+    const store = mockStore({
+      theme: themeMock,
+    });
+
+    render(
+      <Provider store={store}>
+        <EditBadgePopup open={true} badgeValues={badgeWithNullFields} />
+      </Provider>,
+    );
+
+    expect(screen.getByLabelText('Image URL')).toHaveValue('');
+    expect(screen.getByLabelText('Description')).toHaveValue('');
+    expect(
+      screen.getByText(
+        'This badge is missing required information. Please complete all required fields before saving.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Update' })).toBeDisabled();
+  });
 });


### PR DESCRIPTION
# Description

Some legacy badges contain `null` values for required fields such as `imageUrl` and `description`. When an admin tried to edit one of these badges, the Edit Badge form attempted to access `.length` on the null value, causing the Badge Management page to crash.

This PR fixes the issue by safely converting null/undefined required fields to empty strings when loading the edit form, while keeping the existing required-field validation in place.

A warning is also displayed when required badge information is missing so the admin knows the badge needs to be updated before saving.


## Related PRS (if any):

No related backend PR is required for this frontend hotfix.

## Main changes explained:

- Update `EditBadgePopup.jsx` to safely handle null/undefined `badgeName`, `imageUrl`, and `description` values.
- Keep required-field validation for badge name, image URL, and description.
- Add a warning alert when required badge information is missing.
- Keep the Update button disabled until the required fields are completed.


## How to test:

1. Check out the current branch
2. Run `npm install` if dependencies are not already installed.
3. Run the frontend locally using:
   `npm run start:local`
4. Make sure the local backend is running.
5. Log in as an admin user.
6. Go to Badge Management.
7. Edit a legacy badge that has a missing Image URL or Description.
8. Verify the Edit Badge modal opens without crashing.
9. Verify the warning appears when required information is missing.
10. Verify the Update button remains disabled while required fields are missing.
11. Fill in the missing required fields and verify the warning disappears.
12. Open a normal badge with existing Image URL and Description values and verify the values load correctly and no warning appears.


## Screenshots or videos of changes:

Added video showing:

https://github.com/user-attachments/assets/09e00d39-d132-4e1b-b3ea-f1b0eac031b0



Added screenshots showing:
- Legacy badge with missing required fields and warning displayed.
<img width="2047" height="1331" alt="image" src="https://github.com/user-attachments/assets/895445e5-c156-417b-a40e-44203d34c742" />

- Same badge after required fields are filled and warning disappears.

<img width="2047" height="1331" alt="image" src="https://github.com/user-attachments/assets/83b0ae96-a89b-4ee7-85b5-67852effd932" />

- Normal badge opening correctly without the warning.
<img width="2047" height="1331" alt="image" src="https://github.com/user-attachments/assets/3e1464fc-df2b-4e68-9887-a123f9e5f3ed" />



## Note:

This PR only prevents the frontend crash and improves the edit experience for legacy badge records. It does not modify existing badge data in the database or replace missing badge images. Badge data/image cleanup can be handled separately using the master badge assets.
