### PR TITLE
Ansh - 🔥 restore Total Org Summary access

### DIFF
--- a/src/components/TotalOrgSummary/AccordianWrapper/AccordianWrapper.jsx
+++ b/src/components/TotalOrgSummary/AccordianWrapper/AccordianWrapper.jsx
@@ -1,6 +1,6 @@
 import Collapsible from 'react-collapsible';
 import { useSelector } from 'react-redux';
-import './AccordianWrapper.module.css';
+import styles from './AccordianWrapper.module.css';
 
 export default function AccordianWrapper({ children, title }) {
   const darkMode = useSelector(state => state.theme.darkMode);


### PR DESCRIPTION
# Description

Total Org Summary was crashing on load because `AccordianWrapper.jsx` referenced `styles['accordion-wrapper']` without importing the CSS module as `styles`.

This hotfix updates the CSS module import so the accordion component renders correctly.

## Root Cause

PR #4040 introduced the `styles['accordion-wrapper']` reference in `AccordianWrapper.jsx` without defining/importing `styles`, causing:

`ReferenceError: styles is not defined`

## How to test

1. Run the frontend locally.
2. Log in as an admin.
3. Navigate to Total Org Summary.
4. Verify the page no longer crashes with `styles is not defined`.
5. Verify the accordion sections render normally.

## Related backend fix

A separate HGNRest PR handles a backend stats aggregation issue discovered while testing this page.