### PR TITLE
Som Ramnani - fix(projectMembershipReducer.js): preserve project membership state to prevent Members page crash

### DIFF
--- a/src/components/Projects/Members/__tests__/Members.navigation.test.jsx
+++ b/src/components/Projects/Members/__tests__/Members.navigation.test.jsx
@@ -1,0 +1,107 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import thunk from 'redux-thunk';
+import { MemoryRouter, Route, Switch } from 'react-router-dom';
+import axios from 'axios';
+import Projects from '../../Projects';
+import Members from '../Members';
+import { projectMembershipReducer } from '~/reducers/projectMembershipReducer';
+import { ENDPOINTS } from '~/utils/URL';
+
+vi.mock('axios');
+vi.mock('../../AddProject', () => ({ default: () => null }));
+vi.mock('~/utils/permissions', () => ({ default: () => () => false }));
+vi.mock('~/actions/projects', () => ({
+  fetchAllProjects: () => () => {},
+  fetchAllArchivedProjects: () => () => {},
+  modifyProject: () => () => {},
+  clearError: () => () => {},
+}));
+vi.mock('~/components/UserProfile/EditableModal/EditableInfoModal', () => ({
+  default: () => null,
+}));
+
+const project = {
+  _id: 'project1', projectName: 'Test Project', category: 'Society', isActive: true,
+};
+const member = { _id: 'user1', firstName: 'Jane', lastName: 'Member', isActive: true };
+
+function renderNavigation(initialPath = '/projects') {
+  const store = createStore(combineReducers({
+    projectMembers: projectMembershipReducer,
+    allProjects: (state = { projects: [project], status: 200, fetched: true, fetching: false }) => state,
+    theme: (state = { darkMode: false }) => state,
+    userProfile: (state = { role: 'Manager' }) => state,
+    projectById: (state = { projectName: project.projectName }) => state,
+  }), applyMiddleware(thunk));
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Switch>
+          <Route exact path="/projects" component={Projects} />
+          <Route path="/project/members/:projectId" component={Members} />
+        </Switch>
+      </MemoryRouter>
+    </Provider>,
+  );
+  return { store };
+}
+
+function membersLink() {
+  return screen.getAllByRole('link').find(
+    link => link.getAttribute('href') === `/project/members/${project._id}`,
+  );
+}
+
+describe('Projects to Members navigation', () => {
+  let resolveMembers;
+
+  beforeEach(() => {
+    axios.get.mockReset();
+    axios.get.mockImplementation(url => {
+      if (url === ENDPOINTS.PROJECTS_WITH_ACTIVE_USERS) {
+        return Promise.resolve({ data: { project1: 1 } });
+      }
+      if (url === ENDPOINTS.PROJECT_MEMBER(project._id)) {
+        return new Promise(resolve => { resolveMembers = resolve; });
+      }
+      if (url === ENDPOINTS.PROJECT_BY_ID(project._id)) return Promise.resolve({ data: project });
+      if (url === ENDPOINTS.USER_PROFILES) return Promise.resolve({ data: [] });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+  });
+
+  it.each(['success', 'failure'])('opens Members after a count request %s', async outcome => {
+    if (outcome === 'failure') axios.get.mockRejectedValueOnce(new Error('Count request failed'));
+    const { store } = renderNavigation();
+    await waitFor(() => {
+      if (outcome === 'success') {
+        expect(store.getState().projectMembers.activeMemberCounts).toEqual({ project1: 1 });
+      } else {
+        expect(store.getState().projectMembers.error.message).toBe('Count request failed');
+      }
+    });
+
+    fireEvent.click(membersLink());
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+    expect(axios.get).toHaveBeenCalledWith(ENDPOINTS.PROJECT_MEMBER(project._id));
+    await act(async () => { resolveMembers({ data: [member] }); });
+    expect(await screen.findByText('Jane Member')).toBeInTheDocument();
+    expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
+
+    const backLink = screen.getAllByRole('link').find(link => link.getAttribute('href') === '/projects/');
+    fireEvent.click(backLink);
+    expect(await screen.findByText('Projects')).toBeInTheDocument();
+    expect(membersLink()).toBeInTheDocument();
+  });
+
+  it('loads Members on direct entry with fresh state', async () => {
+    renderNavigation(`/project/members/${project._id}`);
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+    await act(async () => { resolveMembers({ data: [member] }); });
+    expect(await screen.findByText('Jane Member')).toBeInTheDocument();
+    expect(axios.get).not.toHaveBeenCalledWith(ENDPOINTS.PROJECTS_WITH_ACTIVE_USERS);
+  });
+});

--- a/src/reducers/__tests__/projectMembershipReducer.test.js
+++ b/src/reducers/__tests__/projectMembershipReducer.test.js
@@ -121,4 +121,26 @@ describe('projectMembershipReducer', () => {
     };
     expect(projectMembershipReducer(initialState, action)).toEqual(expectedState);
   });
+
+  it.each([
+    [types.FETCH_PROJECTS_ACTIVE_USERS_SUCCESS, 'activeMemberCounts', { project1: 3 }],
+    [types.FETCH_PROJECTS_ACTIVE_USERS_ERROR, 'error', 'Count request failed'],
+  ])('preserves membership state when handling %s', (type, field, payload) => {
+    const state = {
+      ...initialState,
+      projectName: 'Test Project',
+      members: [{ _id: 'member1' }],
+      foundUsers: [{ _id: 'user1' }],
+      foundProjectMembers: [{ _id: 'member2' }],
+      activeMemberCounts: { existingProject: 2 },
+      fetching: true,
+      fetched: false,
+      error: 'Existing error',
+    };
+    const result = projectMembershipReducer(state, { type, payload });
+    expect(result).toEqual({ ...state, [field]: payload });
+    expect(result.members).toBe(state.members);
+    expect(result.foundUsers).toBe(state.foundUsers);
+    expect(result.foundProjectMembers).toBe(state.foundProjectMembers);
+  });
 });

