### PR TITLE
Jaden: Fix Community Members list filtering, sorting, and search (follow-up to #4281) (DONE Jaden)

### DIFF
--- a/src/components/HGNHelpSkillsDashboard/CommunityMembersPage.jsx
+++ b/src/components/HGNHelpSkillsDashboard/CommunityMembersPage.jsx
@@ -12,11 +12,9 @@ function CommunityMembersPage() {
   const [selectedSkills, setSelectedSkills] = useState(location.state?.initialSkills || []);
   const [selectedPreferences, setSelectedPreferences] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState('name');
   const [sortOrder, setSortOrder] = useState('asc');
   const darkMode = useSelector(state => state.theme.darkMode);
 
-  const handleSortByChange = event => setSortBy(event.target.value);
   const handleSortOrderChange = event => setSortOrder(event.target.value);
 
   return (
@@ -26,21 +24,8 @@ function CommunityMembersPage() {
       <SearchBar searchQuery={searchQuery} setSearchQuery={setSearchQuery} darkMode={darkMode} />
 
       <div className={styles.toolbar}>
-        <label htmlFor="communitySortBy" className={styles.sortLabel}>
-          Sort by:
-        </label>
-        <select
-          id="communitySortBy"
-          className={styles.sortSelect}
-          value={sortBy}
-          onChange={handleSortByChange}
-        >
-          <option value="name">Name</option>
-          <option value="score">Score</option>
-        </select>
-
         <label htmlFor="communitySortOrder" className={styles.sortLabel}>
-          Order:
+          Sort by name:
         </label>
         <select
           id="communitySortOrder"
@@ -48,8 +33,8 @@ function CommunityMembersPage() {
           value={sortOrder}
           onChange={handleSortOrderChange}
         >
-          <option value="asc">Ascending</option>
-          <option value="desc">Descending</option>
+          <option value="asc">A to Z</option>
+          <option value="desc">Z to A</option>
         </select>
       </div>
 
@@ -74,7 +59,6 @@ function CommunityMembersPage() {
           selectedSkills={selectedSkills}
           selectedPreferences={selectedPreferences}
           searchQuery={searchQuery.trim()}
-          sortBy={sortBy}
           sortOrder={sortOrder}
         />
       </div>

--- a/src/components/HGNHelpSkillsDashboard/RankedUserList.jsx
+++ b/src/components/HGNHelpSkillsDashboard/RankedUserList.jsx
@@ -80,6 +80,8 @@ function RankedUserList({ selectedSkills, selectedPreferences, searchQuery, sort
         const users = Array.isArray(response.data) ? response.data : [];
         setAllUsers(users.map(normalizeUser));
       } catch (err) {
+        // Network/parse failures are surfaced to the user via the error state below;
+        // there is nothing else to recover here.
         setError('Unable to load community members. Please try again later.');
         setAllUsers([]);
       } finally {
@@ -101,9 +103,9 @@ function RankedUserList({ selectedSkills, selectedPreferences, searchQuery, sort
     }
 
     if (selectedPreferences && selectedPreferences.length > 0) {
-      const userPreferences = (user.preferences || []).map(pref => pref.toLowerCase());
+      const userPreferences = new Set((user.preferences || []).map(pref => pref.toLowerCase()));
       const matchesPreferences = selectedPreferences.every(pref =>
-        userPreferences.includes(pref.toLowerCase()),
+        userPreferences.has(pref.toLowerCase()),
       );
       if (!matchesPreferences) return false;
     }

--- a/src/components/HGNHelpSkillsDashboard/RankedUserList.jsx
+++ b/src/components/HGNHelpSkillsDashboard/RankedUserList.jsx
@@ -80,9 +80,8 @@ function RankedUserList({ selectedSkills, selectedPreferences, searchQuery, sort
         const users = Array.isArray(response.data) ? response.data : [];
         setAllUsers(users.map(normalizeUser));
       } catch (err) {
-        // Network/parse failures are surfaced to the user via the error state below;
-        // there is nothing else to recover here.
-        setError('Unable to load community members. Please try again later.');
+        const detail = err.response?.status ? ` (${err.response.status})` : '';
+        setError(`Unable to load community members. Please try again later.${detail}`);
         setAllUsers([]);
       } finally {
         setLoading(false);

--- a/src/components/HGNHelpSkillsDashboard/RankedUserList.jsx
+++ b/src/components/HGNHelpSkillsDashboard/RankedUserList.jsx
@@ -2,6 +2,7 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { ENDPOINTS } from '~/utils/URL';
 import styles from './style/RankedUserList.module.css';
 import UserCard from './UserCard';
 
@@ -62,72 +63,61 @@ const normalizeUser = user => {
   };
 };
 
-function RankedUserList({ selectedSkills, selectedPreferences, searchQuery, sortBy, sortOrder }) {
+function RankedUserList({ selectedSkills, selectedPreferences, searchQuery, sortOrder }) {
   const [allUsers, setAllUsers] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const darkMode = useSelector(state => state.theme.darkMode);
 
+  // Load every community member once, then filter/search/sort on the client so all
+  // skills in the filter list work regardless of the backend's skill-key handling.
   useEffect(() => {
     const fetchUsers = async () => {
       setLoading(true);
+      setError(null);
       try {
-        const params = {};
-        const hasFilters =
-          (selectedSkills && selectedSkills.length > 0) ||
-          (selectedPreferences && selectedPreferences.length > 0) ||
-          (searchQuery && searchQuery.trim().length > 0);
-
-        if (selectedSkills && selectedSkills.length > 0) params.skills = selectedSkills.join(',');
-        if (selectedPreferences && selectedPreferences.length > 0)
-          params.preferences = selectedPreferences.join(',');
-        if (searchQuery && searchQuery.trim().length > 0) params.search = searchQuery.trim();
-
-        const endpoint = hasFilters
-          ? `${process.env.REACT_APP_APIENDPOINT}/hgnform/ranked`
-          : `${process.env.REACT_APP_APIENDPOINT}/hgnHelp/community`;
-
-        if (!hasFilters && sortBy === 'name' && sortOrder) {
-          params.sortOrder = sortOrder;
-        }
-
-        const response = await axios.get(endpoint, {
-          params,
-        });
-        setAllUsers(response.data.map(normalizeUser));
+        const response = await axios.get(ENDPOINTS.HGN_COMMUNITY_MEMBERS);
+        const users = Array.isArray(response.data) ? response.data : [];
+        setAllUsers(users.map(normalizeUser));
       } catch (err) {
-        // error handled silently
+        setError('Unable to load community members. Please try again later.');
+        setAllUsers([]);
       } finally {
         setLoading(false);
       }
     };
 
     fetchUsers();
-  }, [selectedSkills, selectedPreferences, searchQuery, sortOrder]);
+  }, []);
 
-  // Client-side filter by searchQuery on top of API results
-  const filteredUsers = searchQuery
-    ? allUsers.filter(user => {
-        const name = (user.name || '').toLowerCase();
-        const skills = (user.topSkills || []).join(' ').toLowerCase();
-        return (
-          name.includes(searchQuery.toLowerCase()) || skills.includes(searchQuery.toLowerCase())
-        );
-      })
-    : allUsers;
+  const query = searchQuery.trim().toLowerCase();
 
-  const sortedUsers = [...filteredUsers].sort((a, b) => {
-    if (sortBy === 'score') {
-      const scoreA = typeof a.score === 'number' ? a.score : -Infinity;
-      const scoreB = typeof b.score === 'number' ? b.score : -Infinity;
-      if (scoreA < scoreB) return sortOrder === 'desc' ? 1 : -1;
-      if (scoreA > scoreB) return sortOrder === 'desc' ? -1 : 1;
-      const nameA = (a.name || '').toLowerCase();
-      const nameB = (b.name || '').toLowerCase();
-      if (nameA < nameB) return -1;
-      if (nameA > nameB) return 1;
-      return 0;
+  const filteredUsers = allUsers.filter(user => {
+    const userSkills = (user.topSkills || []).map(skill => skill.toLowerCase());
+
+    if (selectedSkills && selectedSkills.length > 0) {
+      const matchesSkills = selectedSkills.every(skill => userSkills.includes(skill.toLowerCase()));
+      if (!matchesSkills) return false;
     }
 
+    if (selectedPreferences && selectedPreferences.length > 0) {
+      const userPreferences = (user.preferences || []).map(pref => pref.toLowerCase());
+      const matchesPreferences = selectedPreferences.every(pref =>
+        userPreferences.includes(pref.toLowerCase()),
+      );
+      if (!matchesPreferences) return false;
+    }
+
+    if (query) {
+      const name = (user.name || '').toLowerCase();
+      const matchesQuery = name.includes(query) || userSkills.some(skill => skill.includes(query));
+      if (!matchesQuery) return false;
+    }
+
+    return true;
+  });
+
+  const sortedUsers = [...filteredUsers].sort((a, b) => {
     const nameA = (a.name || '').toLowerCase();
     const nameB = (b.name || '').toLowerCase();
     if (nameA < nameB) return sortOrder === 'desc' ? 1 : -1;
@@ -135,8 +125,9 @@ function RankedUserList({ selectedSkills, selectedPreferences, searchQuery, sort
     return 0;
   });
 
-  if (loading) return <p className={`${styles.message}`}>Loading ranked users...</p>;
-  if (!sortedUsers.length) return <p className={`${styles.message}`}>No users found.</p>;
+  if (loading) return <p className={`${styles.message}`}>Loading community members...</p>;
+  if (error) return <p className={`${styles.message}`}>{error}</p>;
+  if (!sortedUsers.length) return <p className={`${styles.message}`}>No members found.</p>;
 
   return (
     <div className={darkMode ? `${styles.darkMode}` : ''}>
@@ -155,7 +146,6 @@ RankedUserList.propTypes = {
   selectedSkills: PropTypes.arrayOf(PropTypes.string),
   selectedPreferences: PropTypes.arrayOf(PropTypes.string),
   searchQuery: PropTypes.string,
-  sortBy: PropTypes.string,
   sortOrder: PropTypes.string,
 };
 

--- a/src/components/HGNHelpSkillsDashboard/UserCard.jsx
+++ b/src/components/HGNHelpSkillsDashboard/UserCard.jsx
@@ -39,15 +39,17 @@ function UserCard({ user }) {
       </div>
 
       <div className={`${styles.scoreSkillsWrapper}`}>
-        <div className={`${styles.scoreLine}`}>
-          <span className={`${styles.scoreLabel}`}>Score:</span>
-          <span
-            className={`${styles.scoreValue} ${score >= 5 ? styles.scoreHigh : styles.scoreLow}`}
-          >
-            {score}
-          </span>
-          <span className={`${styles.scoreMax}`}> / 10</span>
-        </div>
+        {typeof score === 'number' && (
+          <div className={`${styles.scoreLine}`}>
+            <span className={`${styles.scoreLabel}`}>Score:</span>
+            <span
+              className={`${styles.scoreValue} ${score >= 5 ? styles.scoreHigh : styles.scoreLow}`}
+            >
+              {score}
+            </span>
+            <span className={`${styles.scoreMax}`}> / 10</span>
+          </div>
+        )}
 
         <div className={`${styles.skillsSection}`}>
           <div className={`${styles.skillsLabel}`}>Top Skills:</div>

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -758,6 +758,7 @@ export const ENDPOINTS = {
 
   // Help Request & Feedback Modal endpoints
   HGN_FORM_RANKED: `${APIEndpoint}/hgnform/ranked`,
+  HGN_COMMUNITY_MEMBERS: `${APIEndpoint}/hgnHelp/community`,
   HELP_REQUEST_CHECK_MODAL: userId => `${APIEndpoint}/helprequest/check-modal/${userId}`,
   FEEDBACK_CLOSE_PERMANENTLY: `${APIEndpoint}/feedback/close-permanently`,
   FEEDBACK_SUBMIT: `${APIEndpoint}/feedback/submit`,


### PR DESCRIPTION
Jaden: Fix Community Members list filtering, sorting, and search (follow-up to #4281) (DONE Jaden)- #5514

<img width="445" height="661" alt="image" src="https://github.com/user-attachments/assets/c3b09d08-f07b-4f81-8685-15269da42630" />

## Description

Follow-up fixes for PR #4281. Addresses reviewer feedback and bugs in the `/hgnhelp/community` page.

### Changes

- **Endpoint config** - replaced the hard-coded `http://localhost:4500` URL with `ENDPOINTS.HGN_COMMUNITY_MEMBERS` from `src/utils/URL.js`, so the page works in every environment (Aditya-gam's comment).
- **Load all members** - the list no longer switches to `/hgnform/ranked` when a filter is active. It fetches the full member list from `/hgnHelp/community` once and does all filtering, searching, and sorting on the client, so no member is excluded by the request and every skill in the filter list works (Aditya-gam's comment).
- **Search** - now matches on member name and skill keywords.
- **Error handling** - fetch failures show a message instead of being silently swallowed; non-array responses are guarded against.
- **Sort** - removed the non-functional Score option (the endpoint returns no score); kept the A-to-Z / Z-to-A name sort.
- **Member card** - hides the Score line when there is no numeric score, instead of rendering `Score: undefined / 10`.

### Known limitation

The three aggregate skills (Frontend/Backend, MERN, Leadership) live on the form's `general` section, which `/hgnHelp/community` does not return, so filtering by those three yields no results. Fixing that needs a backend change in HGNRest and will be a separate PR.

## How to test

1. Check out this branch, `npm install`, run the app.
2. Log in as owner, go to `/hgnhelp/community`.
3. Confirm all members load up front.
4. Search by a member name and by a skill keyword - results update.
5. Toggle skill filters (single and multi-select) - only matching members remain; Clear All resets.
6. Toggle A to Z / Z to A - card order flips.
7. Verify light and dark mode.

## Related PRs

Follow-up to #4281


https://github.com/user-attachments/assets/d0d69cf7-e054-4710-9762-65301b66ff8b