### PR TITLE
Gayatri - fix(job-form-builder): question numbers now follow position on Move Up/Down (Ticket #1)

### DIFF
--- a/src/components/Collaboration/FormPreviewModal.jsx
+++ b/src/components/Collaboration/FormPreviewModal.jsx
@@ -5,6 +5,7 @@ import {
   resolveInputType,
   STANDARD_APPLICANT_FIELDS,
   isFieldRequired,
+  numberedQuestionLabel,
 } from './jobFormQuestionUtils';
 
 /**
@@ -40,7 +41,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
         return (
           <div key={fieldKey} className={styles.previewField}>
             <label className={styles.previewLabel}>
-              {questionText}
+              {numberedQuestionLabel(questionText, index)}
               {requiredMark}
             </label>
             <input
@@ -58,7 +59,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
         return (
           <div key={fieldKey} className={styles.previewField}>
             <label className={styles.previewLabel}>
-              {questionText}
+              {numberedQuestionLabel(questionText, index)}
               {requiredMark}
             </label>
             <textarea placeholder="Enter text here" disabled className={styles.previewTextarea} />
@@ -69,7 +70,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
         return (
           <div key={fieldKey} className={styles.previewField}>
             <label className={styles.previewLabel}>
-              {questionText}
+              {numberedQuestionLabel(questionText, index)}
               {requiredMark}
             </label>
             <input type="date" disabled className={styles.previewInput} />
@@ -80,7 +81,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
         return (
           <div key={fieldKey} className={styles.previewField}>
             <label className={styles.previewLabel}>
-              {questionText}
+              {numberedQuestionLabel(questionText, index)}
               {requiredMark}
             </label>
             <input type="file" disabled className={styles.previewInput} />
@@ -91,7 +92,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
         return (
           <div key={fieldKey} className={styles.previewField}>
             <label className={styles.previewLabel}>
-              {questionText}
+              {numberedQuestionLabel(questionText, index)}
               {requiredMark}
             </label>
             <div className={styles.previewOptions}>
@@ -120,7 +121,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
         return (
           <div key={fieldKey} className={styles.previewField}>
             <label className={styles.previewLabel}>
-              {questionText}
+              {numberedQuestionLabel(questionText, index)}
               {requiredMark}
             </label>
             <div className={styles.previewOptions}>
@@ -150,7 +151,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
         return (
           <div key={fieldKey} className={styles.previewField}>
             <label className={styles.previewLabel}>
-              {questionText}
+              {numberedQuestionLabel(questionText, index)}
               {requiredMark}
             </label>
             <select disabled className={styles.previewSelect}>
@@ -169,7 +170,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
         return (
           <div key={fieldKey} className={styles.previewField}>
             <label className={styles.previewLabel}>
-              {questionText}
+              {numberedQuestionLabel(questionText, index)}
               {requiredMark}
             </label>
             <input

--- a/src/components/Collaboration/FormPreviewModal.jsx
+++ b/src/components/Collaboration/FormPreviewModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styles from './FormPreviewModal.module.css';
 import {
   normalizeQuestionType,
@@ -7,6 +8,31 @@ import {
   isFieldRequired,
   numberedQuestionLabel,
 } from './jobFormQuestionUtils';
+
+/**
+ * Shared label block for preview fields: renders the live position-based
+ * number + question text + required marker. Extracted to avoid repeating
+ * this block across every question-type render case below.
+ */
+function PreviewFieldLabel({ text, index, requiredMark }) {
+  return (
+    <label className={styles.previewLabel}>
+      {numberedQuestionLabel(text, index)}
+      {requiredMark}
+    </label>
+  );
+}
+
+PreviewFieldLabel.propTypes = {
+  text: PropTypes.string,
+  index: PropTypes.number.isRequired,
+  requiredMark: PropTypes.node,
+};
+
+PreviewFieldLabel.defaultProps = {
+  text: '',
+  requiredMark: null,
+};
 
 /**
  * FormPreviewModal Component
@@ -40,10 +66,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
       case 'textbox':
         return (
           <div key={fieldKey} className={styles.previewField}>
-            <label className={styles.previewLabel}>
-              {numberedQuestionLabel(questionText, index)}
-              {requiredMark}
-            </label>
+            <PreviewFieldLabel text={questionText} index={index} requiredMark={requiredMark} />
             <input
               type={resolveInputType(field)}
               placeholder={
@@ -58,10 +81,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
       case 'textarea':
         return (
           <div key={fieldKey} className={styles.previewField}>
-            <label className={styles.previewLabel}>
-              {numberedQuestionLabel(questionText, index)}
-              {requiredMark}
-            </label>
+            <PreviewFieldLabel text={questionText} index={index} requiredMark={requiredMark} />
             <textarea placeholder="Enter text here" disabled className={styles.previewTextarea} />
           </div>
         );
@@ -69,10 +89,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
       case 'date':
         return (
           <div key={fieldKey} className={styles.previewField}>
-            <label className={styles.previewLabel}>
-              {numberedQuestionLabel(questionText, index)}
-              {requiredMark}
-            </label>
+            <PreviewFieldLabel text={questionText} index={index} requiredMark={requiredMark} />
             <input type="date" disabled className={styles.previewInput} />
           </div>
         );
@@ -80,10 +97,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
       case 'file':
         return (
           <div key={fieldKey} className={styles.previewField}>
-            <label className={styles.previewLabel}>
-              {numberedQuestionLabel(questionText, index)}
-              {requiredMark}
-            </label>
+            <PreviewFieldLabel text={questionText} index={index} requiredMark={requiredMark} />
             <input type="file" disabled className={styles.previewInput} />
           </div>
         );
@@ -91,10 +105,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
       case 'checkbox':
         return (
           <div key={fieldKey} className={styles.previewField}>
-            <label className={styles.previewLabel}>
-              {numberedQuestionLabel(questionText, index)}
-              {requiredMark}
-            </label>
+            <PreviewFieldLabel text={questionText} index={index} requiredMark={requiredMark} />
             <div className={styles.previewOptions}>
               {options &&
                 options.map((option, optIdx) => (
@@ -120,10 +131,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
       case 'radio':
         return (
           <div key={fieldKey} className={styles.previewField}>
-            <label className={styles.previewLabel}>
-              {numberedQuestionLabel(questionText, index)}
-              {requiredMark}
-            </label>
+            <PreviewFieldLabel text={questionText} index={index} requiredMark={requiredMark} />
             <div className={styles.previewOptions}>
               {options &&
                 options.map((option, optIdx) => (
@@ -150,10 +158,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
       case 'dropdown':
         return (
           <div key={fieldKey} className={styles.previewField}>
-            <label className={styles.previewLabel}>
-              {numberedQuestionLabel(questionText, index)}
-              {requiredMark}
-            </label>
+            <PreviewFieldLabel text={questionText} index={index} requiredMark={requiredMark} />
             <select disabled className={styles.previewSelect}>
               <option>Select an option</option>
               {options &&
@@ -169,10 +174,7 @@ function FormPreviewModal({ isOpen, onClose, formFields, jobTitle, darkMode }) {
       default:
         return (
           <div key={fieldKey} className={styles.previewField}>
-            <label className={styles.previewLabel}>
-              {numberedQuestionLabel(questionText, index)}
-              {requiredMark}
-            </label>
+            <PreviewFieldLabel text={questionText} index={index} requiredMark={requiredMark} />
             <input
               type="text"
               placeholder="Enter text here"

--- a/src/components/Collaboration/JobFormbuilder.jsx
+++ b/src/components/Collaboration/JobFormbuilder.jsx
@@ -22,6 +22,8 @@ import {
   normalizeQuestionForApi,
   prepareQuestionClone,
   normalizeLoadedQuestions,
+  numberedQuestionLabel,
+  stripLeadingQuestionNumber,
 } from './jobFormQuestionUtils';
 
 function JobFormBuilder() {
@@ -221,7 +223,7 @@ function JobFormBuilder() {
   const editField = (field, index) => {
     // Transform the field structure to match what QuestionEditModal expects
     const questionForEdit = {
-      label: field.questionText,
+      label: stripLeadingQuestionNumber(field.questionText),
       type: field.questionType,
       options: field.options,
       required: isFieldRequired(field),
@@ -483,7 +485,7 @@ function JobFormBuilder() {
                     />
                     <div className={styles.formField}>
                       <label className={`${styles.fieldLabel} ${styles.jbformLabel}`}>
-                        {field.questionText}
+                        {numberedQuestionLabel(field.questionText, index)}
                         {isFieldRequired(field) && (
                           <span className={styles.requiredMark} aria-hidden="true">
                             {' '}

--- a/src/components/Collaboration/__tests__/jobFormQuestionUtils.numbering.test.js
+++ b/src/components/Collaboration/__tests__/jobFormQuestionUtils.numbering.test.js
@@ -1,20 +1,13 @@
 import { stripLeadingQuestionNumber, numberedQuestionLabel } from '../jobFormQuestionUtils';
 
 describe('stripLeadingQuestionNumber', () => {
-  it('strips a "N.)" style prefix', () => {
-    expect(stripLeadingQuestionNumber('13.) What is your name?')).toBe('What is your name?');
-  });
-
-  it('strips a "N." style prefix', () => {
-    expect(stripLeadingQuestionNumber('2. What is your email?')).toBe('What is your email?');
-  });
-
-  it('strips a "N)" style prefix', () => {
-    expect(stripLeadingQuestionNumber('7) What is your role?')).toBe('What is your role?');
-  });
-
-  it('strips a "N-" style prefix', () => {
-    expect(stripLeadingQuestionNumber('4- What is your role?')).toBe('What is your role?');
+  it.each([
+    ['13.) What is your name?', 'What is your name?', '"N.)" style prefix'],
+    ['2. What is your email?', 'What is your email?', '"N." style prefix'],
+    ['7) What is your role?', 'What is your role?', '"N)" style prefix'],
+    ['4- What is your role?', 'What is your role?', '"N-" style prefix'],
+  ])('strips a %s (%s)', (input, expected) => {
+    expect(stripLeadingQuestionNumber(input)).toBe(expected);
   });
 
   it('leaves text without a leading number untouched', () => {

--- a/src/components/Collaboration/__tests__/jobFormQuestionUtils.numbering.test.js
+++ b/src/components/Collaboration/__tests__/jobFormQuestionUtils.numbering.test.js
@@ -1,0 +1,54 @@
+import { stripLeadingQuestionNumber, numberedQuestionLabel } from '../jobFormQuestionUtils';
+
+describe('stripLeadingQuestionNumber', () => {
+  it('strips a "N.)" style prefix', () => {
+    expect(stripLeadingQuestionNumber('13.) What is your name?')).toBe('What is your name?');
+  });
+
+  it('strips a "N." style prefix', () => {
+    expect(stripLeadingQuestionNumber('2. What is your email?')).toBe('What is your email?');
+  });
+
+  it('strips a "N)" style prefix', () => {
+    expect(stripLeadingQuestionNumber('7) What is your role?')).toBe('What is your role?');
+  });
+
+  it('strips a "N-" style prefix', () => {
+    expect(stripLeadingQuestionNumber('4- What is your role?')).toBe('What is your role?');
+  });
+
+  it('leaves text without a leading number untouched', () => {
+    expect(stripLeadingQuestionNumber('What is your name?')).toBe('What is your name?');
+  });
+
+  it('does not strip a number that is not at the very start', () => {
+    expect(stripLeadingQuestionNumber('Question 5 details')).toBe('Question 5 details');
+  });
+
+  it('returns empty string for null/undefined/empty input', () => {
+    expect(stripLeadingQuestionNumber(null)).toBe('');
+    expect(stripLeadingQuestionNumber(undefined)).toBe('');
+    expect(stripLeadingQuestionNumber('')).toBe('');
+  });
+});
+
+describe('numberedQuestionLabel', () => {
+  it('prepends the correct 1-based number for a given index', () => {
+    expect(numberedQuestionLabel('What is your name?', 0)).toBe('1.) What is your name?');
+    expect(numberedQuestionLabel('What is your email?', 4)).toBe('5.) What is your email?');
+  });
+
+  it('replaces a stale embedded number with the live position-based number', () => {
+    // Question was originally 3rd (index 2) but moved to 1st (index 0):
+    // old baked-in "3.)" should be replaced with the correct "1.)"
+    expect(numberedQuestionLabel('3.) What is your name?', 0)).toBe('1.) What is your name?');
+  });
+
+  it('works correctly across a simulated reorder (swap)', () => {
+    const fields = ['1.) Name', '2.) Email', '3.) Phone'];
+    // simulate moving index 2 up to index 0
+    const reordered = [fields[2], fields[0], fields[1]];
+    const labels = reordered.map((text, index) => numberedQuestionLabel(text, index));
+    expect(labels).toEqual(['1.) Phone', '2.) Name', '3.) Email']);
+  });
+});

--- a/src/components/Collaboration/jobFormQuestionUtils.js
+++ b/src/components/Collaboration/jobFormQuestionUtils.js
@@ -68,3 +68,21 @@ export function normalizeLoadedQuestions(questions = []) {
     };
   });
 }
+
+/**
+ * Strip a leading manually-typed number prefix (e.g. "13.)", "2.", "7)")
+ * from question text so the live position-based number (rendered
+ * separately) doesn't end up duplicated or stale after reordering.
+ */
+export function stripLeadingQuestionNumber(text) {
+  return String(text || '').replace(/^\s*\d+\s*[.):-]+\s*/, '');
+}
+
+/**
+ * Build the display label for a question at a given position: strips
+ * any old manually-typed number and prepends the current, correct
+ * position-based number so it always stays in sync after moves.
+ */
+export function numberedQuestionLabel(text, index) {
+  return `${index + 1}.) ${stripLeadingQuestionNumber(text)}`;
+}


