### PR TITLE
Amaresh: Fix dark mode row hover and button styling in Promotion Eligibility table

### DIFF
--- a/src/components/HGNPRDashboard/PromotionEligibility.module.css
+++ b/src/components/HGNPRDashboard/PromotionEligibility.module.css
@@ -101,7 +101,7 @@
   background-color: #121212;
 }
 
-.promo_table-container.dark .promo_table tr:hover {
+.promo_table_container.dark .promo_table tr:hover {
   background-color: #555;
 }
 
@@ -130,7 +130,7 @@
 }
 
 .promo_table_container.dark .review_btn,
-.promo-table_container.dark .process_promo_btn {
+.promo_table_container.dark .process_promo_btn {
   background-color: #3b82f6;
   color: white;
 }


### PR DESCRIPTION
## Description

<img width="756" height="691" alt="Screenshot 2026-09-12 at 1 21 47 PM" src="https://github.com/user-attachments/assets/ff28d432-851d-4b1b-ad98-2a594037b1eb" />
<img width="778" height="694" alt="Screenshot 2026-09-12 at 1 21 59 PM" src="https://github.com/user-attachments/assets/662ee185-91bf-4f54-ac89-84fb45d36688" />
<img width="759" height="368" alt="Screenshot 2026-09-12 at 1 22 12 PM" src="https://github.com/user-attachments/assets/d2501dfa-63f4-4ae3-a243-2a0cbb3f7262" />

Fixes a dark mode styling bug in the Promotion Eligibility table found during manual end-to-end testing of task mentioned in the image above. Hovering over a table row in dark mode showed a washed-out, low-contrast background instead of the intended dark hover state.

Root cause: `PromotionEligibility.module.css` had two CSS class-name typos that silently prevented the dark-mode selectors from ever matching the actual DOM class (`promo_table_container`, applied in `PromotionEligibility.jsx`):
- `.promo_table-container.dark .promo_table tr:hover` (hyphen instead of underscore): row hover background never applied, so the row fell back to a lighter, unstyled hover.
- `.promo-table_container.dark .process_promo_btn` (hyphen instead of underscore):  the dark-mode background/color rule for the "Process Promotions" button never applied.

## Related PRS (if any):
This frontend PR is related to backend PR [#2347](https://github.com/OneCommunityGlobal/HGNRest/pull/2347).

## Main changes explained:
- Update `src/components/HGNPRDashboard/PromotionEligibility.module.css` for correcting `promo_table-container` → `promo_table_container` on the dark-mode row-hover selector, and `promo-table_container` → `promo_table_container` on the dark-mode `process_promo_btn` background selector.

## How to test:
1. Check out the current branch
2. Run `npm install` and start the app locally
3. Clear site data/cache
4. Log in as admin user (Dev Admin account)
5. Go to PR Dashboard → Promotion Eligibility (`/pr-dashboard/promotion-eligibility`)
6. Toggle dark mode
7. Hover over any row in the table; the background should be a solid dark grey (`#555`), not washed out/light
8. Verify this new feature works in dark mode; confirm "Review for this week" and "Process Promotions" buttons still render with correct blue background and white text

## Screenshots or videos of changes:
<img width="1470" height="880" alt="Screenshot 2026-09-12 at 1 12 23 PM" src="https://github.com/user-attachments/assets/c0f98a33-edcb-4734-9992-17c6b904cd3d" />


## Note: