### PR TITLE
Gayatri - fix(bm-dashboard): Cost Prediction chart date filter issues (Ticket #1 - PR #5403)

### DIFF
--- a/src/components/BMDashboard/WeeklyProjectSummary/CostPredictionChart.jsx
+++ b/src/components/BMDashboard/WeeklyProjectSummary/CostPredictionChart.jsx
@@ -58,6 +58,46 @@ const PROJECTS = [
 const DEFAULT_WINDOW_MONTHS = 6;
 const TODAY_STR = new Date().toISOString().slice(0, 10);
 
+const MONTH_NAMES = [
+  'january',
+  'february',
+  'march',
+  'april',
+  'may',
+  'june',
+  'july',
+  'august',
+  'september',
+  'october',
+  'november',
+  'december',
+];
+
+// Parses a "Month YYYY" label (e.g. "March 2026") into a local Date set to
+// the 1st of that month. Avoids relying on the native Date constructor's
+// implementation-defined parsing of non-ISO strings, which behaves
+// inconsistently across browsers/engines.
+export function parseMonthLabel(label) {
+  const parts = String(label || '')
+    .trim()
+    .split(/\s+/);
+  if (parts.length !== 2) return new Date(NaN);
+  const monthIndex = MONTH_NAMES.indexOf(parts[0].toLowerCase());
+  const year = Number(parts[1]);
+  if (monthIndex === -1 || Number.isNaN(year)) return new Date(NaN);
+  return new Date(year, monthIndex, 1);
+}
+
+// Parses a "YYYY-MM-DD" date-input value into a local Date, avoiding the
+// UTC-midnight interpretation the Date constructor applies to bare ISO
+// date strings (which can shift the date by a day in non-UTC timezones).
+export function parseIsoDateOnly(value) {
+  if (!value) return null;
+  const [y, m, d] = value.split('-').map(Number);
+  if (!y || !m || !d) return null;
+  return new Date(y, m - 1, d);
+}
+
 const SAMPLE_DATA_BASE = {
   'building-1': { plannedStart: 400, plannedGrowth: 5.6, actualStart: 380, actualGrowth: 5.4 },
   'building-2': { plannedStart: 700, plannedGrowth: 9.2, actualStart: 660, actualGrowth: 9.0 },
@@ -337,17 +377,17 @@ function CostPredictionChart({ projectId }) {
       return chartData.slice(-DEFAULT_WINDOW_MONTHS);
     }
     return chartData.filter(d => {
-      const pointDate = new Date(d.month);
+      const pointDate = parseMonthLabel(d.month);
 
       if (dateRange.start) {
-        const s = new Date(dateRange.start);
-        const startMonth = new Date(s.getFullYear(), s.getMonth(), 1);
-        if (pointDate < startMonth) return false;
+        const s = parseIsoDateOnly(dateRange.start);
+        const startMonth = s && new Date(s.getFullYear(), s.getMonth(), 1);
+        if (startMonth && pointDate < startMonth) return false;
       }
       if (dateRange.end) {
-        const e = new Date(dateRange.end);
-        const endMonth = new Date(e.getFullYear(), e.getMonth(), 1);
-        if (pointDate > endMonth) return false;
+        const e = parseIsoDateOnly(dateRange.end);
+        const endMonth = e && new Date(e.getFullYear(), e.getMonth(), 1);
+        if (endMonth && pointDate > endMonth) return false;
       }
       return true;
     });
@@ -469,7 +509,10 @@ function CostPredictionChart({ projectId }) {
             value={dateRange.end}
             min={dateRange.start || undefined}
             max={TODAY_STR}
-            onChange={e => setDateRange(prev => ({ ...prev, end: e.target.value }))}
+            onChange={e => {
+              const clamped = e.target.value > TODAY_STR ? TODAY_STR : e.target.value;
+              setDateRange(prev => ({ ...prev, end: clamped }));
+            }}
           />
         </div>
 

--- a/src/components/BMDashboard/WeeklyProjectSummary/__tests__/CostPredictionChart.dateParsing.test.js
+++ b/src/components/BMDashboard/WeeklyProjectSummary/__tests__/CostPredictionChart.dateParsing.test.js
@@ -1,0 +1,51 @@
+import { parseMonthLabel, parseIsoDateOnly } from '../CostPredictionChart';
+
+describe('parseMonthLabel', () => {
+  it.each([
+    ['January 2026', 2026, 0],
+    ['March 2026', 2026, 2],
+    ['December 2025', 2025, 11],
+  ])('parses "%s" into year %i, month index %i', (label, year, monthIndex) => {
+    const result = parseMonthLabel(label);
+    expect(result.getFullYear()).toBe(year);
+    expect(result.getMonth()).toBe(monthIndex);
+    expect(result.getDate()).toBe(1);
+  });
+
+  it('is case-insensitive on the month name', () => {
+    const result = parseMonthLabel('march 2026');
+    expect(result.getMonth()).toBe(2);
+  });
+
+  it('returns an invalid Date for malformed input', () => {
+    expect(Number.isNaN(parseMonthLabel('not a date').getTime())).toBe(true);
+    expect(Number.isNaN(parseMonthLabel('').getTime())).toBe(true);
+    expect(Number.isNaN(parseMonthLabel(null).getTime())).toBe(true);
+    expect(Number.isNaN(parseMonthLabel('Marchtober 2026').getTime())).toBe(true);
+  });
+});
+
+describe('parseIsoDateOnly', () => {
+  it('parses a YYYY-MM-DD string into a local Date with matching Y/M/D', () => {
+    const result = parseIsoDateOnly('2026-03-17');
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(2); // March = index 2
+    expect(result.getDate()).toBe(17);
+  });
+
+  it('does not shift the date across a month/day boundary regardless of local timezone', () => {
+    // This is the core regression check: new Date('2026-03-01') (native
+    // constructor) can resolve to Feb 28 in timezones behind UTC. Our
+    // parser must never do that.
+    const result = parseIsoDateOnly('2026-03-01');
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(2);
+    expect(result.getDate()).toBe(1);
+  });
+
+  it('returns null for empty/undefined input', () => {
+    expect(parseIsoDateOnly('')).toBeNull();
+    expect(parseIsoDateOnly(undefined)).toBeNull();
+    expect(parseIsoDateOnly(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
 Description
Fixes  1 (bug list priority medium — Application/Job Posting Page - Fix issues in Date filter in Planned vs Actual cost tracking chart in Financial Tracking)

Location: BM Dashboard → Financials Tracking → Total Construction Summary

Fixes two bugs in the Planned Vs Actual costs tracking chart:

1. End Date filter allowed selecting future dates. The native `max={TODAY_STR}` attribute on the date input isn't reliably enforced across browsers on manual keyboard entry, so added explicit clamping in the onChange handler as well.

2. The chart's X-axis did not honor the selected Start Date (e.g. selecting 03/17/2026 caused the chart to begin from April 2026 instead of March 2026). Root cause: both the chart's month labels ("March 2026") and the date-input values ("2026-03-17") were being re-parsed with the native Date constructor, whose handling of non-ISO strings is implementation-defined, and whose handling of bare ISO date-only strings applies a UTC-midnight interpretation that can shift the local date by up to a day depending on timezone.

   Added `parseMonthLabel()` (explicit month-name lookup, no locale/engine-dependent parsing) and `parseIsoDateOnly()` (splits the YYYY-MM-DD value directly, avoiding UTC/local timezone drift) and used both in the chart's date-range filtering logic instead of raw `new Date(...)` calls.

8 new unit tests cover both parsers, including a direct regression check for the month/day-shift bug.

 Related PRS (if any):
Related to previous PRs #3514, #4354.

 Main changes explained:
- Update `CostPredictionChart.jsx` for clamping the End Date to today and replacing ambiguous `new Date(...)` string parsing with two explicit, timezone-safe helper functions.
- Create `CostPredictionChart.dateParsing.test.js` for unit test coverage of both new parsing helpers.

## How to test:
1. Check out this branch: `gayatri/fix-cost-prediction-date-filter`
2. `npm install` (or `yarn`), run frontend + backend dev servers
3. Clear site data/cache
4. Log in as admin user
5. Go to `/bmdashboard/totalconstructionsummary` → scroll to **Financials Tracking**
6. In the **Planned Vs Actual costs tracking** chart, try setting **End Date** to a future date — it should clamp back to today instead of accepting it (feel free to include screenshot here)
7. Set **Start Date** to `03/17/2026` — verify the chart's X-axis now begins at **March 2026**, not April
8. Run unit tests: `npx vitest src/components/BMDashboard/WeeklyProjectSummary/__tests__/CostPredictionChart.dateParsing.test.js` → 8/8 should pass
9. Verify this fix works in dark mode as well

Screenshots or videos of changes:


Note:
Heads up — noticed a branch `Mahathi_improve_planned_vs_actual_cost_chart` on the remote that may also be touching this same chart. Worth checking for overlap before merging either PR.