### PR TITLE
Gayatri - fix(job-form-builder): accessible tooltip for Clear Template button (Ticket #16)

### DIFF
--- a/src/components/Collaboration/QuestionSetManager.jsx
+++ b/src/components/Collaboration/QuestionSetManager.jsx
@@ -2,6 +2,7 @@
 /* eslint-disable no-console */
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { UncontrolledTooltip } from 'reactstrap';
 import axios from 'axios';
 import { useSelector } from 'react-redux';
 import { ENDPOINTS } from '../../utils/URL';
@@ -400,6 +401,7 @@ function QuestionSetManager({ formFields, setFormFields, onImportQuestions, dark
                 {isLoading ? 'Loading...' : 'Clone with Template'}
               </button>
               <button
+                id="clear-template-button"
                 type="button"
                 onClick={() => {
                   if (formFields.length > 0) {
@@ -413,10 +415,16 @@ function QuestionSetManager({ formFields, setFormFields, onImportQuestions, dark
                 }}
                 className={styles.clearTemplateButton}
                 disabled={formFields.length === 0}
-                title="Remove all fields and reset the template to a clean state"
               >
                 Clear Template
               </button>
+              <UncontrolledTooltip
+                placement="top"
+                target="clear-template-button"
+                trigger="hover focus"
+              >
+                Remove all fields and reset the template to a clean state
+              </UncontrolledTooltip>
               <button
                 type="button"
                 onClick={appendTemplate}


### PR DESCRIPTION
Description
Fixes # 16 (bug list priority low — Application/Job Posting Page - Finishing Followup fixes for PR 4590. Fix 'Clear Template' button doesn't remove fields from template issue)

Note: the core "Clear Template" button bug (button not removing fields from the template) was already confirmed fixed on `development` in an earlier commit — no changes needed for that part.

This PR addresses the remaining sub-requirement from the ticket: "Additionally, add a tooltip to describe the action and ensure it is accessible and visible on hover or focus." The button previously had a native `title` attribute, which only shows on mouse hover and is not reliably triggered by keyboard focus in any major browser — failing that requirement for keyboard-only users.

Related PRS (if any):
Related to PR #2928 , PR #1167 

 Main changes explained:
- Update `QuestionSetManager.jsx` — replaced the native `title` attribute on the Clear Template button with reactstrap's `UncontrolledTooltip` using `trigger="hover focus"`, matching the tooltip pattern already used elsewhere in the codebase (`UserProfile/ToolTips`). This attaches the same show/hide behavior to both mouse hover and keyboard focus/blur events.

 How to test:
1. Check out this branch: `gayatri/clear-template-tooltip-accessibility`
2. `npm install` (or `yarn`), run frontend + backend dev servers
3. Go to `/jobformbuilder`, add at least one custom question so "Clear Template" becomes enabled
4. Hover your mouse over "Clear Template" — confirm the tooltip appears with the text "Remove all fields and reset the template to a clean state"
5. Click into the page, then Tab to the "Clear Template" button using only the keyboard — confirm the same tooltip appears on focus
6. Confirm clicking the button still shows the existing confirmation dialog and correctly clears all fields on confirm

Screenshots or videos of changes:


Note:
The keyboard-focus behavior was verified via code review (trigger="hover focus" uses the same underlying show/hide mechanism as the confirmed-working hover trigger, not separate logic) rather than a manual screenshot, since a manual repro proved fiddly with the available input devices. Happy to add a screenshot of the hover state if useful for review.