### PR DESCRIPTION
# Description
<img width="284" height="690" alt="question" src="https://github.com/user-attachments/assets/5f030c44-8d82-44d6-b1d0-d7e5ce35fba5" />

Fixes # 1 (bug list priority high — Application/Job Posting Page/Function: Followup fixes for permission to create different question sets — specifically the Move Up renumbering issue re-confirmed by Aditya Dubey on Sep 9, 2026)

When clicking the Move Up arrow on a question, the question correctly moved to its new position in the list, but its displayed number stayed attached to the old position instead of recalculating (e.g. resulting in 2,1,3 instead of 1,2,3). The same incorrect numbering was also reflected in the Preview Form.

Root cause: numbers like "3.)" were literal characters manually typed into the question label text (`questionText`) — there was no live, position-based numbering anywhere in the app. Moving a question's array position obviously doesn't rewrite arbitrary text a user typed, so old numbers stayed stuck to the wrong questions after a move.

## Related PRs (if any):
Related to previous PRs #3989, #1685, PR #5103 (reviewer Deepigha's feedback on this issue).

## Main changes explained:
- Update `jobFormQuestionUtils.js` — added `stripLeadingQuestionNumber()` (strips a leading manually-typed number prefix like "13.)", "2.", "7)", "4-") and `numberedQuestionLabel()` (strips any old number and prepends the correct live number based on current array position).
- Update `JobFormbuilder.jsx` — the question list now renders `numberedQuestionLabel(field.questionText, index)` instead of raw `field.questionText`, so the number always matches current position. Also updated `editField()` to strip the number before populating the edit modal, so editing a question doesn't show or re-save a stale embedded number.
- Update `FormPreviewModal.jsx` — all 8 field-type render cases (textbox, textarea, date, file, checkbox, radio, dropdown, default) updated to use `numberedQuestionLabel()`, so the Preview Form's numbering stays in sync with the builder.
- Create `jobFormQuestionUtils.numbering.test.js` — 10 unit tests covering prefix stripping (various formats), live number generation, and a simulated reorder/swap that directly models the reported bug.

