### PR TITLE
Aditya - Job Application Form: cap logo and restore First and Last name fields

### DIFF
--- a/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
+++ b/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
@@ -410,15 +410,15 @@ function validateHoursPerWeekAnswer(label, answer) {
   return null;
 }
 
-function validateName(name) {
+function validateName(name, label = 'Name') {
   const trimmed = String(name || '').trim();
 
-  if (!trimmed) return 'Name is required.';
-  if (trimmed.length < 2) return 'Name must be at least 2 characters.';
-  if (trimmed.length > 100) return 'Name must not exceed 100 characters.';
+  if (!trimmed) return `${label} is required.`;
+  if (trimmed.length < 2) return `${label} must be at least 2 characters.`;
+  if (trimmed.length > 100) return `${label} must not exceed 100 characters.`;
 
   if (!/^[\p{L}\s'-]+$/u.test(trimmed)) {
-    return 'Name may contain only letters, spaces, hyphens, and apostrophes.';
+    return `${label} may contain only letters, spaces, hyphens, and apostrophes.`;
   }
 
   return '';
@@ -478,16 +478,25 @@ function validateTimeZone(timeZone) {
   return '';
 }
 
-function getProfileValidationErrors({ applicantName, applicantEmail, phone, location, timeZone }) {
+function getProfileValidationErrors({
+  firstName,
+  lastName,
+  applicantEmail,
+  phone,
+  location,
+  timeZone,
+}) {
   const errors = {};
 
-  const nameError = validateName(applicantName);
+  const firstNameError = validateName(firstName, 'First name');
+  const lastNameError = validateName(lastName, 'Last name');
   const emailError = validateEmail(applicantEmail);
   const phoneError = validatePhone(phone);
   const locationError = validateLocation(location);
   const timeZoneError = validateTimeZone(timeZone);
 
-  if (nameError) errors.applicantName = nameError;
+  if (firstNameError) errors.firstName = firstNameError;
+  if (lastNameError) errors.lastName = lastNameError;
   if (emailError) errors.applicantEmail = emailError;
   if (phoneError) errors.phone = phoneError;
   if (locationError) errors.location = locationError;
@@ -659,7 +668,8 @@ function JobApplicationForm() {
   const [jobTitleInput, setJobTitleInput] = useState('');
   const [filteredForm, setFilteredForm] = useState(null);
   const [showDescription, setShowDescription] = useState(false);
-  const [applicantName, setApplicantName] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [applicantEmail, setApplicantEmail] = useState('');
   const [applicantLocation, setApplicantLocation] = useState('');
   const [timeZone, setTimeZone] = useState('');
@@ -729,7 +739,13 @@ function JobApplicationForm() {
 
   const applyQuestionnairePreFill = data => {
     if (!data) return;
-    if (data.name) setApplicantName(data.name);
+    if (data.name) {
+      const [firstPart, ...restParts] = String(data.name)
+        .trim()
+        .split(/\s+/);
+      setFirstName(firstPart || '');
+      setLastName(restParts.join(' '));
+    }
     if (data.email) setApplicantEmail(data.email);
     if (data.location) {
       setApplicantLocation(data.location);
@@ -1059,7 +1075,8 @@ function JobApplicationForm() {
 
   const validateBeforeSubmit = () => {
     const profileErrors = getProfileValidationErrors({
-      applicantName,
+      firstName,
+      lastName,
       applicantEmail,
       phone,
       location: applicantLocation,
@@ -1079,7 +1096,8 @@ function JobApplicationForm() {
   };
 
   const resetFormAfterSubmit = () => {
-    setApplicantName('');
+    setFirstName('');
+    setLastName('');
     setApplicantEmail('');
     setApplicantLocation('');
     setTimeZone('');
@@ -1112,7 +1130,8 @@ function JobApplicationForm() {
     setFieldErrors(prev => {
       const next = { ...prev };
 
-      delete next.applicantName;
+      delete next.firstName;
+      delete next.lastName;
       delete next.applicantEmail;
       delete next.location;
       delete next.timeZone;
@@ -1143,7 +1162,7 @@ function JobApplicationForm() {
       formData.append(
         'payload',
         JSON.stringify({
-          applicantName: applicantName.trim(),
+          applicantName: `${firstName.trim()} ${lastName.trim()}`.trim(),
           applicantEmail: applicantEmail.trim(),
           profile: {
             locationTimezone,
@@ -1299,28 +1318,28 @@ function JobApplicationForm() {
             <div className={styles.formContentGroup}>
               <div className={styles.formProfileDetailGroup}>
                 <div className={styles.profileField}>
-                  <label htmlFor="jaf-applicant-name" className={styles.fieldLabel}>
-                    <span>Name</span>
+                  <label htmlFor="jaf-applicant-first-name" className={styles.fieldLabel}>
+                    <span>First Name</span>
                     <span className={styles.requiredMark} aria-hidden="true">
                       *
                     </span>
                   </label>
 
                   <input
-                    id="jaf-applicant-name"
+                    id="jaf-applicant-first-name"
                     type="text"
-                    placeholder="Name"
+                    placeholder="First Name"
                     className={`${styles.inputField} ${
-                      fieldErrors.applicantName ? styles.inputFieldError : ''
+                      fieldErrors.firstName ? styles.inputFieldError : ''
                     }`}
-                    value={applicantName}
+                    value={firstName}
                     onChange={e => {
-                      setApplicantName(e.target.value);
+                      setFirstName(e.target.value);
 
-                      if (fieldErrors.applicantName) {
+                      if (fieldErrors.firstName) {
                         setFieldErrors(prev => {
                           const next = { ...prev };
-                          delete next.applicantName;
+                          delete next.firstName;
                           return next;
                         });
                       }
@@ -1329,13 +1348,55 @@ function JobApplicationForm() {
                     maxLength={100}
                     required
                     aria-required="true"
-                    aria-invalid={Boolean(fieldErrors.applicantName)}
-                    autoComplete="name"
+                    aria-invalid={Boolean(fieldErrors.firstName)}
+                    autoComplete="given-name"
                   />
 
-                  {fieldErrors.applicantName && (
+                  {fieldErrors.firstName && (
                     <p className={styles.fieldError} role="alert">
-                      {fieldErrors.applicantName}
+                      {fieldErrors.firstName}
+                    </p>
+                  )}
+                </div>
+
+                <div className={styles.profileField}>
+                  <label htmlFor="jaf-applicant-last-name" className={styles.fieldLabel}>
+                    <span>Last Name</span>
+                    <span className={styles.requiredMark} aria-hidden="true">
+                      *
+                    </span>
+                  </label>
+
+                  <input
+                    id="jaf-applicant-last-name"
+                    type="text"
+                    placeholder="Last Name"
+                    className={`${styles.inputField} ${
+                      fieldErrors.lastName ? styles.inputFieldError : ''
+                    }`}
+                    value={lastName}
+                    onChange={e => {
+                      setLastName(e.target.value);
+
+                      if (fieldErrors.lastName) {
+                        setFieldErrors(prev => {
+                          const next = { ...prev };
+                          delete next.lastName;
+                          return next;
+                        });
+                      }
+                    }}
+                    minLength={2}
+                    maxLength={100}
+                    required
+                    aria-required="true"
+                    aria-invalid={Boolean(fieldErrors.lastName)}
+                    autoComplete="family-name"
+                  />
+
+                  {fieldErrors.lastName && (
+                    <p className={styles.fieldError} role="alert">
+                      {fieldErrors.lastName}
                     </p>
                   )}
                 </div>

--- a/src/components/Collaboration/JobApplicationForm/JobApplicationForm.module.css
+++ b/src/components/Collaboration/JobApplicationForm/JobApplicationForm.module.css
@@ -17,6 +17,12 @@
   padding: 0;
 }
 
+.logo img {
+  max-width: 220px;
+  height: auto;
+  object-fit: contain;
+}
+
 .header {
   display: flex;
   flex-direction: column;
@@ -71,7 +77,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   appearance: none;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
   -webkit-appearance: none;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
   -moz-appearance: none;
   background-image: url("data:image/svg+xml;utf8,<svg fill='%23666' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>");
   background-repeat: no-repeat;
@@ -905,6 +913,7 @@
     grid-column: auto;
   }
 }
+
 /* User Requirements Section */
 .userRequirementsSection {
   margin: 20px 0;


### PR DESCRIPTION
# Description

The `/job-application` page displayed an oversized One Community logo and one combined Name field. This restores the earlier 220px logo cap and separate validated First Name and Last Name inputs while preserving the existing backend payload contract.

## Original task

On the specific application page, keep the One Community branding proportionate and collect First Name and Last Name separately.

[Open the exact master Google Doc task](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit?tab=t.0#bookmark=id.s3q4ihc3g8oe)

### Master Google Doc task entry

<img width="1050" height="2826" alt="Master Google Doc - application logo and separate name fields" src="https://github.com/user-attachments/assets/83e75750-9cf3-468c-ba54-63db0e87ad00" />

## Related PRS (if any):

PR #5228 previously added the logo cap and separate name fields; later work overwrote both changes. No backend changes.

## Main changes explained:

1. Caps the logo at 220px while preserving its aspect ratio.
2. Replaces the combined Name input with required First Name and Last Name inputs.
3. Validates each name independently with field-specific messages.
4. Adds `given-name` and `family-name` autocomplete metadata.
5. Splits questionnaire-prefill names into first and remaining name parts.
6. Recombines both values into the existing `applicantName` payload field, so the backend contract does not change.
7. Keeps the responsive grid behavior so both fields stack cleanly on mobile.

## How to test:
1. Check out `Aditya_fix_job_application_logo_and_name_fields`. **Stop any running dev server first**, then run `rm -rf node_modules/.vite` and `npm run start:local`. The backend must be running.
   - If you still see a single **Name\*** field, the old build is being served. Clear the Vite cache again and hard-refresh.
2. Log in. `/job-application` is a protected route. Test as Volunteer and as Admin.
3. Open `/job-application` and pick any role from the dropdown if no form is shown.
4. **Logo:** confirm the One Community logo is at most 220px wide and keeps its proportions.
5. **Name fields:** confirm there are two separate required inputs, **First Name\*** and **Last Name\***, instead of one Name field.
6. **Validation:** with each field on its own, check these messages:
   - empty → `First name is required.` / `Last name is required.`
   - one character → `First name must be at least 2 characters.`
   - digits or symbols → `First name may contain only letters, spaces, hyphens, and apostrophes.`
7. **Payload:** fill the form validly and submit. In DevTools → Network, open the `POST` to the job-application submit endpoint and confirm the form data has a single `applicantName` equal to `"<First> <Last>"`. The backend contract is unchanged.
8. **Prefill (optional, needs a real questionnaire referral ID):** open `/job-application?ref=<referralId>` for a questionnaire whose name has several parts (e.g. "Mary Ann Smith"). Confirm First Name = `Mary` and Last Name = `Ann Smith`.
9. Repeat in dark mode and below 768px width (the fields should stack).
10. Run `npm run build`. (No unit tests cover `JobApplicationForm`.)

## Screenshots or videos of changes:

_Evidence sources: local QA mock using Owner-level fixture data, plus the real local application running against the development backend with the Dev Admin account._

### Desktop

<img width="1440" height="1000" alt="Job Application Profile - Desktop" src="https://github.com/user-attachments/assets/93cdcefb-1692-4282-904f-d431562e2f7e" />

### Mobile — capped logo

<img width="390" height="844" alt="Job Application - Mobile Capped Logo" src="https://github.com/user-attachments/assets/9dc06d58-4694-42cf-a360-3ce521930cbe" />

### Mobile — stacked First Name and Last Name fields

<img width="390" height="844" alt="Job Application - Mobile First and Last Name Fields" src="https://github.com/user-attachments/assets/990ee509-7e5e-40b9-84cf-6553679d82a2" />