--- a/src/reducers/projectMembershipReducer.js
+++ b/src/reducers/projectMembershipReducer.js
@@ -82,10 +82,12 @@ export const projectMembershipReducer = (allMembership = allMembershipInital, ac
 
     case types.FETCH_PROJECTS_ACTIVE_USERS_SUCCESS:
       return {
+        ...allMembership,
         activeMemberCounts: action.payload,
       };
     case types.FETCH_PROJECTS_ACTIVE_USERS_ERROR:
       return {
+        ...allMembership,
         error: action.payload,
       };
 


### PR DESCRIPTION
# Description
Fixes an issue where clicking the **Members icon under Other Links → Projects** displayed _“Something went wrong”_ while opening the same link in a new tab worked.

The active-member count request replaced the entire project-members Redux state on both success and failure, removing arrays required by the Members page. This PR preserves the existing state while updating only the member counts or error field.

https://github.com/user-attachments/assets/2b00234a-b5e2-4d83-86bc-9c8924e054be

## Related PRS (if any):
This frontend PR is related to the development backend PR.

## Main changes explained:
- Updated both active-member count handlers in projectMembershipReducer to preserve existing state.
- Added reducer tests verifying that member lists, search results, and loading flags remain intact.
- Added navigation regression tests covering successful and failed count requests, delayed member responses, direct entry, and returning to Projects.
- Kept the existing Members link and route unchanged.

## How to test:
1. Check out into this PR branch.
2. Run `npm install`, then `npm run start`
3. Log in with an account that can access `Other Links → Projects`.
4. Open Other Links → Projects and wait for the active-member counts to load.
5. Click a project’s Members icon normally. Verify that the Members page loads without displaying “Something went wrong” and shows the selected project’s members.
6. Return to Projects and repeat with another project.
7. Open the Members link in a new tab and refresh that page. Verify both load successfully.
8. Repeat the navigation checks in dark mode.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/619b4655-0b52-4132-969c-508194e55fc2