### PR TITLE
Aditya - Job Analytics: show All as the default Date and Role filter display

### DIFF
--- a/src/components/JobAnalytics/JobsHitsApplicationsChart/JobsHitsApplicationsChart.jsx
+++ b/src/components/JobAnalytics/JobsHitsApplicationsChart/JobsHitsApplicationsChart.jsx
@@ -114,7 +114,7 @@ const JobsHitsApplicationsChart = () => {
                 selectsStart
                 startDate={startDate}
                 endDate={endDate}
-                placeholderText="Start Date"
+                placeholderText="All"
                 className={`${styles.datePicker} ${darkMode ? styles.bgSpaceCadet : ''}`}
               />
             </div>
@@ -132,7 +132,7 @@ const JobsHitsApplicationsChart = () => {
                 selectsEnd
                 startDate={startDate}
                 endDate={endDate}
-                placeholderText="End Date"
+                placeholderText="All"
                 className={`${styles.datePicker} ${darkMode ? styles.bgSpaceCadet : ''}`}
               />
             </div>
@@ -148,6 +148,7 @@ const JobsHitsApplicationsChart = () => {
                 isMulti
                 options={roleOptions}
                 onChange={setSelectedRoles}
+                placeholder="All"
                 className={styles.roleSelector}
                 styles={{
                   control: base => ({


### PR DESCRIPTION
# Description

The Hits and Applications chart opened with blank Date and Role controls even though the original requirement says both filters should default to **All**. This makes the initial unfiltered state explicit without changing the filtering behavior.

## Original task

Job Posting Page Analytics follow-up: set the Date and Role filters to their default value of “All” on `/job-analytics`.

[Open master Google Doc Task 13](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit?tab=t.0#bookmark=id.lts771wdz9f7)

### Master Google Doc task entry

<img width="850" height="700" alt="Master Google Doc - Task 13 analytics filter defaults" src="https://github.com/user-attachments/assets/5e1a1c79-fcac-477b-8b92-5dd509a9197a" />

## Related PRS (if any):

Related historical work: frontend PR #4325 and backend PR #1882. No backend changes in this PR.

## Main changes explained:

1. Changed both date-picker placeholders from “Start Date” and “End Date” to “All”.
2. Added the “All” placeholder to the multi-select Role control.
3. Kept the existing empty values and API behavior unchanged; this is a display correction only.

## How to test:

1. Check out this branch, install dependencies, and run `npm run start:local`.
2. Open `/job-analytics`.
3. Confirm Start Date, End Date, and Role display “All” before filters are selected.
4. Select a date range and one or more roles; confirm the graph still updates.
5. Clear the filters and confirm the controls return to “All”.
6. Repeat in dark mode.
7. Run the focused analytics tests and `npm run build`.

## Screenshots or videos of changes:

_Evidence source: local application running against the development backend with the Dev Admin account._

### Analytics filters default to All

<img width="1366" height="900" alt="Job Analytics - All Filter Defaults" src="https://github.com/user-attachments/assets/ee865049-dc7f-4ab1-b01b-dd0a25f841bf" />

## Note:

This PR intentionally does not include the separate chart alignment, overflow, or dark-mode contrast follow-ups.