## How to test:
1. Check out this branch: `gayatri/jobformbuilder-move-up-renumbering`
2. `npm install` (or `yarn`), run frontend + backend dev servers as usual
3. Log in as a user with job-form management permissions, go to `/jobformbuilder`
4. Add at least 3 distinct questions via the Field Label input
5. Click the ↑ (Move Up) arrow on the last question — confirm it moves to the top **and** its number updates to "1.)", with the other questions renumbering accordingly
6. Repeat with ↓ (Move Down) — confirm the same correct renumbering
7. Click **Preview Form** — confirm the numbers shown there exactly match the builder's current order
8. Run unit tests: `npx vitest src/components/Collaboration/__tests__/jobFormQuestionUtils.numbering.test.js` → 10/10 should pass

## Screenshots or videos of changes:
<img width="1042" height="1148" alt="3" src="https://github.com/user-attachments/assets/6cf5d09f-54ec-4004-b2fa-a9647920b51a" />
<img width="748" height="1326" alt="2" src="https://github.com/user-attachments/assets/508fe85d-4be6-4e8e-a752-c466517f8026" />
<img width="980" height="1211" alt="1" src="https://github.com/user-attachments/assets/be162c13-47e5-4e40-93d2-cb2493708dd2" />


## Note:
No backend changes needed — this is purely a display-layer fix. The underlying stored `questionText` (including any old baked-in numbers from before this fix) is left untouched by this change; going forward, editing a question strips old numbers so data cleans up naturally over time. No destructive rewrite of existing production data was performed.