### PR TITLE
Gayatri - fix(job-form-builder): warn on duplicate questions in Add/Append flows (Ticket #8)

### DIFF
--- a/src/components/Collaboration/JobFormbuilder.jsx
+++ b/src/components/Collaboration/JobFormbuilder.jsx
@@ -22,6 +22,7 @@ import {
   normalizeQuestionForApi,
   prepareQuestionClone,
   normalizeLoadedQuestions,
+  isDuplicateQuestion,
 } from './jobFormQuestionUtils';
 
 function JobFormBuilder() {
@@ -308,6 +309,11 @@ function JobFormBuilder() {
     }
 
     const fieldToAdd = normalizeQuestionForApi(newField);
+
+    if (isDuplicateQuestion(fieldToAdd, formFields)) {
+      const confirmAdd = window.confirm('You already have a similar question. Add Anyway?');
+      if (!confirmAdd) return;
+    }
     const updatedFields = [...formFields, fieldToAdd];
     setFormFields(updatedFields);
 

--- a/src/components/Collaboration/QuestionSetManager.jsx
+++ b/src/components/Collaboration/QuestionSetManager.jsx
@@ -7,7 +7,11 @@ import { useSelector } from 'react-redux';
 import { ENDPOINTS } from '../../utils/URL';
 import QuestionEditModal from './QuestionEditModal';
 import styles from './QuestionSetManager.module.css';
-import { buildJobFormRequestor, isFieldRequired } from './jobFormQuestionUtils';
+import {
+  buildJobFormRequestor,
+  isFieldRequired,
+  findDuplicateQuestions,
+} from './jobFormQuestionUtils';
 
 function QuestionSetManager({ formFields, setFormFields, onImportQuestions, darkMode = false }) {
   const { auth } = useSelector(state => state);
@@ -247,14 +251,29 @@ function QuestionSetManager({ formFields, setFormFields, onImportQuestions, dark
 
       if (template) {
         // Check if template has _id (server template) or not (local template)
+        let newQuestions;
         if (template._id) {
           // Get template fields for appending from the server
           const templateData = await api.getTemplateById(template._id);
-          onImportQuestions([...formFields, ...templateData.fields]);
+          newQuestions = templateData.fields;
         } else {
           // Use the local template directly
-          onImportQuestions([...formFields, ...template.fields]);
+          newQuestions = template.fields;
         }
+
+        const duplicates = findDuplicateQuestions(newQuestions, formFields);
+        let questionsToAppend = newQuestions;
+
+        if (duplicates.length > 0) {
+          const confirmAdd = window.confirm(
+            `${duplicates.length} question(s) in this template appear similar to questions you already have. Add Anyway?`,
+          );
+          if (!confirmAdd) {
+            questionsToAppend = newQuestions.filter(q => !duplicates.includes(q));
+          }
+        }
+
+        onImportQuestions([...formFields, ...questionsToAppend]);
 
         alert(`Template "${selectedTemplate}" appended successfully!`);
       }

--- a/src/components/Collaboration/__tests__/jobFormQuestionUtils.duplicateDetection.test.js
+++ b/src/components/Collaboration/__tests__/jobFormQuestionUtils.duplicateDetection.test.js
@@ -1,0 +1,109 @@
+import {
+  normalizeQuestionText,
+  isDuplicateQuestion,
+  findDuplicateQuestions,
+} from '../jobFormQuestionUtils';
+
+describe('normalizeQuestionText', () => {
+  it('trims leading and trailing whitespace', () => {
+    expect(normalizeQuestionText('  What is your name?  ')).toBe('what is your name');
+  });
+
+  it('collapses internal whitespace', () => {
+    expect(normalizeQuestionText('What   is    your name?')).toBe('what is your name');
+  });
+
+  it('lowercases the text', () => {
+    expect(normalizeQuestionText('WHAT IS YOUR NAME?')).toBe('what is your name');
+  });
+
+  it('strips trailing punctuation', () => {
+    expect(normalizeQuestionText('What is your name???')).toBe('what is your name');
+    expect(normalizeQuestionText('What is your name.')).toBe('what is your name');
+    expect(normalizeQuestionText('What is your name;')).toBe('what is your name');
+  });
+
+  it('returns empty string for null/undefined/empty input', () => {
+    expect(normalizeQuestionText(null)).toBe('');
+    expect(normalizeQuestionText(undefined)).toBe('');
+    expect(normalizeQuestionText('')).toBe('');
+  });
+});
+
+describe('isDuplicateQuestion', () => {
+  const existingFields = [
+    { questionText: 'What is your favorite color?' },
+    { questionText: 'How many years of experience do you have?' },
+  ];
+
+  it('returns true for an exact match', () => {
+    const candidate = { questionText: 'What is your favorite color?' };
+    expect(isDuplicateQuestion(candidate, existingFields)).toBe(true);
+  });
+
+  it('returns true for a near-exact match (different casing/spacing/punctuation)', () => {
+    const candidate = { questionText: '  what IS your   favorite color??  ' };
+    expect(isDuplicateQuestion(candidate, existingFields)).toBe(true);
+  });
+
+  it('returns false when the question is genuinely new', () => {
+    const candidate = { questionText: 'What is your greatest weakness?' };
+    expect(isDuplicateQuestion(candidate, existingFields)).toBe(false);
+  });
+
+  it('returns false when candidate text is empty', () => {
+    const candidate = { questionText: '' };
+    expect(isDuplicateQuestion(candidate, existingFields)).toBe(false);
+  });
+
+  it('returns false when existingFields is empty', () => {
+    const candidate = { questionText: 'What is your favorite color?' };
+    expect(isDuplicateQuestion(candidate, [])).toBe(false);
+  });
+
+  it('supports fields using the label property instead of questionText', () => {
+    const fieldsWithLabel = [{ label: 'What is your favorite color?' }];
+    const candidate = { label: 'What is your favorite color?' };
+    expect(isDuplicateQuestion(candidate, fieldsWithLabel)).toBe(true);
+  });
+});
+
+describe('findDuplicateQuestions', () => {
+  const existingFields = [{ questionText: 'What is your favorite color?' }];
+
+  it('returns only the candidates that duplicate existing fields', () => {
+    const candidates = [
+      { questionText: 'What is your favorite color?' }, // duplicate
+      { questionText: 'What is your dream job?' }, // new
+    ];
+    const result = findDuplicateQuestions(candidates, existingFields);
+    expect(result).toHaveLength(1);
+    expect(result[0].questionText).toBe('What is your favorite color?');
+  });
+
+  it('returns an empty array when there are no duplicates', () => {
+    const candidates = [
+      { questionText: 'What is your dream job?' },
+      { questionText: 'Why do you want to work here?' },
+    ];
+    expect(findDuplicateQuestions(candidates, existingFields)).toEqual([]);
+  });
+
+  it('detects duplicates within the candidate batch itself', () => {
+    const candidates = [
+      { questionText: 'What is your dream job?' },
+      { questionText: 'what is your DREAM job???' }, // duplicate of the one above
+    ];
+    const result = findDuplicateQuestions(candidates, []);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns an empty array when candidates is empty', () => {
+    expect(findDuplicateQuestions([], existingFields)).toEqual([]);
+  });
+
+  it('returns an empty array when existingFields is empty and no internal duplicates', () => {
+    const candidates = [{ questionText: 'A' }, { questionText: 'B' }];
+    expect(findDuplicateQuestions(candidates, [])).toEqual([]);
+  });
+});

--- a/src/components/Collaboration/jobFormQuestionUtils.js
+++ b/src/components/Collaboration/jobFormQuestionUtils.js
@@ -68,3 +68,52 @@ export function normalizeLoadedQuestions(questions = []) {
     };
   });
 }
+
+/**
+ * Normalize question text for duplicate comparison: trim, collapse
+ * internal whitespace, lowercase, and strip trailing punctuation.
+ */
+export function normalizeQuestionText(text) {
+  return String(text || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/[.,!?;:]+$/, '');
+}
+
+/**
+ * Returns true if a question with matching (normalized) text already
+ * exists in existingFields. Pure function, safe to unit test standalone.
+ */
+export function isDuplicateQuestion(candidate, existingFields = []) {
+  const candidateText = normalizeQuestionText(candidate?.questionText || candidate?.label);
+  if (!candidateText) return false;
+  return existingFields.some(
+    field => normalizeQuestionText(field?.questionText || field?.label) === candidateText,
+  );
+}
+
+/**
+ * Given a batch of candidate questions (e.g. from a template being
+ * appended) and the current form fields, returns the subset of candidates
+ * that look like duplicates — either against existingFields or against
+ * an earlier candidate in the same batch.
+ */
+export function findDuplicateQuestions(candidates = [], existingFields = []) {
+  const seen = new Set(
+    existingFields
+      .map(field => normalizeQuestionText(field?.questionText || field?.label))
+      .filter(Boolean),
+  );
+  const duplicates = [];
+  candidates.forEach(candidate => {
+    const text = normalizeQuestionText(candidate?.questionText || candidate?.label);
+    if (!text) return;
+    if (seen.has(text)) {
+      duplicates.push(candidate);
+    } else {
+      seen.add(text);
+    }
+  });
+  return duplicates;
+}


### PR DESCRIPTION
# Description
<img width="396" height="417" alt="Screenshot 2026-09-17 at 12 54 06 AM" src="https://github.com/user-attachments/assets/228ddd1b-8c77-4c2f-885a-912ea2fce320" />

Fixes # 8 (bug list priority medium — Application/Job Posting Page: Application Form Template — Handle Duplicate Questions Gracefully)

In the /jobformbuilder template builder, the form allowed multiple identical questions to be added without any warning, which could lead to cluttered forms and duplicate data — both via the "Add Question" flow and the "Append Template" flow.

This PR implements soft validation: when a duplicate (or near-duplicate) question is detected, the user sees a warning and can choose to proceed anyway or cancel. If there's no duplicate, the question is added normally with no extra prompt.

Related PRs (if any):
None. This is a standalone frontend change — no backend changes required.

 Main changes explained:
- Update `jobFormQuestionUtils.js` — added `normalizeQuestionText` (trims, collapses whitespace, lowercases, strips trailing punctuation for comparison), `isDuplicateQuestion` (checks a single candidate against existing fields), and `findDuplicateQuestions` (checks a batch of candidates against existing fields and against each other, for the template-append case).
- Update `JobFormbuilder.jsx` — the "Add Question" handler now calls `isDuplicateQuestion` before adding a new field; if a match is found, shows `window.confirm("You already have a similar question. Add Anyway?")`; cancelling aborts the add, confirming proceeds as normal.
- Update `QuestionSetManager.jsx` — the "Append Template" handler now calls `findDuplicateQuestions` against the current form fields before merging in a template's questions; if any overlaps are found, shows a count-based confirm dialog; declining filters out only the overlapping questions while still appending the non-overlapping ones, confirming appends everything.
- Create `jobFormQuestionUtils.duplicateDetection.test.js` — 16 unit tests covering `isDuplicateQuestion` and `findDuplicateQuestions` as pure functions (exact matches, case/whitespace/punctuation variants, empty inputs, batch-internal duplicates).

 How to test:
1. Check out this branch: `gayatri/job-form-duplicate-question-warning`
2. `npm install` (or `yarn`), then run the frontend dev server as usual
3. Log in as a user with job-form management permissions
4. Go to `/jobformbuilder`
5. Test unique add: In "Field Label," type a brand-new question and click Add Field → it should be added instantly, no popup
6. Test duplicate warning (Add Question): Add the same question text again → confirm dialog appears: "You already have a similar question. Add Anyway?"
   - Click Cancel → question is not added, form unchanged
   - Repeat and click OK → question is added as a duplicate entry
7. Test duplicate warning (Append Template):Save the current question set as a template, then remove one of its fields from the live form, then click "Append Template" and select that template → confirm dialog appears showing a count of overlapping questions
   - Cancel → only the non-overlapping questions from the template get merged in, overlapping ones are skipped
   - OK → all questions (including duplicates) get merged in
8. Run unit tests: `npx vitest src/components/Collaboration/__tests__/jobFormQuestionUtils.duplicateDetection.test.js` → 16/16 should pass

 Screenshots or videos of changes:

 Note:
No backend changes were needed — duplicate detection is purely a frontend/client-side soft-validation feature, matching the original ticket's expected outcome ("never fully block adding a question").