### PR TITLE
Aditya - Job Application Form: recognize Document upload questions

### DIFF
--- a/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
+++ b/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
@@ -10,6 +10,7 @@ import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { parsePhoneNumberFromString } from 'libphonenumber-js/max';
 import moment from 'moment-timezone';
+import { isJobApplicationFileUploadQuestion } from './jobApplicationQuestionUtils';
 
 function normalizeTitleKey(s) {
   return String(s || '')
@@ -207,17 +208,6 @@ function formRequiresResumeUpload(form) {
   );
 }
 
-function isFileUploadQuestion(q) {
-  if (isResumeQuestion(q)) return false;
-  const qt = getQuestionType(q);
-  if (['file', 'upload', 'document', 'attachment'].includes(qt)) return true;
-  const label = (q.label || q.questionText || '').toLowerCase();
-  return (
-    /\b(upload|attach|file)\b/.test(label) &&
-    !/\b(work\s*sample|portfolio|writing\s*sample)\b/.test(label)
-  );
-}
-
 function formatFileSize(bytes) {
   if (bytes == null || bytes === 0) return '';
   if (bytes < 1024) return `${bytes} B`;
@@ -375,7 +365,7 @@ function isAnswerEmpty(answer, q) {
 
 function missingRequiredQuestionLabel(q, idx, answers, questionFiles) {
   if (!isQuestionRequired(q)) return null;
-  if (isFileUploadQuestion(q)) {
+  if (isJobApplicationFileUploadQuestion(q)) {
     return questionFiles[idx] ? null : getQuestionLabel(q, idx);
   }
   return isAnswerEmpty(answers[idx], q) ? getQuestionLabel(q, idx) : null;
@@ -520,7 +510,7 @@ function collectMissingRequiredFields({
 }
 
 function serializeAnswerForSubmit(q, idx, answers, questionFiles) {
-  if (!isFileUploadQuestion(q)) return answers[idx];
+  if (!isJobApplicationFileUploadQuestion(q)) return answers[idx];
   const file = questionFiles[idx];
   if (!file) return '';
   return {
@@ -1168,7 +1158,7 @@ function JobApplicationForm() {
       }
 
       visibleQuestions.forEach((q, idx) => {
-        if (isFileUploadQuestion(q) && questionFiles[idx] && q._id) {
+        if (isJobApplicationFileUploadQuestion(q) && questionFiles[idx] && q._id) {
           formData.append(`questionFile_${q._id}`, questionFiles[idx]);
         }
       });
@@ -1571,7 +1561,7 @@ function JobApplicationForm() {
                       )}
                     </h2>
                     {['textbox', 'text'].includes(qt) &&
-                      !isFileUploadQuestion(q) &&
+                      !isJobApplicationFileUploadQuestion(q) &&
                       !isIndividualOrgQuestion && (
                         <>
                           <input
@@ -1696,7 +1686,7 @@ function JobApplicationForm() {
                         </select>
                       )
                     )}
-                    {isFileUploadQuestion(q) && (
+                    {isJobApplicationFileUploadQuestion(q) && (
                       <FileUploadField
                         id={`${formKey}-file`}
                         accept=".pdf,.doc,.docx,.png,.jpg,.jpeg"
@@ -1718,7 +1708,7 @@ function JobApplicationForm() {
                       'radio',
                       'dropdown',
                     ].includes(qt) &&
-                      !isFileUploadQuestion(q) && (
+                      !isJobApplicationFileUploadQuestion(q) && (
                         <input
                           type="text"
                           placeholder="Type your response here"

--- a/src/components/Collaboration/JobApplicationForm/jobApplicationQuestionUtils.js
+++ b/src/components/Collaboration/JobApplicationForm/jobApplicationQuestionUtils.js
@@ -1,0 +1,19 @@
+/** Detect file-upload prompts without treating "document" used as a verb as an upload. */
+export function isJobApplicationFileUploadQuestion(question) {
+  const label = String(question?.label || question?.questionText || '').toLowerCase();
+
+  if (/\b(resume|résumé|curriculum\s*vitae|cv)\b/.test(label)) return false;
+
+  const questionType = String(question?.questionType || question?.type || '').toLowerCase();
+  if (['file', 'upload', 'document', 'attachment'].includes(questionType)) return true;
+
+  if (/\b(work\s*sample|portfolio|writing\s*sample)\b/.test(label)) return false;
+  if (/\b(upload|attach|file)\b/.test(label)) return true;
+
+  return (
+    /^documents?\b(?:\s*(?:\([^)]*\)|[-–—:;,.!*]))*\s*$/.test(label.trim()) ||
+    /\b(first|second|third|additional|supporting|supplemental|other|required|optional)\s+documents?\b(?:\s*(?:\([^)]*\)|[-–—:;,.!*]))*\s*$/.test(
+      label.trim(),
+    )
+  );
+}

--- a/src/components/Collaboration/__tests__/jobApplicationFileUploadQuestion.test.js
+++ b/src/components/Collaboration/__tests__/jobApplicationFileUploadQuestion.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { isJobApplicationFileUploadQuestion } from '../JobApplicationForm/jobApplicationQuestionUtils';
+
+describe('isJobApplicationFileUploadQuestion', () => {
+  it.each(['file', 'upload', 'document', 'attachment'])(
+    'recognizes the explicit %s question type',
+    questionType => {
+      expect(
+        isJobApplicationFileUploadQuestion({ questionType, questionText: 'Additional details' }),
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    'Second Document',
+    'Supporting document (optional)',
+    'Please upload your identity document',
+    'Attach your cover letter',
+  ])('recognizes the upload prompt "%s"', questionText => {
+    expect(isJobApplicationFileUploadQuestion({ questionText })).toBe(true);
+  });
+
+  it.each([
+    'How do you document your work?',
+    'Describe this document',
+    'Tell us about your documentation process',
+    'Upload a work sample',
+    'Portfolio file',
+    'Attach a writing sample',
+  ])('does not misclassify the text prompt "%s"', questionText => {
+    expect(isJobApplicationFileUploadQuestion({ questionText })).toBe(false);
+  });
+
+  it('keeps the dedicated resume upload separate', () => {
+    expect(
+      isJobApplicationFileUploadQuestion({ questionType: 'file', questionText: 'Upload resume' }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
# Description

Application questions labeled with “document” could render as plain text because upload detection recognized “upload,” “attach,” and “file,” but not document-only labels such as **Second Document**. This expands detection while avoiding ordinary sentences that use “document” as a verb.

This issue concerns [Item 38](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit?tab=t.0#bookmark=id.8386p5xtyb3r).

## Original task

Job Application Form — recognize “Document” upload questions on `/job-application` while preserving existing upload, attachment, file, resume, portfolio, and work-sample behavior.

[Open master Google Doc Item 38](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit?tab=t.0#bookmark=id.8386p5xtyb3r)

### Master Google Doc task entry

<img width="1050" height="780" alt="Master Google Doc - Item 38 document upload detection" src="https://github.com/user-attachments/assets/8c632200-cb70-45a0-8c96-1d04cad1d617" />

## Related PRS (if any):

None. No backend changes.

## Main changes explained:

1. Extracted file-question detection into one reusable helper.
2. Recognizes explicit file/upload/document/attachment types and constrained labels such as “Second Document” or “Supporting document (optional)”.
3. Does not misclassify prompts such as “How do you document your work?” or “Describe this document”.
4. Keeps resume upload handling separate and preserves the portfolio/work-sample exclusions.
5. Reuses the same decision for rendering, required validation, serialization, and multipart upload.
6. Added 15 focused regression cases.

## How to test:

1. Check out this branch, install dependencies, and run `npm run start:local`.
2. Open `/job-application` with questions named “Second Document” and “How do you document your work?”.
3. Confirm “Second Document” renders a file picker.
4. Confirm “How do you document your work?” remains a text field.
5. Confirm resume/PDF uploads still render and validate independently.
6. Repeat in light and dark mode.
7. Run `vitest` for `jobApplicationFileUploadQuestion.test.js` and `npm run build`.

## Screenshots or videos of changes:

_Evidence source: local QA mock using Owner-level fixture data._

### Document upload detection

<img width="1440" height="1000" alt="Document Upload Detection - Desktop" src="https://github.com/user-attachments/assets/6e7d4e43-8caa-422f-8a0d-6a37d96a77f0" />
