### PR TITLE
Amaresh: Fix Team Code filter and pie tooltip dark mode display on PR Insights

### DIFF
--- a/src/components/PRAnalyticsDashboard/ReviewsInsight/ActionDoneGraph.jsx
+++ b/src/components/PRAnalyticsDashboard/ReviewsInsight/ActionDoneGraph.jsx
@@ -43,6 +43,10 @@ function ActionDoneGraph({ selectedTeams, teamData, orderedTeamIds }) {
     responsive: true,
     maintainAspectRatio: false,
     plugins: {
+      // ProjectStatus.jsx registers a "centerText" plugin globally, so it draws
+      // "Total Projects / 0" on top of every chart.js chart app-wide. Opt this
+      // chart out (chart.js skips a plugin whose options key is literally false).
+      centerText: false,
       legend: {
         display: true,
         labels: {
@@ -135,7 +139,9 @@ function ActionDoneGraph({ selectedTeams, teamData, orderedTeamIds }) {
             <br />
             Changes Requested: Reviewer requested changes before approval <br />
             <br />
-            Commented: Reviewer left comments but did not approve or request changes
+            Commented: Reviewer left comments but did not approve or request changes <br />
+            <br />
+            The circled number after each team code is that team&apos;s member count.
           </span>
         </span>
       </h2>

--- a/src/components/PRAnalyticsDashboard/ReviewsInsight/PRQualityGraph.jsx
+++ b/src/components/PRAnalyticsDashboard/ReviewsInsight/PRQualityGraph.jsx
@@ -71,7 +71,7 @@ function PRQualityGraph({ selectedTeams, qualityData, isDataViewActive, orderedT
         enabled: true,
         callbacks: {
           // Heading: the chart's own title ("PR Quality Distribution for <team>").
-          title: items => (items && items[0] && items[0].dataset ? items[0].dataset.label : ''),
+          title: items => items?.[0]?.dataset?.label ?? '',
           // Colour-key line: the hovered slice's category and its value
           // ("Sufficient: 1", or "Sufficient: 33.3%" in the percentage view).
           label: ctx => {

--- a/src/components/PRAnalyticsDashboard/ReviewsInsight/PRQualityGraph.jsx
+++ b/src/components/PRAnalyticsDashboard/ReviewsInsight/PRQualityGraph.jsx
@@ -50,9 +50,16 @@ function PRQualityGraph({ selectedTeams, qualityData, isDataViewActive, orderedT
   const options = {
     responsive: true,
     interaction: {
-      mode: 'dataset',
+      // Per-slice hover so the tooltip describes the single slice under the
+      // cursor, not the whole dataset.
+      mode: 'nearest',
+      intersect: true,
     },
     plugins: {
+      // ProjectStatus.jsx registers a "centerText" plugin globally, so it draws
+      // "Total Projects / 0" on top of every chart.js chart app-wide. Opt this
+      // chart out (chart.js skips a plugin whose options key is literally false).
+      centerText: false,
       legend: {
         position: 'bottom',
         labels: {
@@ -60,16 +67,17 @@ function PRQualityGraph({ selectedTeams, qualityData, isDataViewActive, orderedT
           color: darkMode ? '#fff' : '#333',
         },
       },
-      // tooltip: {
-      //   enabled: true,
-      // },
       tooltip: {
-        displayColors: false,
         enabled: true,
         callbacks: {
-          title: items =>
-            items && items[0] ? `${items[0].label}: ${items[0].formattedValue}` : '',
-          label: ctx => (isDataViewActive ? `${ctx.raw.toFixed(1)}%` : ctx.raw),
+          // Heading: the chart's own title ("PR Quality Distribution for <team>").
+          title: items => (items && items[0] && items[0].dataset ? items[0].dataset.label : ''),
+          // Colour-key line: the hovered slice's category and its value
+          // ("Sufficient: 1", or "Sufficient: 33.3%" in the percentage view).
+          label: ctx => {
+            const value = isDataViewActive ? `${Number(ctx.raw).toFixed(1)}%` : ctx.raw;
+            return `${ctx.label}: ${value}`;
+          },
         },
       },
       datalabels: {

--- a/src/components/PRAnalyticsDashboard/ReviewsInsight/ReviewsInsight.jsx
+++ b/src/components/PRAnalyticsDashboard/ReviewsInsight/ReviewsInsight.jsx
@@ -7,6 +7,62 @@ import ActionDoneGraph from './ActionDoneGraph';
 import PRQualityGraph from './PRQualityGraph';
 import sharedStyles from './ReviewsInsight.module.css';
 
+// Dark-mode styling for the Team Code <Select>. Light mode keeps react-select's
+// own defaults (`base.*`); only colours change under dark mode. Shared helpers
+// keep the repeated element shapes to a single definition each.
+const getTeamSelectStyles = darkMode => {
+  const surface = darkMode ? '#1c2541' : '#fff';
+  const fg = darkMode ? '#f1f1f1' : '#000';
+
+  const dmText = base => ({ ...base, color: darkMode ? '#f1f1f1' : base.color });
+  const dmIndicator = base => ({
+    ...base,
+    color: darkMode ? '#b8c1d9' : base.color,
+    ':hover': { color: darkMode ? '#f1f1f1' : base.color },
+  });
+
+  return {
+    control: base => ({
+      ...base,
+      backgroundColor: surface,
+      boxShadow: '2px 2px 4px 1px black',
+      border: 'none',
+      color: fg,
+      minHeight: '40px',
+    }),
+    menu: base => ({ ...base, backgroundColor: surface, color: fg }),
+    menuList: base => ({ ...base, backgroundColor: surface, color: fg }),
+    option: (base, state) => {
+      let optionBg = surface;
+      if (state.isFocused) optionBg = darkMode ? '#23304d' : '#e6e6e6';
+      return { ...base, backgroundColor: optionBg, color: fg, cursor: 'pointer' };
+    },
+    // Selected-team chips: without these, react-select's default light grey chip
+    // stays light in dark mode.
+    multiValue: base => ({
+      ...base,
+      backgroundColor: darkMode ? '#334155' : base.backgroundColor,
+    }),
+    multiValueLabel: dmText,
+    multiValueRemove: base => ({
+      ...base,
+      color: darkMode ? '#f1f1f1' : base.color,
+      ':hover': {
+        backgroundColor: darkMode ? '#48597e' : '#ffbdad',
+        color: darkMode ? '#fff' : '#de350b',
+      },
+    }),
+    placeholder: base => ({ ...base, color: darkMode ? '#b8c1d9' : base.color }),
+    input: dmText,
+    indicatorSeparator: base => ({
+      ...base,
+      backgroundColor: darkMode ? '#48597e' : base.backgroundColor,
+    }),
+    dropdownIndicator: dmIndicator,
+    clearIndicator: dmIndicator,
+  };
+};
+
 function ReviewsInsight() {
   const [duration, setDuration] = useState('Last Week');
   const [selectedTeams, setSelectedTeams] = useState([{ value: 'All', label: 'All Teams' }]);
@@ -132,89 +188,7 @@ function ReviewsInsight() {
             onChange={handleTeamChange}
             placeholder="Search and select teams..."
             classNamePrefix="react-select"
-            styles={{
-              control: base => ({
-                ...base,
-                backgroundColor: darkMode ? '#1c2541' : '#fff',
-                boxShadow: '2px 2px 4px 1px black',
-                border: 'none',
-                color: darkMode ? '#f1f1f1' : '#000',
-                minHeight: '40px',
-              }),
-
-              menu: base => ({
-                ...base,
-                backgroundColor: darkMode ? '#1c2541' : '#fff',
-                color: darkMode ? '#f1f1f1' : '#000',
-              }),
-
-              menuList: base => ({
-                ...base,
-                backgroundColor: darkMode ? '#1c2541' : '#fff',
-                color: darkMode ? '#f1f1f1' : '#000',
-              }),
-
-              option: (base, state) => ({
-                ...base,
-                backgroundColor: state.isFocused
-                  ? darkMode
-                    ? '#23304d'
-                    : '#e6e6e6'
-                  : darkMode
-                  ? '#1c2541'
-                  : '#fff',
-                color: darkMode ? '#f1f1f1' : '#000',
-                cursor: 'pointer',
-              }),
-
-              // Selected-team chips: without these, react-select's default light
-              // grey chip stays light in dark mode.
-              multiValue: base => ({
-                ...base,
-                backgroundColor: darkMode ? '#334155' : base.backgroundColor,
-              }),
-
-              multiValueLabel: base => ({
-                ...base,
-                color: darkMode ? '#f1f1f1' : base.color,
-              }),
-
-              multiValueRemove: base => ({
-                ...base,
-                color: darkMode ? '#f1f1f1' : base.color,
-                ':hover': {
-                  backgroundColor: darkMode ? '#48597e' : '#ffbdad',
-                  color: darkMode ? '#fff' : '#de350b',
-                },
-              }),
-
-              placeholder: base => ({
-                ...base,
-                color: darkMode ? '#b8c1d9' : base.color,
-              }),
-
-              input: base => ({
-                ...base,
-                color: darkMode ? '#f1f1f1' : base.color,
-              }),
-
-              indicatorSeparator: base => ({
-                ...base,
-                backgroundColor: darkMode ? '#48597e' : base.backgroundColor,
-              }),
-
-              dropdownIndicator: base => ({
-                ...base,
-                color: darkMode ? '#b8c1d9' : base.color,
-                ':hover': { color: darkMode ? '#f1f1f1' : base.color },
-              }),
-
-              clearIndicator: base => ({
-                ...base,
-                color: darkMode ? '#b8c1d9' : base.color,
-                ':hover': { color: darkMode ? '#f1f1f1' : base.color },
-              }),
-            }}
+            styles={getTeamSelectStyles(darkMode)}
           />
         </div>
 

--- a/src/components/PRAnalyticsDashboard/ReviewsInsight/ReviewsInsight.jsx
+++ b/src/components/PRAnalyticsDashboard/ReviewsInsight/ReviewsInsight.jsx
@@ -166,6 +166,54 @@ function ReviewsInsight() {
                 color: darkMode ? '#f1f1f1' : '#000',
                 cursor: 'pointer',
               }),
+
+              // Selected-team chips: without these, react-select's default light
+              // grey chip stays light in dark mode.
+              multiValue: base => ({
+                ...base,
+                backgroundColor: darkMode ? '#334155' : base.backgroundColor,
+              }),
+
+              multiValueLabel: base => ({
+                ...base,
+                color: darkMode ? '#f1f1f1' : base.color,
+              }),
+
+              multiValueRemove: base => ({
+                ...base,
+                color: darkMode ? '#f1f1f1' : base.color,
+                ':hover': {
+                  backgroundColor: darkMode ? '#48597e' : '#ffbdad',
+                  color: darkMode ? '#fff' : '#de350b',
+                },
+              }),
+
+              placeholder: base => ({
+                ...base,
+                color: darkMode ? '#b8c1d9' : base.color,
+              }),
+
+              input: base => ({
+                ...base,
+                color: darkMode ? '#f1f1f1' : base.color,
+              }),
+
+              indicatorSeparator: base => ({
+                ...base,
+                backgroundColor: darkMode ? '#48597e' : base.backgroundColor,
+              }),
+
+              dropdownIndicator: base => ({
+                ...base,
+                color: darkMode ? '#b8c1d9' : base.color,
+                ':hover': { color: darkMode ? '#f1f1f1' : base.color },
+              }),
+
+              clearIndicator: base => ({
+                ...base,
+                color: darkMode ? '#b8c1d9' : base.color,
+                ':hover': { color: darkMode ? '#f1f1f1' : base.color },
+              }),
             }}
           />
         </div>


### PR DESCRIPTION
## Description

<img width="820" height="464" alt="Screenshot 2026-09-10 at 1 35 28 PM" src="https://github.com/user-attachments/assets/20526eed-92b3-4fad-a9af-3ebbc0b153d1" />
<img width="818" height="597" alt="Screenshot 2026-09-10 at 1 35 44 PM" src="https://github.com/user-attachments/assets/2815ecfd-6f51-4292-8646-961e824792c5" />

The "Team Code" multi-select filter on the **PR Reviews Insights** page (`/pull-request-analytics/reviews-insight`) does not render correctly in dark mode. The selected-team chips stay light grey with dark text, and the dropdown arrow, clear-all "×", separator, placeholder and typed-input text are all low-contrast against the dark background. This is a follow-up fix for PR #4392, which added this filter but only styled the control/menu/options for dark mode, not the selection chips or indicators.

While fixing this, two more dark-mode rendering problems on the same page were addressed:
- The pie-chart hover tooltip in **PR Quality Distribution** had its heading and colour-key line swapped; the heading showed `Sufficient: 1` and the body showed a bare number, instead of the heading showing `PR Quality Distribution for <team>` and the key line showing `Sufficient: 1`.
- `ProjectStatus.jsx` registers a chart.js `centerText` plugin globally, so its near-black "Total Projects / 0" text was painted on top of both charts on this page, unreadable in dark mode and overlapping the pie.

## Related PRS (if any):
None. This is a frontend-only change; no backend changes are required. It is a follow-up to the already-merged frontend PR #4392.

## Main changes explained:
- **Update `src/components/PRAnalyticsDashboard/ReviewsInsight/ReviewsInsight.jsx`**: added dark-mode `styles` entries to the `<Select>` Team Code filter that were missing: `multiValue` (chip background), `multiValueLabel` (chip text), `multiValueRemove` (chip "×" and its hover), `placeholder`, `input`, `indicatorSeparator`, `dropdownIndicator`, `clearIndicator`. All are gated on `darkMode` and fall back to the react-select defaults in light mode.
- **Update `src/components/PRAnalyticsDashboard/ReviewsInsight/PRQualityGraph.jsx`**: fixed the pie tooltip callbacks: `title` now returns the dataset label (`PR Quality Distribution for <team>`), `label` returns `<category>: <value>` (e.g. `Sufficient: 1`, or `Sufficient: 33.3%` in the PERCENT view). Set `interaction.mode: 'nearest'` + `intersect: true` so the tooltip describes the single hovered slice rather than the whole dataset. Added `plugins.centerText: false` to opt this chart out of the globally-registered plugin.
- **Update `src/components/PRAnalyticsDashboard/ReviewsInsight/ActionDoneGraph.jsx`**: added `plugins.centerText: false` for the same reason, and added one line to the existing info (ℹ️) tooltip explaining that the circled number after each team code is that team's member count.

## How to test:
1. Check out branch `amaresh/fix-pr-insights-team-code-filter-dark-mode`
2. `npm install`, then `npm run start:local` (or `npx vite`)
3. Clear site data / cache
4. Log in as an admin (or any user with PR Dashboard access)
5. Go to **PR Dashboard → PR Reviews Insights** (or navigate directly to `/pull-request-analytics/reviews-insight`)
6. Set **Duration** to "All Time" so the charts have data
7. **Light mode**: confirm the Team Code filter, chips, dropdown/clear icons, and both chart tooltips look exactly as before (no visual change)
8. Enable dark mode and verify:
   - Selected-team chips have a dark slate background with white text; the chip "×" and its hover state are readable
   - The dropdown arrow, clear-all "×", separator bar, placeholder text, and typed search text are all clearly visible
   - Hovering a slice in **PR Quality Distribution** shows a tooltip whose heading is `PR Quality Distribution for <team>` and whose key line is `<category>: <value>` not swapped
   - No black "Total Projects / 0" text appears on top of either the pie or the bar chart
   - Hovering the ℹ️ next to **PR: Action Done** shows the member-count explanation line

## Screenshots or videos of changes:
<img width="1470" height="880" alt="Screenshot 2026-09-10 at 1 45 41 PM" src="https://github.com/user-attachments/assets/ed4e14bf-577c-4e87-8631-906c1572d8a6" />


## Note: