### PR TITLE
Ruthwik Fix issues with the start and pause timer buttons in Firefox

### DIFF
--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -1006,9 +1006,10 @@ function Timer({ authUser, darkMode, isPopout }) {
           </button>
           {!started || paused ? (
             <button
+              key={'timer-btn-start'}
               type="button"
               disabled={isButtonDisabled}
-              onMouseDown={handleStartButton}
+              onClick={handleStartButton}
               aria-label="Start timer"
               style={{ background: 'none', border: 'none' }}
             >
@@ -1029,7 +1030,8 @@ function Timer({ authUser, darkMode, isPopout }) {
             <button
               type="button"
               disabled={isButtonDisabled}
-              onMouseDown={sendPause}
+              key={'timer-btn-pause'}
+              onClick={sendPause}
               aria-label="Pause timer"
               style={{ background: 'none', border: 'none' }}
             >
@@ -1046,7 +1048,7 @@ function Timer({ authUser, darkMode, isPopout }) {
           <button
             type="button"
             disabled={!started || isButtonDisabled}
-            onMouseDown={handleStopButton}
+            onClick={handleStopButton}
             title="Stop timer and log time"
             aria-label="Stop timer and log time"
             style={{ background: 'none', border: 'none' }}

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -325,7 +325,7 @@ function Timer({ authUser, darkMode, isPopout }) {
     if (viewingUserId == null) {
       return {
         sendStart: () => sendJsonMessageNoQueue({ action: action.START_TIMER }),
-        sendPause: () => sendJsonMessageNoQueue({ action: action.PAUSE_TIMER }),
+        sendPause: () => sendJsonMessageNoQueue({ action: action.PAUSE_TIMER }, false),
         sendClear: () => sendJsonMessageNoQueue({ action: action.CLEAR_TIMER }),
         sendStop: () => {
           sendJsonMessageNoQueue({ action: action.STOP_TIMER });
@@ -1008,7 +1008,7 @@ function Timer({ authUser, darkMode, isPopout }) {
             <button
               type="button"
               disabled={isButtonDisabled}
-              onClick={handleStartButton}
+              onMouseDown={handleStartButton}
               aria-label="Start timer"
               style={{ background: 'none', border: 'none' }}
             >
@@ -1029,7 +1029,7 @@ function Timer({ authUser, darkMode, isPopout }) {
             <button
               type="button"
               disabled={isButtonDisabled}
-              onClick={sendPause}
+              onMouseDown={sendPause}
               aria-label="Pause timer"
               style={{ background: 'none', border: 'none' }}
             >
@@ -1046,7 +1046,7 @@ function Timer({ authUser, darkMode, isPopout }) {
           <button
             type="button"
             disabled={!started || isButtonDisabled}
-            onClick={handleStopButton}
+            onMouseDown={handleStopButton}
             title="Stop timer and log time"
             aria-label="Stop timer and log time"
             style={{ background: 'none', border: 'none' }}

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -1004,47 +1004,44 @@ function Timer({ authUser, darkMode, isPopout }) {
               />
             </div>
           </button>
-          {!started || paused ? (
-            <button
-              key={'timer-btn-start'}
-              type="button"
-              disabled={isButtonDisabled}
-              onClick={handleStartButton}
-              aria-label="Start timer"
-              style={{ background: 'none', border: 'none' }}
+          <button
+            key="persistent-timer-toggle-btn"
+            type="button"
+            disabled={isButtonDisabled}
+            onClick={e => {
+              console.log('DEBUG Clicked', e.target);
+              e.preventDefault();
+              e.stopPropagation();
+              if (!started || paused) {
+                handleStartButton();
+                console.log('DEBUG Start');
+              } else {
+                sendPause();
+                console.log('DEBUG Pause');
+              }
+            }}
+            aria-label={!started || paused ? 'Start timer' : 'Pause timer'}
+            style={{ background: 'none', border: 'none' }}
+          >
+            <div
+              className={cs(
+                css.iconWrapper,
+                isButtonDisabled ? css.btnDisabled : css.transitionColor,
+              )}
+              style={{ pointerEvents: 'none' }}
             >
-              <div
-                className={cs(
-                  css.iconWrapper,
-                  isButtonDisabled ? css.btnDisabled : css.transitionColor,
-                )}
-              >
+              {/* Only the inner visual icon changes, leaving the parent button completely untouched */}
+              {!started || paused ? (
                 <FaPlayCircle
                   className={remaining !== 0 ? css.btn : css.btnDisabled}
                   fontSize="1.5rem"
                   title="Start timer"
                 />
-              </div>
-            </button>
-          ) : (
-            <button
-              type="button"
-              disabled={isButtonDisabled}
-              key={'timer-btn-pause'}
-              onClick={sendPause}
-              aria-label="Pause timer"
-              style={{ background: 'none', border: 'none' }}
-            >
-              <div
-                className={cs(
-                  css.iconWrapper,
-                  isButtonDisabled ? css.btnDisabled : css.transitionColor,
-                )}
-              >
+              ) : (
                 <FaPauseCircle className={css.btn} fontSize="1.5rem" title="Pause timer" />
-              </div>
-            </button>
-          )}
+              )}
+            </div>
+          </button>
           <button
             type="button"
             disabled={!started || isButtonDisabled}

--- a/src/components/Timer/Timer.jsx
+++ b/src/components/Timer/Timer.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable jsx-a11y/media-has-caption */
+import { setUser } from '@sentry/browser';
 import cs from 'classnames';
 import moment from 'moment';
 import PropTypes from 'prop-types';
@@ -126,6 +127,10 @@ function Timer({ authUser, darkMode, isPopout }) {
   const timeToLog = moment.duration(goal - remaining);
   const logHours = timeToLog.hours();
   const logMinutes = timeToLog.minutes();
+
+  // Handle visual race conditions for the timer start and pause buttons
+  const [userIntent, setUserIntent] = useState(null); // Tracks 'START' or 'PAUSE' locally
+  const isCurrentlyPaused = userIntent ? userIntent === 'PAUSE' : !started || paused;
 
   const sendJsonMessageNoQueue = useCallback(msg => sendJsonMessage(msg, false), [sendMessage]);
 
@@ -324,8 +329,14 @@ function Timer({ authUser, darkMode, isPopout }) {
   const wsJsonMessageHandler = useMemo(() => {
     if (viewingUserId == null) {
       return {
-        sendStart: () => sendJsonMessageNoQueue({ action: action.START_TIMER }),
-        sendPause: () => sendJsonMessageNoQueue({ action: action.PAUSE_TIMER }, false),
+        sendStart: () => {
+          setUserIntent('START');
+          sendJsonMessageNoQueue({ action: action.START_TIMER });
+        },
+        sendPause: () => {
+          setUserIntent('PAUSE');
+          sendJsonMessageNoQueue({ action: action.PAUSE_TIMER });
+        },
         sendClear: () => sendJsonMessageNoQueue({ action: action.CLEAR_TIMER }),
         sendStop: () => {
           sendJsonMessageNoQueue({ action: action.STOP_TIMER });
@@ -346,10 +357,14 @@ function Timer({ authUser, darkMode, isPopout }) {
       };
     }
     return {
-      sendStart: () =>
-        sendJsonMessageNoQueue({ action: action.START_TIMER, userId: viewingUserId }),
-      sendPause: () =>
-        sendJsonMessageNoQueue({ action: action.PAUSE_TIMER, userId: viewingUserId }),
+      sendStart: () => {
+        setUserIntent('START');
+        sendJsonMessageNoQueue({ action: action.START_TIMER, userId: viewingUserId });
+      },
+      sendPause: () => {
+        setUserIntent('PAUSE');
+        sendJsonMessageNoQueue({ action: action.PAUSE_TIMER, userId: viewingUserId });
+      },
       sendClear: () =>
         sendJsonMessageNoQueue({ action: action.CLEAR_TIMER, userId: viewingUserId }),
       sendStop: () => {
@@ -565,7 +580,19 @@ function Timer({ authUser, darkMode, isPopout }) {
     } = lastJsonMessage || defaultMessage;
 
     setMessage(lastJsonMessage || defaultMessage);
-    setRunning(startedLJM && !pausedLJM);
+    // Clear our visual intent lock the exact moment the server catches up
+    if (userIntent === 'START' && startedLJM && !pausedLJM) {
+      setUserIntent(null);
+    } else if (userIntent === 'PAUSE' && pausedLJM) {
+      setUserIntent(null);
+    }
+
+    // Keep the running flag synced, favoring local user clicks over in-flight frames
+    if (userIntent !== null) {
+      setRunning(userIntent === 'START');
+    } else {
+      setRunning(startedLJM && !pausedLJM);
+    }
 
     // Show inactivity or time-over modals based on message state
     setInacModal(forcedPauseLJM);
@@ -1004,44 +1031,45 @@ function Timer({ authUser, darkMode, isPopout }) {
               />
             </div>
           </button>
-          <button
-            key="persistent-timer-toggle-btn"
-            type="button"
-            disabled={isButtonDisabled}
-            onClick={e => {
-              console.log('DEBUG Clicked', e.target);
-              e.preventDefault();
-              e.stopPropagation();
-              if (!started || paused) {
-                handleStartButton();
-                console.log('DEBUG Start');
-              } else {
-                sendPause();
-                console.log('DEBUG Pause');
-              }
-            }}
-            aria-label={!started || paused ? 'Start timer' : 'Pause timer'}
-            style={{ background: 'none', border: 'none' }}
-          >
-            <div
-              className={cs(
-                css.iconWrapper,
-                isButtonDisabled ? css.btnDisabled : css.transitionColor,
-              )}
-              style={{ pointerEvents: 'none' }}
+          {isCurrentlyPaused ? (
+            <button
+              type="button"
+              disabled={isButtonDisabled}
+              onClick={handleStartButton}
+              aria-label="Start timer"
+              style={{ background: 'none', border: 'none' }}
             >
-              {/* Only the inner visual icon changes, leaving the parent button completely untouched */}
-              {!started || paused ? (
+              <div
+                className={cs(
+                  css.iconWrapper,
+                  isButtonDisabled ? css.btnDisabled : css.transitionColor,
+                )}
+              >
                 <FaPlayCircle
                   className={remaining !== 0 ? css.btn : css.btnDisabled}
                   fontSize="1.5rem"
                   title="Start timer"
                 />
-              ) : (
+              </div>
+            </button>
+          ) : (
+            <button
+              type="button"
+              disabled={isButtonDisabled}
+              onClick={sendPause}
+              aria-label="Pause timer"
+              style={{ background: 'none', border: 'none' }}
+            >
+              <div
+                className={cs(
+                  css.iconWrapper,
+                  isButtonDisabled ? css.btnDisabled : css.transitionColor,
+                )}
+              >
                 <FaPauseCircle className={css.btn} fontSize="1.5rem" title="Pause timer" />
-              )}
-            </div>
-          </button>
+              </div>
+            </button>
+          )}
           <button
             type="button"
             disabled={!started || isButtonDisabled}


### PR DESCRIPTION
# Description
Fixes issues with the start and pause timer buttons requiring multiple clicks to register in Firefox. See the video attached below.

https://github.com/user-attachments/assets/1fae8efd-38b1-4466-9e70-d949d871dde9



## Related PRS (if any):
Frontend only fixes. Builds off the work of #5275.
…

## Main changes explained:
Added some extra local state to indicate the current user intent i.e. start or pause to aid in updating the button visually when websocket packets are delayed or there is a race condition between them coming in and the local state updating to reflect changes.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as any user
5. Click on the the start button after the page has loaded fully. It should immediately respond to the click and change to a pause state alongside triggering a backend req to start the timer.
6. Click on the pause button once and it should also immediately respond to the click and change back to play alongside pausing backend timer. 
7.  Try different durations between starting the pause and play and also frequencies of pause and play to see if responds quickly without requiring multiple clicks.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/246f27f3-f743-4028-a0ab-5aa865960099

