### PR TITLE
Aditya - Suggested Jobs: route Apply Now to the internal application form

### DIFF
--- a/src/components/Collaboration/SuggestedJobsList.jsx
+++ b/src/components/Collaboration/SuggestedJobsList.jsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { ApiEndpoint } from '../../utils/URL';
 import { toast } from 'react-toastify';
 import OneCommunityImage from '../../assets/images/logo2.png';
 import styles from './SuggestedJobsList.module.css';
 
 function SuggestedJobsList() {
+  const history = useHistory();
   const [categories, setCategories] = useState([]);
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState('');
@@ -33,6 +35,22 @@ function SuggestedJobsList() {
     }
 
     return cleaned || 'No detailed description available.';
+  };
+
+  const handleApplyNow = ad => {
+    const title = ad.title || '';
+    const search = title ? `?jobTitle=${encodeURIComponent(title)}` : '';
+    history.push({
+      pathname: '/job-application',
+      search,
+      state: {
+        jobId: ad._id,
+        jobTitle: title,
+        jobDescription: ad.description || '',
+        requirements: ad.requirements || [],
+        category: ad.category || 'General',
+      },
+    });
   };
   // Fetch categories on mount
   useEffect(() => {
@@ -239,15 +257,13 @@ function SuggestedJobsList() {
                 </div>
               )}
 
-              <a
-                href={`https://www.onecommunityglobal.org/collaboration/job-application/${ad._id}`}
-                target="_blank"
-                rel="noopener noreferrer"
+              <button
+                type="button"
+                className={`btn btn-primary ${styles.applyNowBtn}`}
+                onClick={() => handleApplyNow(ad)}
               >
-                <button type="submit" className={`btn btn-primary ${styles.applyNowBtn}`}>
-                  Apply Now
-                </button>
-              </a>
+                Apply Now
+              </button>
             </div>
           ))}
 


### PR DESCRIPTION
# Description

The Suggested Jobs list sent **Apply Now** to an external One Community WordPress URL instead of the internal application flow. This restores navigation to `/job-application` and carries the selected job context with it.

## Original task

On `/suggestedjobslist`, selecting **Apply Now** should open the internal application form for the selected role.

[Open the exact master Google Doc task](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit?tab=t.0#bookmark=id.hsvl1vit03tw)

### Master Google Doc task entry

<img width="1050" height="1450" alt="Master Google Doc - Apply Now internal application task" src="https://github.com/user-attachments/assets/5539caf5-a46d-4b00-88bd-a7c88ac44bf3" />

## Related PRS (if any):

PR #4958 is marked Done in the master document but does not modify this behavior. No backend changes.

## Main changes explained:

1. Replaced the external anchor and nested button with one semantic button.
2. Uses React Router history to navigate to `/job-application`.
3. Adds the encoded job title to the query string and passes the job ID, title, description, requirements, and category in route state.
4. Keeps a `General` category fallback when the selected job has no category.

## How to test:

1. Check out this branch, install dependencies, and run `npm run start:local`.
2. Open `/suggestedjobslist` with job data available.
3. Click **Apply Now** on a listing.
4. Confirm the browser remains on Highest Good Network and opens `/job-application?jobTitle=...`.
5. Confirm the selected job’s title, description, requirements, and category populate the application flow.
6. Repeat in dark mode and at a narrow mobile width.
7. Run the focused Collaboration tests and `npm run build`.

## Screenshots or videos of changes:

_Evidence source: local application running against the development backend with the Dev Admin account._

### Suggested Jobs source

<img width="1366" height="900" alt="Suggested Jobs - Apply Now Source" src="https://github.com/user-attachments/assets/a0c25932-1285-46a7-b29f-cccc7eb24e4b" />

### Apply Now opens the internal application

<img width="1366" height="900" alt="Apply Now - Internal Job Application Route" src="https://github.com/user-attachments/assets/5d3f4301-9577-4d2a-ab08-9b4d22bc9bcc" />

Observed destination during verification: `http://localhost:3000/job-application?jobTitle=Office%20Coordinator`.

## Note:

This changes only the Suggested Jobs Apply Now route. Missing or mismatched application-form data is handled separately.
