### PR TITLE
Aditya - Job Application Form: keep the job-title mismatch warning visible

### DIFF
--- a/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
+++ b/src/components/Collaboration/JobApplicationForm/JobApplicationForm.jsx
@@ -155,9 +155,9 @@ function resolveNavigationJobTitle(jobDataFromRedirect, location) {
 function notifyInitialFormSelection(navTitle, formMatch, chosen) {
   if (!navTitle || formMatch) return;
   if (chosen) {
-    toast.info(
+    toast.warn(
       `Could not match "${navTitle}" to a form title. Showing "${chosen.title}" — pick another role from the dropdown if this is not the right application.`,
-      { autoClose: 7000 },
+      { autoClose: false, closeOnClick: false },
     );
     return;
   }


### PR DESCRIPTION
# Description
When `/job-application` is opened with a job title that doesn't match any saved application form (e.g. from a job card on `/collaboration`), the page falls back to another form and shows a warning. That warning used to disappear after seven seconds, so an applicant could fill out the wrong job's application without noticing. This keeps the warning on screen until the user closes it.

This issue concerns [Item 39](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit?tab=t.0#bookmark=id.tvqan9gv2a4b).

## Original task
Suggested Jobs — keep the job-title mismatch warning visible on `/collaboration` and `/job-application` whenever the selected job cannot be matched to its intended form.

**Scope note:** `/collaboration` has no mismatch warning of its own. Clicking a job card there opens `/job-application?jobTitle=<title>`, and the warning shows up on that page. This PR covers that path.

**Out of scope:** the manual job-title box + **Go** button on `/job-application`. When nothing matches, it shows a separate info toast, "No form matches that job title.", and leaves the current form in place without substituting a fallback. That path has no wrong-form risk, so this PR doesn't change it.

[Open master Google Doc Item 39](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit?tab=t.0#bookmark=id.tvqan9gv2a4b)

### Master Google Doc task entry

<img width="1050" height="620" alt="Master Google Doc - Item 39 persistent mismatch warning" src="https://github.com/user-attachments/assets/266747bd-6615-451d-95ba-2c0aae474110" />

## Related PRS (if any):

None. No backend changes. The missing matching form remains a separate content/data issue.

## Main changes explained:
1. The fallback warning in `notifyInitialFormSelection` changes from `toast.info` to `toast.warn` (amber).
2. `autoClose` goes from 7000 ms to `false`, so the warning stays until dismissed.
3. `closeOnClick: false`, so an accidental click on the warning body doesn't dismiss it.
4. The message text is unchanged: `Could not match "<title>" to a form title. Showing "<fallback form>" — pick another role from the dropdown if this is not the right application.`

## How to test:
1. Check out `Aditya_fix_job_title_mismatch_warning`. If a dev server is already running, stop it first, then run `npm run start:local`. The backend must be running.
2. Log in. `/job-application` is a protected route. Test as Volunteer and as Admin.
3. Open **`/job-application?jobTitle=Astronaut`**, or any title with no matching form. Alternatively, go to `/collaboration` and click a job card whose title has no matching form.
   - **Don't** use the job-title box + Go button. That's the separate "No form matches that job title." toast described above, and this PR doesn't change it.
4. Confirm an **amber** warning appears with the exact text: `Could not match "Astronaut" to a form title. Showing "…"`.
5. Wait more than 7 seconds and confirm it's still visible.
6. Click the body of the warning and confirm it stays.
7. Close it with the × and confirm it goes away.
8. Repeat in light and dark mode.
9. Run `npm run build`. (No unit tests cover `JobApplicationForm`.)

## Screenshots or videos of changes:

_Evidence source: local application running against the development backend with the Dev Admin account._

### Persistent job-title mismatch warning

<img width="1366" height="900" alt="Job Title Mismatch - Persistent Warning" src="https://github.com/user-attachments/assets/55c3f976-1a3c-4d16-9588-47365c5e85a7" />

