### PR TITLE
Aditya - Job Form Builder: restore the unsaved-changes warning

### DIFF
--- a/src/components/Collaboration/JobFormbuilder.jsx
+++ b/src/components/Collaboration/JobFormbuilder.jsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import axios from 'axios';
 import { useDispatch, useSelector } from 'react-redux';
+import { Prompt } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import styles from './JobFormBuilder.module.css';
 import { ENDPOINTS } from '~/utils/URL';
@@ -23,6 +24,7 @@ import {
   prepareQuestionClone,
   normalizeLoadedQuestions,
 } from './jobFormQuestionUtils';
+import { hasUnsavedJobFormChanges } from './jobFormDirtyState';
 
 function JobFormBuilder() {
   const dispatch = useDispatch();
@@ -63,6 +65,7 @@ function JobFormBuilder() {
   };
 
   const [jobTitle, setJobTitle] = useState('Please Choose an option');
+  const [initialJobTitle, setInitialJobTitle] = useState('Please Choose an option');
   const jobPositions = JOB_FORM_POSITION_OPTIONS;
 
   const [newOption, setNewOption] = useState('');
@@ -71,10 +74,24 @@ function JobFormBuilder() {
   const [editingIndex, setEditingIndex] = useState(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
-  const markAsSaved = fields => {
+  const markAsSaved = (fields, savedJobTitle) => {
     setInitialFormFields(structuredClone(fields));
+    if (savedJobTitle !== undefined) setInitialJobTitle(savedJobTitle);
     setHasUnsavedChanges(false);
   };
+
+  // Prevent refresh while unsaved changes exist
+  useEffect(() => {
+    const handler = event => {
+      if (hasUnsavedChanges) {
+        event.preventDefault();
+        event.returnValue = '';
+      }
+    };
+
+    globalThis.addEventListener('beforeunload', handler);
+    return () => globalThis.removeEventListener('beforeunload', handler);
+  }, [hasUnsavedChanges]);
 
   // Reset builder after template is saved
   const resetBuilderState = () => {
@@ -102,9 +119,12 @@ function JobFormBuilder() {
           const formId = firstForm._id || firstForm.id;
 
           setCurrentFormId(formId);
-          setFormFields(normalizeLoadedQuestions(firstForm.questions || []));
-          setJobTitle(firstForm.title || 'Please Choose an option');
-          markAsSaved(normalizeLoadedQuestions(firstForm.questions || []));
+          const loadedQuestions = normalizeLoadedQuestions(firstForm.questions || []);
+          const loadedTitle = firstForm.title || 'Please Choose an option';
+
+          setFormFields(loadedQuestions);
+          setJobTitle(loadedTitle);
+          markAsSaved(loadedQuestions, loadedTitle);
           setNewField(initialNewField);
 
           console.log('Auto-loaded form:', formId);
@@ -119,14 +139,18 @@ function JobFormBuilder() {
 
   // Detect unsaved changes
   useEffect(() => {
-    const changed =
-      JSON.stringify(formFields) !== JSON.stringify(initialFormFields) ||
-      JSON.stringify(newField) !== JSON.stringify(initialNewField) ||
-      templateName !== '' ||
-      selectedTemplate !== '';
+    const changed = hasUnsavedJobFormChanges({
+      formFields,
+      initialFormFields,
+      newField,
+      initialNewField,
+      templateName,
+      jobTitle,
+      initialJobTitle,
+    });
 
     setHasUnsavedChanges(changed);
-  }, [formFields, newField, templateName, selectedTemplate, initialFormFields]);
+  }, [formFields, initialFormFields, newField, templateName, jobTitle, initialJobTitle]);
 
   const syncFieldAction = async (actionLabel, apiCall, rollback) => {
     try {
@@ -361,7 +385,7 @@ function JobFormBuilder() {
         requestor: getRequestor(),
       });
 
-      markAsSaved(formFields);
+      markAsSaved(formFields, jobTitle);
       console.log('Form updated successfully');
       alert('Form saved successfully!');
     } catch (error) {
@@ -376,6 +400,10 @@ function JobFormBuilder() {
 
   return (
     <div className={`${styles.pageWrapper} ${darkMode ? styles.darkMode : ''}`}>
+      <Prompt
+        when={hasUnsavedChanges}
+        message="You have unsaved changes. Are you sure you want to leave this page?"
+      />
       <div className={styles.formBuilderContainer}>
         <img
           src={OneCommunityImage}

--- a/src/components/Collaboration/__tests__/jobFormUnsavedChanges.test.js
+++ b/src/components/Collaboration/__tests__/jobFormUnsavedChanges.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { hasUnsavedJobFormChanges } from '../jobFormDirtyState';
+
+const initialNewField = {
+  questionText: '',
+  questionType: 'textbox',
+  options: [],
+  visible: true,
+  isRequired: false,
+  required: false,
+};
+
+function getState(overrides = {}) {
+  return {
+    formFields: [{ questionText: 'Why?' }],
+    initialFormFields: [{ questionText: 'Why?' }],
+    newField: initialNewField,
+    initialNewField,
+    templateName: '',
+    jobTitle: 'Software Engineer',
+    initialJobTitle: 'Software Engineer',
+    ...overrides,
+  };
+}
+
+describe('hasUnsavedJobFormChanges', () => {
+  it('returns false when the persisted form state is unchanged', () => {
+    expect(hasUnsavedJobFormChanges(getState())).toBe(false);
+  });
+
+  it('tracks a changed job title', () => {
+    expect(hasUnsavedJobFormChanges(getState({ jobTitle: 'Project Manager' }))).toBe(true);
+  });
+
+  it('tracks changed form fields', () => {
+    expect(
+      hasUnsavedJobFormChanges(
+        getState({ formFields: [{ questionText: 'Why do you want to volunteer?' }] }),
+      ),
+    ).toBe(true);
+  });
+
+  it('tracks a partially entered new question', () => {
+    expect(
+      hasUnsavedJobFormChanges(
+        getState({ newField: { ...initialNewField, questionText: 'New question' } }),
+      ),
+    ).toBe(true);
+  });
+
+  it('tracks an unsaved template name', () => {
+    expect(hasUnsavedJobFormChanges(getState({ templateName: 'Engineering form' }))).toBe(true);
+  });
+});

--- a/src/components/Collaboration/jobFormDirtyState.js
+++ b/src/components/Collaboration/jobFormDirtyState.js
@@ -1,0 +1,16 @@
+export function hasUnsavedJobFormChanges({
+  formFields,
+  initialFormFields,
+  newField,
+  initialNewField,
+  templateName,
+  jobTitle,
+  initialJobTitle,
+}) {
+  return (
+    JSON.stringify(formFields) !== JSON.stringify(initialFormFields) ||
+    JSON.stringify(newField) !== JSON.stringify(initialNewField) ||
+    templateName !== '' ||
+    jobTitle !== initialJobTitle
+  );
+}


### PR DESCRIPTION
# Description

Editing a Job Form Builder form and navigating away or refreshing could silently discard the changes. This restores protection for both in-app navigation and browser refresh, and only enables it while the form differs from its last saved state.

## Original task

Application Form Template — warn users before page refresh or navigation when unsaved changes exist on `/jobformbuilder`.

[Open master Google Doc Task 4](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit?tab=t.0#bookmark=id.aj5trdyn0c3j)

### Master Google Doc task entry

<img width="1050" height="890" alt="Master Google Doc - Task 4 unsaved changes warning" src="https://github.com/user-attachments/assets/35c76911-9912-4589-a782-813160256023" />

## Related PRS (if any):

Related historical work: PR #4414 and hotfix PR #4817. The protection existed previously and was lost during a later merge-conflict resolution. No backend changes.

## Main changes explained:

1. Adds React Router `Prompt` protection for in-app navigation.
2. Adds a `beforeunload` handler for refresh, tab close, and browser navigation.
3. Tracks changes to questions, partially entered new questions, template names, and the selected job title.
4. Records the loaded and successfully saved title and question set as the clean baseline.
5. Removes `selectedTemplate` from dirty-state detection because selecting a template alone does not edit the form.
6. Adds five focused dirty-state regression tests.

## How to test:

1. Check out this branch, install dependencies, and run `npm run start:local`.
2. Log in as an Owner and open `/jobformbuilder`.
3. Navigate away without editing; confirm no warning appears.
4. Change the title, a question, a new-question value, or the template name.
5. Navigate to Dashboard; confirm the browser asks whether to leave.
6. Cancel and confirm the edited form remains open.
7. Refresh and confirm the browser also warns.
8. Save the form, then navigate away; confirm the warning no longer appears.
9. Run `jobFormUnsavedChanges.test.js` and `npm run build`.

## Screenshots or videos of changes:

_Evidence sources: the real local application running against the development backend with the Dev Admin account, plus a local Owner-level QA fixture for the retained-page state._

### Tracked unsaved edit before navigation

<img width="1366" height="900" alt="Job Form Builder - Tracked Unsaved Template Change" src="https://github.com/user-attachments/assets/e31ddcac-ff6d-46fb-9b31-f9b8ba82adc4" />

### Navigation cancelled after unsaved-changes warning

<img width="1440" height="1000" alt="Unsaved Changes - Navigation Cancelled" src="https://github.com/user-attachments/assets/7265d3d3-9e1b-4673-a3d7-77a8b8c9a417" />

_The confirmation itself is browser-native UI and is not included in the page screenshot. The first image shows a tracked dirty-state value; the second shows the form retained after cancelling navigation. The focused regression tests cover clean versus dirty-state detection._
