### PR TITLE
Aditya - Job Form Builder: fix dark mode fields and labels

### DIFF
--- a/src/components/Collaboration/FormPreviewModal.module.css
+++ b/src/components/Collaboration/FormPreviewModal.module.css
@@ -313,6 +313,12 @@
   background-color: var(--jfb-blue);
 }
 
+.darkMode .previewEmptyMessage {
+  color: #bbb;
+  background-color: #333;
+  border-color: #555;
+}
+
 /* Responsive Design */
 @media (width <= 768px) {
   .modalContainer {

--- a/src/components/Collaboration/JobFormBuilder.module.css
+++ b/src/components/Collaboration/JobFormBuilder.module.css
@@ -353,6 +353,7 @@
 }
 
 .darkMode .jobformSelect {
+  appearance: none;
   background-image: url("data:image/svg+xml;utf8,<svg fill='lightgray' height='20' viewBox='0 0 20 20' width='20' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>");
   background-repeat: no-repeat;
   background-position: right 12px center;

--- a/src/components/Collaboration/JobFormbuilder.jsx
+++ b/src/components/Collaboration/JobFormbuilder.jsx
@@ -578,10 +578,10 @@ function JobFormBuilder() {
                       }));
                     }}
                   >
-                    <option value="textbox">TextBox</option>
+                    <option value="textbox">Text Box</option>
                     <option value="email">Email</option>
-                    <option value="textarea">Textarea</option>
-                    <option value="checkbox">Checkbox</option>
+                    <option value="textarea">Text Area</option>
+                    <option value="checkbox">Check Box</option>
                     <option value="radio">Radio</option>
                     <option value="dropdown">Dropdown</option>
                     <option value="date">Date</option>


### PR DESCRIPTION
# Description

Three Job Form Builder presentation defects remained in dark mode: the empty-preview message had poor contrast, select controls displayed duplicate arrows, and Input Type labels used compressed wording. This fixes those defects without changing stored question types.

## Original task

Application Form Template follow-up on `/jobformbuilder`: complete dark-mode presentation, remove duplicate select arrows, and display “Text Box,” “Text Area,” and “Check Box”.

[Open master Google Doc Task 5](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit?tab=t.0#bookmark=id.7ujwn9oe9ei)

### Master Google Doc task entry

<img width="1050" height="2810" alt="Master Google Doc - Task 5 Job Form Builder dark mode" src="https://github.com/user-attachments/assets/8c9d7331-dce0-4a46-871b-5e24ec351724" />

## Related PRS (if any):

Related historical work: PR #4526. The master document links this area to the original question-set work in PR #2928 and backend PR #1167. No backend changes.

## Main changes explained:

1. Gives the empty-preview message readable dark-theme text, background, and border colors.
2. Applies `appearance: none` to the dark-mode job-form selector so only the custom arrow is visible.
3. Changes visible Input Type labels to “Text Box,” “Text Area,” and “Check Box”.
4. Preserves the underlying `textbox`, `textarea`, and `checkbox` values, so saved data and API behavior are unchanged.

## How to test:

1. Check out this branch, install dependencies, and run `npm run start:local`.
2. Log in as an Owner and open `/jobformbuilder`.
3. Enable dark mode and open an empty Preview Form; confirm the central message is readable.
4. Confirm the job-form and Input Type selectors show one arrow each.
5. Confirm the visible labels read “Text Box,” “Text Area,” and “Check Box”.
6. Select and save each affected type; confirm the underlying behavior is unchanged.
7. Run the focused Collaboration tests and `npm run build`.

## Screenshots or videos of changes:

_Evidence source: real local application running against the development backend with the Dev Admin account._

### Dark-mode selector with one arrow

<img width="1366" height="900" alt="Job Form Builder - Dark Mode Select With One Arrow" src="https://github.com/user-attachments/assets/9735f6b2-3fe7-4b01-8c96-872b7d4b3e5c" />

### Correctly spaced Input Type labels

<img width="1200" height="177" alt="Job Form Builder - Text Box Text Area and Check Box Labels" src="https://github.com/user-attachments/assets/be6d6b91-3936-4456-b5ad-31a6b8916dbb" />
